### PR TITLE
feat: global "Unlocked — thanks" toast on IAP unlock

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -2,6 +2,7 @@ import { DarkTheme, Stack, ThemeProvider } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { UnlockToast } from '@/components/UnlockToast';
 import { DeepLinkHandler } from '@/lib/DeepLink';
 import { EntitlementProvider } from '@/lib/EntitlementContext';
 import { SettingsProvider } from '@/lib/SettingsContext';
@@ -35,6 +36,8 @@ export default function RootLayout() {
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           </Stack>
+          {/* Global overlay: survives the Paywall unmount on unlock (see UnlockToast). */}
+          <UnlockToast />
         </ThemeProvider>
       </EntitlementProvider>
     </SettingsProvider>

--- a/app/components/UnlockToast.tsx
+++ b/app/components/UnlockToast.tsx
@@ -1,0 +1,76 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { subscribeUnlocked } from '@/lib/EntitlementContext';
+import { mono, theme } from '@/lib/theme';
+
+/** Matches the launch-tab toast lifetime. */
+const UNLOCK_TOAST_MS = 1500;
+
+/**
+ * Global, non-blocking "Unlocked — thanks" toast.
+ *
+ * Mounted at the root layout (a sibling of the navigator), so it survives the
+ * Paywall unmount that happens the instant an unlock flips the gate: Gated swaps
+ * Paywall for the real tab content the moment entitlement becomes 'purchased'
+ * (see components/Gated.tsx), so a toast rendered inside Paywall would die with
+ * it. This one lives above the tabs and fires off EntitlementContext's one-shot
+ * unlock signal, so it covers buy, restore, and out-of-band/deferred purchases
+ * — announcing once, then auto-dismissing (~1.5s). No confirmation screen: the
+ * native purchase sheet already confirmed the transaction.
+ */
+export function UnlockToast() {
+  const insets = useSafeAreaInsets();
+  const [shown, setShown] = useState(false);
+  const [early, setEarly] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = subscribeUnlocked((info) => {
+      setEarly(info.isEarlyAdopter);
+      setShown(true);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setShown(false), UNLOCK_TOAST_MS);
+    });
+    return () => {
+      unsub();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  if (!shown) return null;
+
+  return (
+    <View style={[styles.toast, { top: insets.top + 12 }]} pointerEvents="none">
+      <Text style={styles.toastText}>Unlocked — thanks</Text>
+      {early && <Text style={styles.earlyText}>★ Early Adopter unlocked</Text>}
+    </View>
+  );
+}
+
+// Box matches the launch-tab toast (lib theme, dark ops-console look); anchored
+// at the top since, unlike the in-tab toast, this floats above the tab bar too.
+const styles = StyleSheet.create({
+  toast: {
+    position: 'absolute',
+    left: 24,
+    right: 24,
+    backgroundColor: theme.inset,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+    gap: 4,
+    shadowColor: '#000',
+    shadowOpacity: 0.4,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 8 },
+    elevation: 12,
+    zIndex: 1000,
+  },
+  toastText: { color: theme.text, fontSize: 14, fontWeight: '600', fontFamily: mono },
+  earlyText: { color: theme.amber, fontSize: 12, fontWeight: '700', fontFamily: mono },
+});

--- a/app/lib/EntitlementContext.tsx
+++ b/app/lib/EntitlementContext.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 
@@ -16,6 +17,45 @@ import {
   TRIAL_DAYS,
 } from './entitlement';
 import { setOnPurchased } from './purchase';
+
+/** Payload handed to the global unlock toast when an unlock first completes. */
+export type UnlockInfo = { isEarlyAdopter: boolean };
+
+// A tiny module-scope event bus for the one-shot "unlock just completed" signal.
+// It lives outside React state so a global toast (mounted above the tabs) can
+// react without the purchase flow depending on it, and so a genuine unlock is
+// announced AT MOST ONCE per app session no matter which path delivered it
+// (buy, restore, or an out-of-band/deferred purchase on a later launch).
+const unlockedListeners = new Set<(info: UnlockInfo) => void>();
+let unlockAnnounced = false;
+let pendingUnlock: UnlockInfo | null = null;
+
+/**
+ * Subscribe to the "unlock just completed" signal. Fires at most once per app
+ * session, the moment entitlement first transitions to 'purchased'. If the
+ * unlock fired before any listener mounted (e.g. a deferred purchase delivered
+ * during launch, before the toast subscribed), the latched event is handed to
+ * the first subscriber. Returns an unsubscribe fn.
+ */
+export function subscribeUnlocked(cb: (info: UnlockInfo) => void): () => void {
+  unlockedListeners.add(cb);
+  if (pendingUnlock) {
+    const info = pendingUnlock;
+    pendingUnlock = null;
+    cb(info);
+  }
+  return () => {
+    unlockedListeners.delete(cb);
+  };
+}
+
+function emitUnlocked(info: UnlockInfo): void {
+  if (unlockedListeners.size === 0) {
+    pendingUnlock = info; // latch until the toast subscribes
+    return;
+  }
+  for (const l of unlockedListeners) l(info);
+}
 
 type EntitlementContextValue = {
   entitlement: Entitlement;
@@ -42,13 +82,33 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
   });
   const [ready, setReady] = useState(false);
 
+  // Live mirror of the current state so recordPurchase() can tell a genuine
+  // unlock transition from a redundant call without adding a dependency.
+  const stateRef = useRef(entitlement.state);
+  useEffect(() => {
+    stateRef.current = entitlement.state;
+  }, [entitlement.state]);
+
   const refresh = useCallback(async () => {
     setEntitlement(await getEntitlement());
   }, []);
 
   const recordPurchase = useCallback(async () => {
+    const wasPurchased = stateRef.current === 'purchased';
     await markPurchased();
-    setEntitlement(await getEntitlement());
+    const next = await getEntitlement();
+    setEntitlement(next);
+    // Announce the global "Unlocked — thanks" toast exactly once, only on a real
+    // transition into 'purchased'. Every genuine unlock path funnels through
+    // recordPurchase (Paywall buy/restore, and the store listener's onPurchased
+    // for out-of-band/deferred purchases), so this one hook covers them all. The
+    // module-level latch dedupes buy()'s double call (the purchase listener AND
+    // the Paywall both invoke recordPurchase) and won't re-fire on a later
+    // restore in the same session.
+    if (!unlockAnnounced && !wasPurchased && next.state === 'purchased') {
+      unlockAnnounced = true;
+      emitUnlocked({ isEarlyAdopter: next.isEarlyAdopter });
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What

A brief, non-blocking **"Unlocked — thanks"** toast that fires the moment a Play/Apple unlock purchase succeeds — auto-dismiss ~1.5s, no confirmation screen (the native purchase sheet already confirmed).

## The catch it solves

`Paywall` calls `recordPurchase()`, which flips entitlement to `'purchased'`; `Gated` then immediately swaps Paywall for the tab content and **unmounts Paywall**. A toast rendered inside Paywall dies with it. So this is a **global** toast mounted at the root layout (above the tab navigator), fired off a one-shot signal in `EntitlementContext`.

## How

- `EntitlementContext` gains `subscribeUnlocked()`, emitted from `recordPurchase()` — the single chokepoint every genuine unlock funnels through:
  - Paywall **buy**, Paywall **restore**, and the store listener's **`onPurchased`** (out-of-band / deferred purchases delivered on a later launch).
- A module-level latch makes it fire **at most once per session** (dedupes `buy()`'s double call — the purchase listener *and* Paywall both call `recordPurchase`) and only on a real transition into `'purchased'` — so returning buyers (whom `revalidateWithStore` flips silently, without `recordPurchase`) are never toasted.
- A pending-latch covers the launch race where a deferred purchase arrives before the toast mounts.
- If `isEarlyAdopter`, the toast adds a ★ Early Adopter line (matches the amber badge accent).

## Files
- `app/lib/EntitlementContext.tsx` — one-shot unlock signal + `recordPurchase` hook
- `app/components/UnlockToast.tsx` — global toast (new), matches the launch-tab toast look
- `app/app/_layout.tsx` — mounts `<UnlockToast/>` above the navigator

## Verify
- `tsc --noEmit` clean.
- Unit-tested the signal semantics (7/7): buy double-call → 1 toast; returning buyer → 0; restore → 1; deferred-before-mount → latched + delivered; repeat restore → no re-toast; early-adopter flag propagates.
- On-device sandbox exercise (buy → toast shows once after Paywall unmounts; restore too) still recommended on the next dev build.

Constraints kept: client-side only, no new network calls, dark ops-console theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)