### PR TITLE
feat: live screen preview — gamescopectl capture, validated on-box (roadmap Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Couchside is deliberately small and boring about security:
 - **Scoped sudo, nothing more.** The installer writes a `visudo`-validated sudoers rule granting the agent user passwordless sudo for exactly five things: `systemctl restart sddm`, `systemctl reboot`, `systemctl poweroff`, `systemctl suspend`, and `journalctl`. Nothing else. Actions are a fixed table; there is no "run arbitrary command" route.
 - **Journal access is allowlisted.** Only units on the configured watchlist can be read, with line counts clamped server-side, so a leaked token can't be used to trawl the whole system journal.
 - **LAN-only by design.** The API is plain HTTP on port 8787 and is meant to stay on your local network. The firewall rule opens the port locally; **do not port-forward it**. There is no relay, no cloud endpoint, and the app never talks to anything except your agent.
-- No client-addressable file routes — the only file the agent ever serves is the album-art image a running media player itself advertises (validated against a small realpath allowlist, image-sniffed, 2 MiB cap; the client passes a player id, never a path). Subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
+- No client-addressable file routes. The agent serves image bytes on two routes only: the album-art image a running media player advertises (realpath-allowlisted, image-sniffed, 2 MiB cap; client passes a player id, never a path) and an on-demand screen-preview frame captured to a tmpfs file that's deleted right after (rate-clamped, off by default in the app). Subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
 
 ## Uninstall
 

--- a/agent/README.md
+++ b/agent/README.md
@@ -149,6 +149,8 @@ All responses carry permissive CORS headers; `OPTIONS` returns 204.
 | `/api/media` | GET | Now-playing across MPRIS players: `{"available":true,"players":[{id,identity,status,title,artist,album,position_ms,length_ms,rate,can_seek,can_go_next,can_go_previous,can_play,can_pause,art,art_key}]}`. Read over the user session bus via `busctl` (ships with systemd). 404 when there is no session bus / `busctl`; 200 with an empty list when idle. Playing players first, capped at 8. Added in 2.8.0 |
 | `/api/media/<player>/<op>` | POST | Transport op; `<op>` ∈ `play pause play_pause next previous stop seek`. `seek` body `{"position_ms":int}` (absolute; `SetPosition` with a `Seek`-delta fallback). Unknown op / dead player → 404. ActionResult shape |
 | `/api/media/art?player=<id>&k=<art_key>` | GET | Album-art bytes for the player's current track. Serves only a `file://` image the player advertised, under a realpath allowlist, image-sniffed, 2 MiB cap; `http(s)` art is never fetched. The client passes a player id + cache-key, never a path. `Cache-Control: private, max-age=3600`. 404 when no servable art |
+| `/api/screen` | GET | Screen-capture probe: `{"available":true,"session":"gamescope"\|"desktop","backends":[...],"formats":["image/jpeg"]}`. 404 when no capture path (no gamescope socket / no `spectacle`, or no downscaler). Added in 2.8.0 |
+| `/api/screen/frame` | GET | One freshly-captured frame, downscaled to a ~960px JPEG (`Cache-Control: no-store`). gamescope Game Mode via `gamescopectl screenshot` (async write, polled to completion); KDE Desktop via `spectacle`; downscaled with ImageMagick/ffmpeg. A single-flight lock + 500 ms server cache cap captures at ~2/s no matter how many clients poll; 503 on capture failure. The client passes no path; `?t=` is ignored server-side |
 
 **Media players:** any MPRIS-speaking app works (Spotify, Firefox/Chromium, VLC, mpv, …). **Kodi** needs its MPRIS add-on enabled to appear here.
 
@@ -342,12 +344,14 @@ success, so the app's TV strip can be built without any hardware.
   actions and system-journal reads will then fail).
 - **Allowlists, not shells**: journal reads are limited to the configured
   unit list; actions are a fixed config table run with argument lists
-  (`shell=False`), so no arbitrary commands. The only file the agent serves is
-  the album-art image a running media player advertises — validated against a
-  small realpath allowlist (`/tmp`, `$XDG_RUNTIME_DIR`, `~/.cache`, `~/.var`,
-  `~/.mozilla`), image-sniffed, 2 MiB cap; the client passes a player id, never
-  a path. The `lines` parameter is clamped; errors return brief JSON, never
-  tracebacks.
+  (`shell=False`), so no arbitrary commands. No route takes a client-supplied
+  file path. The agent serves image bytes on exactly two routes: the album-art
+  image a running media player advertises (validated against a small realpath
+  allowlist — `/tmp`, `$XDG_RUNTIME_DIR`, `~/.cache`, `~/.var`, `~/.mozilla` —
+  image-sniffed, 2 MiB cap; client passes a player id) and an on-demand screen
+  frame captured to a tmpfs file that is deleted immediately after
+  (rate-clamped to ~2/s, 12 MiB cap; client passes no path). The `lines`
+  parameter is clamped; errors return brief JSON, never tracebacks.
 - **LAN-only, plain HTTP**: there is no TLS. Keep port 8787 on your local
   network and do **not** port-forward it. Anyone with the token on your LAN
   controls the box.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -29,6 +29,7 @@ import tempfile
 import termios
 import threading
 import time
+import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, unquote
 
@@ -2533,6 +2534,235 @@ def mock_mpris_art(player, art_key):
 
 
 # ---------------------------------------------------------------------------
+# Live screen preview: grab one composited frame on demand, downscale to a
+# small JPEG, serve over the bearer port (reuses _send_bytes, §3c). gamescope
+# (Game Mode) does NOT implement wlr-screencopy, so grim fails — the primary
+# path is `gamescopectl screenshot <path>`, which writes a 4K PNG
+# ASYNCHRONOUSLY (~1.4s on a real Bazzite box), downscaled to a ~60KB 960px
+# JPEG via ImageMagick/ffmpeg. KDE Desktop sessions use spectacle. All
+# invocations + timings verified on-box.
+# ---------------------------------------------------------------------------
+
+SCREEN_MIN_INTERVAL_S = 0.5       # server floor: at most ~2 captures/sec, any client count
+SCREEN_CAPTURE_TIMEOUT_S = 8      # per-step ceiling (gamescopectl async write + downscale)
+SCREEN_MAX_BYTES = 12 * 1024 * 1024
+SCREEN_WIDTH = 960                # downscale target width
+SCREEN_LOCK = threading.Lock()    # single-flight: never stack captures
+_SCREEN = None                    # capability dict or None; set by set_screen
+_SCREEN_CACHE = {"ts": 0.0, "data": None, "mime": None}  # 500 ms frame cache
+
+
+def _screen_downscaler():
+    """(argv-builder, name) for a PNG->JPEG downscaler, or (None, None). Prefers
+    ImageMagick, then ffmpeg — both ship on gaming boxes; keeps the agent off PIL
+    (absent on stock SteamOS)."""
+    if shutil.which("magick"):
+        return (lambda src, dst: ["magick", src, "-resize", "%dx" % SCREEN_WIDTH,
+                                  "-quality", "80", dst], "magick")
+    if shutil.which("convert"):
+        return (lambda src, dst: ["convert", src, "-resize", "%dx" % SCREEN_WIDTH,
+                                  "-quality", "80", dst], "convert")
+    if shutil.which("ffmpeg"):
+        return (lambda src, dst: ["ffmpeg", "-y", "-loglevel", "error", "-i", src,
+                                  "-vf", "scale=%d:-1" % SCREEN_WIDTH, "-q:v", "6", dst],
+                "ffmpeg")
+    return (None, None)
+
+
+def set_screen(mock):
+    """Detect a capture path at startup: gamescopectl when a gamescope socket
+    exists, else spectacle for a KDE desktop. Requires a downscaler for real
+    frames (a raw 4K PNG is too big to stream)."""
+    global _SCREEN
+    if mock:
+        _SCREEN = {"session": "mock", "backends": ["mock"], "dscale": None}
+        return
+    dbuild, _ = _screen_downscaler()
+    if dbuild is None:
+        _SCREEN = None
+        return
+    gs = [s for s in _wayland_display_sockets() if s.startswith("gamescope-")]
+    backends = []
+    if shutil.which("gamescopectl") and gs:
+        backends.append("gamescopectl")
+    if shutil.which("spectacle"):
+        backends.append("spectacle")
+    if not backends:
+        _SCREEN = None
+        return
+    _SCREEN = {"session": "gamescope" if gs else "desktop", "backends": backends,
+               "dscale": dbuild, "gs_socket": gs[0] if gs else None}
+
+
+def _screen_env():
+    env = _user_env()
+    if _SCREEN and _SCREEN.get("gs_socket"):
+        env["WAYLAND_DISPLAY"] = _SCREEN["gs_socket"]
+    else:
+        socks = _wayland_display_sockets()
+        if len(socks) == 1:
+            env["WAYLAND_DISPLAY"] = socks[0]
+    env.setdefault("DISPLAY", ":0")
+    return env
+
+
+def _png_complete(path):
+    """True when a PNG is fully written: >=100 bytes and ends in the IEND chunk.
+    gamescopectl writes async, so the file appears before it is complete."""
+    try:
+        if os.path.getsize(path) < 100:
+            return False
+        with open(path, "rb") as f:
+            f.seek(-8, os.SEEK_END)
+            return f.read(8) == b"IEND\xaeB`\x82"
+    except OSError:
+        return False
+
+
+def _grab_gamescopectl(env, outdir):
+    """`gamescopectl screenshot <png>` then poll for the async write to settle."""
+    png = os.path.join(outdir, "frame.png")
+    try:
+        os.unlink(png)
+    except OSError:
+        pass
+    try:
+        subprocess.run(["gamescopectl", "screenshot", png], env=env,
+                       timeout=SCREEN_CAPTURE_TIMEOUT_S,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        return None
+    deadline = time.monotonic() + SCREEN_CAPTURE_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if os.path.exists(png):
+            s1 = os.path.getsize(png)
+            time.sleep(0.1)
+            if s1 == os.path.getsize(png) and _png_complete(png):
+                return png
+        time.sleep(0.1)
+    return None
+
+
+def _grab_spectacle(env, outdir):
+    """`spectacle -b -n -o <png>` (background, no notify) for a KDE desktop."""
+    png = os.path.join(outdir, "frame.png")
+    try:
+        os.unlink(png)
+    except OSError:
+        pass
+    try:
+        subprocess.run(["spectacle", "-b", "-n", "-o", png], env=env,
+                       timeout=SCREEN_CAPTURE_TIMEOUT_S,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        return None
+    return png if _png_complete(png) else None
+
+
+def real_screen_frame():
+    """Capture one frame -> (jpeg_bytes, "image/jpeg") or None. Single-flight +
+    500 ms cache so any number of pollers cause at most ~2 captures/sec."""
+    if _SCREEN is None:
+        return None
+    now = time.monotonic()
+    if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
+        return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+    if not SCREEN_LOCK.acquire(blocking=False):
+        # A capture is already running: serve the last frame if we have one,
+        # else wait for the in-flight capture rather than starting a second.
+        if _SCREEN_CACHE["data"] is not None:
+            return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+        SCREEN_LOCK.acquire()
+    try:
+        now = time.monotonic()
+        if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
+            return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+        env = _screen_env()
+        outdir = os.path.join(XDG_RUNTIME_DIR, "couchside-screen")
+        try:
+            os.makedirs(outdir, mode=0o700, exist_ok=True)
+        except OSError:
+            return None
+        png = os.path.join(outdir, "frame.png")
+        jpg = os.path.join(outdir, "frame.jpg")
+        try:
+            grabbed = None
+            for backend in _SCREEN["backends"]:
+                if backend == "gamescopectl":
+                    grabbed = _grab_gamescopectl(env, outdir)
+                elif backend == "spectacle":
+                    grabbed = _grab_spectacle(env, outdir)
+                if grabbed:
+                    break
+            if not grabbed:
+                return None
+            data = None
+            try:
+                subprocess.run(_SCREEN["dscale"](grabbed, jpg), env=env,
+                               timeout=SCREEN_CAPTURE_TIMEOUT_S,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                with open(jpg, "rb") as f:
+                    data = f.read(SCREEN_MAX_BYTES + 1)
+            except Exception:
+                return None
+            if not data or len(data) > SCREEN_MAX_BYTES:
+                return None
+            _SCREEN_CACHE.update(ts=time.monotonic(), data=data, mime="image/jpeg")
+            return (data, "image/jpeg")
+        finally:
+            # Always clean tmpfs, even when the grab itself failed (no partial
+            # frame.png left behind on a box that never captures successfully).
+            for p in (png, jpg):
+                try:
+                    os.unlink(p)
+                except OSError:
+                    pass
+    finally:
+        SCREEN_LOCK.release()
+
+
+def screen_info():
+    """{available, session, backends, formats} or None when no capture path."""
+    if _SCREEN is None:
+        return None
+    return {"available": True, "session": _SCREEN["session"],
+            "backends": _SCREEN["backends"], "formats": ["image/jpeg"]}
+
+
+def _encode_png(w, h, rows):
+    """Encode 8-bit RGBA scanlines (each `bytes` of length w*4) to PNG bytes.
+    Pure zlib + struct, no PIL (§3e); also copied to the Windows GDI port."""
+    def _chunk(tag, data):
+        body = tag + data
+        return (struct.pack(">I", len(data)) + body
+                + struct.pack(">I", zlib.crc32(body) & 0xffffffff))
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)  # RGBA, no interlace
+    raw = b"".join(b"\x00" + r for r in rows)  # per-scanline filter byte 0
+    return (b"\x89PNG\r\n\x1a\n" + _chunk(b"IHDR", ihdr)
+            + _chunk(b"IDAT", zlib.compress(raw, 6)) + _chunk(b"IEND", b""))
+
+
+_MOCK_SCREEN_N = 0
+
+
+def mock_screen_frame():
+    """--mock: a small stdlib PNG with a moving band, so the app's preview works
+    on macOS without a compositor."""
+    global _MOCK_SCREEN_N
+    _MOCK_SCREEN_N += 1
+    w, h = 320, 180
+    band = (_MOCK_SCREEN_N * 12) % w
+    rows = []
+    for y in range(h):
+        row = bytearray()
+        for x in range(w):
+            r = 220 if abs(x - band) <= 6 else 30
+            row += bytes((r, (255 * y) // h, (255 * x) // w, 255))
+        rows.append(bytes(row))
+    return (_encode_png(w, h, rows), "image/png")
+
+
+# ---------------------------------------------------------------------------
 # Virtual gamepad: evdev/uinput constants and pure-stdlib uinput driver
 # ---------------------------------------------------------------------------
 
@@ -3897,11 +4127,23 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
         self._log(code, started)
 
+    # Chatty routes whose success (2xx) is sampled so a ~1-2 fps poll can't
+    # scroll real diagnostics out of the journal's window (§3f). Errors and the
+    # first hit of a burst still log.
+    _SAMPLED_PATHS = ("/api/screen/frame",)
+    _sample_last = {}  # path -> monotonic time of last logged success
+    _SAMPLE_EVERY_S = 15
+
     def _log(self, code, started):
         dur_ms = int((time.monotonic() - started) * 1000)
         # Never log query strings: /ws/gamepad carries ?token=<secret>, and
         # this stdout lands in journald (which /api/journal serves back out).
         path = self.path.split("?", 1)[0]
+        if path in self._SAMPLED_PATHS and code < 400:
+            now = time.monotonic()
+            if now - Handler._sample_last.get(path, 0) < self._SAMPLE_EVERY_S:
+                return  # suppress this frame; a recent one already logged
+            Handler._sample_last[path] = now
         if "?" in self.path:
             path += "?<redacted>"
         print("%s %s %s %d %dms" % (
@@ -4072,6 +4314,27 @@ class Handler(BaseHTTPRequestHandler):
                     data, mime = art
                     self._send_bytes(200, data, mime, started,
                                      cache_control="private, max-age=3600")
+            elif path == "/api/screen":
+                # Probe-and-appear: 404 when no capture path so the app hides the
+                # preview card; a body describes the session + backends.
+                info = {"available": True, "session": "mock",
+                        "backends": ["mock"], "formats": ["image/png"]} \
+                    if self.mock else screen_info()
+                if info is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, info, started)
+            elif path == "/api/screen/frame":
+                # One fresh frame. Single-flight + 500ms cache cap captures at
+                # ~2/s server-side; no-store so frames (may show passwords) are
+                # never cached. High-frequency, so _log samples it.
+                frame = mock_screen_frame() if self.mock else real_screen_frame()
+                if frame is None:
+                    self._send(503, {"error": "capture failed"}, started)
+                else:
+                    data, mime = frame
+                    self._send_bytes(200, data, mime, started,
+                                     cache_control="no-store")
             else:
                 self._send(404, {"error": "not found"}, started)
         except BrokenPipeError:
@@ -4657,6 +4920,7 @@ def main():
     _inject_suspend_action(args.mock)
     set_tv(args.mock)
     set_mpris(args.mock)
+    set_screen(args.mock)
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)
 
     Handler.token = load_token(args)
@@ -4675,6 +4939,8 @@ def main():
     print("tv: %s" % ("%s (%s)" % (info["backend"], info["adapter"])
                       if info else "unavailable"), flush=True)
     print("mpris: %s" % ("available" if BUSCTL else "unavailable"), flush=True)
+    print("screen: %s" % (("%s (%s)" % (_SCREEN["session"], ",".join(_SCREEN["backends"])))
+                          if _SCREEN else "unavailable"), flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
+import { ScreenPreview } from '@/components/ScreenPreview';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
@@ -205,6 +206,9 @@ function ConsoleScreen() {
             </Card>
           </>
         )}
+
+        {/* Live screen preview (probe-and-appear; hidden when no capture path) */}
+        <ScreenPreview />
 
         {/* Units */}
         {configured && (

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -1,0 +1,249 @@
+/**
+ * Live screen preview (Console tab). Probe-and-appear: renders nothing until the
+ * box reports a capture path (gamescope/desktop), then a sticky card. Preview is
+ * OFF by default — captures cost GPU — until the user taps START. While active it
+ * pulls one frame ~every second from the resolved host as a base64 data URI (no
+ * disk cache: a frame may show a password prompt), and auto-stops when the tab
+ * blurs or the app backgrounds. Tap the frame for a fullscreen modal.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useFocusEffect } from 'expo-router';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState, AppStateStatus, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, screenFrameSource, ScreenInfo } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, theme } from '@/lib/theme';
+
+const FRAME_INTERVAL_MS = 1000;
+const FULLSCREEN_INTERVAL_MS = 700;
+
+export function ScreenPreview() {
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  // Slow probe: just detects whether capture is possible on this box.
+  const probe = usePoll<ScreenInfo | null>(
+    () => api.screenInfo(settings),
+    30000,
+    ready && configured,
+  );
+  // Sticky: once a box has ever reported capture support, keep the card so a
+  // later 404 (e.g. the greeter after a session restart) is explained, not hidden.
+  const everSupported = useRef(false);
+  if (probe.data) everSupported.current = true;
+  const supported = probe.data != null;
+
+  const [active, setActive] = useState(false);
+  const [frame, setFrame] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [lastGood, setLastGood] = useState<number | null>(null);
+  const [fullscreen, setFullscreen] = useState(false);
+
+  // Generation token: each start() owns a unique gen; any stop()/start() bumps
+  // it so orphaned in-flight tick chains self-terminate at their next check and
+  // can never overlap (a shared boolean can't tell chains apart). timerRef holds
+  // the one pending frame timer so stop() can cancel it too.
+  const genRef = useRef(0);
+  const focusedRef = useRef(true);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const stop = useCallback(() => {
+    genRef.current++;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(
+    (intervalMs: number) => {
+      stop(); // cancel any prior chain + pending timer first
+      const myGen = ++genRef.current;
+      const run = async () => {
+        if (genRef.current !== myGen) return;
+        const uri = await screenFrameSource(settings);
+        if (genRef.current !== myGen) return; // superseded/stopped mid-fetch
+        if (uri) {
+          setFrame(uri);
+          setFailed(false);
+          setLastGood(Date.now());
+        } else {
+          setFailed(true);
+        }
+        if (genRef.current === myGen) {
+          timerRef.current = setTimeout(run, intervalMs);
+        }
+      };
+      void run();
+    },
+    [settings, stop],
+  );
+
+  const intervalFor = useCallback(
+    () => (fullscreen ? FULLSCREEN_INTERVAL_MS : FRAME_INTERVAL_MS),
+    [fullscreen],
+  );
+
+  // Drive the loop from the active toggle + fullscreen cadence.
+  useEffect(() => {
+    if (active && focusedRef.current) start(intervalFor());
+    else stop();
+    return stop;
+  }, [active, intervalFor, start, stop]);
+
+  // Pause on blur (leaving the tab) and on backgrounding; resume on return.
+  useFocusEffect(
+    useCallback(() => {
+      focusedRef.current = true;
+      if (active) start(intervalFor());
+      const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
+        if (s === 'active') {
+          focusedRef.current = true;
+          if (active) start(intervalFor());
+        } else {
+          focusedRef.current = false;
+          stop();
+        }
+      });
+      return () => {
+        focusedRef.current = false;
+        stop();
+        sub.remove();
+      };
+    }, [active, intervalFor, start, stop]),
+  );
+
+  const toggle = useCallback(() => {
+    hapticLight();
+    setActive((a) => {
+      if (a) {
+        setFrame(null);
+        setFailed(false);
+      }
+      return !a;
+    });
+  }, []);
+
+  if (!supported && !everSupported.current) return null;
+
+  const noSession = !supported && everSupported.current;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.title}>SCREEN</Text>
+        {supported && (
+          <Pressable
+            onPress={toggle}
+            style={({ pressed }) => [styles.pill, active && styles.pillOn, pressed && styles.pressed]}>
+            <Ionicons
+              name={active ? 'stop' : 'play'}
+              size={12}
+              color={active ? theme.bg : theme.green}
+            />
+            <Text style={[styles.pillText, active && styles.pillTextOn]}>
+              {active ? 'STOP' : 'START PREVIEW'}
+            </Text>
+          </Pressable>
+        )}
+      </View>
+
+      {noSession ? (
+        <View style={styles.stateBox}>
+          <Ionicons name="tv-outline" size={26} color={theme.textFaint} />
+          <Text style={styles.stateText}>no capturable session (greeter?)</Text>
+        </View>
+      ) : !active ? (
+        <View style={styles.stateBox}>
+          <Ionicons name="eye-outline" size={26} color={theme.textFaint} />
+          <Text style={styles.stateText}>Preview is off. Tap START to see the screen.</Text>
+        </View>
+      ) : (
+        <Pressable onPress={() => frame && setFullscreen(true)}>
+          <View style={styles.frameWrap}>
+            {frame ? (
+              <Image source={{ uri: frame }} style={styles.frame} resizeMode="contain" />
+            ) : (
+              <View style={styles.frameLoading}>
+                <Text style={styles.stateText}>capturing…</Text>
+              </View>
+            )}
+            {failed && frame && (
+              <View style={styles.failBadge}>
+                <Text style={styles.failText}>
+                  CAPTURE FAILED{lastGood ? ` · last ${new Date(lastGood).toLocaleTimeString()}` : ''}
+                </Text>
+              </View>
+            )}
+          </View>
+        </Pressable>
+      )}
+
+      <Modal visible={fullscreen} transparent animationType="fade" onRequestClose={() => setFullscreen(false)}>
+        <Pressable style={styles.fsRoot} onPress={() => setFullscreen(false)}>
+          {frame && <Image source={{ uri: frame }} style={styles.fsImage} resizeMode="contain" />}
+          <View style={styles.fsHint} pointerEvents="none">
+            <Text style={styles.fsHintText}>tap to close</Text>
+          </View>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+  },
+  header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    borderColor: theme.green,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 4,
+    paddingHorizontal: 10,
+  },
+  pillOn: { backgroundColor: theme.green },
+  pillText: { color: theme.green, fontSize: 11, fontWeight: '700', fontFamily: mono },
+  pillTextOn: { color: theme.bg },
+  pressed: { opacity: 0.7 },
+
+  stateBox: { alignItems: 'center', justifyContent: 'center', paddingVertical: 22, gap: 8 },
+  stateText: { color: theme.textDim, fontSize: 13, textAlign: 'center' },
+
+  frameWrap: {
+    borderRadius: 8,
+    overflow: 'hidden',
+    backgroundColor: '#000',
+    aspectRatio: 16 / 9,
+  },
+  frame: { width: '100%', height: '100%' },
+  frameLoading: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  failBadge: {
+    position: 'absolute',
+    top: 6,
+    left: 6,
+    backgroundColor: 'rgba(0,0,0,0.72)',
+    borderRadius: 6,
+    paddingVertical: 3,
+    paddingHorizontal: 8,
+  },
+  failText: { color: theme.amber, fontSize: 10, fontWeight: '700', fontFamily: mono },
+
+  fsRoot: { flex: 1, backgroundColor: 'rgba(0,0,0,0.95)', alignItems: 'center', justifyContent: 'center' },
+  fsImage: { width: '100%', height: '100%' },
+  fsHint: { position: 'absolute', bottom: 30 },
+  fsHintText: { color: theme.textDim, fontSize: 12, fontFamily: mono },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -176,6 +176,14 @@ export type MediaPlayer = {
 
 export type Media = { available: boolean; players: MediaPlayer[] };
 
+/** Screen-capture capability of the box (probe-and-appear). */
+export type ScreenInfo = {
+  available: boolean;
+  session: 'gamescope' | 'desktop' | 'mock' | null;
+  backends: string[];
+  formats: string[];
+};
+
 export type LaunchResult = {
   ok: boolean;
   /** Present when ok is false. */
@@ -354,6 +362,28 @@ export async function mediaArtSource(
   const url = `http://${host}:${settings.port}/api/media/art?player=${encodeURIComponent(
     player,
   )}&k=${encodeURIComponent(artKey)}`;
+  try {
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
+    if (!res.ok) return null;
+    const type = res.headers.get('Content-Type') || 'image/jpeg';
+    const buf = await res.arrayBuffer();
+    if (buf.byteLength === 0) return null;
+    return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fetch one live screen-preview frame from the resolved host (§3b) with bearer
+ * auth, as a base64 data: URI for <Image>. Inlined (never a raw <Image> URL)
+ * because the URL can't carry the token and frames are no-store — a frame may
+ * show a password prompt, so nothing is written to Fresco's disk cache. null on
+ * failure or 503 (capture failed). `t` cache-busts each frame.
+ */
+export async function screenFrameSource(settings: ConnSettings): Promise<string | null> {
+  const host = resolveEffectiveHost(settings);
+  const url = `http://${host}:${settings.port}/api/screen/frame?t=${Date.now()}`;
   try {
     const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
     if (!res.ok) return null;
@@ -700,6 +730,15 @@ export const api = {
       timeoutMs: 8000,
       body,
     });
+  },
+
+  /**
+   * Screen-capture capability. Probe-and-appear: resolves null on 404 (agent
+   * < 2.8 or no capture path) so the preview card hides. Frames come from
+   * screenFrameSource(), not this method.
+   */
+  screenInfo(settings: ConnSettings): Promise<ScreenInfo | null> {
+    return probeOrNull(request<ScreenInfo>(settings, '/api/screen', { timeoutMs: 8000 }));
   },
 };
 


### PR DESCRIPTION
Roadmap **Phase 4 — live screen preview §4.4** (the flagship-risk feature). Based on main (Phases 0–3 already merged).

## Validated LIVE on Bazzite before writing app code
The roadmap gated all app work on an on-box `gamescopectl` go/no-go. I ran it on 10.1.1.60 and it **passed**, pinning the exact chain (and confirming a real screenshot came back through the agent):
- gamescope does **not** implement wlr-screencopy → primary path is `gamescopectl screenshot <path>`, which writes a **4K PNG asynchronously (~1.4s)** → poll to completion (size-settle + PNG `IEND` trailer).
- Downscale to ~960px JPEG via **ImageMagick/ffmpeg** (no PIL — stock SteamOS lacks it): real 3840×2160 5.1MB → **960×540 60KB in ~0.38s**.
- KDE Desktop fallback: `spectacle -b -n -o`.
- End-to-end through the agent: `/api/screen/frame` returned a real 960×540 60KB JPEG of the couch screen.

## Agent
- `set_screen` (backend + downscaler detection), `real_screen_frame` (single-flight `SCREEN_LOCK` + 500ms cache → ≤~2 captures/sec regardless of pollers; tmpfs frames **always cleaned**, even on failed grabs), `GET /api/screen` (probe → 404 hides card), `GET /api/screen/frame` (503 on failure, `no-store`).
- Infra: `_encode_png` (stdlib §3e) for the mock; `_log` samples the frame route (§3f) so 1fps doesn't scroll the journal. Reuses `_send_bytes` (§3c).
- **Security**: no client-supplied path, rate + 12 MiB clamps; both READMEs' security model updated for the two image routes (art + screen).

## App
`ScreenInfo` type + `api.screenInfo` (404→null) + `screenFrameSource` (auth'd binary → data URI via §3b resolved host). **ScreenPreview** card: probe-gated + sticky, **OFF by default** (captures cost GPU) with START/STOP, a **generation-token frame loop** that can't double-run, auto-stop on blur/background, tap → fullscreen modal. Mounted on Console.

## Verification
py_compile, tsc, mock frame route, **live capture on real hardware**, adversarial review → agent **safe**; the app's one **blocker** (overlapping frame loops from a shared alive-boolean) is fixed with generation tokens + timer tracking, plus two low nits.

## Pending — hardware
Windows GDI capture port (deferred, no key-SSH to EMERY-PC). On-device visual smoke of the ScreenPreview card + fullscreen once the merged agent is on the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
