### PR TITLE
fix: Pad tab crashed the Android app when the box host was empty (2.5.1)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -398,7 +398,22 @@ export class GamepadClient {
     this.setStatus('connecting', null);
 
     const { host, port, token, lastIp } = this.conn;
-    const target = this.useFallback && lastIp ? lastIp : host;
+    // Resolve to a NON-EMPTY host. `host` is blank when the box was paired by IP
+    // before its mDNS name was learned (the settings default host is ''), and the
+    // cached LAN IP is then the real address — the HTTP API falls back to it the
+    // same way. This MUST never hand an empty host to the native WebSocket: okhttp
+    // throws IllegalArgumentException("Invalid URL host: \"\"") on the native
+    // modules thread (mqt_v_native), which the try/catch below CANNOT catch (it is
+    // raised asynchronously, off the JS thread) and which crashes the whole app.
+    const cleanHost = (host || '').trim();
+    const cleanIp = (lastIp || '').trim();
+    const target = this.useFallback && cleanIp ? cleanIp : cleanHost || cleanIp;
+    if (!target || !port) {
+      // Nothing dialable yet (box not paired, no address). Stay quietly errored;
+      // connect() re-runs when host/port/token change, so pairing recovers this.
+      this.setStatus('error', null);
+      return;
+    }
     const url = `ws://${target}:${port}/ws/gamepad?token=${encodeURIComponent(token)}`;
 
     let ws: WebSocket;


### PR DESCRIPTION
## The crash (live in 2.5.0 on Play)

Opening the **Pad** tab fully closed the app on Android. Captured via `adb logcat` on a Motorola Razr 2023 (Android 15):

```
FATAL EXCEPTION: mqt_v_native
java.lang.IllegalArgumentException: Invalid URL host: ""
    at okhttp3.HttpUrl$Builder.parse$okhttp(HttpUrl.kt:1337)
    at com.facebook.react.modules.websocket.WebSocketModule.connect(WebSocketModule.kt:97)
```

## Root cause

The Pad tab is the only screen that opens a native WebSocket (`ws://<host>:<port>/ws/gamepad`). When `settings.host` was blank — the default, e.g. a box paired by IP with the address only in `lastIp` — it dialed `ws://:8787/...`. On Android the native connect runs asynchronously on the native-modules thread (`mqt_v_native`), so the `try/catch` around `new WebSocket()` **cannot** catch okhttp's throw, and the unhandled exception kills the whole app.

That's why only the Pad tab crashed (every other tab uses `fetch`, which tolerates a blank host and already falls back to `lastIp` via `resolveEffectiveHost`).

## Fix

`gamepad.ts` `open()` now resolves to a **non-empty** host — prefer `host`, fall back to the cached `lastIp` (matching the HTTP path) — and never hands an empty host to the native WebSocket, bailing cleanly if nothing is dialable yet.

- Verified the resolution logic across the crash input + edge cases (empty host + known IP → dials the IP; both empty → no WebSocket, no crash; whitespace host → bail).
- Bumped 2.5.0 → 2.5.1 (versionCode 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)