### PR TITLE
fix: Decky plugin invisible in loader — chown root:root on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -703,6 +703,11 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
     if curl -fsSL "$PLUGIN_URL" -o "${decky_tmp}/Couchside.tar.gz" \
         && sudo rm -rf "$DECKY_PLUGIN_DIR" \
         && sudo tar -xzf "${decky_tmp}/Couchside.tar.gz" -C "$DECKY_PLUGINS"; then
+        # Force root ownership: a release archive built in CI can carry the
+        # runner's UID/GID, and `sudo tar -x` preserves it — Decky Loader then
+        # skips a plugin it doesn't see as root-owned (no error, just missing
+        # from the menu). Store installs are root-owned; match that.
+        sudo chown -R root:root "$DECKY_PLUGIN_DIR" 2>/dev/null || true
         sudo systemctl restart plugin_loader.service 2>/dev/null || true
         note "panel installed. Open the Decky menu in Game Mode to see it."
     else


### PR DESCRIPTION
## Symptom
Couchside plugin installed on a Legion Go (SteamOS) but **never appeared in the Decky menu**. Files were all correct (v0.2.1, agent 2.8.1) — but the plugin dir was owned by phantom UID **1001** while every other (working) plugin was **root:root**, and Decky created no per-plugin log dir for it → the loader skipped it at scan.

## Cause
The release archive was `tar`'d in GitHub Actions, which stored the runner's UID/GID (1001). `sudo tar -x` on-box preserves numeric ownership, so the plugin landed owned by a nonexistent user. Decky only loads root-owned plugins.

## Fix (two layers)
- **`couchside-decky` workflow** (separate commit, already pushed): `tar --owner=0 --group=0 --numeric-owner` so the archive records root — re-cut as v0.2.2.
- **`install.sh`** (this PR): `sudo chown -R root:root "$DECKY_PLUGIN_DIR"` after extract, so even an already-published archive installs correctly.

## On-box remediation (already-affected boxes)
```
sudo chown -R root:root ~/homebrew/plugins/Couchside && sudo systemctl restart plugin_loader
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)