### PR TITLE
Non-app hardening: agent DoS/robustness, installer portability, Windows parity, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,101 @@
+name: CI
+
+# Fast, minimal gate for the box agent. Two jobs:
+#   compile — cross-platform py_compile syntax check of every agent entrypoint,
+#             including the Windows agent (py_compile is syntax-only, so it is a
+#             valid gate on ubuntu; a real windows-latest smoke build is a
+#             future add — see the note in the job below).
+#   smoke   — boot couchsided.py headless in --mock mode on a spare port and hit
+#             a real authed endpoint to prove it serves + auth still works.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      # py_compile is a pure-syntax check and is cross-platform: compiling the
+      # Windows agent here on ubuntu catches syntax regressions without a Windows
+      # runner. Task 27: a genuine windows-latest build/import of couchsided-win.py
+      # (pywin32 / ViGEmBus deps, tray widget) is a FUTURE add and intentionally
+      # not gated here so CI stays fast and free of Windows-only dependencies.
+      - name: py_compile agent entrypoints
+        run: |
+          python3 -m py_compile \
+            agent/couchsided.py \
+            agent/win/couchsided-win.py \
+            agent/qr.py
+          echo "py_compile OK"
+
+  smoke:
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      # Boot the agent headless with --mock (never touches uinput/hardware/CEC),
+      # a throwaway literal token, and a minimal valid config on a spare port.
+      # Then hit an AUTHED endpoint (/api/status) with the token and assert
+      # 200 + JSON. /api/ping is public by design (pre-auth), so we also verify a
+      # no-token request to /api/status is rejected (401) to prove the auth gate.
+      - name: Boot agent (mock) and probe authed endpoint
+        run: |
+          set -euo pipefail
+          PORT=8791
+          TOKEN="ci-smoke-$RANDOM$RANDOM"
+          CFG="$RUNNER_TEMP/couchside-ci-config.json"
+          cat > "$CFG" <<'JSON'
+          {
+            "units": [{"name": "sshd.service", "scope": "system"}],
+            "actions": {}
+          }
+          JSON
+
+          python3 agent/couchsided.py \
+            --mock --host 127.0.0.1 --port "$PORT" \
+            --token "$TOKEN" --config "$CFG" \
+            > "$RUNNER_TEMP/agent.log" 2>&1 &
+          AGENT_PID=$!
+          # Always dump the log and reap the agent, even on failure.
+          trap 'echo "----- agent.log -----"; cat "$RUNNER_TEMP/agent.log" || true; kill "$AGENT_PID" 2>/dev/null || true' EXIT
+
+          # Wait for the socket to bind (best-effort boot; ~9s budget).
+          for i in $(seq 1 30); do
+            if curl -fsS "http://127.0.0.1:$PORT/api/ping" >/dev/null 2>&1; then
+              echo "agent bound after $i tries"
+              break
+            fi
+            if ! kill -0 "$AGENT_PID" 2>/dev/null; then
+              echo "agent process exited during boot" >&2
+              exit 1
+            fi
+            sleep 0.3
+          done
+
+          # Public pre-auth endpoint must be 200.
+          PING_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/api/ping")
+          echo "GET /api/ping -> $PING_CODE"
+          [ "$PING_CODE" = "200" ] || { echo "expected /api/ping 200, got $PING_CODE" >&2; exit 1; }
+
+          # No token -> the authed endpoint must reject (proves the gate is live).
+          NOAUTH_CODE=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/api/status")
+          echo "GET /api/status (no token) -> $NOAUTH_CODE"
+          [ "$NOAUTH_CODE" = "401" ] || { echo "expected /api/status 401 without token, got $NOAUTH_CODE" >&2; exit 1; }
+
+          # With token -> 200 and a JSON body.
+          BODY="$RUNNER_TEMP/status.json"
+          AUTH_CODE=$(curl -s -o "$BODY" -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/api/status")
+          echo "GET /api/status (token) -> $AUTH_CODE"
+          [ "$AUTH_CODE" = "200" ] || { echo "expected /api/status 200 with token, got $AUTH_CODE" >&2; exit 1; }
+          python3 -c "import json,sys; json.load(open('$BODY')); print('authed body is valid JSON')"
+
+          echo "smoke OK"

--- a/.github/workflows/notify-decky.yml
+++ b/.github/workflows/notify-decky.yml
@@ -4,10 +4,19 @@ name: Notify Decky plugin of agent changes
 # and cuts a fresh plugin release immediately, instead of waiting for that repo's
 # daily safety-net schedule.
 #
-# OPTIONAL SETUP for the instant path: add a repo secret DECKY_DISPATCH_TOKEN — a
+# INSTANT SYNC IS OPT-IN AND REQUIRES A SECRET.
+#   - WITH the DECKY_DISPATCH_TOKEN repo secret set: this job fires a
+#     repository_dispatch at couchside-decky the moment the agent changes on
+#     main, so the plugin rebuilds within minutes.
+#   - WITHOUT the secret (the default): this job is a deliberate, harmless no-op.
+#     It does NOT fail the run. The couchside-decky repo's own DAILY scheduled
+#     job still picks up this change and rebuilds the plugin within 24h, so the
+#     plugin never goes stale — you just don't get the instant rebuild.
+#
+# To enable the instant path, add a repo secret named DECKY_DISPATCH_TOKEN — a
 # fine-grained PAT with "Contents: read/write" (or classic `repo`) scope on
-# emerytech/couchside-decky. Without it this job is a harmless no-op and the
-# couchside-decky daily schedule still keeps the plugin in sync within 24h.
+# emerytech/couchside-decky. This workflow does NOT create or assume any token;
+# it reads the secret if present and otherwise skips cleanly.
 
 on:
   push:
@@ -24,8 +33,10 @@ jobs:
           TOKEN: ${{ secrets.DECKY_DISPATCH_TOKEN }}
         run: |
           if [ -z "$TOKEN" ]; then
-            echo "DECKY_DISPATCH_TOKEN not set — skipping instant sync."
-            echo "couchside-decky's daily schedule will pick up this change within 24h."
+            echo "SKIP: repo secret DECKY_DISPATCH_TOKEN is not set."
+            echo "Instant sync is OPT-IN and needs that secret; this run is a clean no-op (not a failure)."
+            echo "The couchside-decky repo's own DAILY schedule will still rebuild the plugin within 24h."
+            echo "To enable instant sync, add DECKY_DISPATCH_TOKEN (see the comment at the top of this file)."
             exit 0
           fi
           curl -fsSL -X POST \

--- a/agent/couchside.service
+++ b/agent/couchside.service
@@ -1,6 +1,9 @@
 ; Couchside box agent: systemd unit TEMPLATE.
-; install.sh substitutes __USER__ and __UID__ with the invoking desktop user
-; and installs the result to /etc/systemd/system/couchside.service.
+; install.sh substitutes __USER__, __UID__ and __EXEC__ (the resolved daemon
+; path) with the invoking desktop user's real values and installs the result to
+; /etc/systemd/system/couchside.service. Do NOT hardcode /home here: the home
+; can live at /var/home (Bazzite/ostree), be a systemd-homed image, or an LDAP
+; path — install.sh injects the real install dir so the unit works anywhere.
 [Unit]
 Description=Couchside box agent
 After=network-online.target
@@ -13,7 +16,7 @@ User=__USER__
 ; with the udev rule the installer writes for /dev/uinput.
 SupplementaryGroups=input
 Environment=XDG_RUNTIME_DIR=/run/user/__UID__
-ExecStart=/usr/bin/python3 /home/__USER__/.local/opt/couchside/couchsided.py
+ExecStart=/usr/bin/python3 __EXEC__
 Restart=always
 RestartSec=3
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1150,6 +1150,69 @@ def _steam_libraries(root):
     return libs
 
 
+# The set of steamapps library dirs changes rarely (only when the user adds a
+# Steam library), but re-reading libraryfolders.vdf + realpath'ing every entry
+# on each launch and each downloads poll is wasteful. Cache the discovered
+# library list per root for _STEAM_LIB_TTL seconds. Best-effort: never raises.
+_STEAM_LIB_TTL = 30.0
+_STEAM_LIB_CACHE = {"root": None, "at": 0.0, "val": None}
+_STEAM_LIB_LOCK = threading.Lock()
+
+
+def _steam_libraries_cached(root):
+    """_steam_libraries(root) memoized for _STEAM_LIB_TTL seconds. Keyed on the
+    root path so a changed root invalidates the cache. A lost race just
+    recomputes, which is harmless."""
+    now = time.monotonic()
+    with _STEAM_LIB_LOCK:
+        c = _STEAM_LIB_CACHE
+        if (c["val"] is not None and c["root"] == root
+                and now - c["at"] <= _STEAM_LIB_TTL):
+            return list(c["val"])
+    libs = _steam_libraries(root)
+    with _STEAM_LIB_LOCK:
+        _STEAM_LIB_CACHE.update(root=root, at=now, val=list(libs))
+    return libs
+
+
+def _steam_game_installed(appid):
+    """True iff appid names a real (non-tool) Steam game with a manifest on disk.
+
+    Validates against the SPECIFIC appmanifest_<appid>.acf in each library
+    instead of globbing + parsing every manifest, so the launch path is O(#
+    libraries) file stats rather than O(# installed games) parses. appid must
+    be all-digits (caller-validated) so the filename can't escape the dir.
+    Read-only, best-effort; never raises.
+    """
+    try:
+        if not (isinstance(appid, str) and appid.isdigit()):
+            return False
+        root = _steam_root()
+        if root is None:
+            return False
+        for steamapps in _steam_libraries_cached(root):
+            mf = os.path.join(steamapps, "appmanifest_%s.acf" % appid)
+            try:
+                if not os.path.isfile(mf):
+                    continue
+                with open(mf, "r", encoding="utf-8", errors="replace") as f:
+                    fields = _parse_acf(f.read())
+            except OSError:
+                continue
+            except Exception:
+                continue
+            mid = fields.get("appid")
+            name = fields.get("name")
+            if mid != appid or not name:
+                continue
+            if _is_steam_tool(appid, name):
+                continue
+            return True
+        return False
+    except Exception:
+        return False
+
+
 def _parse_acf(text, keys=("appid", "name")):
     """Extract simple quoted top-level keys from an appmanifest .acf blob.
 
@@ -1197,7 +1260,7 @@ def discover_steam_games():
         if root is None:
             return []
         games = {}  # appid(str) -> name
-        for steamapps in _steam_libraries(root):
+        for steamapps in _steam_libraries_cached(root):
             try:
                 manifests = glob.glob(os.path.join(steamapps, "appmanifest_*.acf"))
             except Exception:
@@ -1268,7 +1331,7 @@ def steam_downloads():
             return []
         keys = ("appid", "name", "StateFlags", "BytesToDownload", "BytesDownloaded")
         found = {}  # appid(str) -> dict
-        for steamapps in _steam_libraries(root):
+        for steamapps in _steam_libraries_cached(root):
             try:
                 manifests = glob.glob(os.path.join(steamapps, "appmanifest_*.acf"))
             except Exception:
@@ -1374,11 +1437,12 @@ def _launcher_argv(launcher_id):
         appid = launcher_id[len("steam:"):]
         if not appid.isdigit():
             return None
-        # Only launch a Steam game we actually discovered (matches the listed
-        # launchers); an unknown/uninstalled appid is not a launcher.
-        for game in discover_steam_games():
-            if game["id"] == launcher_id:
-                return ["steam", "steam://rungameid/%s" % appid]
+        # Only launch a Steam game we actually have installed (matches the
+        # listed launchers); an unknown/uninstalled appid is not a launcher.
+        # Validate the SPECIFIC appmanifest_<appid>.acf rather than globbing +
+        # parsing every manifest on each launch.
+        if _steam_game_installed(appid):
+            return ["steam", "steam://rungameid/%s" % appid]
         return None
     if _valid_launcher_id(launcher_id):
         for l in LAUNCHERS:
@@ -1478,87 +1542,100 @@ def _new_launcher_id(label, existing_ids):
     return candidate
 
 
-def _write_config_launchers(new_launchers):
+def _write_config_launchers_locked(new_launchers):
     """Persist LAUNCHERS = new_launchers to CONFIG_PATH atomically.
+
+    CONFIG_LOCK MUST already be held by the caller — this is the body of the
+    read-modify-write and callers (add_launcher/delete_launcher) hold the lock
+    across their cap-check + build + this write so a concurrent writer can't
+    clobber from a stale LAUNCHERS snapshot.
 
     Reads the current config.json (or starts from a minimal skeleton if it is
     missing/unreadable/malformed), replaces the "launchers" key, and writes it
     back via a temp file + os.replace so a crash never leaves a truncated
-    config that would wedge the Restart=always daemon. Serialized by
-    CONFIG_LOCK. Raises on I/O failure (the caller maps it to a 500).
+    config that would wedge the Restart=always daemon. Raises on I/O failure
+    (the caller maps it to a 500).
     """
-    with CONFIG_LOCK:
+    raw = None
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except (OSError, ValueError):
         raw = None
+    if not isinstance(raw, dict):
+        # No usable config on disk: build a minimal one that still round-
+        # trips through _parse_config (units/actions are required there).
+        raw = {
+            "units": [{"name": name, "scope": scope}
+                      for name, scope in WATCHLIST],
+            "actions": {
+                aid: {"danger": spec["danger"], "cmd": list(spec["cmd"]),
+                      "label": spec["label"],
+                      "description": spec["description"],
+                      "user_env": spec["user_env"],
+                      "detached": spec["detached"]}
+                for aid, spec in ACTIONS.items()
+            },
+        }
+    raw["launchers"] = [
+        {"id": l["id"], "label": l["label"], "cmd": list(l["cmd"])}
+        for l in new_launchers
+    ]
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(raw, f, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, CONFIG_PATH)
+    except Exception:
         try:
-            with open(CONFIG_PATH, "r", encoding="utf-8") as f:
-                raw = json.load(f)
-        except (OSError, ValueError):
-            raw = None
-        if not isinstance(raw, dict):
-            # No usable config on disk: build a minimal one that still round-
-            # trips through _parse_config (units/actions are required there).
-            raw = {
-                "units": [{"name": name, "scope": scope}
-                          for name, scope in WATCHLIST],
-                "actions": {
-                    aid: {"danger": spec["danger"], "cmd": list(spec["cmd"]),
-                          "label": spec["label"],
-                          "description": spec["description"],
-                          "user_env": spec["user_env"],
-                          "detached": spec["detached"]}
-                    for aid, spec in ACTIONS.items()
-                },
-            }
-        raw["launchers"] = [
-            {"id": l["id"], "label": l["label"], "cmd": list(l["cmd"])}
-            for l in new_launchers
-        ]
-        directory = os.path.dirname(CONFIG_PATH) or "."
-        fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(raw, f, indent=2)
-                f.write("\n")
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, CONFIG_PATH)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
-        # Only mutate the in-memory list once the write succeeded.
-        global LAUNCHERS
-        LAUNCHERS = new_launchers
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    # Only mutate the in-memory list once the write succeeded.
+    global LAUNCHERS
+    LAUNCHERS = new_launchers
 
 
 def add_launcher(label, cmd):
     """Validate + persist a new custom launcher; return its Launcher dict.
 
     Raises ConfigError on invalid input (mapped to HTTP 400 by the caller).
+
+    The whole read-modify-write (cap-check, id-derivation from the current set,
+    build, persist) runs under CONFIG_LOCK so two concurrent adds can't both
+    snapshot the same LAUNCHERS and clobber each other's write.
     """
     if not isinstance(label, str) or not label.strip() or len(label) > MAX_LABEL_LEN:
         raise ConfigError("label must be a non-empty string")
     if not _valid_cmd(cmd):
         raise ConfigError("cmd must be a non-empty list of non-empty strings")
-    if len(LAUNCHERS) >= MAX_LAUNCHERS:
-        raise ConfigError("too many launchers (max %d)" % MAX_LAUNCHERS)
     label = label.strip()
-    existing = {l["id"] for l in LAUNCHERS}
-    lid = _new_launcher_id(label, existing)
-    new = list(LAUNCHERS) + [{"id": lid, "label": label, "cmd": list(cmd)}]
-    _write_config_launchers(new)
+    with CONFIG_LOCK:
+        if len(LAUNCHERS) >= MAX_LAUNCHERS:
+            raise ConfigError("too many launchers (max %d)" % MAX_LAUNCHERS)
+        existing = {l["id"] for l in LAUNCHERS}
+        lid = _new_launcher_id(label, existing)
+        new = list(LAUNCHERS) + [{"id": lid, "label": label, "cmd": list(cmd)}]
+        _write_config_launchers_locked(new)
     return {"id": lid, "label": label, "kind": "custom"}
 
 
 def delete_launcher(launcher_id):
     """Remove a custom launcher by id; persist. Returns True, or False if the
-    id is a valid custom id that isn't present. Raises on persist failure."""
-    if not any(l["id"] == launcher_id for l in LAUNCHERS):
-        return False
-    new = [l for l in LAUNCHERS if l["id"] != launcher_id]
-    _write_config_launchers(new)
+    id is a valid custom id that isn't present. Raises on persist failure.
+
+    Presence-check + build + persist run under CONFIG_LOCK together so a
+    concurrent add/delete can't clobber from a stale LAUNCHERS snapshot."""
+    with CONFIG_LOCK:
+        if not any(l["id"] == launcher_id for l in LAUNCHERS):
+            return False
+        new = [l for l in LAUNCHERS if l["id"] != launcher_id]
+        _write_config_launchers_locked(new)
     return True
 
 
@@ -4276,6 +4353,17 @@ class Handler(BaseHTTPRequestHandler):
     server_version = APP_NAME + "/" + VERSION
     protocol_version = "HTTP/1.1"
 
+    # Per-connection socket read timeout. socketserver's setup() applies this
+    # via connection.settimeout(), so a stalled or idle keep-alive client can't
+    # pin a worker thread forever (a timed-out read raises and the thread ends).
+    timeout = 30
+
+    # Hard cap on a request body we will read into memory. Enforced BEFORE any
+    # body read (see _read_body) so an unauthenticated LAN client can't force a
+    # huge allocation via a large Content-Length. 8 MiB comfortably covers the
+    # only bodies this agent accepts (tiny launcher/volume/power JSON).
+    MAX_BODY_BYTES = 8 * 1024 * 1024
+
     # set by main()
     token = ""
     token_file = None   # path to re-read the current token for /pair
@@ -4584,11 +4672,27 @@ class Handler(BaseHTTPRequestHandler):
         self._send_bytes(200, body, "image/jpeg", started,
                          extra_headers={"Cache-Control": "public, max-age=604800"})
 
+    def _body_too_large(self):
+        """True iff the declared Content-Length exceeds MAX_BODY_BYTES.
+
+        Checked from the header alone, BEFORE any read, so a huge declared body
+        is rejected without allocating for it. Callers that hit this must reply
+        413 and close the connection (the body is never drained)."""
+        try:
+            n = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            return False
+        return n > self.MAX_BODY_BYTES
+
     def _read_body(self):
         """Read and return the request body bytes (always drains it).
 
         Draining is mandatory: on an HTTP/1.1 keep-alive connection any leftover
-        body bytes would be parsed as the next request line and desync it.
+        body bytes would be parsed as the next request line and desync it. The
+        size is capped at MAX_BODY_BYTES; callers must gate on _body_too_large()
+        first so an oversize body is rejected before we ever read it. A
+        Content-Length above the cap that slips through here is clamped and the
+        connection marked for close, so we still never allocate unbounded.
         """
         try:
             n = int(self.headers.get("Content-Length") or 0)
@@ -4596,24 +4700,43 @@ class Handler(BaseHTTPRequestHandler):
             n = 0
         if n <= 0:
             return b""
+        if n > self.MAX_BODY_BYTES:
+            # Defensive: normal paths gate on _body_too_large() before reading.
+            self.close_connection = True
+            n = self.MAX_BODY_BYTES
         return self.rfile.read(n)
 
     def do_POST(self):
         started = time.monotonic()
-        # Always drain the body first (see _read_body), even on the paths that
-        # ignore it, so keep-alive connections never desync.
-        body = self._read_body()
         try:
             parsed = urlparse(self.path)
             path = parsed.path.rstrip("/")
 
             if not path.startswith("/api/"):
+                # Unknown route: authorize-agnostic 404, but drain the body so a
+                # keep-alive connection doesn't desync (unless it's oversize).
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                self._read_body()
                 self._send(404, {"error": "not found"}, started)
                 return
 
+            # Authorize BEFORE reading the body: an unauthenticated client must
+            # not be able to make us allocate for its body. Reject + close so the
+            # undrained body can't desync a keep-alive connection.
             if not self._authorized():
+                self.close_connection = True
                 self._send(401, {"error": "unauthorized"}, started)
                 return
+
+            # Authorized: now enforce the size cap, then read the body.
+            if self._body_too_large():
+                self.close_connection = True
+                self._send(413, {"error": "request body too large"}, started)
+                return
+            body = self._read_body()
 
             prefix = "/api/actions/"
             if path.startswith(prefix):
@@ -4822,20 +4945,32 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_DELETE(self):
         started = time.monotonic()
-        # Drain any body for keep-alive safety (DELETE bodies are unusual but
-        # a client may send Content-Length: 0 or a stray body).
-        self._read_body()
         try:
             parsed = urlparse(self.path)
             path = parsed.path.rstrip("/")
 
             if not path.startswith("/api/"):
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                self._read_body()  # drain for keep-alive safety
                 self._send(404, {"error": "not found"}, started)
                 return
 
+            # Authorize BEFORE reading the body (see do_POST).
             if not self._authorized():
+                self.close_connection = True
                 self._send(401, {"error": "unauthorized"}, started)
                 return
+
+            # DELETE bodies are unusual but a client may send one; cap + drain it
+            # for keep-alive safety now that we've authorized.
+            if self._body_too_large():
+                self.close_connection = True
+                self._send(413, {"error": "request body too large"}, started)
+                return
+            self._read_body()
 
             lprefix = "/api/launchers/"
             if path.startswith(lprefix):

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -1694,13 +1694,29 @@ if IS_WINDOWS:
         except Exception:
             pass
 
-    def read_box_muted():
-        """Current default-render-endpoint mute (True/False), or None."""
+    # CoInitializeEx return values that mean THIS call took ownership and the
+    # thread must balance with CoUninitialize: S_OK (0) and S_FALSE (1, already
+    # inited in the SAME mode). RPC_E_CHANGED_MODE means another init on this
+    # thread owns COM in a different mode — do NOT uninit then.
+    _RPC_E_CHANGED_MODE = 0x80010106
+
+    def _with_endpoint_volume(fn):
+        """Acquire the default-render-endpoint IAudioEndpointVolume, invoke
+        fn(volume_ptr_value), and tear everything down: releases every COM
+        object AND balances CoInitializeEx with CoUninitialize (the missing
+        CoUninitialize was leaking a COM apartment refcount on every /api/tv
+        poll). Returns fn's result, or None on any failure. Never raises."""
         enumerator = ctypes.c_void_p()
         device = ctypes.c_void_p()
         volume = ctypes.c_void_p()
+        need_uninit = False
         try:
-            _ole32.CoInitializeEx(None, 0)  # COINIT_MULTITHREADED
+            hr = _ole32.CoInitializeEx(None, 0)  # COINIT_MULTITHREADED
+            # Uninit only when we actually initialized (S_OK/S_FALSE), never on
+            # RPC_E_CHANGED_MODE or any hard failure.
+            need_uninit = hr in (0, 1)
+            if hr not in (0, 1) and hr != _RPC_E_CHANGED_MODE:
+                return None
             clsid = _GUID.from_str(_CLSID_MMDeviceEnumerator)
             iid_enum = _GUID.from_str(_IID_IMMDeviceEnumerator)
             hr = _ole32.CoCreateInstance(
@@ -1724,23 +1740,69 @@ if IS_WINDOWS:
                           ctypes.byref(volume))
             if hr != 0 or not volume:
                 return None
-            # IAudioEndpointVolume::GetMute (slot 15)
-            muted = ctypes.c_int(0)
-            get_mute = _com_method(volume.value, 15,
-                                   ctypes.POINTER(ctypes.c_int))
-            hr = get_mute(ctypes.byref(muted))
-            if hr != 0:
-                return None
-            return bool(muted.value)
+            return fn(volume.value)
         except Exception:
             return None
         finally:
             for obj in (volume, device, enumerator):
                 if obj:
                     _com_release(obj.value)
+            if need_uninit:
+                try:
+                    _ole32.CoUninitialize()
+                except Exception:
+                    pass
+
+    def read_box_muted():
+        """Current default-render-endpoint mute (True/False), or None."""
+        def _get(vol):
+            # IAudioEndpointVolume::GetMute (slot 15)
+            muted = ctypes.c_int(0)
+            get_mute = _com_method(vol, 15, ctypes.POINTER(ctypes.c_int))
+            if get_mute(ctypes.byref(muted)) != 0:
+                return None
+            return bool(muted.value)
+        return _with_endpoint_volume(_get)
+
+    def read_box_volume():
+        """Current default-render-endpoint scalar volume as a float 0.0-1.0,
+        or None. Uses IAudioEndpointVolume::GetMasterVolumeLevelScalar
+        (vtable slot 9): the same 0..1 taper the Windows volume slider uses,
+        so it lines up with the app's percentage."""
+        def _get(vol):
+            level = ctypes.c_float(0.0)
+            get_scalar = _com_method(vol, 9, ctypes.POINTER(ctypes.c_float))
+            if get_scalar(ctypes.byref(level)) != 0:
+                return None
+            return max(0.0, min(1.0, float(level.value)))
+        return _with_endpoint_volume(_get)
+
+    def set_box_volume_scalar(level01):
+        """Set the endpoint scalar volume to level01 (0.0-1.0) via
+        IAudioEndpointVolume::SetMasterVolumeLevelScalar (vtable slot 7).
+        Returns True on success. A positive level also clears mute (slot 14
+        SetMute) so the change is audible, matching the Linux soft_set_volume
+        unmute-on-raise behaviour."""
+        lvl = max(0.0, min(1.0, float(level01)))
+        def _set(vol):
+            set_scalar = _com_method(vol, 7, ctypes.c_float, ctypes.c_void_p)
+            if set_scalar(ctypes.c_float(lvl), None) != 0:
+                return False
+            if lvl > 0.0:
+                # SetMute(FALSE, NULL) — best-effort; ignore its hr.
+                set_mute = _com_method(vol, 14, ctypes.c_int, ctypes.c_void_p)
+                set_mute(0, None)
+            return True
+        return bool(_with_endpoint_volume(_set))
 else:
     def read_box_muted():
         return None
+
+    def read_box_volume():
+        return None
+
+    def set_box_volume_scalar(level01):
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -1993,6 +2055,38 @@ def mock_soft(op):
             "stderr": "", "duration_ms": 100}
 
 
+def _soft_volume_pct():
+    """Box volume as an integer 0-100, or None if unreadable. Reads the same
+    Core Audio endpoint that backs the mute state, so the app's slider and the
+    volume rocker agree."""
+    v = read_box_volume()
+    if v is None:
+        return None
+    return max(0, min(100, int(round(v * 100))))
+
+
+def soft_set_volume(level):
+    """Set the box volume to <level> percent (0-100) directly on the Core Audio
+    endpoint (SetMasterVolumeLevelScalar). Unlike the Linux agent, Windows has
+    no gamescope OSD to satisfy, and SetMasterVolumeLevelScalar is exactly what
+    the volume slider drives, so a single scalar write both changes the level
+    and shows nothing surprising. ActionResult-shaped, plus a "level" field so
+    the app's slider can snap to the real value."""
+    start = time.monotonic()
+    level = max(0, min(100, int(level)))
+
+    def result(ok, cur, note):
+        return {"ok": ok, "exit_code": 0 if ok else -1,
+                "stdout": note if ok else "", "stderr": "" if ok else note,
+                "level": cur,
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+
+    if not set_box_volume_scalar(level / 100.0):
+        return result(False, _soft_volume_pct(), "box volume set failed")
+    cur = _soft_volume_pct()
+    return result(True, level if cur is None else cur, "level %d" % level)
+
+
 # ---- unified dispatch --------------------------------------------------------
 
 
@@ -2087,6 +2181,11 @@ def tv_info():
         "tv_volume": hw is not None,
         "tv_power": hw is not None,
         "muted": read_box_muted() if box_vol else None,
+        # Current levels (0-100 or null) so the app's slider shows and keeps a
+        # real position. Box level is the Core Audio scalar; the Windows panel
+        # backend has no volume read-back, so tv_volume_level stays null.
+        "box_volume_level": _soft_volume_pct() if box_vol else None,
+        "tv_volume_level": None,
     }
 
 
@@ -2115,6 +2214,904 @@ def tv_send(op, mock, target=None):
     if soft_available():
         return mock_soft(op) if mock else real_soft(op)
     return None
+
+
+# ---------------------------------------------------------------------------
+# Now-playing + transport via Windows System Media Transport Controls (SMTC)
+#
+# The Windows analog of the Linux agent's MPRIS control. Two halves, each
+# best-effort and fully wrapped so failure degrades to 404/unavailable and
+# never touches an existing endpoint:
+#   * metadata  — the current SMTC session (title/artist/album/status/timeline)
+#                 read through WinRT's GlobalSystemMediaTransportControlsSession-
+#                 Manager, driven from a short PowerShell script (no pip WinRT
+#                 dep; stdlib only). Read-only.
+#   * transport — the OS media keys via SendInput (VK_MEDIA_*), exactly like a
+#                 keyboard's play/next/prev buttons. These are GLOBAL (the shell
+#                 routes them to the active session), so there is one synthetic
+#                 player id ("system") rather than a per-app address.
+#
+# NEEDS ON-WINDOWS TESTING: the PowerShell WinRT bridge (async GetAwaiter /
+# thumbnail stream) is written to the documented API but unverified on a real
+# box. All of it is wrapped; on any failure smtc_info() returns an available
+# session list that may be empty, and the app simply shows nothing.
+# ---------------------------------------------------------------------------
+
+VK_MEDIA_NEXT_TRACK = 0xB0
+VK_MEDIA_PREV_TRACK = 0xB1
+VK_MEDIA_STOP = 0xB2
+VK_MEDIA_PLAY_PAUSE = 0xB3
+
+# Transport op -> media-key VK. play/pause/play_pause all fold onto the single
+# hardware PLAY_PAUSE toggle (media keys expose no distinct play vs pause), so
+# the app's play and pause buttons both toggle — matching a real remote.
+SMTC_KEY_OPS = {
+    "play": VK_MEDIA_PLAY_PAUSE,
+    "pause": VK_MEDIA_PLAY_PAUSE,
+    "play_pause": VK_MEDIA_PLAY_PAUSE,
+    "next": VK_MEDIA_NEXT_TRACK,
+    "previous": VK_MEDIA_PREV_TRACK,
+    "stop": VK_MEDIA_STOP,
+}
+# Contract parity with MPRIS_OPS: the app may offer a seek control, but media
+# keys can't seek, so "seek" is accepted as a known op and reported unsupported.
+SMTC_OPS = tuple(SMTC_KEY_OPS) + ("seek",)
+
+# The single synthetic player id. SMTC transport is global, so there is no real
+# per-app addressing; the app just needs a stable id to POST ops against.
+SMTC_PLAYER_ID = "system"
+
+SMTC_ART_MAX = 2 * 1024 * 1024  # 2 MiB read cap on album art (MPRIS parity)
+SMTC_TIMEOUT = 6
+
+# Cache the last metadata read briefly so a poll of /api/media plus the app's
+# art fetch don't each spawn PowerShell; art resolution reuses the cached key.
+_SMTC_LOCK = threading.Lock()
+_SMTC_CACHE = {"at": 0.0, "val": None}
+_SMTC_TTL = 1.0
+
+# PowerShell that prints ONE line of JSON describing the current SMTC session,
+# or "null". Kept inert on failure (any throw -> the outer runner returns None).
+_SMTC_PS = r"""
+$ErrorActionPreference = 'Stop'
+function Await($t, $rt) {
+  $m = [System.WindowsRuntimeSystemExtensions].GetMethods() |
+    Where-Object { $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and $_.IsGenericMethod } |
+    Select-Object -First 1
+  $g = $m.MakeGenericMethod($rt)
+  $task = $g.Invoke($null, @($t))
+  $task.Wait(-1) | Out-Null
+  return $task.Result
+}
+try {
+  [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager, Windows.Media.Control, ContentType=WindowsRuntime] | Out-Null
+  [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManagerRequestedEventArgs, Windows.Media.Control, ContentType=WindowsRuntime] | Out-Null
+  $mgrType = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager]
+  $mgr = Await ($mgrType::RequestAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager])
+  $s = $mgr.GetCurrentSession()
+  if ($null -eq $s) { 'null'; exit 0 }
+  $props = Await ($s.TryGetMediaPropertiesAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties])
+  $pb = $s.GetPlaybackInfo()
+  $tl = $s.GetTimelineProperties()
+  $status = [int]$pb.PlaybackStatus
+  $hasArt = $false
+  if ($props.Thumbnail -ne $null) { $hasArt = $true }
+  $o = [ordered]@{
+    id       = [string]$s.SourceAppUserModelId
+    title    = [string]$props.Title
+    artist   = [string]$props.Artist
+    album    = [string]$props.AlbumTitle
+    status   = $status
+    pos_ms   = [long]$tl.Position.TotalMilliseconds
+    len_ms   = [long]$tl.EndTime.TotalMilliseconds
+    can_next = [bool]$pb.Controls.IsNextEnabled
+    can_prev = [bool]$pb.Controls.IsPreviousEnabled
+    can_play = [bool]$pb.Controls.IsPlayEnabled
+    can_pause= [bool]$pb.Controls.IsPauseEnabled
+    has_art  = $hasArt
+  }
+  ($o | ConvertTo-Json -Compress)
+} catch { 'null' }
+"""
+
+# PowerShell that writes the current SMTC thumbnail to $env:CS_ART_OUT and
+# prints "ok"/"none". Separate from metadata so the (heavier) stream copy runs
+# only when the app actually requests art.
+_SMTC_ART_PS = r"""
+$ErrorActionPreference = 'Stop'
+function Await($t, $rt) {
+  $m = [System.WindowsRuntimeSystemExtensions].GetMethods() |
+    Where-Object { $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and $_.IsGenericMethod } |
+    Select-Object -First 1
+  $g = $m.MakeGenericMethod($rt)
+  $task = $g.Invoke($null, @($t))
+  $task.Wait(-1) | Out-Null
+  return $task.Result
+}
+try {
+  [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager, Windows.Media.Control, ContentType=WindowsRuntime] | Out-Null
+  $mgrType = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager]
+  $mgr = Await ($mgrType::RequestAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager])
+  $s = $mgr.GetCurrentSession()
+  if ($null -eq $s) { 'none'; exit 0 }
+  $props = Await ($s.TryGetMediaPropertiesAsync()) ([Windows.Media.Control.GlobalSystemMediaTransportControlsSessionMediaProperties])
+  if ($props.Thumbnail -eq $null) { 'none'; exit 0 }
+  $stream = Await ($props.Thumbnail.OpenReadAsync()) ([Windows.Storage.Streams.IRandomAccessStreamWithContentType])
+  $size = [int]$stream.Size
+  if ($size -le 0 -or $size -gt 2097152) { 'none'; exit 0 }
+  $reader = [Windows.Storage.Streams.DataReader]::new($stream)
+  Await ($reader.LoadAsync($size)) ([uint32]) | Out-Null
+  $bytes = New-Object byte[] $size
+  $reader.ReadBytes($bytes)
+  [System.IO.File]::WriteAllBytes($env:CS_ART_OUT, $bytes)
+  'ok'
+} catch { 'none' }
+"""
+
+# SMTC PlaybackStatus enum -> the app's status vocabulary (MPRIS parity).
+_SMTC_STATUS = {4: "Playing", 5: "Paused"}
+
+
+def _smtc_str(v):
+    return v if isinstance(v, str) else ""
+
+
+def _smtc_art_key(session):
+    """Stable cache-buster for the current track's art, derived from the track
+    identity (never a path). Changes when the track changes."""
+    basis = "%s|%s|%s" % (session.get("title", ""), session.get("artist", ""),
+                          session.get("album", ""))
+    return hashlib.sha1(basis.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _run_powershell(script, timeout, env=None):
+    """Run a PowerShell script from stdin; return stdout text, or None on any
+    failure. -Command - reads the script from stdin so no temp file / no
+    quoting minefield. Never raises."""
+    try:
+        r = subprocess.run(
+            ["powershell", "-NoProfile", "-NonInteractive",
+             "-ExecutionPolicy", "Bypass", "-Command", "-"],
+            input=script, capture_output=True, text=True, timeout=timeout,
+            creationflags=_RUN_FLAGS, env=env)
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    return r.stdout
+
+
+def _smtc_read():
+    """Current SMTC session as a raw dict (PowerShell JSON), or None. Cached
+    for _SMTC_TTL to keep /api/media polling cheap. Never raises."""
+    if not IS_WINDOWS:
+        return None
+    now = time.monotonic()
+    with _SMTC_LOCK:
+        if _SMTC_CACHE["val"] is not None and now - _SMTC_CACHE["at"] < _SMTC_TTL:
+            return _SMTC_CACHE["val"]
+    out = _run_powershell(_SMTC_PS, SMTC_TIMEOUT)
+    val = None
+    if out:
+        line = out.strip()
+        if line and line.lower() != "null":
+            try:
+                parsed = json.loads(line)
+                if isinstance(parsed, dict):
+                    val = parsed
+            except Exception:
+                val = None
+    with _SMTC_LOCK:
+        _SMTC_CACHE.update(at=time.monotonic(), val=val)
+    return val
+
+
+def _smtc_player_info():
+    """The single SMTC player dict (MPRIS-player-shaped), or None when nothing
+    is playing/paused. Never raises."""
+    session = _smtc_read()
+    if not isinstance(session, dict):
+        return None
+    status = _SMTC_STATUS.get(session.get("status"), "Stopped")
+    def _int(v):
+        try:
+            return max(0, int(v))
+        except (TypeError, ValueError):
+            return 0
+    has_art = bool(session.get("has_art"))
+    return {
+        "id": SMTC_PLAYER_ID,
+        "identity": _smtc_str(session.get("id")) or "Media",
+        "status": status,
+        "title": _smtc_str(session.get("title")),
+        "artist": _smtc_str(session.get("artist")),
+        "album": _smtc_str(session.get("album")),
+        "position_ms": _int(session.get("pos_ms")),
+        "length_ms": _int(session.get("len_ms")),
+        "rate": 1.0,
+        # Media keys can't seek; report no seek so the app hides the scrubber.
+        "can_seek": False,
+        "can_go_next": bool(session.get("can_next")),
+        "can_go_previous": bool(session.get("can_prev")),
+        "can_play": bool(session.get("can_play")),
+        "can_pause": bool(session.get("can_pause")),
+        "art": has_art,
+        "art_key": _smtc_art_key(session) if has_art else "",
+    }
+
+
+def smtc_available():
+    """True when SMTC control is even plausible (Windows). The metadata read is
+    probe-and-appear at /api/media, so this only gates the whole feature off on
+    non-Windows."""
+    return IS_WINDOWS
+
+
+def smtc_info():
+    """{"available":True,"players":[...]} or None when SMTC is unavailable.
+    A live-but-idle box returns an empty players list (matches MPRIS)."""
+    if not smtc_available():
+        return None
+    info = _smtc_player_info()
+    return {"available": True, "players": [info] if info is not None else []}
+
+
+def real_smtc_op(player, op):
+    """Run a transport op by tapping the matching media key. ActionResult-shaped,
+    or None for an unknown player / unsupported op (route 404s). The media key is
+    global, so `player` is validated only against the synthetic id."""
+    if player != SMTC_PLAYER_ID:
+        return None
+    start = time.monotonic()
+    if op == "seek":
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "seek is not supported over media keys",
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+    vk = SMTC_KEY_OPS.get(op)
+    if vk is None:
+        return None
+    try:
+        _send_inputs([_key_input(vk, True), _key_input(vk, False)])
+    except OSError as e:
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "%s: %s" % (e.__class__.__name__, e),
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+    # A key tap invalidates the cached metadata (status likely changed).
+    with _SMTC_LOCK:
+        _SMTC_CACHE.update(at=0.0, val=None)
+    return {"ok": True, "exit_code": 0, "stdout": "sent %s" % op, "stderr": "",
+            "duration_ms": int((time.monotonic() - start) * 1000)}
+
+
+def smtc_art(player, art_key):
+    """Resolve the CURRENT session's thumbnail bytes (the client supplies no
+    path), enforce the 2 MiB cap, and sniff the image type. Returns (data, mime)
+    or None. `art_key` must match the current track's key (else the track
+    changed -> 404). Never raises."""
+    if player != SMTC_PLAYER_ID:
+        return None
+    session = _smtc_read()
+    if not isinstance(session, dict) or not session.get("has_art"):
+        return None
+    if art_key and _smtc_art_key(session) != art_key:
+        return None
+    tmp = None
+    try:
+        fd, tmp = tempfile.mkstemp(prefix="cs-art-", suffix=".img")
+        os.close(fd)
+        env = dict(os.environ)
+        env["CS_ART_OUT"] = tmp
+        out = _run_powershell(_SMTC_ART_PS, SMTC_TIMEOUT, env=env)
+        if not out or out.strip().lower() != "ok":
+            return None
+        if os.path.getsize(tmp) > SMTC_ART_MAX:
+            return None
+        with open(tmp, "rb") as f:
+            data = f.read(SMTC_ART_MAX + 1)
+        if not data or len(data) > SMTC_ART_MAX:
+            return None
+        mime = _sniff_image(data)
+        return (data, mime) if mime else None
+    except Exception:
+        return None
+    finally:
+        if tmp:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass
+
+
+# --- SMTC mock (parity with mock_mpris_*) ------------------------------------
+_MOCK_SMTC_POS = 0
+# 1x1 transparent PNG so --mock album art works off-box.
+_MOCK_ART_PNG = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==")
+
+
+def mock_smtc_info():
+    global _MOCK_SMTC_POS
+    _MOCK_SMTC_POS = (_MOCK_SMTC_POS + 3000) % 214000
+    return {"available": True, "players": [{
+        "id": SMTC_PLAYER_ID, "identity": "Groove", "status": "Playing",
+        "title": "Midnight City", "artist": "M83",
+        "album": "Hurry Up, We're Dreaming",
+        "position_ms": _MOCK_SMTC_POS, "length_ms": 214000, "rate": 1.0,
+        "can_seek": False, "can_go_next": True, "can_go_previous": True,
+        "can_play": True, "can_pause": True, "art": True,
+        "art_key": "mockart1",
+    }]}
+
+
+def mock_smtc_op(player, op):
+    if player != SMTC_PLAYER_ID:
+        return None
+    if op == "seek":
+        return {"ok": False, "exit_code": -1, "stdout": "",
+                "stderr": "seek is not supported over media keys",
+                "duration_ms": 10}
+    if op not in SMTC_KEY_OPS:
+        return None
+    print("[smtc] %s %s" % (player, op), flush=True)
+    return {"ok": True, "exit_code": 0,
+            "stdout": "[mock smtc] %s %s" % (player, op),
+            "stderr": "", "duration_ms": 40}
+
+
+def mock_smtc_art(player, art_key):
+    if player != SMTC_PLAYER_ID:
+        return None
+    return (_MOCK_ART_PNG, "image/png")
+
+
+# --- image magic-byte sniffing (shared by SMTC art + screen frames) ----------
+_ART_MAGIC = (
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def _sniff_image(data):
+    """Magic-byte image type, or None (so a text/HTML file can't be served)."""
+    for magic, mime in _ART_MAGIC:
+        if data.startswith(magic):
+            return mime
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Screen preview: one downscaled JPEG frame per request via GDI BitBlt.
+#
+# The Windows analog of the Linux agent's gamescope/grim capture. Pure ctypes
+# GDI (CreateCompatibleDC/BitBlt/GetDIBits over the virtual screen), downscaled
+# with StretchBlt (HALFTONE), then encoded to JPEG. No PIL: JPEG comes from the
+# built-in Windows Imaging Component (WIC) via a tiny PowerShell one-liner that
+# re-encodes a stdlib-written BMP, keeping this dependency-free. Single-flight +
+# a short cache cap the capture rate exactly like the Linux path.
+#
+# 404 semantics: capture is BLOCKED on the secure desktop (UAC / lock screen)
+# and from a session-0 service; both surface as a BitBlt/GetDIBits failure, and
+# real_screen_frame() returns None so the route replies 503 (transient) while
+# screen_info() still advertises the backend. When capture can never work
+# (non-Windows real mode) screen_info() returns None so /api/screen 404s and the
+# app hides the card entirely.
+#
+# NEEDS ON-WINDOWS TESTING: the GDI structs + the BMP->JPEG WIC re-encode are
+# written to the documented APIs but unverified on a real box.
+# ---------------------------------------------------------------------------
+
+SCREEN_WIDTH = 960                 # downscale target width
+SCREEN_MAX_BYTES = 12 * 1024 * 1024
+SCREEN_MIN_INTERVAL_S = 0.5        # server floor: at most ~2 captures/sec
+SCREEN_CAPTURE_TIMEOUT_S = 8
+SCREEN_LOCK = threading.Lock()     # single-flight: never stack captures
+_SCREEN_CACHE = {"ts": 0.0, "data": None, "mime": None}
+_SCREEN = None                     # capability dict or None; set by set_screen
+
+if IS_WINDOWS:
+    _gdi32 = ctypes.WinDLL("gdi32", use_last_error=True)
+
+    SM_XVIRTUALSCREEN = 76
+    SM_YVIRTUALSCREEN = 77
+    SM_CXVIRTUALSCREEN = 78
+    SM_CYVIRTUALSCREEN = 79
+    SRCCOPY = 0x00CC0020
+    DIB_RGB_COLORS = 0
+    BI_RGB = 0
+    HALFTONE = 4
+
+    class _BITMAPINFOHEADER(ctypes.Structure):
+        _fields_ = [
+            ("biSize", ctypes.c_uint32), ("biWidth", ctypes.c_int32),
+            ("biHeight", ctypes.c_int32), ("biPlanes", ctypes.c_uint16),
+            ("biBitCount", ctypes.c_uint16), ("biCompression", ctypes.c_uint32),
+            ("biSizeImage", ctypes.c_uint32),
+            ("biXPelsPerMeter", ctypes.c_int32),
+            ("biYPelsPerMeter", ctypes.c_int32),
+            ("biClrUsed", ctypes.c_uint32), ("biClrImportant", ctypes.c_uint32),
+        ]
+
+    class _BITMAPINFO(ctypes.Structure):
+        _fields_ = [("bmiHeader", _BITMAPINFOHEADER),
+                    ("bmiColors", ctypes.c_uint32 * 3)]
+
+
+def _bmp_bytes(width, height, bgr_rows_top_down):
+    """Wrap top-down 24-bit BGR scanlines (each padded to a 4-byte boundary) in
+    a BITMAPFILEHEADER+BITMAPINFOHEADER so WIC can re-encode it. Negative height
+    marks the DIB top-down."""
+    row_stride = (width * 3 + 3) & ~3
+    pixel_bytes = row_stride * height
+    # BITMAPFILEHEADER (14) + BITMAPINFOHEADER (40)
+    file_size = 14 + 40 + pixel_bytes
+    fileheader = struct.pack("<2sIHHI", b"BM", file_size, 0, 0, 14 + 40)
+    infoheader = struct.pack("<IiiHHIIiiII", 40, width, -height, 1, 24,
+                             BI_RGB, pixel_bytes, 0, 0, 0, 0)
+    return fileheader + infoheader + bgr_rows_top_down
+
+
+def set_screen(mock):
+    """Probe the capture path (call after load_config). --mock always advertises
+    a stdlib PNG backend. Real Windows advertises the GDI backend unconditionally
+    (whether a given frame succeeds is decided per-request); non-Windows real
+    mode has no capture path."""
+    global _SCREEN
+    if mock:
+        _SCREEN = {"session": "mock", "backends": ["mock"]}
+    elif IS_WINDOWS:
+        _SCREEN = {"session": "desktop", "backends": ["gdi"]}
+    else:
+        _SCREEN = None
+
+
+def screen_info():
+    """{available, session, backends, formats} or None when no capture path."""
+    if _SCREEN is None:
+        return None
+    return {"available": True, "session": _SCREEN["session"],
+            "backends": _SCREEN["backends"], "formats": ["image/jpeg"]}
+
+
+def _capture_bmp():
+    """Grab the whole virtual screen, downscale to SCREEN_WIDTH via StretchBlt,
+    and return (bmp_bytes, w, h) or None on any failure (secure desktop, no
+    session). Never raises. Pure GDI: no third-party capture lib."""
+    if not IS_WINDOWS:
+        return None
+    src_dc = mem_dc = dst_dc = None
+    src_bmp = dst_bmp = None
+    try:
+        _user32.GetSystemMetrics.restype = ctypes.c_int
+        vx = _user32.GetSystemMetrics(SM_XVIRTUALSCREEN)
+        vy = _user32.GetSystemMetrics(SM_YVIRTUALSCREEN)
+        vw = _user32.GetSystemMetrics(SM_CXVIRTUALSCREEN)
+        vh = _user32.GetSystemMetrics(SM_CYVIRTUALSCREEN)
+        if vw <= 0 or vh <= 0:
+            return None
+        # Downscale target: cap width at SCREEN_WIDTH, keep aspect (never upsize).
+        if vw > SCREEN_WIDTH:
+            dw = SCREEN_WIDTH
+            dh = max(1, int(round(vh * (SCREEN_WIDTH / float(vw)))))
+        else:
+            dw, dh = vw, vh
+
+        _user32.GetDC.restype = ctypes.c_void_p
+        _user32.GetDC.argtypes = [ctypes.c_void_p]
+        src_dc = _user32.GetDC(None)
+        if not src_dc:
+            return None
+        _gdi32.CreateCompatibleDC.restype = ctypes.c_void_p
+        _gdi32.CreateCompatibleDC.argtypes = [ctypes.c_void_p]
+        _gdi32.CreateCompatibleBitmap.restype = ctypes.c_void_p
+        _gdi32.CreateCompatibleBitmap.argtypes = [ctypes.c_void_p,
+                                                  ctypes.c_int, ctypes.c_int]
+        mem_dc = _gdi32.CreateCompatibleDC(src_dc)
+        dst_dc = _gdi32.CreateCompatibleDC(src_dc)
+        if not mem_dc or not dst_dc:
+            return None
+        src_bmp = _gdi32.CreateCompatibleBitmap(src_dc, vw, vh)
+        dst_bmp = _gdi32.CreateCompatibleBitmap(src_dc, dw, dh)
+        if not src_bmp or not dst_bmp:
+            return None
+        _gdi32.SelectObject.restype = ctypes.c_void_p
+        _gdi32.SelectObject.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        _gdi32.SelectObject(mem_dc, src_bmp)
+        _gdi32.SelectObject(dst_dc, dst_bmp)
+        _gdi32.BitBlt.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_int,
+                                  ctypes.c_int, ctypes.c_int, ctypes.c_void_p,
+                                  ctypes.c_int, ctypes.c_int, ctypes.c_uint32]
+        if not _gdi32.BitBlt(mem_dc, 0, 0, vw, vh, src_dc, vx, vy, SRCCOPY):
+            return None
+        _gdi32.SetStretchBltMode.argtypes = [ctypes.c_void_p, ctypes.c_int]
+        _gdi32.SetStretchBltMode(dst_dc, HALFTONE)
+        _gdi32.StretchBlt.argtypes = [
+            ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+            ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_int,
+            ctypes.c_int, ctypes.c_int, ctypes.c_uint32]
+        if not _gdi32.StretchBlt(dst_dc, 0, 0, dw, dh, mem_dc, 0, 0, vw, vh,
+                                 SRCCOPY):
+            return None
+        # Pull the downscaled bitmap out as top-down 24-bit BGR.
+        bmi = _BITMAPINFO()
+        bmi.bmiHeader.biSize = ctypes.sizeof(_BITMAPINFOHEADER)
+        bmi.bmiHeader.biWidth = dw
+        bmi.bmiHeader.biHeight = -dh   # negative => top-down
+        bmi.bmiHeader.biPlanes = 1
+        bmi.bmiHeader.biBitCount = 24
+        bmi.bmiHeader.biCompression = BI_RGB
+        row_stride = (dw * 3 + 3) & ~3
+        buf = ctypes.create_string_buffer(row_stride * dh)
+        _gdi32.GetDIBits.argtypes = [
+            ctypes.c_void_p, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint32,
+            ctypes.c_void_p, ctypes.POINTER(_BITMAPINFO), ctypes.c_uint32]
+        scanned = _gdi32.GetDIBits(dst_dc, dst_bmp, 0, dh, buf,
+                                   ctypes.byref(bmi), DIB_RGB_COLORS)
+        if scanned == 0:
+            return None
+        return (_bmp_bytes(dw, dh, buf.raw), dw, dh)
+    except Exception:
+        return None
+    finally:
+        try:
+            if src_bmp:
+                _gdi32.DeleteObject.argtypes = [ctypes.c_void_p]
+                _gdi32.DeleteObject(src_bmp)
+            if dst_bmp:
+                _gdi32.DeleteObject(dst_bmp)
+            if mem_dc:
+                _gdi32.DeleteDC.argtypes = [ctypes.c_void_p]
+                _gdi32.DeleteDC(mem_dc)
+            if dst_dc:
+                _gdi32.DeleteDC(dst_dc)
+            if src_dc:
+                _user32.ReleaseDC.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+                _user32.ReleaseDC(None, src_dc)
+        except Exception:
+            pass
+
+
+# PowerShell that re-encodes a BMP ($env:CS_BMP_IN) to a JPEG
+# ($env:CS_JPG_OUT) using the built-in System.Drawing codec (WIC). Prints
+# "ok"/"err". Keeps JPEG encoding dependency-free (no PIL).
+_SCREEN_JPEG_PS = r"""
+$ErrorActionPreference = 'Stop'
+try {
+  Add-Type -AssemblyName System.Drawing
+  $img = [System.Drawing.Image]::FromFile($env:CS_BMP_IN)
+  try { $img.Save($env:CS_JPG_OUT, [System.Drawing.Imaging.ImageFormat]::Jpeg) }
+  finally { $img.Dispose() }
+  'ok'
+} catch { 'err' }
+"""
+
+
+def _bmp_to_jpeg(bmp):
+    """Re-encode BMP bytes to JPEG via the Windows System.Drawing codec. Returns
+    JPEG bytes or None. Never raises."""
+    bmp_path = jpg_path = None
+    try:
+        fd, bmp_path = tempfile.mkstemp(prefix="cs-scr-", suffix=".bmp")
+        with os.fdopen(fd, "wb") as f:
+            f.write(bmp)
+        fd, jpg_path = tempfile.mkstemp(prefix="cs-scr-", suffix=".jpg")
+        os.close(fd)
+        env = dict(os.environ)
+        env["CS_BMP_IN"] = bmp_path
+        env["CS_JPG_OUT"] = jpg_path
+        out = _run_powershell(_SCREEN_JPEG_PS, SCREEN_CAPTURE_TIMEOUT_S, env=env)
+        if not out or out.strip().lower() != "ok":
+            return None
+        with open(jpg_path, "rb") as f:
+            data = f.read(SCREEN_MAX_BYTES + 1)
+        if not data or len(data) > SCREEN_MAX_BYTES:
+            return None
+        return data if _sniff_image(data) == "image/jpeg" else None
+    except Exception:
+        return None
+    finally:
+        for p in (bmp_path, jpg_path):
+            if p:
+                try:
+                    os.remove(p)
+                except OSError:
+                    pass
+
+
+def real_screen_frame():
+    """One fresh JPEG frame as (data, "image/jpeg"), or None when capture is
+    blocked/failing (secure desktop, session-0). Single-flight + short cache so
+    concurrent clients share one capture (matches the Linux path). Never raises."""
+    if _SCREEN is None:
+        return None
+    now = time.monotonic()
+    if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
+        return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+    if not SCREEN_LOCK.acquire(blocking=False):
+        # Another capture is in flight; serve the last frame if we have one.
+        if _SCREEN_CACHE["data"] is not None:
+            return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+        SCREEN_LOCK.acquire()
+    try:
+        now = time.monotonic()
+        if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
+            return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
+        cap = _capture_bmp()
+        if cap is None:
+            return None
+        bmp, _w, _h = cap
+        data = _bmp_to_jpeg(bmp)
+        if not data:
+            return None
+        _SCREEN_CACHE.update(ts=time.monotonic(), data=data, mime="image/jpeg")
+        return (data, "image/jpeg")
+    finally:
+        SCREEN_LOCK.release()
+
+
+_MOCK_SCREEN_N = 0
+
+
+def _encode_png(w, h, rows):
+    """Encode 8-bit RGBA scanlines (each `bytes` of length w*4) to PNG bytes.
+    Pure zlib + struct, no PIL (mirrors the Linux agent)."""
+    import zlib
+
+    def _chunk(tag, data):
+        body = tag + data
+        return (struct.pack(">I", len(data)) + body
+                + struct.pack(">I", zlib.crc32(body) & 0xffffffff))
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)  # RGBA, no interlace
+    raw = b"".join(b"\x00" + r for r in rows)  # per-scanline filter byte 0
+    return (b"\x89PNG\r\n\x1a\n" + _chunk(b"IHDR", ihdr)
+            + _chunk(b"IDAT", zlib.compress(raw, 6)) + _chunk(b"IEND", b""))
+
+
+def mock_screen_frame():
+    """--mock: a small stdlib PNG with a moving band, so the app's preview works
+    off-box."""
+    global _MOCK_SCREEN_N
+    _MOCK_SCREEN_N += 1
+    w, h = 320, 180
+    band = (_MOCK_SCREEN_N * 12) % w
+    rows = []
+    for y in range(h):
+        row = bytearray()
+        for x in range(w):
+            r = 220 if abs(x - band) <= 6 else 30
+            row += bytes((r, (255 * y) // h, (255 * x) // w, 255))
+        rows.append(bytes(row))
+    return (_encode_png(w, h, rows), "image/png")
+
+
+# ---------------------------------------------------------------------------
+# Sleep timer + scheduled wake (/api/power/schedule|sleep|wake).
+#
+# The Windows analog of the Linux agent's threading.Timer suspend + RTC alarm.
+#   * sleep — an in-process one-shot threading.Timer firing the existing
+#             suspend/poweroff action; deliberately volatile (a restart clears
+#             it; the app detects that by polling). Identical to Linux.
+#   * wake  — a scheduled wake set with SetWaitableTimer(fResume=TRUE) on a
+#             DEDICATED daemon thread that blocks in WaitForSingleObject until
+#             the timer fires (the OS then resumes the machine from sleep). This
+#             mirrors the Linux RTC alarm's "survives the suspend" contract as
+#             closely as a user-mode agent can: the timer object lives as long
+#             as the agent process, so the wake holds across a suspend but NOT
+#             across an agent restart/reboot (documented; the app polls state).
+#
+# A waitable timer only resumes the box if the platform allows wake timers
+# (powercfg) and the agent process stays alive across the suspend — true for the
+# logon-triggered task the agent runs under. NEEDS ON-WINDOWS TESTING.
+# ---------------------------------------------------------------------------
+
+SLEEP_MIN_S, SLEEP_MAX_S = 60, 8 * 3600
+WAKE_MIN_S, WAKE_MAX_S = 120, 86100
+SLEEP_ACTIONS = ("suspend", "poweroff")
+
+POWER_MOCK = False          # set by set_power_schedule(mock)
+SLEEP_LOCK = threading.Lock()
+_SLEEP = {"timer": None, "action": None, "fire_at": 0.0}
+
+WAKE_LOCK = threading.Lock()
+# {"handle": HANDLE, "thread": Thread, "fire_at": epoch, "cancel": Event} or None
+_WAKE = None
+_MOCK_WAKE = {"fire_at": 0}
+
+
+def set_power_schedule(mock):
+    global POWER_MOCK
+    POWER_MOCK = mock
+
+
+def sleep_can_arm(action):
+    """(ok, error). The action must be a known sleep action present in ACTIONS.
+    Unlike Linux there is no sudoers gate (an interactive Windows user may
+    suspend/shutdown unprivileged), so presence in ACTIONS is sufficient."""
+    if action not in SLEEP_ACTIONS:
+        return (False, "unknown action")
+    if POWER_MOCK:
+        return (True, None)
+    if ACTIONS.get(action) is None:
+        return (False, "%s unavailable" % action)
+    return (True, None)
+
+
+def _sleep_info_locked():
+    if _SLEEP["timer"] is None:
+        return None
+    return {"action": _SLEEP["action"], "fire_at": int(_SLEEP["fire_at"]),
+            "remaining_s": max(0, int(_SLEEP["fire_at"] - time.time()))}
+
+
+def _sleep_cancel_locked():
+    if _SLEEP["timer"] is not None:
+        _SLEEP["timer"].cancel()
+    _SLEEP.update(timer=None, action=None, fire_at=0.0)
+
+
+def sleep_arm(delay_s, action):
+    """Arm a one-shot suspend/poweroff after delay_s, replacing any prior arm."""
+    with SLEEP_LOCK:
+        _sleep_cancel_locked()
+        fire_at = time.time() + delay_s
+
+        def _fire():
+            with SLEEP_LOCK:
+                if _SLEEP["timer"] is not timer:  # cancelled or superseded
+                    return
+                _SLEEP.update(timer=None, action=None, fire_at=0.0)
+            r = mock_action(action) if POWER_MOCK else real_action(action)
+            print("[sleep] fired %s: ok=%s" % (action, r.get("ok")), flush=True)
+
+        timer = threading.Timer(delay_s, _fire)
+        timer.daemon = True
+        _SLEEP.update(timer=timer, action=action, fire_at=fire_at)
+        timer.start()
+        return _sleep_info_locked()
+
+
+def sleep_cancel():
+    with SLEEP_LOCK:
+        _sleep_cancel_locked()
+
+
+def sleep_info():
+    with SLEEP_LOCK:
+        return _sleep_info_locked()
+
+
+def wake_available():
+    """True when a scheduled wake can be armed: --mock, or a real Windows box
+    (waitable timers are always present; whether the platform actually resumes
+    is a powercfg/BIOS concern the app surfaces to the user)."""
+    return POWER_MOCK or IS_WINDOWS
+
+
+if IS_WINDOWS:
+    # SetWaitableTimer / CreateWaitableTimerW signatures.
+    _kernel32.CreateWaitableTimerW.restype = ctypes.c_void_p
+    _kernel32.CreateWaitableTimerW.argtypes = [ctypes.c_void_p, ctypes.c_int,
+                                               ctypes.c_wchar_p]
+    _kernel32.SetWaitableTimer.argtypes = [
+        ctypes.c_void_p, ctypes.POINTER(ctypes.c_int64), ctypes.c_long,
+        ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int]
+    _kernel32.WaitForSingleObject.argtypes = [ctypes.c_void_p, ctypes.c_uint32]
+    _kernel32.WaitForSingleObject.restype = ctypes.c_uint32
+
+
+def _wake_clear_locked():
+    global _WAKE
+    if _WAKE is not None:
+        _WAKE["cancel"].set()
+        if IS_WINDOWS and _WAKE.get("handle"):
+            try:
+                # CancelWaitableTimer then CloseHandle so the waiter unblocks.
+                _kernel32.CancelWaitableTimer(ctypes.c_void_p(_WAKE["handle"]))
+                _kernel32.CloseHandle(ctypes.c_void_p(_WAKE["handle"]))
+            except Exception:
+                pass
+        _WAKE = None
+
+
+def wake_set(at_epoch):
+    """Arm a resume-from-sleep at wall-time at_epoch via SetWaitableTimer with
+    fResume=TRUE, replacing any prior wake. Returns True on success. A dedicated
+    daemon thread blocks on the timer so the object stays referenced until it
+    fires or is cancelled."""
+    global _WAKE
+    if POWER_MOCK:
+        with WAKE_LOCK:
+            _MOCK_WAKE["fire_at"] = int(at_epoch)
+        print("[wake] mock alarm at %d" % int(at_epoch), flush=True)
+        return True
+    if not IS_WINDOWS:
+        return False
+    with WAKE_LOCK:
+        _wake_clear_locked()
+        try:
+            handle = _kernel32.CreateWaitableTimerW(None, 1, None)  # manual reset
+            if not handle:
+                return False
+            # Negative 100ns relative time, or a positive absolute FILETIME. Use
+            # an ABSOLUTE due-time so clock skew between now and fire is exact:
+            # FILETIME epoch is 1601-01-01; 116444736000000000 100ns ticks to
+            # the Unix epoch.
+            due_ft = int((at_epoch + 11644473600) * 10000000)
+            due = ctypes.c_int64(due_ft)
+            # fResume=TRUE (last arg) => wake the system from sleep when it fires.
+            ok = _kernel32.SetWaitableTimer(
+                ctypes.c_void_p(handle), ctypes.byref(due), 0, None, None, 1)
+            if not ok:
+                _kernel32.CloseHandle(ctypes.c_void_p(handle))
+                return False
+        except Exception:
+            return False
+
+        cancel = threading.Event()
+
+        def _waiter(h=handle, ev=cancel, fire_at=int(at_epoch)):
+            # Block until the timer fires (resuming the box) or we're cancelled.
+            try:
+                _kernel32.WaitForSingleObject(ctypes.c_void_p(h), 0xFFFFFFFF)
+            except Exception:
+                pass
+            if not ev.is_set():
+                print("[wake] fired at %d" % fire_at, flush=True)
+            with WAKE_LOCK:
+                global _WAKE
+                if _WAKE is not None and _WAKE.get("handle") == h:
+                    try:
+                        _kernel32.CloseHandle(ctypes.c_void_p(h))
+                    except Exception:
+                        pass
+                    _WAKE = None
+
+        t = threading.Thread(target=_waiter, daemon=True, name="wake-timer")
+        _WAKE = {"handle": handle, "thread": t, "fire_at": int(at_epoch),
+                 "cancel": cancel}
+        t.start()
+        return True
+
+
+def wake_clear():
+    """Cancel the scheduled wake (idempotent)."""
+    if POWER_MOCK:
+        with WAKE_LOCK:
+            _MOCK_WAKE["fire_at"] = 0
+        return True
+    with WAKE_LOCK:
+        _wake_clear_locked()
+    return True
+
+
+def wake_info():
+    """Current scheduled wake as {fire_at, remaining_s} (wall time) or None."""
+    if POWER_MOCK:
+        fa = _MOCK_WAKE["fire_at"]
+        if fa and fa > time.time():
+            return {"fire_at": int(fa), "remaining_s": int(fa - time.time())}
+        return None
+    with WAKE_LOCK:
+        if _WAKE is None:
+            return None
+        fa = _WAKE["fire_at"]
+    if fa and fa > time.time():
+        return {"fire_at": int(fa), "remaining_s": int(fa - time.time())}
+    return None
+
+
+def power_schedule_info():
+    """The /api/power/schedule payload (matches the Linux shape)."""
+    return {
+        "sleep": sleep_info(),
+        "wake": wake_info(),
+        "wake_available": wake_available(),
+        "limits": {"sleep_min_s": SLEEP_MIN_S, "sleep_max_s": SLEEP_MAX_S,
+                   "wake_min_s": WAKE_MIN_S, "wake_max_s": WAKE_MAX_S},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -2782,10 +3779,22 @@ class Handler(BaseHTTPRequestHandler):
             self.wfile.write(body)
         self._log(code, started)
 
+    # Chatty routes whose success (2xx) is sampled so a ~1-2 fps poll can't
+    # scroll real diagnostics out of the journal's window. Errors and the first
+    # hit of a burst still log.
+    _SAMPLED_PATHS = ("/api/screen/frame",)
+    _sample_last = {}  # path -> monotonic time of last logged success
+    _SAMPLE_EVERY_S = 15
+
     def _log(self, code, started):
         dur_ms = int((time.monotonic() - started) * 1000)
         # Never log query strings: /ws/gamepad carries ?token=<secret>.
         path = self.path.split("?", 1)[0]
+        if path in self._SAMPLED_PATHS and code < 400:
+            now = time.monotonic()
+            if now - Handler._sample_last.get(path, 0) < self._SAMPLE_EVERY_S:
+                return  # suppress this frame; a recent one already logged
+            Handler._sample_last[path] = now
         if "?" in self.path:
             path += "?<redacted>"
         print("%s %s %s %d %dms" % (
@@ -2809,6 +3818,29 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         if body:
             self.wfile.write(body)
+        self._log(code, started)
+
+    def _send_bytes(self, code, data, content_type, started,
+                    cache_control=None, extra_headers=None):
+        """Write a raw binary body (album art, screen frames) with an EXACT
+        Content-Length (keep-alive safety under HTTP/1.1) and the same CORS
+        headers as _send."""
+        self.send_response(code)
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers",
+                         "Authorization, Content-Type")
+        self.send_header("Access-Control-Allow-Methods",
+                         "GET, POST, DELETE, OPTIONS")
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        if cache_control:
+            self.send_header("Cache-Control", cache_control)
+        if extra_headers:
+            for k, v in extra_headers.items():
+                self.send_header(k, v)
+        self.end_headers()
+        if data:
+            self.wfile.write(data)
         self._log(code, started)
 
     def _authorized(self):
@@ -2896,6 +3928,55 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "not found"}, started)
                 else:
                     self._send(200, info, started)
+            elif path == "/api/media":
+                # Probe-and-appear: 404 when SMTC is unavailable so the app
+                # hides the Now Playing card; 200 with an empty list when idle.
+                info = mock_smtc_info() if self.mock else smtc_info()
+                if info is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, info, started)
+            elif path == "/api/media/art":
+                # Album art bytes for a player's CURRENT track. The client passes
+                # only player id + art_key (a cache-buster) — never a path.
+                q = parse_qs(parsed.query)
+                player = (q.get("player") or [""])[0]
+                key = (q.get("k") or [""])[0]
+                art = None
+                if player:
+                    art = (mock_smtc_art(player, key) if self.mock
+                           else smtc_art(player, key))
+                if art is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    data, mime = art
+                    self._send_bytes(200, data, mime, started,
+                                     cache_control="private, max-age=3600")
+            elif path == "/api/screen":
+                # Probe-and-appear: 404 when no capture path so the app hides the
+                # preview card; a body describes the session + backends.
+                info = ({"available": True, "session": "mock",
+                         "backends": ["mock"], "formats": ["image/png"]}
+                        if self.mock else screen_info())
+                if info is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, info, started)
+            elif path == "/api/screen/frame":
+                # One fresh frame. Single-flight + short cache cap captures
+                # server-side; no-store so frames (may show passwords) are never
+                # cached. High-frequency, so _log samples it.
+                frame = mock_screen_frame() if self.mock else real_screen_frame()
+                if frame is None:
+                    self._send(503, {"error": "capture failed"}, started)
+                else:
+                    data, mime = frame
+                    self._send_bytes(200, data, mime, started,
+                                     cache_control="no-store")
+            elif path == "/api/power/schedule":
+                # Always 200: reports the (volatile) sleep timer + the scheduled
+                # wake. Old agents 404 -> the app hides the rows.
+                self._send(200, power_schedule_info(), started)
             else:
                 self._send(404, {"error": "not found"}, started)
         except BrokenPipeError:
@@ -2959,6 +4040,108 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(200, result, started)
                 return
 
+            # POST /api/tv/volume: absolute volume {"level": 0-100, "target":
+            # "box"|"tv"}. Box converges on the Core Audio endpoint scalar; the
+            # Windows panel has no absolute-set/read frame, so target "tv" 404s
+            # (no backend). Checked before the generic /api/tv/<op> route.
+            if path == "/api/tv/volume":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                    lvl = int(req.get("level"))
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "level must be an integer"},
+                               started)
+                    return
+                if not 0 <= lvl <= 100:
+                    self._send(400, {"error": "level must be 0-100"}, started)
+                    return
+                tgt = req.get("target") or "box"
+                if tgt == "tv":
+                    # No Windows TV backend can set an absolute level.
+                    self._send(404, {"error": "no tv volume backend"}, started)
+                    return
+                if not soft_available():
+                    self._send(404, {"error": "no box volume backend"}, started)
+                    return
+                result = ({"ok": True, "exit_code": 0, "level": lvl,
+                           "stdout": "[mock] box volume %d" % lvl,
+                           "stderr": "", "duration_ms": 100}
+                          if self.mock else soft_set_volume(lvl))
+                self._send(200, result, started)
+                return
+
+            # POST /api/media/<player>/<op>: SMTC transport. Checked before the
+            # generic /api/tv/ route (both live under /api/, distinct prefixes).
+            mprefix = "/api/media/"
+            if path.startswith(mprefix):
+                rest = path[len(mprefix):]
+                parts = rest.rsplit("/", 1)
+                if len(parts) != 2 or not parts[0] or not parts[1]:
+                    self._send(404, {"error": "not found"}, started)
+                    return
+                player, op = unquote(parts[0]), parts[1]
+                if op not in SMTC_OPS:
+                    self._send(404, {"error": "unknown media op"}, started)
+                    return
+                result = (mock_smtc_op(player, op) if self.mock
+                          else real_smtc_op(player, op))
+                if result is None:
+                    self._send(404, {"error": "unknown player"}, started)
+                    return
+                self._send(200, result, started)
+                return
+
+            # POST /api/power/sleep: arm a delayed suspend/poweroff.
+            if path == "/api/power/sleep":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError
+                    delay_s = int(req.get("delay_s"))
+                    action = req.get("action")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400,
+                               {"error": "delay_s (int) and action required"},
+                               started)
+                    return
+                if not SLEEP_MIN_S <= delay_s <= SLEEP_MAX_S:
+                    self._send(400, {"error": "delay_s out of range"}, started)
+                    return
+                ok, err = sleep_can_arm(action)
+                if not ok:
+                    self._send(400, {"error": err}, started)
+                    return
+                self._send(200, {"sleep": sleep_arm(delay_s, action)}, started)
+                return
+
+            # POST /api/power/wake: set a scheduled wake to an absolute time.
+            if path == "/api/power/wake":
+                if not wake_available():
+                    self._send(409, {"error": "no wake backend"}, started)
+                    return
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    at = int(req.get("at"))
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "at (epoch seconds) required"},
+                               started)
+                    return
+                now = time.time()
+                if not now + WAKE_MIN_S <= at <= now + WAKE_MAX_S:
+                    self._send(400, {"error": "at must be %d-%ds out"
+                                     % (WAKE_MIN_S, WAKE_MAX_S)}, started)
+                    return
+                if not wake_set(at):
+                    # 503 not 500: the platform/driver refusing the wake timer is
+                    # a transient/unsupported-backend condition, not an agent bug
+                    # (matches the capture-failed convention elsewhere).
+                    self._send(503, {"error": "wake set failed"}, started)
+                    return
+                self._send(200, {"wake": wake_info()}, started)
+                return
+
             tprefix = "/api/tv/"
             if path.startswith(tprefix):
                 op = path[len(tprefix):]
@@ -3010,6 +4193,17 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "unknown launcher"}, started)
                     return
                 self._send(200, {"ok": True}, started)
+                return
+
+            # DELETE /api/power/sleep: cancel the armed sleep timer (idempotent).
+            if path == "/api/power/sleep":
+                sleep_cancel()
+                self._send(200, {"sleep": None}, started)
+                return
+            # DELETE /api/power/wake: clear the scheduled wake (idempotent).
+            if path == "/api/power/wake":
+                wake_clear()
+                self._send(200, {"wake": None}, started)
                 return
 
             self._send(404, {"error": "not found"}, started)
@@ -3343,6 +4537,8 @@ def main():
     load_config(args.config)
     _inject_steam_action(args.mock)
     set_tv(args.mock)
+    set_screen(args.mock)
+    set_power_schedule(args.mock)
     if IS_WINDOWS and not args.mock:
         start_load_sampler()
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)

--- a/install.sh
+++ b/install.sh
@@ -98,6 +98,135 @@ ask_yn() {
     [[ "$reply" == [yY]* ]]
 }
 
+deregister_steam_shortcut() {
+    # Remove the "Couchside — Pair Phone" tile from every Steam account's
+    # shortcuts.vdf (symmetric with register_steam_shortcut, used on --uninstall).
+    # If a pristine .couchside-bak backup exists, restore it verbatim; otherwise
+    # surgically drop our entry and reserialize. Steam only reads shortcuts.vdf at
+    # startup and rewrites it on exit, so edits while Steam runs are lost — note
+    # that and continue (best-effort, never fatal).
+    local steamroot=""
+    for d in "$HOME/.local/share/Steam" "$HOME/.steam/steam" \
+             "$HOME/.var/app/com.valvesoftware.Steam/data/Steam"; do
+        [ -d "$d/userdata" ] && { steamroot="$(cd "$d" && pwd -P)"; break; }
+    done
+    if [ -z "$steamroot" ]; then
+        return 0
+    fi
+    if pgrep -x steam >/dev/null 2>&1; then
+        note "Steam is running; it rewrites shortcuts.vdf on exit. Close Steam and"
+        note "re-run --uninstall if the 'Couchside — Pair Phone' tile lingers."
+    fi
+
+    STEAMROOT="$steamroot" python3 - <<'PYVDF'
+# Remove our non-Steam shortcut from shortcuts.vdf (binary VDF, pure stdlib).
+# Prefer restoring the pristine .couchside-bak; else drop our entry in place.
+import os, struct
+
+APPNAME = "Couchside — Pair Phone"
+STEAMROOT = os.environ["STEAMROOT"]
+
+
+def parse_map(buf, pos):
+    out = {}
+    while True:
+        t = buf[pos]; pos += 1
+        if t == 0x08:
+            return out, pos
+        end = buf.index(b"\x00", pos)
+        key = buf[pos:end].decode("utf-8", "replace"); pos = end + 1
+        if t == 0x00:
+            val, pos = parse_map(buf, pos)
+        elif t == 0x01:
+            end = buf.index(b"\x00", pos)
+            val = buf[pos:end].decode("utf-8", "replace"); pos = end + 1
+        elif t == 0x02:
+            val = struct.unpack_from("<i", buf, pos)[0]; pos += 4
+        else:
+            raise ValueError("unknown VDF field type 0x%02x" % t)
+        out[key] = val
+
+
+def ser_map(m):
+    out = bytearray()
+    for k, v in m.items():
+        kb = k.encode("utf-8")
+        if isinstance(v, dict):
+            out += b"\x00" + kb + b"\x00" + ser_map(v)
+        elif isinstance(v, int):
+            out += b"\x02" + kb + b"\x00" + struct.pack("<i", v)
+        else:
+            out += b"\x01" + kb + b"\x00" + str(v).encode("utf-8") + b"\x00"
+    out += b"\x08"
+    return bytes(out)
+
+
+def is_ours(entry):
+    if not isinstance(entry, dict):
+        return False
+    name = entry.get("AppName", entry.get("appname", ""))
+    return isinstance(name, str) and name.strip().lower() == APPNAME.strip().lower()
+
+
+udir = os.path.join(STEAMROOT, "userdata")
+if not os.path.isdir(udir):
+    raise SystemExit(0)
+for acct in sorted(os.listdir(udir)):
+    if not acct.isdigit() or acct == "0":
+        continue
+    cfg = os.path.join(udir, acct, "config")
+    path = os.path.join(cfg, "shortcuts.vdf")
+    bak = path + ".couchside-bak"
+    if not os.path.exists(path):
+        continue
+    # Surgically remove ONLY our entry and reserialize. Do NOT restore the
+    # pristine .couchside-bak verbatim as the preferred path: Steam rewrites
+    # shortcuts.vdf on exit, so the backup lacks any non-Steam tiles the user
+    # added AFTER install — restoring it would silently wipe them. The backup is
+    # kept only as a last-resort fallback when the live file can't be parsed.
+    with open(path, "rb") as f:
+        buf = f.read()
+    root = None
+    try:
+        root, _ = parse_map(buf, 0)
+    except Exception as e:
+        print("    ! %s: could not parse (%s)" % (path, e))
+    # Edit in place only if we parsed it AND can reproduce it byte-for-byte.
+    if root is not None and isinstance(root.get("shortcuts"), dict) and ser_map(root) == buf:
+        shortcuts = root["shortcuts"]
+        ours = [k for k, v in shortcuts.items() if is_ours(v)]
+        if ours:
+            for k in ours:
+                del shortcuts[k]
+            # Renumber remaining entries to keep the 0..N-1 index Steam expects.
+            kept = [shortcuts[k] for k in sorted(shortcuts, key=lambda x: int(x)
+                                                 if x.isdigit() else 1 << 30)]
+            root["shortcuts"] = {str(i): v for i, v in enumerate(kept)}
+            tmp = path + ".couchside-tmp"
+            with open(tmp, "wb") as f:
+                f.write(ser_map(root))
+            os.replace(tmp, path)
+            print("    - account %s: removed the Couchside tile" % acct)
+    elif os.path.exists(bak):
+        # Live file unparseable/unreproducible: fall back to the pristine backup.
+        tmp = path + ".couchside-tmp"
+        with open(bak, "rb") as bf, open(tmp, "wb") as tf:
+            tf.write(bf.read())
+        os.replace(tmp, path)
+        print("    = account %s: unparseable live file; restored pre-Couchside backup" % acct)
+    else:
+        print("    ! %s: could not edit and no backup, leaving it alone" % path)
+        continue
+    # The pristine backup has served its purpose; drop it so a later reinstall
+    # re-captures a fresh one.
+    if os.path.exists(bak):
+        try:
+            os.remove(bak)
+        except OSError:
+            pass
+PYVDF
+}
+
 # ---------------------------------------------------------------------------
 # (a) Preflight checks
 # ---------------------------------------------------------------------------
@@ -134,6 +263,9 @@ if [ "$UNINSTALL" -eq 1 ]; then
     note "removed $INSTALL_DIR (incl. the couchside-pair launcher script)"
     rm -f "$PAIR_DESKTOP"
     note "removed $PAIR_DESKTOP"
+    # Symmetric with install: pull the "Couchside — Pair Phone" tile out of every
+    # Steam account's shortcuts.vdf so uninstall doesn't leave a dead tile.
+    deregister_steam_shortcut || note "couldn't clean the Steam tile (skipping)"
     sudo rm -f /etc/systemd/network/50-couchside-wol.link
     note "removed the Wake-on-LAN .link file"
     sudo rm -f /etc/udev/rules.d/99-couchside-uinput.rules \
@@ -193,7 +325,19 @@ else
     # Optional: don't abort the install if only the QR helper fails to fetch.
     curl -fsSL "$QR_URL" -o "$WORK_DIR/qr.py" 2>/dev/null || true
 fi
+# Integrity / sanity gate (FAIL CLOSED): never install code we just fetched
+# without first checking it parses. py_compile catches a truncated download or an
+# HTML error page served in place of the .py, so a half-written daemon can't be
+# installed and left crash-looping. This is a SANITY gate, not authentication.
+# TODO (stronger follow-up): pin DAEMON_URL/UNIT_URL to a tagged release and
+# verify a published SHA256SUMS (curl the sums + `sha256sum -c`) so a
+# compromised or MITM'd raw.githubusercontent.com response is rejected too.
 python3 -m py_compile "$WORK_DIR/couchsided.py" || die "downloaded couchsided.py does not compile, aborting."
+# The unit is not Python; sanity-check it's a non-empty [Service] file so a
+# failed/HTML fetch can't be installed as the systemd unit.
+if ! grep -q '^\[Service\]' "$WORK_DIR/couchside.service" 2>/dev/null; then
+    die "downloaded couchside.service is missing/invalid (no [Service] section), aborting."
+fi
 
 # ---------------------------------------------------------------------------
 # (c) Install the daemon to ~/.local/opt/couchside
@@ -327,7 +471,11 @@ $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl suspend
-$USER_NAME ALL=(root) NOPASSWD: /usr/bin/journalctl *
+# Constrain to the exact call the daemon makes: real_journal() runs
+# journalctl -u <unit> -n <n> --no-pager -o short-iso via sudo. Requiring the
+# leading -u blocks a bare journalctl --file=/... or --directory=/... that a
+# trailing bare wildcard would have allowed (arbitrary-file read as root).
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/journalctl -u *
 SUDOERS
     echo "------------------------------------------------------------------"
     cat "$WORK_DIR/couchside-sudoers"
@@ -419,7 +567,16 @@ fi
 # (g) systemd unit
 # ---------------------------------------------------------------------------
 say "Installing systemd unit $UNIT_DST"
-sed -e "s|__USER__|$USER_NAME|g" -e "s|__UID__|$USER_UID|g" \
+# Inject the RESOLVED daemon path (never a hardcoded /home): $HOME may be
+# /var/home on Bazzite/ostree, a systemd-homed image, or an LDAP path, so a
+# literal /home/$USER ExecStart would silently never start there. Substitute the
+# __EXEC__ placeholder (current template) AND rewrite the old hardcoded
+# /home/__USER__/.local/opt/couchside/couchsided.py path so a raw-fetched older
+# unit is healed the same way.
+DAEMON_PATH="$INSTALL_DIR/couchsided.py"
+sed -e "s|/home/__USER__/.local/opt/couchside/couchsided.py|__EXEC__|g" \
+    -e "s|__EXEC__|$DAEMON_PATH|g" \
+    -e "s|__USER__|$USER_NAME|g" -e "s|__UID__|$USER_UID|g" \
     "$WORK_DIR/couchside.service" > "$WORK_DIR/couchside.service.rendered"
 sudo install -m 0644 -o root -g root "$WORK_DIR/couchside.service.rendered" "$UNIT_DST"
 sudo systemctl daemon-reload
@@ -750,9 +907,23 @@ done
 # (j) Verify + pairing info
 # ---------------------------------------------------------------------------
 say "Verifying: http://127.0.0.1:${PORT}/api/ping"
-sleep 2
-curl -fsS "http://127.0.0.1:${PORT}/api/ping"
-echo
+# Soft retry with backoff: a slow-binding agent must NOT trip `set -e` and abort
+# the script BEFORE we print the pairing token/QR below. Poll a few times, then
+# degrade to a warning — the token/QR still print so pairing isn't blocked.
+ping_ok=0
+for attempt in 1 2 3 4 5 6; do
+    if curl -fsS "http://127.0.0.1:${PORT}/api/ping" 2>/dev/null; then
+        ping_ok=1
+        echo
+        break
+    fi
+    sleep "$attempt"   # 1s,2s,3s,... ~21s total before giving up
+done
+if [ "$ping_ok" -ne 1 ]; then
+    note "agent not answering on :${PORT} yet. It may still be starting; check"
+    note "'systemctl status couchside.service' and 'journalctl -u couchside'."
+    note "Your pairing token/QR are below and remain valid once it comes up."
+fi
 
 TOKEN="$(cat "$TOKEN_FILE")"
 # Resolve the hostname WITHOUT the `hostname` command. SteamOS doesn't ship it.


### PR DESCRIPTION
Implements the verified non-app improvement audit (all outside app/). Compile/lint clean; adversarially reviewed — 2 regressions found + fixed pre-commit (uninstall wiping other Steam tiles; 500→503 on Windows wake).

**Linux agent:** auth-before-body-read + 8MiB cap (anti-OOM), socket timeout, steam appid cache, CONFIG_LOCK across launcher writes.
**Windows agent:** absolute volume + level, CoUninitialize leak fix, memoized sc qdescription, and parity ports /api/media (SMTC), /api/screen (GDI→JPEG), /api/power/sleep+wake — all wrapped (404/503). ⚠️ The 3 large ports are compile+mock verified only; need EMERY-PC testing. No machine-identifying info.
**Installer:** portable systemd unit path (fixes silent no-start on Bazzite/ostree /var/home), verify retry loop, tighter journalctl sudoers, py_compile fetched agent, safe symmetric uninstall.
**CI:** new ci.yml — compile gate + agent boot/authed-endpoint smoke test (the guardrail that'd have caught the Pad-tab regression).

Follow-up (non-blocking): journalctl sudoers still injection-leaky by nature; a fixed-arg wrapper would be airtight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)