### PR TITLE
feat: media transport / now-playing (MPRIS) + _send_bytes & resolved-host infra (roadmap Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Couchside is deliberately small and boring about security:
 - **Scoped sudo, nothing more.** The installer writes a `visudo`-validated sudoers rule granting the agent user passwordless sudo for exactly five things: `systemctl restart sddm`, `systemctl reboot`, `systemctl poweroff`, `systemctl suspend`, and `journalctl`. Nothing else. Actions are a fixed table; there is no "run arbitrary command" route.
 - **Journal access is allowlisted.** Only units on the configured watchlist can be read, with line counts clamped server-side, so a leaked token can't be used to trawl the whole system journal.
 - **LAN-only by design.** The API is plain HTTP on port 8787 and is meant to stay on your local network. The firewall rule opens the port locally; **do not port-forward it**. There is no relay, no cloud endpoint, and the app never talks to anything except your agent.
-- No file-serving routes, subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
+- No client-addressable file routes — the only file the agent ever serves is the album-art image a running media player itself advertises (validated against a small realpath allowlist, image-sniffed, 2 MiB cap; the client passes a player id, never a path). Subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
 
 ## Uninstall
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -146,6 +146,11 @@ All responses carry permissive CORS headers; `OPTIONS` returns 204.
 | `/api/tv/volume` | POST | Absolute volume. Body `{"level":0-100,"target":"box"\|"tv"}`. Box converges via media-key steps (Game-Mode OSD); TV via the RS-232 closed loop. Returns the ActionResult plus the final `level` |
 | `/api/tv/source/<id>` | POST | Switch the display's input source (panel only). `<id>` is one of the `sources` from `GET /api/tv`. Unknown id / no panel → 404 |
 | `/api/tv/key/<k>` | POST | Send a factory-remote key (panel only). `<k>` ∈ `up down left right ok menu home back settings bright_up bright_down` |
+| `/api/media` | GET | Now-playing across MPRIS players: `{"available":true,"players":[{id,identity,status,title,artist,album,position_ms,length_ms,rate,can_seek,can_go_next,can_go_previous,can_play,can_pause,art,art_key}]}`. Read over the user session bus via `busctl` (ships with systemd). 404 when there is no session bus / `busctl`; 200 with an empty list when idle. Playing players first, capped at 8. Added in 2.8.0 |
+| `/api/media/<player>/<op>` | POST | Transport op; `<op>` ∈ `play pause play_pause next previous stop seek`. `seek` body `{"position_ms":int}` (absolute; `SetPosition` with a `Seek`-delta fallback). Unknown op / dead player → 404. ActionResult shape |
+| `/api/media/art?player=<id>&k=<art_key>` | GET | Album-art bytes for the player's current track. Serves only a `file://` image the player advertised, under a realpath allowlist, image-sniffed, 2 MiB cap; `http(s)` art is never fetched. The client passes a player id + cache-key, never a path. `Cache-Control: private, max-age=3600`. 404 when no servable art |
+
+**Media players:** any MPRIS-speaking app works (Spotify, Firefox/Chromium, VLC, mpv, …). **Kodi** needs its MPRIS add-on enabled to appear here.
 
 ## Virtual gamepad, mouse & keyboard (WS protocol v2)
 
@@ -337,8 +342,12 @@ success, so the app's TV strip can be built without any hardware.
   actions and system-journal reads will then fail).
 - **Allowlists, not shells**: journal reads are limited to the configured
   unit list; actions are a fixed config table run with argument lists
-  (`shell=False`), so no arbitrary commands and no file-serving routes. The
-  `lines` parameter is clamped; errors return brief JSON, never tracebacks.
+  (`shell=False`), so no arbitrary commands. The only file the agent serves is
+  the album-art image a running media player advertises — validated against a
+  small realpath allowlist (`/tmp`, `$XDG_RUNTIME_DIR`, `~/.cache`, `~/.var`,
+  `~/.mozilla`), image-sniffed, 2 MiB cap; the client passes a player id, never
+  a path. The `lines` parameter is clamped; errors return brief JSON, never
+  tracebacks.
 - **LAN-only, plain HTTP**: there is no TLS. Keep port 8787 on your local
   network and do **not** port-forward it. Anyone with the token on your LAN
   controls the box.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -2147,6 +2147,347 @@ def tv_send(op, mock, target=None):
 
 
 # ---------------------------------------------------------------------------
+# MPRIS media-player control (now-playing + transport) over the user session
+# bus via `busctl`. Named MPRIS_*/mpris_* so it never collides with the box's
+# OS-volume media-key device (_MEDIA_DEV / SOFT_MEDIA_KEYS / UInputMediaKeys),
+# which is a different "media". No new listener/port; ships with systemd.
+# ---------------------------------------------------------------------------
+
+MPRIS_PREFIX = "org.mpris.MediaPlayer2."
+MPRIS_OBJPATH = "/org/mpris/MediaPlayer2"
+MPRIS_PLAYER_IFACE = "org.mpris.MediaPlayer2.Player"
+MPRIS_MAX_PLAYERS = 8
+MPRIS_ART_MAX = 2 * 1024 * 1024  # 2 MiB read cap on album art
+
+# Fixed transport op -> Player method. Closed table: no client string reaches
+# D-Bus; "seek" is handled separately (SetPosition, Seek-delta fallback).
+MPRIS_METHODS = {
+    "play": "Play", "pause": "Pause", "play_pause": "PlayPause",
+    "next": "Next", "previous": "Previous", "stop": "Stop",
+}
+MPRIS_OPS = tuple(MPRIS_METHODS) + ("seek",)
+
+BUSCTL = None            # "busctl" when usable (or in --mock), else None
+_MPRIS_ART_ROOTS = ()    # realpath allowlist for file:// art, set by set_mpris
+
+
+def mpris_available():
+    """True when the user session bus and busctl are both present."""
+    return (shutil.which("busctl") is not None
+            and os.path.exists(os.path.join(XDG_RUNTIME_DIR, "bus")))
+
+
+def set_mpris(mock):
+    """Startup probe. Enables MPRIS when busctl + the session bus exist (always
+    in --mock), and computes the realpath allowlist for file:// album art."""
+    global BUSCTL, _MPRIS_ART_ROOTS
+    home = os.path.expanduser("~")
+    roots = []
+    for p in ("/tmp", XDG_RUNTIME_DIR, os.path.join(home, ".cache"),
+              os.path.join(home, ".var"), os.path.join(home, ".mozilla")):
+        try:
+            roots.append(os.path.realpath(p))
+        except Exception:
+            pass
+    _MPRIS_ART_ROOTS = tuple(roots)
+    BUSCTL = "busctl" if (mock or mpris_available()) else None
+
+
+def _bus_val(v):
+    """Unwrap one busctl --json=short variant {"type","data"} to a Python value,
+    recursing into a{sv} dicts. Arrays/scalars pass through. Never raises."""
+    if not isinstance(v, dict) or "data" not in v:
+        return v
+    d = v["data"]
+    if str(v.get("type", "")).startswith("a{") and isinstance(d, dict):
+        return {k: _bus_val(x) for k, x in d.items()}
+    return d
+
+
+def _busctl_json(args, timeout=2):
+    """busctl --user --json=short <args> -> parsed JSON, or None. Never raises;
+    runs with the user session env so it targets the right bus."""
+    if BUSCTL is None:
+        return None
+    try:
+        r = subprocess.run([BUSCTL, "--user", "--json=short"] + list(args),
+                           capture_output=True, timeout=timeout, env=_user_env())
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        return json.loads(r.stdout.decode("utf-8", "replace"))
+    except Exception:
+        return None
+
+
+def _busctl_call(argv, start, timeout=3):
+    """Run a busctl method call; return an ActionResult (mirrors real_cec)."""
+    try:
+        r = subprocess.run(argv, capture_output=True, timeout=timeout,
+                           env=_user_env())
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "busctl timed out",
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+    except Exception as e:
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "%s: %s" % (e.__class__.__name__, e),
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+    return {"ok": r.returncode == 0, "exit_code": r.returncode,
+            "stdout": (r.stdout or b"").decode("utf-8", "replace"),
+            "stderr": (r.stderr or b"").decode("utf-8", "replace"),
+            "duration_ms": int((time.monotonic() - start) * 1000)}
+
+
+def _mpris_list_names():
+    """Bus names of all MPRIS players (org.mpris.MediaPlayer2.*)."""
+    obj = _busctl_json(["call", "org.freedesktop.DBus", "/org/freedesktop/DBus",
+                        "org.freedesktop.DBus", "ListNames"])
+    names = obj.get("data") if isinstance(obj, dict) else None
+    if not isinstance(names, list):
+        return []
+    return [n for n in names
+            if isinstance(n, str) and n.startswith(MPRIS_PREFIX)
+            and all(c.isalnum() or c in "._-" for c in n)]
+
+
+def _mpris_getall(name):
+    """Merged GetAll on the empty interface -> every property across BOTH MPRIS
+    interfaces (Identity + PlaybackStatus/Metadata/...) in one call. Returns a
+    flat {prop: value} dict (values unwrapped), or {} on failure."""
+    obj = _busctl_json(["call", name, MPRIS_OBJPATH,
+                        "org.freedesktop.DBus.Properties", "GetAll", "s", ""])
+    if not isinstance(obj, dict):
+        return {}
+    data = obj.get("data")
+    if isinstance(data, list) and data and isinstance(data[0], dict):
+        data = data[0]  # tolerate a single-out-arg wrapped as a list
+    if not isinstance(data, dict):
+        return {}
+    return {k: _bus_val(v) for k, v in data.items()}
+
+
+def _mpris_str(v):
+    return v if isinstance(v, str) else ""
+
+
+def _mpris_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _art_key(url):
+    """Short stable cache-buster for an art URL (changes with the track)."""
+    if not url:
+        return ""
+    return hashlib.sha1(url.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _art_url_path(url):
+    """If `url` is a file:// path under the art allowlist, return the real path;
+    else None. Keeps "no client-addressable file routes" honest — only art a
+    running player advertises, under a small set of cache dirs. Never raises."""
+    if not isinstance(url, str) or not url.startswith("file://"):
+        return None
+    try:
+        real = os.path.realpath(unquote(urlparse(url).path))
+    except Exception:
+        return None
+    for root in _MPRIS_ART_ROOTS:
+        if real == root or real.startswith(root + os.sep):
+            return real
+    return None
+
+
+def _mpris_player_info(name):
+    """Build the player dict for one MPRIS name, or None on failure."""
+    props = _mpris_getall(name)
+    if not props:
+        return None
+    meta = props.get("Metadata")
+    if not isinstance(meta, dict):
+        meta = {}
+    artists = meta.get("xesam:artist")
+    if isinstance(artists, list):
+        artist = ", ".join(str(a) for a in artists if isinstance(a, str))
+    else:
+        artist = _mpris_str(artists)
+    art_url = _mpris_str(meta.get("mpris:artUrl"))
+    servable = _art_url_path(art_url) is not None  # file:// only; http(s) never fetched
+    length_us = _mpris_int(meta.get("mpris:length"))
+    pos_us = _mpris_int(props.get("Position"))
+    status = _mpris_str(props.get("PlaybackStatus"))
+    try:
+        rate = float(props.get("Rate"))
+    except (TypeError, ValueError):
+        rate = 1.0
+    return {
+        "id": name[len(MPRIS_PREFIX):],
+        "identity": _mpris_str(props.get("Identity")) or name[len(MPRIS_PREFIX):],
+        "status": status if status in ("Playing", "Paused", "Stopped") else "Stopped",
+        "title": _mpris_str(meta.get("xesam:title")),
+        "artist": artist,
+        "album": _mpris_str(meta.get("xesam:album")),
+        "position_ms": pos_us // 1000 if pos_us > 0 else 0,
+        "length_ms": length_us // 1000 if length_us > 0 else 0,
+        "rate": rate,
+        "can_seek": bool(props.get("CanSeek")),
+        "can_go_next": bool(props.get("CanGoNext")),
+        "can_go_previous": bool(props.get("CanGoPrevious")),
+        "can_play": bool(props.get("CanPlay")),
+        "can_pause": bool(props.get("CanPause")),
+        "art": servable,
+        "art_key": _art_key(art_url) if servable else "",
+    }
+
+
+def list_mpris_players():
+    """All MPRIS players, Playing first, capped at MPRIS_MAX_PLAYERS. Best-effort;
+    per-player failures are skipped. The name list is capped BEFORE the (one
+    GetAll each) loop so a box that spawns many idle players (Chromium) can't
+    blow the time budget; results are then sorted Playing-first. Worst case is
+    (1 + MPRIS_MAX_PLAYERS) busctl calls, each bounded by the 2 s subprocess
+    timeout (a live bus answers in ms); pathological all-hang ceiling ~18 s."""
+    names = _mpris_list_names()[:MPRIS_MAX_PLAYERS]
+    players = []
+    for n in names:
+        info = _mpris_player_info(n)
+        if info is not None:
+            players.append(info)
+    order = {"Playing": 0, "Paused": 1}
+    players.sort(key=lambda p: (order.get(p["status"], 2), p["identity"].lower()))
+    return players
+
+
+def mpris_info():
+    """{"available":True,"players":[...]} or None when MPRIS is unavailable."""
+    if BUSCTL is None:
+        return None
+    return {"available": True, "players": list_mpris_players()}
+
+
+def _mpris_seek(name, position_ms, start):
+    """Seek to an absolute position (ms). Prefers SetPosition (needs the current
+    trackid); falls back to a relative Seek for players that reject it."""
+    if position_ms is None or position_ms < 0:
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "position_ms required", "duration_ms": 0}
+    props = _mpris_getall(name)
+    meta = props.get("Metadata") if isinstance(props.get("Metadata"), dict) else {}
+    trackid = _mpris_str(meta.get("mpris:trackid"))
+    length_us = _mpris_int(meta.get("mpris:length"))
+    pos_us = position_ms * 1000
+    if length_us > 0:
+        pos_us = max(0, min(length_us, pos_us))
+    if trackid:
+        r = _busctl_call([BUSCTL, "--user", "call", name, MPRIS_OBJPATH,
+                          MPRIS_PLAYER_IFACE, "SetPosition", "ox",
+                          trackid, str(pos_us)], start)
+        if r["ok"]:
+            return r
+    delta = pos_us - _mpris_int(props.get("Position"))
+    return _busctl_call([BUSCTL, "--user", "call", name, MPRIS_OBJPATH,
+                         MPRIS_PLAYER_IFACE, "Seek", "x", str(delta)], start)
+
+
+def real_mpris_op(player, op, position_ms=None):
+    """Run a transport op on <player>. ActionResult-shaped, or None for an
+    unknown/dead player or op (route 404s). Re-validates the player against a
+    fresh ListNames so we never act on a name that vanished."""
+    start = time.monotonic()
+    name = MPRIS_PREFIX + player
+    if name not in _mpris_list_names():
+        return None
+    if op == "seek":
+        return _mpris_seek(name, position_ms, start)
+    method = MPRIS_METHODS.get(op)
+    if method is None:
+        return None
+    return _busctl_call([BUSCTL, "--user", "call", name, MPRIS_OBJPATH,
+                         MPRIS_PLAYER_IFACE, method], start)
+
+
+_ART_MAGIC = (
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def _sniff_image(data):
+    """Magic-byte image type, or None (so a text/HTML file can't be served)."""
+    for magic, mime in _ART_MAGIC:
+        if data.startswith(magic):
+            return mime
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def mpris_art(player, art_key):
+    """Resolve <player>'s CURRENT advertised art file (the client never supplies
+    a path), enforce the 2 MiB read cap, and sniff the image type. Returns
+    (data, mime) or None. `art_key` must match the current track's key (else the
+    track changed — 404)."""
+    props = _mpris_getall(MPRIS_PREFIX + player)
+    meta = props.get("Metadata") if isinstance(props.get("Metadata"), dict) else {}
+    art_url = _mpris_str(meta.get("mpris:artUrl"))
+    if art_key and _art_key(art_url) != art_key:
+        return None
+    path = _art_url_path(art_url)
+    if path is None:
+        return None
+    try:
+        if os.path.getsize(path) > MPRIS_ART_MAX:  # cheap pre-filter
+            return None
+        with open(path, "rb") as f:
+            data = f.read(MPRIS_ART_MAX + 1)  # read-time enforcement
+    except OSError:
+        return None
+    if len(data) > MPRIS_ART_MAX:
+        return None
+    mime = _sniff_image(data)
+    return (data, mime) if mime else None
+
+
+_MOCK_MPRIS_POS = 0
+# 1x1 transparent PNG, so --mock album art works on macOS with no player.
+_MOCK_ART_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")
+
+
+def mock_mpris_info():
+    """--mock: one advancing Spotify-like player."""
+    global _MOCK_MPRIS_POS
+    _MOCK_MPRIS_POS = (_MOCK_MPRIS_POS + 3000) % 214000
+    return {"available": True, "players": [{
+        "id": "spotify", "identity": "Spotify", "status": "Playing",
+        "title": "Midnight City", "artist": "M83",
+        "album": "Hurry Up, We're Dreaming",
+        "position_ms": _MOCK_MPRIS_POS, "length_ms": 214000, "rate": 1.0,
+        "can_seek": True, "can_go_next": True, "can_go_previous": True,
+        "can_play": True, "can_pause": True, "art": True, "art_key": "mockart1",
+    }]}
+
+
+def mock_mpris_op(player, op, position_ms=None):
+    print("[mpris] %s %s%s" % (player, op,
+          "" if position_ms is None else " -> %dms" % position_ms), flush=True)
+    return {"ok": True, "exit_code": 0,
+            "stdout": "[mock mpris] %s %s" % (player, op),
+            "stderr": "", "duration_ms": 40}
+
+
+def mock_mpris_art(player, art_key):
+    return (_MOCK_ART_PNG, "image/png")
+
+
+# ---------------------------------------------------------------------------
 # Virtual gamepad: evdev/uinput constants and pure-stdlib uinput driver
 # ---------------------------------------------------------------------------
 
@@ -3486,6 +3827,25 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
         self._log(code, started)
 
+    def _send_bytes(self, code, data, content_type, started, cache_control=None):
+        """Write a raw binary body with an EXACT Content-Length (keep-alive
+        safety under protocol_version HTTP/1.1) and the same CORS headers as
+        _send. Used for image bytes — album art now, screen frames later."""
+        self.send_response(code)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers",
+                         "Authorization, Content-Type")
+        self.send_header("Access-Control-Allow-Methods",
+                         "GET, POST, DELETE, OPTIONS")
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        if cache_control:
+            self.send_header("Cache-Control", cache_control)
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
+        self._log(code, started)
+
     def _authorized(self):
         auth = self.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
@@ -3581,6 +3941,30 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "not found"}, started)
                 else:
                     self._send(200, info, started)
+            elif path == "/api/media":
+                # Probe-and-appear: 404 when no session bus / busctl so the app
+                # hides the Now Playing card; 200 with an empty list when idle.
+                info = mock_mpris_info() if self.mock else mpris_info()
+                if info is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, info, started)
+            elif path == "/api/media/art":
+                # Album art bytes for a player's CURRENT track. The client passes
+                # only player id + art_key (a cache-buster) — never a path.
+                q = parse_qs(parsed.query)
+                player = (q.get("player") or [""])[0]
+                key = (q.get("k") or [""])[0]
+                art = None
+                if player:
+                    art = (mock_mpris_art(player, key) if self.mock
+                           else (mpris_art(player, key) if BUSCTL else None))
+                if art is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    data, mime = art
+                    self._send_bytes(200, data, mime, started,
+                                     cache_control="private, max-age=3600")
             else:
                 self._send(404, {"error": "not found"}, started)
         except BrokenPipeError:
@@ -3721,6 +4105,39 @@ class Handler(BaseHTTPRequestHandler):
                               "stderr": "", "duration_ms": 100}
                 else:
                     result = real_panel_source(sid)
+                self._send(200, result, started)
+                return
+
+            # POST /api/media/<player>/<op>: MPRIS transport. <op> is a fixed
+            # word; the seek op carries {"position_ms":int}. Unknown op / dead
+            # player -> 404. Placed before the generic /api/tv/ route.
+            mprefix = "/api/media/"
+            if path.startswith(mprefix):
+                rest = path[len(mprefix):]
+                parts = rest.rsplit("/", 1)
+                if len(parts) != 2 or not parts[0] or not parts[1]:
+                    self._send(404, {"error": "not found"}, started)
+                    return
+                player, op = unquote(parts[0]), parts[1]
+                if op not in MPRIS_OPS:
+                    self._send(404, {"error": "unknown media op"}, started)
+                    return
+                position_ms = None
+                if op == "seek":
+                    try:
+                        req = json.loads(body.decode("utf-8")) if body else {}
+                        if not isinstance(req, dict):
+                            raise ValueError("body must be a JSON object")
+                        position_ms = int(req.get("position_ms"))
+                    except (ValueError, TypeError, UnicodeDecodeError):
+                        self._send(400, {"error": "position_ms must be an integer"},
+                                   started)
+                        return
+                result = (mock_mpris_op(player, op, position_ms) if self.mock
+                          else real_mpris_op(player, op, position_ms))
+                if result is None:
+                    self._send(404, {"error": "unknown player"}, started)
+                    return
                 self._send(200, result, started)
                 return
 
@@ -4112,6 +4529,7 @@ def main():
     _inject_session_actions()
     _inject_suspend_action(args.mock)
     set_tv(args.mock)
+    set_mpris(args.mock)
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)
 
     Handler.token = load_token(args)
@@ -4129,6 +4547,7 @@ def main():
     info = tv_info()
     print("tv: %s" % ("%s (%s)" % (info["backend"], info["adapter"])
                       if info else "unavailable"), flush=True)
+    print("mpris: %s" % ("available" if BUSCTL else "unavailable"), flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -2246,6 +2246,9 @@ def _mpris_list_names():
     obj = _busctl_json(["call", "org.freedesktop.DBus", "/org/freedesktop/DBus",
                         "org.freedesktop.DBus", "ListNames"])
     names = obj.get("data") if isinstance(obj, dict) else None
+    # busctl wraps the single 'as' out-arg as data:[[name, ...]] — unwrap it.
+    if isinstance(names, list) and names and isinstance(names[0], list):
+        names = names[0]
     if not isinstance(names, list):
         return []
     return [n for n in names
@@ -2254,19 +2257,27 @@ def _mpris_list_names():
 
 
 def _mpris_getall(name):
-    """Merged GetAll on the empty interface -> every property across BOTH MPRIS
-    interfaces (Identity + PlaybackStatus/Metadata/...) in one call. Returns a
-    flat {prop: value} dict (values unwrapped), or {} on failure."""
-    obj = _busctl_json(["call", name, MPRIS_OBJPATH,
-                        "org.freedesktop.DBus.Properties", "GetAll", "s", ""])
-    if not isinstance(obj, dict):
-        return {}
-    data = obj.get("data")
-    if isinstance(data, list) and data and isinstance(data[0], dict):
-        data = data[0]  # tolerate a single-out-arg wrapped as a list
-    if not isinstance(data, dict):
-        return {}
-    return {k: _bus_val(v) for k, v in data.items()}
+    """Every property across BOTH MPRIS interfaces (Player transport props +
+    the root MediaPlayer2 Identity), merged into a flat {prop: value} dict
+    (values unwrapped), or {} on total failure.
+
+    The empty-interface form `GetAll s ""` is NOT supported by real players
+    (verified on-box: busctl returns 'No such interface ""'), so we query each
+    interface explicitly. Per-call D-Bus wait is bounded with --timeout=1 so a
+    hung player can't stall the list."""
+    props = {}
+    for iface in (MPRIS_PLAYER_IFACE, "org.mpris.MediaPlayer2"):
+        obj = _busctl_json(["--timeout=1", "call", name, MPRIS_OBJPATH,
+                            "org.freedesktop.DBus.Properties", "GetAll", "s", iface])
+        if not isinstance(obj, dict):
+            continue
+        data = obj.get("data")
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            data = data[0]  # single a{sv} out-arg wrapped as a list
+        if isinstance(data, dict):
+            for k, v in data.items():
+                props[k] = _bus_val(v)
+    return props
 
 
 def _mpris_str(v):
@@ -3213,25 +3224,80 @@ _CTRL_V_EVENTS = [
 ]
 
 
-def _wayland_sockets():
-    """Non-lock wayland-* sockets in XDG_RUNTIME_DIR (best-effort, never raises)."""
+def _wayland_display_sockets():
+    """Names of wayland DISPLAY sockets in XDG_RUNTIME_DIR. Recognizes the
+    standard wayland-<N> and gamescope's gamescope-<N> (Bazzite / Steam Deck
+    Game Mode names its compositor socket gamescope-0, NOT wayland-0), while
+    excluding lock files and gamescope's -ei / -stats side sockets. Never raises."""
+    out = []
     try:
-        return [e for e in os.listdir(XDG_RUNTIME_DIR)
-                if e.startswith("wayland-") and not e.endswith(".lock")]
+        for e in os.listdir(XDG_RUNTIME_DIR):
+            if e.endswith(".lock"):
+                continue
+            if e.startswith("wayland-") and e[len("wayland-"):].isdigit():
+                out.append(e)
+            elif e.startswith("gamescope-") and e[len("gamescope-"):].isdigit():
+                out.append(e)
     except OSError:
-        return []
+        pass
+    return out
+
+
+def _paste_env():
+    """Session env for wl-copy/wl-paste, with WAYLAND_DISPLAY pinned to the one
+    detected display socket (gamescope-0 in Game Mode); _session_env alone only
+    finds wayland-<N>, which gamescope does not create."""
+    env = _session_env()
+    socks = _wayland_display_sockets()
+    if len(socks) == 1:
+        env["WAYLAND_DISPLAY"] = socks[0]
+    return env
+
+
+_PASTE_OK = None  # tri-state cache: None = unprobed, then True/False
 
 
 def _paste_available():
-    """True when a SAFE clipboard-paste path exists: wl-copy AND wl-paste are
-    present AND exactly one wayland session socket exists. The single-socket
-    requirement is a safety gate — with two sessions, wl-copy could set the
-    clipboard on one while Ctrl+V lands in the other (pasting a stale/foreign
-    clipboard, e.g. a password), so we decline (ascii-degrade) rather than risk
-    it. Delivery is additionally verified per-paste via wl-paste read-back."""
+    """True only when a clipboard paste actually WORKS: wl-copy + wl-paste exist,
+    exactly one wayland display socket exists (single-socket safety gate against
+    wrong-session pastes), AND a real wl-copy->wl-paste roundtrip succeeds.
+
+    The roundtrip is essential, not paranoia: gamescope (Bazzite / Steam Deck
+    Game Mode) exposes a wayland socket but does NOT implement
+    wl_data_device_manager, so wl-copy silently fails there. Presence alone would
+    wrongly advertise unicode; the roundtrip degrades Game Mode to ascii while
+    keeping real Desktop-Mode wayland sessions on unicode. Probed once, cached,
+    and clipboard-preserving (restores whatever was there)."""
+    global _PASTE_OK
+    if _PASTE_OK is not None:
+        return _PASTE_OK
+    _PASTE_OK = False
     if shutil.which("wl-copy") is None or shutil.which("wl-paste") is None:
         return False
-    return len(_wayland_sockets()) == 1
+    if len(_wayland_display_sockets()) != 1:
+        return False
+    env = _paste_env()
+    sentinel = b"couchside-clip-probe"
+    try:
+        orig = subprocess.run(["wl-paste", "-n"], env=env, timeout=2,
+                              stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        saved = orig.stdout if orig.returncode == 0 else None
+        subprocess.run(["wl-copy"], input=sentinel, env=env, timeout=2,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        time.sleep(0.05)
+        rb = subprocess.run(["wl-paste", "-n"], env=env, timeout=2,
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+        _PASTE_OK = rb.returncode == 0 and rb.stdout == sentinel
+        if _PASTE_OK:  # restore the user's clipboard, don't leave the sentinel
+            if saved:
+                subprocess.run(["wl-copy"], input=saved, env=env, timeout=2,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            else:
+                subprocess.run(["wl-copy", "--clear"], env=env, timeout=2,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        _PASTE_OK = False
+    return _PASTE_OK
 
 
 def _text_caps(mock):
@@ -3282,7 +3348,7 @@ def clipboard_paste(text, kbd, mock, entry):
         return True
     if entry.get("_paste_dead"):
         return False
-    env = _session_env()
+    env = _paste_env()
     try:
         subprocess.run(["wl-copy"], input=text.encode("utf-8"), env=env,
                        timeout=2, check=True,

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
+import { NowPlayingCard } from '@/components/NowPlayingCard';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
@@ -144,6 +145,9 @@ function ConsoleScreen() {
             </Pressable>
           </View>
         )}
+
+        {/* Now Playing (MPRIS) — probe-and-appear; hidden when no media backend */}
+        <NowPlayingCard />
 
         {s && (
           <>

--- a/app/components/NowPlayingCard.tsx
+++ b/app/components/NowPlayingCard.tsx
@@ -1,0 +1,311 @@
+/**
+ * Now Playing card (Console tab). Polls /api/media (MPRIS) and shows the active
+ * player's track with a tap-to-seek progress bar and capability-gated transport
+ * controls. Probe-and-appear: renders nothing when the agent has no media
+ * backend (404 -> null) or no players. Album art is fetched as a base64 data
+ * URI from the resolved host (never a raw <Image> URL, which can't carry auth).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Image, LayoutChangeEvent, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
+import { hapticLight, hapticMedium } from '@/lib/haptics';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, numeric, theme } from '@/lib/theme';
+
+function fmtTime(ms: number): string {
+  const t = Math.max(0, Math.round(ms / 1000));
+  const m = Math.floor(t / 60);
+  const s = t % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+export function NowPlayingCard() {
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  const poll = usePoll<Media | null>(() => api.media(settings), 5000, ready && configured);
+  const players = poll.data?.players ?? [];
+
+  // Active player: user's pick if still present, else first Playing, else first.
+  const [picked, setPicked] = useState<string | null>(null);
+  const active: MediaPlayer | null = useMemo(() => {
+    if (players.length === 0) return null;
+    if (picked) {
+      const p = players.find((x) => x.id === picked);
+      if (p) return p;
+    }
+    return players.find((x) => x.status === 'Playing') ?? players[0];
+  }, [players, picked]);
+
+  // Album art -> base64 data URI, refetched when the track (art_key) changes.
+  const [artUri, setArtUri] = useState<string | null>(null);
+  useEffect(() => {
+    let alive = true;
+    if (!active || !active.art || !active.art_key) {
+      setArtUri(null);
+      return;
+    }
+    mediaArtSource(settings, active.id, active.art_key).then((uri) => {
+      if (alive) setArtUri(uri);
+    });
+    return () => {
+      alive = false;
+    };
+  }, [active?.id, active?.art, active?.art_key, settings]);
+
+  // Interpolate position between polls while playing (a 1s ticker re-renders).
+  // `tick` is a real dep of displayedMs below, so each tick recomputes it.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    if (active?.status !== 'Playing') return;
+    const id = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [active?.status]);
+
+  const displayedMs = useMemo(() => {
+    if (!active) return 0;
+    let ms = active.position_ms;
+    if (active.status === 'Playing' && poll.lastSuccess != null) {
+      ms += (Date.now() - poll.lastSuccess) * (active.rate || 1);
+    }
+    if (active.length_ms > 0) ms = Math.min(ms, active.length_ms);
+    return Math.max(0, ms);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, poll.lastSuccess, tick]);
+
+  const [barWidth, setBarWidth] = useState(0);
+  const onBarLayout = useCallback((e: LayoutChangeEvent) => {
+    setBarWidth(e.nativeEvent.layout.width);
+  }, []);
+
+  const send = useCallback(
+    async (op: MediaOp, body?: { position_ms: number }) => {
+      if (!active) return;
+      hapticMedium();
+      try {
+        await api.mediaOp(settings, active.id, op, body);
+      } catch {
+        // best-effort transport; the next poll reflects reality
+      }
+      poll.refresh();
+    },
+    [active, settings, poll.refresh],
+  );
+
+  const seekTo = useCallback(
+    (e: { nativeEvent: { locationX: number } }) => {
+      if (!active || !active.can_seek || active.length_ms <= 0 || barWidth <= 0) return;
+      const frac = Math.max(0, Math.min(1, e.nativeEvent.locationX / barWidth));
+      hapticLight();
+      send('seek', { position_ms: Math.round(frac * active.length_ms) });
+    },
+    [active, barWidth, send],
+  );
+
+  if (!active) return null;
+
+  const pct =
+    active.length_ms > 0 ? Math.max(0, Math.min(100, (displayedMs / active.length_ms) * 100)) : 0;
+  const playing = active.status === 'Playing';
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>NOW PLAYING</Text>
+
+      {players.length > 1 && (
+        <View style={styles.pills}>
+          {players.map((p) => {
+            const on = p.id === active.id;
+            return (
+              <Pressable
+                key={p.id}
+                onPress={() => {
+                  hapticLight();
+                  setPicked(p.id);
+                }}
+                style={[styles.pill, on && styles.pillOn]}>
+                <Text style={[styles.pillText, on && styles.pillTextOn]} numberOfLines={1}>
+                  {p.identity}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+
+      <View style={styles.row}>
+        <View style={styles.art}>
+          {artUri ? (
+            <ArtImage uri={artUri} />
+          ) : (
+            <View style={styles.artPlaceholder}>
+              <Ionicons name="musical-notes" size={22} color={theme.textFaint} />
+            </View>
+          )}
+        </View>
+        <View style={styles.meta}>
+          <Text style={styles.trackTitle} numberOfLines={1}>
+            {active.title || active.identity}
+          </Text>
+          <Text style={styles.trackArtist} numberOfLines={1}>
+            {active.artist || active.album || '—'}
+          </Text>
+        </View>
+      </View>
+
+      {/* Progress: tap anywhere to seek (when supported). */}
+      <Pressable onPress={seekTo} disabled={!active.can_seek || active.length_ms <= 0}>
+        <View style={styles.barTrack} onLayout={onBarLayout}>
+          <View style={[styles.barFill, { width: `${pct}%` }]} />
+        </View>
+      </Pressable>
+      <View style={styles.times}>
+        <Text style={styles.time}>{fmtTime(displayedMs)}</Text>
+        <Text style={styles.time}>{active.length_ms > 0 ? fmtTime(active.length_ms) : '--:--'}</Text>
+      </View>
+
+      <View style={styles.transport}>
+        <TransportButton
+          icon="play-skip-back"
+          disabled={!active.can_go_previous}
+          onPress={() => send('previous')}
+        />
+        <TransportButton
+          icon={playing ? 'pause' : 'play'}
+          primary
+          disabled={playing ? !active.can_pause : !active.can_play}
+          onPress={() => send('play_pause')}
+        />
+        <TransportButton
+          icon="play-skip-forward"
+          disabled={!active.can_go_next}
+          onPress={() => send('next')}
+        />
+      </View>
+    </View>
+  );
+}
+
+/** Split out so the art <Image> can fail-soft to a placeholder via onError. */
+function ArtImage({ uri }: { uri: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return (
+      <View style={styles.artPlaceholder}>
+        <Ionicons name="musical-notes" size={22} color={theme.textFaint} />
+      </View>
+    );
+  }
+  return (
+    <Image source={{ uri }} style={styles.artImg} resizeMode="cover" onError={() => setFailed(true)} />
+  );
+}
+
+function TransportButton({
+  icon,
+  onPress,
+  disabled,
+  primary,
+}: {
+  icon: keyof typeof Ionicons.glyphMap;
+  onPress: () => void;
+  disabled?: boolean;
+  primary?: boolean;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      style={({ pressed }) => [
+        styles.tBtn,
+        primary && styles.tBtnPrimary,
+        pressed && styles.tBtnPressed,
+        disabled && styles.tBtnDisabled,
+      ]}>
+      <Ionicons
+        name={icon}
+        size={primary ? 26 : 22}
+        color={disabled ? theme.textFaint : primary ? theme.bg : theme.text}
+      />
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+  },
+  cardTitle: {
+    color: theme.textFaint,
+    fontSize: 11,
+    fontWeight: '700',
+    letterSpacing: 1.2,
+    marginBottom: 10,
+    fontFamily: mono,
+  },
+  pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 10 },
+  pill: {
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+    maxWidth: 160,
+  },
+  pillOn: { backgroundColor: theme.green, borderColor: theme.green },
+  pillText: { color: theme.textDim, fontSize: 11, fontFamily: mono },
+  pillTextOn: { color: theme.bg, fontWeight: '700' },
+
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  art: { width: 56, height: 56, borderRadius: 8, overflow: 'hidden' },
+  artImg: { width: 56, height: 56 },
+  artPlaceholder: {
+    width: 56,
+    height: 56,
+    borderRadius: 8,
+    backgroundColor: theme.inset,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  meta: { flex: 1 },
+  trackTitle: { color: theme.text, fontSize: 15, fontWeight: '700' },
+  trackArtist: { color: theme.textDim, fontSize: 13, marginTop: 2 },
+
+  barTrack: {
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: theme.inset,
+    overflow: 'hidden',
+    marginTop: 14,
+  },
+  barFill: { height: '100%', borderRadius: 3, backgroundColor: theme.green },
+  times: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 6 },
+  time: { color: theme.textDim, fontSize: 11, ...numeric },
+
+  transport: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 18,
+    marginTop: 12,
+  },
+  tBtn: {
+    width: 46,
+    height: 46,
+    borderRadius: 999,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: theme.inset,
+  },
+  tBtnPrimary: { backgroundColor: theme.green, width: 54, height: 54 },
+  tBtnPressed: { opacity: 0.7 },
+  tBtnDisabled: { opacity: 0.4 },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -143,6 +143,33 @@ export type SteamDownload = {
 
 export type Downloads = { downloads: SteamDownload[] };
 
+/** MPRIS transport op, POSTed as /api/media/<player>/<op>. */
+export type MediaOp = 'play' | 'pause' | 'play_pause' | 'next' | 'previous' | 'stop' | 'seek';
+
+/** One MPRIS media player's now-playing snapshot. */
+export type MediaPlayer = {
+  id: string;
+  identity: string;
+  status: 'Playing' | 'Paused' | 'Stopped';
+  title: string;
+  artist: string;
+  album: string;
+  position_ms: number;
+  length_ms: number;
+  rate: number;
+  can_seek: boolean;
+  can_go_next: boolean;
+  can_go_previous: boolean;
+  can_play: boolean;
+  can_pause: boolean;
+  /** True when the agent can serve the art bytes (a file:// the player advertised). */
+  art: boolean;
+  /** Cache-buster for the art fetch; changes when the track changes. */
+  art_key: string;
+};
+
+export type Media = { available: boolean; players: MediaPlayer[] };
+
 export type LaunchResult = {
   ok: boolean;
   /** Present when ok is false. */
@@ -276,6 +303,63 @@ function baseUrl(settings: Pick<Settings, 'host' | 'port'>): string {
   return `http://${settings.host}:${settings.port}`;
 }
 
+// §3b resolved-host: the host that last served each box (keyed host:port).
+// Binary fetches (album art, later screen frames) must hit the SAME host the
+// JSON API proved reachable, not a blind settings.host that mDNS may have
+// stopped resolving under SteamOS Game Mode WiFi power-save.
+const lastGoodHost = new Map<string, string>();
+function hostKey(s: Pick<Settings, 'host' | 'port'>): string {
+  return `${s.host}:${s.port}`;
+}
+export function resolveEffectiveHost(settings: ConnSettings): string {
+  return lastGoodHost.get(hostKey(settings)) ?? settings.host;
+}
+
+const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+/** base64-encode raw bytes (no reliance on btoa/Buffer, which RN may lack). */
+function base64FromArrayBuffer(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  const len = bytes.length;
+  let out = '';
+  for (let i = 0; i < len; i += 3) {
+    const b0 = bytes[i];
+    const b1 = i + 1 < len ? bytes[i + 1] : 0;
+    const b2 = i + 2 < len ? bytes[i + 2] : 0;
+    out += B64_ALPHABET[b0 >> 2];
+    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 >> 4)];
+    out += i + 1 < len ? B64_ALPHABET[((b1 & 15) << 2) | (b2 >> 6)] : '=';
+    out += i + 2 < len ? B64_ALPHABET[b2 & 63] : '=';
+  }
+  return out;
+}
+
+/**
+ * Album art for a player's current track, as a base64 `data:` URI for <Image>.
+ * Fetches from the resolved host (§3b) with the bearer token (an <Image> URL
+ * can't carry Authorization) and inlines the bytes, so nothing sensitive lands
+ * in Fresco's disk cache. Resolves null on any failure / 404 (no art).
+ */
+export async function mediaArtSource(
+  settings: ConnSettings,
+  player: string,
+  artKey: string,
+): Promise<string | null> {
+  const host = resolveEffectiveHost(settings);
+  const url = `http://${host}:${settings.port}/api/media/art?player=${encodeURIComponent(
+    player,
+  )}&k=${encodeURIComponent(artKey)}`;
+  try {
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
+    if (!res.ok) return null;
+    const type = res.headers.get('Content-Type') || 'image/jpeg';
+    const buf = await res.arrayBuffer();
+    if (buf.byteLength === 0) return null;
+    return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
+  } catch {
+    return null;
+  }
+}
+
 /** One fetch attempt against a specific host. Throws ApiError on transport failure. */
 async function attempt(
   host: string,
@@ -350,6 +434,7 @@ async function request<T>(
     settings.lastIp && settings.lastIp !== settings.host ? settings.lastIp : undefined;
 
   let res: Response;
+  let usedHost = settings.host;
   if (method === 'GET' || !fallback) {
     try {
       res = await attempt(settings.host, settings, path, opts);
@@ -361,6 +446,7 @@ async function request<T>(
       const retriable =
         e instanceof ApiError && (e.kind === 'unreachable' || e.kind === 'timeout');
       if (retriable && fallback && method === 'GET' && (await probeTarget(fallback, settings))) {
+        usedHost = fallback;
         res = await attempt(fallback, settings, path, opts);
       } else {
         throw e;
@@ -374,8 +460,15 @@ async function request<T>(
       if (await probeTarget(fallback, settings)) target = fallback;
       // else: send to the configured host anyway and surface its real error.
     }
+    usedHost = target;
     res = await attempt(target, settings, path, opts);
   }
+
+  // Remember which host actually answered (any HTTP status proves it IS this
+  // box and is reachable), so binary fetches — album art, later screen frames —
+  // can target the SAME host instead of a blind settings.host that mDNS may
+  // have stopped resolving. (§3b resolved-host.)
+  lastGoodHost.set(hostKey(settings), usedHost);
 
   if (res.status === 401) {
     throw new ApiError('unauthorized', 'Unauthorized: check token');
@@ -556,6 +649,29 @@ export const api = {
     return request<ActionResult>(settings, `/api/tv/key/${key}`, {
       method: 'POST',
       timeoutMs: 12000,
+    });
+  },
+
+  /**
+   * Now-playing / transport across MPRIS players. Probe-and-appear: resolves
+   * null on 404 (agent < 2.8 or no session bus) so the card hides; 200 with an
+   * empty list means "nothing playing". 8 s budget matches the agent's ceiling.
+   */
+  media(settings: ConnSettings): Promise<Media | null> {
+    return probeOrNull(request<Media>(settings, '/api/media', { timeoutMs: 8000 }));
+  },
+
+  /** One transport op on a player; `seek` carries { position_ms }. */
+  mediaOp(
+    settings: ConnSettings,
+    player: string,
+    op: MediaOp,
+    body?: { position_ms: number },
+  ): Promise<ActionResult> {
+    return request<ActionResult>(settings, `/api/media/${encodeURIComponent(player)}/${op}`, {
+      method: 'POST',
+      timeoutMs: 8000,
+      body,
     });
   },
 };


### PR DESCRIPTION
Roadmap **Phase 3 — media transport / now-playing §4.3** + the shared infra **§3b (resolved-host)** and **§3c (`_send_bytes`)** that Phase 4 reuses. Stacked on #4 (agent 2.8.0 train).

## Feature
Now-playing + transport for any MPRIS player (Spotify, Firefox/Chromium, VLC, mpv, Kodi w/ add-on), read over the user session bus via `busctl` (ships with systemd). No new port/listener. Windows deferred — the old win agent 404s and the card hides.

## Shared infra (Phase 4 will reuse)
- **§3c `Handler._send_bytes`** — raw binary body, **exact Content-Length** (keep-alive safe under HTTP/1.1), same CORS as `_send`.
- **§3b resolved-host** — `request()` records the host that actually answered each box; `resolveEffectiveHost()` + a base64 binary fetch (`mediaArtSource`) so album art is pulled from the **same host** the JSON API proved reachable and inlined as a `data:` URI (bearer auth an `<Image>` URL can't carry; also keeps art out of Fresco's disk cache).

## Agent (`couchsided.py`, `MPRIS_*`-named to avoid the existing media-key device)
- `GET /api/media` — merged `GetAll` on the empty interface (Identity + Player in one call), Playing-first, capped at 8; every `busctl` call bounded + never-raises → 404 / empty list.
- `POST /api/media/<player>/<op>` — fixed op table (`play pause play_pause next previous stop seek`); `seek` = `SetPosition` with a `Seek`-delta fallback.
- `GET /api/media/art` — **`file://` only**, realpath allowlist, **2 MiB read cap**, **magic-byte sniff**; the client passes a player id + cache-key, never a path.
- `--mock` advancing Spotify + embedded PNG art. VERSION stays 2.8.0.

## App
`Media`/`MediaPlayer`/`MediaOp` types; `api.media()` (probe-and-appear 404→null), `mediaOp()`; **NowPlayingCard** on Console: art, 1 s interpolated progress, tap-to-seek, capability-gated transport, multi-player picker. Hidden when no media backend.

## Docs
Rewrote the two "no file-serving routes" security claims (root + agent README) to describe the one player-advertised art route honestly; API table + Kodi add-on note.

## Verification
py_compile, tsc, mock HTTP (list advances, art 200 image/png **keep-alive ×2**, ops 200, bad op 404, seek 400-guard, auth 200/401). Adversarial review → **agent safe**; the one app fix (interpolation ticker memoized away) is applied.

## Pending — hardware
The **real busctl parsing is defensive but unverifiable off-box** — the exact `GetAll --json=short` envelope for a live player is the pending on-box gate (Step 1: on-box `busctl` GetAll sanity on Spotify/Firefox/Kodi). If the envelope differs, real players just don't appear (card hidden) until the parser is nudged — no breakage. A visual NowPlayingCard smoke on-device is also worthwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
