### PR TITLE
feat: text input passthrough — fix smart-quote WS-kill + unicode paste (roadmap Phase 2)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -160,7 +160,10 @@ Auth is the `token` query parameter, checked with `hmac.compare_digest`
 **before** the handshake response: a bad/missing token gets a plain HTTP
 `401` and the socket is closed (no WebSocket handshake). On success the agent
 completes the RFC6455 handshake, creates the uinput device, and sends
-`{"t":"hello","dev":"Microsoft X-Box 360 pad"}` (`dev:"mock"` in `--mock`).
+`{"t":"hello","dev":"Microsoft X-Box 360 pad","text":"unicode"|"ascii"}`
+(`dev:"mock"` in `--mock`). The `text` field advertises how much of a typed
+string the agent can deliver (see **Text input** below); older agents omit it
+and the app defaults by device name.
 
 **One-connection rule:** only one gamepad connection is active at a time. A
 new valid connection *replaces* the old one: the old uinput device is
@@ -179,7 +182,7 @@ the mouse/keyboard messages (v2):
 | `{"t":"m","dx":I,"dy":I}` | Relative mouse move (virtual mouse) |
 | `{"t":"mb","k":"l"\|"r"\|"m","v":0\|1}` | Mouse button down/up |
 | `{"t":"mw","dy":I}` | Mouse wheel |
-| `{"t":"kt","text":"…"}` | Type Unicode text — layout-independent (virtual keyboard) |
+| `{"t":"kt","text":"…"}` | Type text (virtual keyboard) — see **Text input** |
 | `{"t":"k","key":K}` | One special key; `K` ∈ `backspace enter tab esc space up down left right home end` |
 | `{"t":"ping"}` | Keepalive → `{"t":"pong"}` |
 
@@ -187,6 +190,25 @@ Server to client: `hello` (after device ready), `pong`, and
 `{"t":"err","msg":"..."}` followed by close on any error (bad message,
 uinput failure). WS ping (opcode 0x9) is answered with pong (0xA). Idle
 sockets time out after ~60 s.
+
+### Text input
+
+A `{"t":"kt"}` frame never closes the session: characters the ASCII keymap can
+type go through the uinput keyboard; any run of genuinely non-ASCII text
+(emoji, CJK, accents) is delivered by setting the wayland clipboard
+(`wl-copy`, text on stdin) and sending Ctrl+V. Before pressing Ctrl+V the agent
+reads the clipboard back with `wl-paste` and only proceeds if it matches — so a
+failed or wrong-session copy can never paste a stale clipboard. The clipboard is
+cleared a few seconds later.
+
+The `hello` frame's `text` capability is `unicode` only when a **safe** paste
+path exists: `wl-copy` **and** `wl-paste` are installed **and** exactly one
+wayland session socket is present (two sessions make the target ambiguous). Else
+it is `ascii`, and the app strips non-typeable characters client-side. Stock
+SteamOS has no `wl-clipboard` (→ `ascii`); it is common on Bazzite (→ `unicode`).
+The app always normalizes autocorrect artifacts (smart quotes, em dash,
+ellipsis, NBSP) to ASCII regardless, so the common paste-from-notes case types
+reliably on every agent version.
 
 ### uinput notes
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -2236,6 +2236,7 @@ KEY_MINUS, KEY_EQUAL, KEY_BACKSPACE, KEY_TAB = 12, 13, 14, 15
 KEY_Q, KEY_W, KEY_E, KEY_R, KEY_T, KEY_Y = 16, 17, 18, 19, 20, 21
 KEY_U, KEY_I, KEY_O, KEY_P = 22, 23, 24, 25
 KEY_LEFTBRACE, KEY_RIGHTBRACE, KEY_ENTER = 26, 27, 28
+KEY_LEFTCTRL = 29  # for the Ctrl+V paste chord (non-ASCII text delivery)
 KEY_A, KEY_S, KEY_D, KEY_F, KEY_G, KEY_H = 30, 31, 32, 33, 34, 35
 KEY_J, KEY_K, KEY_L, KEY_SEMICOLON = 36, 37, 38, 39
 KEY_APOSTROPHE, KEY_GRAVE, KEY_LEFTSHIFT, KEY_BACKSLASH = 40, 41, 42, 43
@@ -2326,16 +2327,19 @@ SPECIAL_KEYS = {
 }
 
 # All KEY_* codes the virtual keyboard may emit (declared at device create).
+# KEY_LEFTCTRL is included for the Ctrl+V paste chord even though no char maps
+# to it, else the uinput device won't declare the capability and emit fails.
 KEYBOARD_CODES = sorted(
     {code for code, _shift in CHAR_KEYMAP.values()}
     | set(SPECIAL_KEYS.values())
-    | {KEY_LEFTSHIFT}
+    | {KEY_LEFTSHIFT, KEY_LEFTCTRL}
 )
 
 # Names for mock logging of keyboard/mouse EV_KEY events.
 _KEY_CODE_NAMES = {
     KEY_ESC: "KEY_ESC", KEY_BACKSPACE: "KEY_BACKSPACE", KEY_TAB: "KEY_TAB",
     KEY_ENTER: "KEY_ENTER", KEY_SPACE: "KEY_SPACE", KEY_LEFTSHIFT: "KEY_LEFTSHIFT",
+    KEY_LEFTCTRL: "KEY_LEFTCTRL",
     KEY_UP: "KEY_UP", KEY_DOWN: "KEY_DOWN", KEY_LEFT: "KEY_LEFT",
     KEY_RIGHT: "KEY_RIGHT", KEY_HOME: "KEY_HOME", KEY_END: "KEY_END",
     KEY_MINUS: "KEY_MINUS", KEY_EQUAL: "KEY_EQUAL", KEY_LEFTBRACE: "KEY_LEFTBRACE",
@@ -2800,19 +2804,12 @@ def keyboard_events(msg):
         text = msg.get("text")
         if not isinstance(text, str):
             raise ValueError("kt text must be a string")
-        events = []
-        for ch in text:
-            entry = CHAR_KEYMAP.get(ch)
-            if entry is None:
-                raise ValueError("unsupported character %r" % (ch,))
-            code, shift = entry
-            if shift:
-                events.append((EV_KEY, KEY_LEFTSHIFT, 1))
-            events.append((EV_KEY, code, 1))
-            events.append((EV_KEY, code, 0))
-            if shift:
-                events.append((EV_KEY, KEY_LEFTSHIFT, 0))
-        return events
+        # Tolerant: unmappable chars are skipped, never raised. A single smart
+        # quote / emoji used to raise here and kill the whole WS session.
+        # Genuine non-ASCII is delivered via the paste path in
+        # Handler._handle_kt, which intercepts 'kt' before this decoder; this
+        # stays a safe fallback if 'kt' is ever routed straight through.
+        return _type_events(text)
     if t == "k":
         key = msg.get("key")
         if key not in SPECIAL_KEYS:
@@ -2820,6 +2817,154 @@ def keyboard_events(msg):
         code = SPECIAL_KEYS[key]
         return [(EV_KEY, code, 1), (EV_KEY, code, 0)]
     raise ValueError("unknown keyboard message type %r" % (t,))
+
+
+def _type_events(text):
+    """Uinput events to type `text`, skipping any char the ASCII keymap can't
+    produce (tolerant — never raises). Non-typeable chars are handled elsewhere
+    via paste; here they are simply omitted."""
+    events = []
+    for ch in text:
+        entry = CHAR_KEYMAP.get(ch)
+        if entry is None:
+            continue
+        code, shift = entry
+        if shift:
+            events.append((EV_KEY, KEY_LEFTSHIFT, 1))
+        events.append((EV_KEY, code, 1))
+        events.append((EV_KEY, code, 0))
+        if shift:
+            events.append((EV_KEY, KEY_LEFTSHIFT, 0))
+    return events
+
+
+def _split_typeable(text):
+    """Split text into ordered ('type'|'paste', chunk) runs by whether each
+    char is in CHAR_KEYMAP. Typeable runs go through uinput; paste runs go
+    through the clipboard (unicode delivery)."""
+    runs = []
+    cur, buf = None, []
+    for ch in text:
+        kind = "type" if ch in CHAR_KEYMAP else "paste"
+        if kind != cur:
+            if buf:
+                runs.append((cur, "".join(buf)))
+            cur, buf = kind, [ch]
+        else:
+            buf.append(ch)
+    if buf:
+        runs.append((cur, "".join(buf)))
+    return runs
+
+
+# Bounds for one 'kt' frame, so a giant or pathologically-alternating string
+# can't tie up the session's reader thread (each paste run costs ~2 subprocesses
+# + a settle sleep). A real typed message is tiny; these are generous.
+_KT_MAX_CHARS = 4096
+_KT_MAX_PASTE_RUNS = 8
+
+# Ctrl+V chord as uinput events (press ctrl, tap v, release ctrl).
+_CTRL_V_EVENTS = [
+    (EV_KEY, KEY_LEFTCTRL, 1),
+    (EV_KEY, KEY_V, 1),
+    (EV_KEY, KEY_V, 0),
+    (EV_KEY, KEY_LEFTCTRL, 0),
+]
+
+
+def _wayland_sockets():
+    """Non-lock wayland-* sockets in XDG_RUNTIME_DIR (best-effort, never raises)."""
+    try:
+        return [e for e in os.listdir(XDG_RUNTIME_DIR)
+                if e.startswith("wayland-") and not e.endswith(".lock")]
+    except OSError:
+        return []
+
+
+def _paste_available():
+    """True when a SAFE clipboard-paste path exists: wl-copy AND wl-paste are
+    present AND exactly one wayland session socket exists. The single-socket
+    requirement is a safety gate — with two sessions, wl-copy could set the
+    clipboard on one while Ctrl+V lands in the other (pasting a stale/foreign
+    clipboard, e.g. a password), so we decline (ascii-degrade) rather than risk
+    it. Delivery is additionally verified per-paste via wl-paste read-back."""
+    if shutil.which("wl-copy") is None or shutil.which("wl-paste") is None:
+        return False
+    return len(_wayland_sockets()) == 1
+
+
+def _text_caps(mock):
+    """Capability advertised in the hello frame: 'unicode' when we can deliver
+    arbitrary text (via paste), else 'ascii' so the app strips non-typeable
+    chars client-side. --mock always claims unicode."""
+    return "unicode" if (mock or _paste_available()) else "ascii"
+
+
+def _paste_log_once(entry, msg):
+    """Log a paste diagnostic at most once per WS session."""
+    if not entry.get("_paste_logged"):
+        entry["_paste_logged"] = True
+        print("[keyboard] %s" % msg, flush=True)
+
+
+def _schedule_clipboard_clear(entry, env, delay=3.0):
+    """Clear the wayland clipboard a few seconds after a paste, so pasted text
+    (possibly sensitive) does not linger. Generation-guarded: a newer paste
+    bumps the counter and cancels this clear (that paste owns the clipboard and
+    schedules its own)."""
+    gen = entry.get("_paste_gen", 0) + 1
+    entry["_paste_gen"] = gen
+
+    def _clear():
+        if entry.get("_paste_gen") != gen:
+            return
+        try:
+            subprocess.run(["wl-copy", "--clear"], env=env, timeout=2,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        except Exception:
+            pass
+
+    threading.Timer(delay, _clear).start()
+
+
+def clipboard_paste(text, kbd, mock, entry):
+    """Deliver non-ASCII `text` by setting the wayland clipboard and sending
+    Ctrl+V on the session keyboard device. Returns True on a delivered paste.
+
+    Safety: wl-copy receives the text on STDIN (never argv — process cmdlines
+    are world-readable and could leak a password). After copying we read the
+    clipboard back with wl-paste; only if it matches do we press Ctrl+V, so a
+    failed/again-wrong-socket copy can never paste a stale clipboard. On the
+    first hard failure the paste path is marked dead for the session."""
+    if mock:
+        print("[mock] paste %d chars" % len(text), flush=True)
+        return True
+    if entry.get("_paste_dead"):
+        return False
+    env = _session_env()
+    try:
+        subprocess.run(["wl-copy"], input=text.encode("utf-8"), env=env,
+                       timeout=2, check=True,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(0.05)  # let the compositor take ownership of the selection
+        rb = subprocess.run(["wl-paste", "-n"], env=env, timeout=2,
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except Exception as e:
+        entry["_paste_dead"] = True
+        _paste_log_once(entry, "paste unavailable (%s); non-ASCII dropped" % e)
+        return False
+    if rb.returncode != 0 or rb.stdout.decode("utf-8", "replace") != text:
+        # The compositor did not accept our clipboard on this socket: do NOT
+        # Ctrl+V (would paste whatever was there before). Drop this chunk.
+        _paste_log_once(entry, "clipboard read-back mismatch; non-ASCII dropped")
+        return False
+    try:
+        kbd.emit(_CTRL_V_EVENTS)
+    except Exception as e:
+        _paste_log_once(entry, "Ctrl+V emit failed: %s" % e)
+        return False
+    _schedule_clipboard_clear(entry, env)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -3759,7 +3904,8 @@ class Handler(BaseHTTPRequestHandler):
                 return
             entry["device"] = device
             print("[gamepad] connected (%s)" % device.name, flush=True)
-            ws_send_json(conn, {"t": "hello", "dev": device.name})
+            ws_send_json(conn, {"t": "hello", "dev": device.name,
+                                "text": _text_caps(self.mock)})
 
             conn.settimeout(60.0)
             buf = bytearray()
@@ -3817,6 +3963,51 @@ class Handler(BaseHTTPRequestHandler):
     _MOUSE_TYPES = frozenset(("m", "mb", "mw"))
     _KEYBOARD_TYPES = frozenset(("kt", "k"))
 
+    def _handle_kt(self, conn, entry, msg):
+        """Type text tolerantly and keep the session alive no matter what.
+
+        Typeable chars go through the uinput keyboard; genuine non-ASCII goes
+        through the clipboard-paste path. A missing keyboard device or an
+        unavailable paste path just drops the affected chars (logged once) — no
+        err frame, no close. Only a malformed message (non-string text) still
+        err+closes, preserving the protocol contract.
+        """
+        text = msg.get("text")
+        if not isinstance(text, str):
+            ws_send_json(conn, {"t": "err", "msg": "kt text must be a string"})
+            ws_send(conn, WS_OP_CLOSE)
+            return False
+        if not text:
+            return True
+        if len(text) > _KT_MAX_CHARS:
+            _paste_log_once(entry, "kt text too long (%d chars); truncated" % len(text))
+            text = text[:_KT_MAX_CHARS]
+        kbd = entry.get("keyboard")
+        if kbd is None:
+            try:
+                kbd = MockKeyboard() if self.mock else UInputKeyboard()
+            except Exception as e:
+                _paste_log_once(entry, "keyboard unavailable (%s); text dropped" % e)
+                return True
+            entry["keyboard"] = kbd
+            print("[gamepad] keyboard device created (%s)" % kbd.name, flush=True)
+        paste_runs = 0
+        for kind, chunk in _split_typeable(text):
+            if kind == "type":
+                events = _type_events(chunk)
+                if events:
+                    try:
+                        kbd.emit(events)
+                    except Exception as e:
+                        _paste_log_once(entry, "type emit failed: %s" % e)
+            else:
+                paste_runs += 1
+                if paste_runs > _KT_MAX_PASTE_RUNS:
+                    _paste_log_once(entry, "too many paste runs; remaining non-ASCII dropped")
+                    continue
+                clipboard_paste(chunk, kbd, self.mock, entry)
+        return True
+
     def _gamepad_message(self, conn, entry, device, payload):
         """Handle one text frame. Returns False when the session must end.
 
@@ -3836,6 +4027,11 @@ class Handler(BaseHTTPRequestHandler):
         if t == "ping":
             ws_send_json(conn, {"t": "pong"})
             return True
+        if t == "kt":
+            # Text passthrough is handled here, BEFORE the decode table, so it
+            # can never close the session: unmappable chars are dropped and
+            # genuine non-ASCII is pasted, all tolerantly.
+            return self._handle_kt(conn, entry, msg)
 
         # Select decoder, target device slot, and lazy device factory.
         if t in self._MOUSE_TYPES:

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -3132,7 +3132,10 @@ class Handler(BaseHTTPRequestHandler):
                 return
             entry["device"] = device
             print("[gamepad] connected (%s)" % device.name, flush=True)
-            ws_send_json(conn, {"t": "hello", "dev": device.name})
+            # Windows types arbitrary unicode directly via KEYEVENTF_UNICODE,
+            # so it always advertises full-text capability (no paste needed).
+            ws_send_json(conn, {"t": "hello", "dev": device.name,
+                                "text": "unicode"})
 
             conn.settimeout(60.0)
             buf = bytearray()

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.4.2",
+    "version": "2.5.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -817,7 +817,10 @@ function PadScreen() {
       )}
 
       {mode === 'remote' ? (
-        <RemoteView client={client} settings={settings} />
+        <>
+          <RemoteView client={client} settings={settings} />
+          {keyboardBar}
+        </>
       ) : mode === 'swipe' ? (
         <>
           {/* Apple-TV-remote style: big swipe/tap surface + three big buttons */}
@@ -1069,6 +1072,7 @@ function PadScreen() {
               <Stick onMove={stickMove('r')} onRelease={stickRelease('r')} />
             </View>
           </View>
+          {keyboardBar}
         </>
       )}
     </View>

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -19,7 +19,10 @@
  *   -- keyboard (v2) --
  *   {"t":"kt","text":S}                type a string
  *   {"t":"k","key":NAME}              a single special key
- * Server -> client: {"t":"hello","dev":...} | {"t":"pong"} | {"t":"err","msg":...}
+ * Server -> client: {"t":"hello","dev":...,"text":"unicode"|"ascii"} |
+ *   {"t":"pong"} | {"t":"err","msg":...}
+ *   The hello `text` field advertises how much of a typed string the agent can
+ *   deliver; sendText() strips non-typeable chars when it is not "unicode".
  */
 import { Settings } from './settings';
 
@@ -119,6 +122,8 @@ export class GamepadClient {
   private ws: WebSocket | null = null;
   private status: GamepadStatus = 'closed';
   private dev: string | null = null;
+  /** Text capability from the hello frame ('unicode'|'ascii'); null until known. */
+  private textCaps: 'unicode' | 'ascii' | null = null;
   private listener: GamepadStatusListener | null = null;
 
   // Input-injection paused state, signalled by the server (Windows agent):
@@ -357,10 +362,27 @@ export class GamepadClient {
 
   // ---------- keyboard (v2) ----------
 
-  /** Type a string (printable ASCII). Server maps each char to KEY_* codes. */
+  /**
+   * Type a string. Smart-quote / dash / ellipsis / NBSP autocorrect artifacts
+   * are ALWAYS normalized to ASCII (they are never user intent, and this routes
+   * the common case through the reliable per-key path on every agent version).
+   * When the agent did not advertise unicode support, anything the ASCII keymap
+   * cannot type is stripped, so an old agent never receives an unmappable char
+   * (which previously dropped the whole WebSocket).
+   */
   sendText(text: string): void {
-    if (!text) return;
-    this.sendRaw({ t: 'kt', text });
+    let s = text
+      .replace(/[‘’]/g, "'") // smart single quotes
+      .replace(/[“”]/g, '"') // smart double quotes
+      .replace(/[–—]/g, '-') // en/em dash
+      .replace(/…/g, '...') // ellipsis
+      .replace(/\u00a0/g, ' '); // non-breaking space
+    if (this.textCaps !== 'unicode') {
+      // Keep printable ASCII plus tab/newline; drop everything else.
+      s = s.replace(/[^\x20-\x7e\t\n]/g, '');
+    }
+    if (!s) return;
+    this.sendRaw({ t: 'kt', text: s });
   }
 
   /** A single special key press+release (backspace, enter, arrows, …). */
@@ -394,7 +416,7 @@ export class GamepadClient {
       // pending, so ignore events from a socket we have already superseded.
       // (Same guard in onerror/onclose below.)
       if (ws !== this.ws) return;
-      let msg: { t?: string; dev?: string; msg?: string };
+      let msg: { t?: string; dev?: string; msg?: string; text?: string };
       try {
         msg = JSON.parse(String(ev.data));
       } catch {
@@ -403,6 +425,15 @@ export class GamepadClient {
       if (msg.t === 'hello') {
         this.attempt = 0;
         this.dev = typeof msg.dev === 'string' ? msg.dev : null;
+        // Text capability: an explicit hello field wins; otherwise default by
+        // device — old Windows agents (ViGEm) already type full unicode via
+        // KEYEVENTF_UNICODE, old Linux agents are ASCII-only.
+        this.textCaps =
+          msg.text === 'unicode' || msg.text === 'ascii'
+            ? msg.text
+            : this.dev === 'ViGEm X360 pad'
+              ? 'unicode'
+              : 'ascii';
         this.setStatus('connected', this.dev);
         this.startPing();
       } else if (msg.t === 'err') {
@@ -514,9 +545,12 @@ export class GamepadClient {
   private setStatus(status: GamepadStatus, dev: string | null): void {
     this.status = status;
     this.dev = dev;
-    // A blocked hint only makes sense while connected; clear it otherwise so a
-    // stale banner can't outlive the connection.
-    if (status !== 'connected') this.setInputBlocked(false, null);
+    // A blocked hint (and the negotiated text caps) only make sense while
+    // connected; clear them otherwise so nothing stale outlives the connection.
+    if (status !== 'connected') {
+      this.setInputBlocked(false, null);
+      this.textCaps = null;
+    }
     if (this.listener) this.listener(status, dev);
   }
 


### PR DESCRIPTION
Roadmap **Phase 2 — text input passthrough §4.2**. Stacked on #3 (Phase 1) — both are the agent **2.8.0** train, so this PR bases on `feat/steam-download-progress`.

## Fixes a shipped bug
A single smart quote / emoji in a typed string raised `ValueError` in the agent's `kt` decoder and **closed the whole gamepad WebSocket** (every Linux agent ≤ 2.7.0). Paste text from Notes → the pad connection dropped.

## Agent — Linux (`couchsided.py`)
- `keyboard_events` `kt` is now **tolerant** (skips unmappable chars, never raises).
- `Handler._handle_kt` intercepts `kt` before the decode table: typeable runs go through uinput; genuine non-ASCII (emoji / CJK / accents) is delivered by **paste**.
- `clipboard_paste`: `wl-copy` (text on **STDIN**, never argv) → **`wl-paste` read-back verify** → Ctrl+V (`KEY_LEFTCTRL` added). The read-back guarantees our text is on the clipboard before pasting, so a failed/wrong-session copy can never paste a stale/foreign clipboard (e.g. a password). Generation-guarded deferred clear.
- `hello` advertises `text` caps: **`unicode`** only when `wl-copy` **and** `wl-paste` exist **and** exactly one wayland socket (unambiguous session); else **`ascii`**. Passwords are ASCII → always typed via uinput, never pasted.
- Bounded: `kt` capped at 4096 chars + 8 paste runs/frame (self-DoS guard).

## App
- `gamepad.ts`: parse hello `text` caps (default by device — `ViGEm X360 pad`→unicode, else ascii); reset on disconnect. `sendText` **always** normalizes smart quotes/dashes/ellipsis/NBSP→ASCII, and strips non-typeable chars when caps≠`unicode` so an old agent never sees an unmappable char.
- `pad.tsx`: `KeyboardBar` now also renders in **remote** and **portrait gamepad** modes (Kodi search / Steam login); landscape untouched. `app.json` → **2.5.0**.

## Windows
`hello` adds `"text":"unicode"` (KEYEVENTF_UNICODE already types any unicode); no other change.

## Verification
- py_compile, tsc, unit tests (split / tolerant-kt / caps / bounds).
- **Live WS smoke**: socket SURVIVES `café "hi" 😀 done` (ping→pong after); a 6000-char alternating `kt` is truncated + paste-capped.
- Adversarially reviewed **safe** (no WS regression; paste path secure).

## Pending — hardware
On-box **gamescope-clipboard go/no-go** on Bazzite (does a `unicode`-advertised paste actually deliver in Game Mode?). `ascii`-degrade is the safe default until confirmed; the shipped WS-kill fix + KeyboardBar-everywhere land regardless. Small-height (SE-class) KeyboardBar layout pass also best done on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
