### PR TITLE
fix: --uninstall removes udev/modules-load drop-ins

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -136,6 +136,10 @@ if [ "$UNINSTALL" -eq 1 ]; then
     note "removed $PAIR_DESKTOP"
     sudo rm -f /etc/systemd/network/50-couchside-wol.link
     note "removed the Wake-on-LAN .link file"
+    sudo rm -f /etc/udev/rules.d/99-couchside-uinput.rules \
+               /etc/modules-load.d/couchside-uinput.conf
+    sudo udevadm control --reload-rules 2>/dev/null || true
+    note "removed the udev/modules-load drop-ins"
     if [ "$NO_DECKY" -eq 0 ] && sudo test -d "$DECKY_PLUGIN_DIR"; then
         sudo rm -rf "$DECKY_PLUGIN_DIR"
         sudo systemctl restart plugin_loader.service 2>/dev/null || true


### PR DESCRIPTION
## Problem

`install.sh --uninstall` left two files behind:

- `/etc/udev/rules.d/99-couchside-uinput.rules`
- `/etc/modules-load.d/couchside-uinput.conf`

This contradicts `README.md` (Uninstall section), which states the uninstaller removes the **"udev/modules-load drop-ins"**.

## Fix

`--uninstall` now removes both files and runs `udevadm control --reload-rules` so the stale rule drops without a reboot.

## Verified

- The WoL `.link` file (`/etc/systemd/network/50-couchside-wol.link`) was **already** removed by `--uninstall` — not orphaned.
- `couchside-decky/main.py` `uninstall()` **already** removes both uinput files (`UINPUT_UDEV`, `UINPUT_MODLOAD`) — no gap there.
- `bash -n install.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)