### PR TITLE
feat: serve Steam cover art from the agent, not the Steam CDN

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -5,6 +5,7 @@
 Couchside is a companion app for a small open-source agent you install on your own Linux home-theater PC. The short version: **we don't collect anything, because there is nothing to collect.**
 
 - The app communicates **only** with the Couchside agent running on your own machine, over your own local network. There is no cloud service, no relay server, and no third-party endpoint of any kind.
+- **Steam cover art** shown on the Launch tab is served by your own agent from the box's local Steam cache. The app never contacts Steam or any content-delivery network for images.
 - **No data is collected.** No analytics, no crash reporting, no telemetry, no advertising identifiers.
 - **No accounts.** There is nothing to sign up for and no personal information is ever requested.
 - The pairing token you use to authenticate with your agent is stored in the **iOS Keychain** on your device and is sent only to your agent.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -38,7 +38,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.7.0"
+VERSION = "2.7.1"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -993,6 +993,40 @@ def discover_steam_games():
         return launchers
     except Exception:
         return []
+
+
+# Steam caches each game's portrait "library capsule" (600x900 cover art) on
+# disk under the Steam root. Two on-disk layouts exist across Steam versions;
+# the app fetches this from the agent (never a CDN) so it stays LAN-only.
+STEAM_COVER_CACHE = ("appcache", "librarycache")
+
+
+def _steam_cover_path(appid):
+    """Local path to the 600x900 library cover for a Steam appid, or None.
+
+    Looks in <root>/appcache/librarycache/ for both known layouts:
+      new (2023+):  <appid>/library_600x900.jpg
+      old (flat):   <appid>_library_600x900.jpg
+    appid must be all-digits (caller-validated too) so the path can never
+    escape the cache dir. Read-only, best-effort; never raises.
+    """
+    if not (isinstance(appid, str) and appid.isdigit()):
+        return None
+    root = _steam_root()
+    if root is None:
+        return None
+    cache = os.path.join(root, *STEAM_COVER_CACHE)
+    candidates = (
+        os.path.join(cache, appid, "library_600x900.jpg"),
+        os.path.join(cache, "%s_library_600x900.jpg" % appid),
+    )
+    for p in candidates:
+        try:
+            if os.path.isfile(p):
+                return p
+        except OSError:
+            continue
+    return None
 
 
 def list_launchers():
@@ -3187,6 +3221,20 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
         self._log(code, started)
 
+    def _send_bytes(self, code, body, content_type, started, extra_headers=None):
+        """Send a raw byte body (e.g. an image) instead of JSON."""
+        self.send_response(code)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        if extra_headers:
+            for k, v in extra_headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+        self._log(code, started)
+
     def _log(self, code, started):
         dur_ms = int((time.monotonic() - started) * 1000)
         # Never log query strings: /ws/gamepad carries ?token=<secret>, and
@@ -3299,6 +3347,9 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(200, {"actions": actions}, started)
             elif path == "/api/launchers":
                 self._send(200, {"launchers": list_launchers()}, started)
+            elif path.startswith("/api/steam/") and path.endswith("/cover"):
+                appid = path[len("/api/steam/"):-len("/cover")]
+                self._handle_steam_cover(appid, started)
             elif path == "/api/tv":
                 # Probe-and-appear: 404 when no TV backend so the app shows no
                 # TV strip; a body only when a backend is live.
@@ -3316,6 +3367,26 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(500, {"error": e.__class__.__name__}, started)
             except Exception:
                 pass
+
+    def _handle_steam_cover(self, appid, started):
+        """Serve a Steam game's 600x900 cover art from the box's LOCAL Steam
+        cache. No CDN / third-party fetch: the phone talks only to this agent,
+        so the app stays LAN-only. 404 when the appid is malformed, the game
+        isn't installed, or Steam hasn't cached its portrait art yet (the app
+        then shows its text-card fallback)."""
+        cover = _steam_cover_path(appid)
+        if cover is None:
+            self._send(404, {"error": "no cover"}, started)
+            return
+        try:
+            with open(cover, "rb") as f:
+                body = f.read()
+        except OSError:
+            self._send(404, {"error": "no cover"}, started)
+            return
+        # Art is keyed by appid and effectively immutable; let the phone cache it.
+        self._send_bytes(200, body, "image/jpeg", started,
+                         extra_headers={"Cache-Control": "public, max-age=604800"})
 
     def _read_body(self):
         """Read and return the request body bytes (always drains it).

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -5,7 +5,7 @@
  * deleted here. Tapping a tile launches it (haptic + brief toast).
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -26,15 +26,10 @@ import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { api, Launcher } from '@/lib/api';
+import { api, ImageSource, Launcher } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
-
-/** Steam library cover art (600x900 portrait). */
-function coverUrl(appid: number): string {
-  return `https://cdn.cloudflare.steamstatic.com/steam/apps/${appid}/library_600x900.jpg`;
-}
 
 /** Cross-platform confirm (Alert buttons are no-ops on web). */
 function confirmDelete(label: string, onConfirm: () => void) {
@@ -54,22 +49,36 @@ function confirmDelete(label: string, onConfirm: () => void) {
 type TileProps = {
   launcher: Launcher;
   width: number;
+  /** Agent-served cover art, present for Steam tiles; undefined shows the text card. */
+  coverSource?: ImageSource;
+  /** Bumped on pull-to-refresh to retry a cover that previously failed to load. */
+  retryKey?: number;
   onLaunch: () => void;
   onDelete?: () => void;
 };
 
-function LauncherTile({ launcher, width, onLaunch, onDelete }: TileProps) {
+function LauncherTile({ launcher, width, coverSource, retryKey, onLaunch, onDelete }: TileProps) {
   const [imgFailed, setImgFailed] = useState(false);
-  const showArt = launcher.kind === 'steam' && launcher.appid != null && !imgFailed;
+  // A failed cover latches to the text card so <Image> doesn't error-loop; clear
+  // the latch when the URL changes (e.g. the app healed to the box's cached IP)
+  // or the user pull-to-refreshes, so a recovered / newly-cached cover repaints.
+  const uri = coverSource?.uri;
+  useEffect(() => {
+    setImgFailed(false);
+  }, [uri, retryKey]);
+  // Narrowed to a local so the <Image> branch sees a defined source (not the
+  // `ImageSource | undefined` prop): shown only for Steam tiles that haven't errored.
+  const art = imgFailed ? undefined : coverSource;
+  const showArt = art != null;
   const height = Math.round(width * 1.5); // 600x900 aspect
 
   return (
     <Pressable
       onPress={onLaunch}
       style={({ pressed }) => [styles.tile, { width, height }, pressed && styles.tilePressed]}>
-      {showArt ? (
+      {art ? (
         <Image
-          source={{ uri: coverUrl(launcher.appid as number) }}
+          source={art}
           style={styles.tileArt}
           resizeMode="cover"
           onError={() => setImgFailed(true)}
@@ -238,6 +247,8 @@ function LaunchScreen() {
   const [addOpen, setAddOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  // Bumped on pull-to-refresh so tiles retry any cover that failed to load.
+  const [retryKey, setRetryKey] = useState(0);
 
   const list = usePoll<{ launchers: Launcher[] }>(
     () => api.launchers(settings),
@@ -303,6 +314,7 @@ function LaunchScreen() {
 
   const onRefresh = useCallback(() => {
     setRefreshing(true);
+    setRetryKey((k) => k + 1); // let previously-failed covers try again
     list.refresh();
     // usePoll.refresh() re-runs on the next focus tick; drop the spinner soon.
     setTimeout(() => setRefreshing(false), 600);
@@ -388,6 +400,12 @@ function LaunchScreen() {
                 key={l.id}
                 launcher={l}
                 width={tileWidth}
+                coverSource={
+                  l.kind === 'steam' && l.appid != null
+                    ? api.steamCoverSource(settings, l.appid)
+                    : undefined
+                }
+                retryKey={retryKey}
                 onLaunch={() => launch(l)}
                 onDelete={l.kind === 'custom' ? () => remove(l) : undefined}
               />

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -7,6 +7,12 @@ import { Settings } from './settings';
 /** The subset of Settings the API client actually needs. */
 export type ConnSettings = Pick<Settings, 'host' | 'port' | 'token' | 'lastIp'>;
 
+/**
+ * A remote image source (uri + optional request headers). Structurally a subset
+ * of React Native's ImageURISource, so it drops straight into <Image source>.
+ */
+export type ImageSource = { uri: string; headers?: Record<string, string> };
+
 // ---------- Contract types ----------
 
 export type Ping = {
@@ -285,6 +291,15 @@ async function probeTarget(host: string, settings: ConnSettings): Promise<boolea
   }
 }
 
+/**
+ * The address request() last reached this box on — settings.host normally, or
+ * settings.lastIp after an mDNS-break fallback. Cover-art <Image> loads can't
+ * run the fallback probe themselves, so they reuse this to stay on the working
+ * target (see steamCoverSource). Module-scoped: the app talks to one box at a
+ * time, and steamCoverSource only trusts it when it matches the box's host/IP.
+ */
+let lastGoodHost: string | null = null;
+
 async function request<T>(
   settings: ConnSettings,
   path: string,
@@ -305,6 +320,7 @@ async function request<T>(
     settings.lastIp && settings.lastIp !== settings.host ? settings.lastIp : undefined;
 
   let res: Response;
+  let usedHost = settings.host;
   if (method === 'GET' || !fallback) {
     try {
       res = await attempt(settings.host, settings, path, opts);
@@ -317,6 +333,7 @@ async function request<T>(
         e instanceof ApiError && (e.kind === 'unreachable' || e.kind === 'timeout');
       if (retriable && fallback && method === 'GET' && (await probeTarget(fallback, settings))) {
         res = await attempt(fallback, settings, path, opts);
+        usedHost = fallback;
       } else {
         throw e;
       }
@@ -330,7 +347,11 @@ async function request<T>(
       // else: send to the configured host anyway and surface its real error.
     }
     res = await attempt(target, settings, path, opts);
+    usedHost = target;
   }
+  // Remember which address actually reached the box, so cover-art <Image> loads
+  // (which can't run the fallback probe) can reuse the same working target.
+  lastGoodHost = usedHost;
 
   if (res.status === 401) {
     throw new ApiError('unauthorized', 'Unauthorized: check token');
@@ -394,6 +415,32 @@ export const api = {
   /** List discovered Steam games + user-defined custom launchers. */
   launchers(settings: ConnSettings): Promise<{ launchers: Launcher[] }> {
     return request<{ launchers: Launcher[] }>(settings, '/api/launchers');
+  },
+
+  /**
+   * Image source for a Steam game's library cover art (agent >= 2.7.1). The
+   * agent serves the art from the box's OWN local Steam cache, so the phone
+   * never contacts Steam or any CDN — the app stays LAN-only (see PRIVACY.md).
+   *
+   * Auth rides as a Bearer header, which React Native's Image sends on native;
+   * web <img> can't carry it, so covers fall back to the text card there. Reuses
+   * the address request() last reached this box on (so covers follow the cached-IP
+   * fallback in SteamOS Game Mode instead of a dead .local name); if that target
+   * is unreachable, the agent is older, or the art isn't cached yet, the request
+   * fails and the tile's onError shows the text card.
+   */
+  steamCoverSource(settings: ConnSettings, appid: number): ImageSource {
+    // Reuse the last address that reached THIS box (host, or the cached IP after
+    // an mDNS-break fallback). Guarded to this box's known addresses so a stale
+    // value left by a different box is never used.
+    const host =
+      lastGoodHost && (lastGoodHost === settings.host || lastGoodHost === settings.lastIp)
+        ? lastGoodHost
+        : settings.host;
+    return {
+      uri: `${baseUrl({ host, port: settings.port })}/api/steam/${appid}/cover`,
+      headers: { Authorization: `Bearer ${settings.token}` },
+    };
   },
 
   /** Launch a game/app by launcher id. */

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -34,6 +34,9 @@ your own Linux home-theater PC. The short version:
   <li>The app communicates <strong>only</strong> with the Couchside agent
   running on your own machine, over your own local network. There is no cloud
   service, no relay server, and no third-party endpoint.</li>
+  <li><strong>Steam cover art</strong> shown on the Launch tab is served by
+  your own agent from the box's local Steam cache. The app never contacts
+  Steam or any content-delivery network for images.</li>
   <li><strong>No data is collected.</strong> No analytics, no crash reporting,
   no telemetry, no advertising identifiers.</li>
   <li><strong>No accounts.</strong> There is nothing to sign up for and no


### PR DESCRIPTION
## Why
The Launch tab fetched Steam cover art directly from the phone to `cdn.cloudflare.steamstatic.com` — a third-party CDN — which contradicted PRIVACY.md's claim of **"no third-party endpoint of any kind."** This routes the art through the on-box agent instead, so the app stays genuinely LAN-only. No privacy-label or store-metadata changes needed; the LAN-only / no-cloud / no-third-party claims stay true.

## What
**Agent (2.7.0 → 2.7.1)** — new authed `GET /api/steam/<appid>/cover` serves the box's *own* locally-cached `library_600x900.jpg` (handles both on-disk cache layouts). 404s when the appid is malformed, uninstalled, or not yet cached. `appid` is digit-validated so the path can't escape the cache dir.

**App** — `steamCoverSource()` builds an agent URL with a Bearer header (RN `Image` sends it on native; web `<img>` can't, so covers fall back to the text card there). It reuses the address `request()` last reached the box on, so covers follow the cached-IP fallback in SteamOS Game Mode instead of a dead `.local` name. A failed-cover latch now clears on host-heal and pull-to-refresh so the tile retries.

**Docs** — PRIVACY.md and docs/privacy.html note the art is served locally, never from a CDN.

## Verification
- Agent route integration-tested against a live server + fake Steam cache: both cache layouts serve `200 image/jpeg` + Cache-Control; `401` without/with wrong token; `404` on non-digit / path-traversal / uncached appid; `/api/launchers` unregressed.
- `tsc --noEmit` clean (exit 0).
- Adversarial multi-agent review (8 agents): 0 security/type/correctness bugs; 2 low findings (cover recovery in mDNS-break + write-once failure latch) both fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)