### PR TITLE
chore: notify-decky CI workflow + sync app.json to shipped 2.5.1

### DIFF
--- a/.github/workflows/notify-decky.yml
+++ b/.github/workflows/notify-decky.yml
@@ -1,0 +1,35 @@
+name: Notify Decky plugin of agent changes
+
+# When the agent changes on main, ping emerytech/couchside-decky so it rebuilds
+# and cuts a fresh plugin release immediately, instead of waiting for that repo's
+# daily safety-net schedule.
+#
+# OPTIONAL SETUP for the instant path: add a repo secret DECKY_DISPATCH_TOKEN — a
+# fine-grained PAT with "Contents: read/write" (or classic `repo`) scope on
+# emerytech/couchside-decky. Without it this job is a harmless no-op and the
+# couchside-decky daily schedule still keeps the plugin in sync within 24h.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "agent/couchsided.py"
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger couchside-decky sync & release
+        env:
+          TOKEN: ${{ secrets.DECKY_DISPATCH_TOKEN }}
+        run: |
+          if [ -z "$TOKEN" ]; then
+            echo "DECKY_DISPATCH_TOKEN not set — skipping instant sync."
+            echo "couchside-decky's daily schedule will pick up this change within 24h."
+            exit 0
+          fi
+          curl -fsSL -X POST \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/emerytech/couchside-decky/dispatches \
+            -d '{"event_type":"agent-updated"}'

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "23",
+      "buildNumber": "24",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 10
+      "versionCode": 13
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Two bits of release housekeeping left over from the 2.5.1 crash-fix push:

- **`.github/workflows/notify-decky.yml`** — on push to main touching `agent/couchsided.py`, fires a `repository_dispatch` to `emerytech/couchside-decky` so it rebuilds + cuts a fresh plugin release immediately (instant sync). No-ops until an optional `DECKY_DISPATCH_TOKEN` secret is added; the decky repo's daily schedule + fetch-from-main already keep the plugin current without it. (Its original commit was lost to a tooling hiccup during the release.)
- **`app/app.json`** — record the EAS-autoIncremented shipped versions: iOS build 24, Android versionCode 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)