### PR TITLE
security: audit fixes (CORS, DoS caps, Windows body cap, SHA256SUMS)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4470,11 +4470,9 @@ class Handler(BaseHTTPRequestHandler):
     def _send(self, code, payload, started, extra_headers=None):
         body = b"" if payload is None else json.dumps(payload).encode("utf-8")
         self.send_response(code)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers",
-                         "Authorization, Content-Type")
-        self.send_header("Access-Control-Allow-Methods",
-                         "GET, POST, DELETE, OPTIONS")
+        # No CORS: this is a LAN service for the native app + WS, neither of
+        # which need it; sending ACAO:* let a malicious browser tab read
+        # responses cross-origin.
         if payload is not None:
             self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -4490,13 +4488,11 @@ class Handler(BaseHTTPRequestHandler):
                     cache_control=None, extra_headers=None):
         """Write a raw binary body (image bytes: Steam covers, album art, later
         screen frames) with an EXACT Content-Length (keep-alive safety under
-        protocol_version HTTP/1.1) and the same CORS headers as _send."""
+        protocol_version HTTP/1.1)."""
         self.send_response(code)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers",
-                         "Authorization, Content-Type")
-        self.send_header("Access-Control-Allow-Methods",
-                         "GET, POST, DELETE, OPTIONS")
+        # No CORS: this is a LAN service for the native app + WS, neither of
+        # which need it; sending ACAO:* let a malicious browser tab read
+        # responses cross-origin.
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(data)))
         if cache_control:
@@ -5306,6 +5302,41 @@ class Handler(BaseHTTPRequestHandler):
         return True
 
 
+class BoundedThreadingHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer with a hard cap on concurrent connections so a
+    connection flood cannot exhaust threads/FDs. A non-blocking semaphore is
+    acquired before the worker thread is spawned; over the cap the socket is
+    closed and the connection rejected. Released when the request finishes.
+
+    Note: the long-lived /ws/gamepad connection holds a slot for the entire
+    Pad session, so the cap must comfortably exceed a household's phones.
+    """
+    _MAX_CONNECTIONS = 128
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._conn_sem = threading.BoundedSemaphore(self._MAX_CONNECTIONS)
+
+    def process_request(self, request, client_address):
+        if not self._conn_sem.acquire(blocking=False):
+            # Over the concurrency cap: reject rather than pile up threads.
+            try:
+                self.shutdown_request(request)
+            except Exception:
+                pass
+            return
+        super().process_request(request, client_address)
+
+    def process_request_thread(self, request, client_address):
+        try:
+            super().process_request_thread(request, client_address)
+        finally:
+            try:
+                self._conn_sem.release()
+            except ValueError:
+                pass
+
+
 def load_token(args):
     if args.token:
         return args.token
@@ -5353,7 +5384,7 @@ def main():
     Handler.port = port
     Handler.mock = args.mock
 
-    server = ThreadingHTTPServer((args.host, port), Handler)
+    server = BoundedThreadingHTTPServer((args.host, port), Handler)
     server.daemon_threads = True
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -3725,6 +3725,12 @@ class Handler(BaseHTTPRequestHandler):
     server_version = APP_NAME + "/" + VERSION
     protocol_version = "HTTP/1.1"
 
+    # Hard cap on a request body we will read into memory. Enforced BEFORE any
+    # body read (see _read_body) so an unauthenticated LAN client can't force a
+    # huge allocation via a large Content-Length. 8 MiB comfortably covers the
+    # only bodies this agent accepts (tiny launcher/volume/power JSON).
+    MAX_BODY_BYTES = 8 * 1024 * 1024
+
     # set by main()
     token = ""
     token_file = None   # path to re-read the current token for /pair
@@ -3804,11 +3810,9 @@ class Handler(BaseHTTPRequestHandler):
     def _send(self, code, payload, started, extra_headers=None):
         body = b"" if payload is None else json.dumps(payload).encode("utf-8")
         self.send_response(code)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers",
-                         "Authorization, Content-Type")
-        self.send_header("Access-Control-Allow-Methods",
-                         "GET, POST, DELETE, OPTIONS")
+        # No CORS: this is a LAN service for the native app + WS, neither of
+        # which need it; sending ACAO:* let a malicious browser tab read
+        # responses cross-origin.
         if payload is not None:
             self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(body)))
@@ -3823,14 +3827,11 @@ class Handler(BaseHTTPRequestHandler):
     def _send_bytes(self, code, data, content_type, started,
                     cache_control=None, extra_headers=None):
         """Write a raw binary body (album art, screen frames) with an EXACT
-        Content-Length (keep-alive safety under HTTP/1.1) and the same CORS
-        headers as _send."""
+        Content-Length (keep-alive safety under HTTP/1.1)."""
         self.send_response(code)
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Headers",
-                         "Authorization, Content-Type")
-        self.send_header("Access-Control-Allow-Methods",
-                         "GET, POST, DELETE, OPTIONS")
+        # No CORS: this is a LAN service for the native app + WS, neither of
+        # which need it; sending ACAO:* let a malicious browser tab read
+        # responses cross-origin.
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(data)))
         if cache_control:
@@ -3987,31 +3988,70 @@ class Handler(BaseHTTPRequestHandler):
             except Exception:
                 pass
 
+    def _body_too_large(self):
+        """True iff the declared Content-Length exceeds MAX_BODY_BYTES.
+
+        Checked from the header alone, BEFORE any read, so a huge declared body
+        is rejected without allocating for it. Callers that hit this must reply
+        413 and close the connection (the body is never drained)."""
+        try:
+            n = int(self.headers.get("Content-Length") or 0)
+        except ValueError:
+            return False
+        return n > self.MAX_BODY_BYTES
+
     def _read_body(self):
         """Read and return the request body bytes (always drains it, so
-        keep-alive connections never desync)."""
+        keep-alive connections never desync).
+
+        The size is capped at MAX_BODY_BYTES; callers must gate on
+        _body_too_large() first so an oversize body is rejected before we ever
+        read it. A Content-Length above the cap that slips through here is
+        clamped and the connection marked for close, so we never allocate
+        unbounded."""
         try:
             n = int(self.headers.get("Content-Length") or 0)
         except ValueError:
             n = 0
         if n <= 0:
             return b""
+        if n > self.MAX_BODY_BYTES:
+            # Defensive: normal paths gate on _body_too_large() before reading.
+            self.close_connection = True
+            n = self.MAX_BODY_BYTES
         return self.rfile.read(n)
 
     def do_POST(self):
         started = time.monotonic()
-        body = self._read_body()
         try:
             parsed = urlparse(self.path)
             path = parsed.path.rstrip("/")
 
             if not path.startswith("/api/"):
+                # Unknown route: authorize-agnostic 404, but drain the body so a
+                # keep-alive connection doesn't desync (unless it's oversize).
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                self._read_body()
                 self._send(404, {"error": "not found"}, started)
                 return
 
+            # Authorize BEFORE reading the body: an unauthenticated client must
+            # not be able to make us allocate for its body. Reject + close so the
+            # undrained body can't desync a keep-alive connection.
             if not self._authorized():
+                self.close_connection = True
                 self._send(401, {"error": "unauthorized"}, started)
                 return
+
+            # Authorized: now enforce the size cap, then read the body.
+            if self._body_too_large():
+                self.close_connection = True
+                self._send(413, {"error": "request body too large"}, started)
+                return
+            body = self._read_body()
 
             prefix = "/api/actions/"
             if path.startswith(prefix):
@@ -4167,18 +4207,32 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_DELETE(self):
         started = time.monotonic()
-        self._read_body()
         try:
             parsed = urlparse(self.path)
             path = parsed.path.rstrip("/")
 
             if not path.startswith("/api/"):
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                self._read_body()  # drain for keep-alive safety
                 self._send(404, {"error": "not found"}, started)
                 return
 
+            # Authorize BEFORE reading the body (see do_POST).
             if not self._authorized():
+                self.close_connection = True
                 self._send(401, {"error": "unauthorized"}, started)
                 return
+
+            # DELETE bodies are unusual but a client may send one; cap + drain it
+            # for keep-alive safety now that we've authorized.
+            if self._body_too_large():
+                self.close_connection = True
+                self._send(413, {"error": "request body too large"}, started)
+                return
+            self._read_body()
 
             lprefix = "/api/launchers/"
             if path.startswith(lprefix):

--- a/install.sh
+++ b/install.sh
@@ -24,6 +24,13 @@ QR_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/qr.py"
 # Built Decky Loader plugin, shipped as a tarball because the compiled frontend
 # (dist/) isn't checked into git, so raw source wouldn't give a working panel.
 PLUGIN_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/Couchside.tar.gz"
+# Checksum for the tarball above, published as a sibling asset in the SAME
+# release. Verifying against it guards against a corrupted/truncated download,
+# transport tampering, or a swapped-in Couchside.tar.gz asset. Note: because the
+# sums file comes from the same release, this is integrity, NOT full authenticity
+# — a signing key + branch protection would be needed to prove the release itself
+# wasn't produced maliciously (out of scope here).
+PLUGIN_SUMS_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/SHA256SUMS"
 
 PORT_DEFAULT=8787
 INSTALL_DIR="${HOME}/.local/opt/couchside"
@@ -895,7 +902,43 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
     decky_tmp="$(mktemp -d)"
     # Decky's plugin dir is root-owned (same as a store install), so place the
     # files with sudo and let plugin_loader load them on restart.
-    if curl -fsSL "$PLUGIN_URL" -o "${decky_tmp}/Couchside.tar.gz" \
+    #
+    # Supply-chain integrity gate: fetch SHA256SUMS from the SAME release and
+    # verify Couchside.tar.gz against it before extracting. This catches a
+    # corrupted/truncated download, transport tampering, or a swapped-in tarball
+    # asset. It is NOT full authenticity — the sums file is from the same release,
+    # so proving the release itself is genuine would need branch protection +
+    # release signing (out of scope here). A mismatch or missing checksum aborts
+    # only the panel install (non-fatal: the agent is already installed above).
+    decky_verify_ok() {
+        curl -fsSL "$PLUGIN_URL" -o "${decky_tmp}/Couchside.tar.gz" || {
+            note "couldn't download the panel tarball (skipping)."
+            return 1
+        }
+        curl -fsSL "$PLUGIN_SUMS_URL" -o "${decky_tmp}/SHA256SUMS" || {
+            note "couldn't download SHA256SUMS for the panel; refusing to install unverified (skipping)."
+            return 1
+        }
+        # Verify only our tarball's line. `-c` checks entries whose filename
+        # exists in the cwd, so run it from the temp dir. Prefer sha256sum, fall
+        # back to `shasum -a 256` (present on Bazzite / most distros).
+        (
+            cd "$decky_tmp" || exit 1
+            grep -F ' Couchside.tar.gz' SHA256SUMS > SHA256SUMS.tarball || exit 1
+            if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum -c SHA256SUMS.tarball >/dev/null 2>&1
+            elif command -v shasum >/dev/null 2>&1; then
+                shasum -a 256 -c SHA256SUMS.tarball >/dev/null 2>&1
+            else
+                exit 1
+            fi
+        ) || {
+            note "panel checksum verification FAILED (corrupt/tampered/missing entry); refusing to install (skipping)."
+            return 1
+        }
+        return 0
+    }
+    if decky_verify_ok \
         && sudo rm -rf "$DECKY_PLUGIN_DIR" \
         && sudo tar -xzf "${decky_tmp}/Couchside.tar.gz" -C "$DECKY_PLUGINS"; then
         # Force root ownership: a release archive built in CI can carry the


### PR DESCRIPTION
Fixes from the security audit (all non-app, adversarially reviewed, compile/lint clean). No Critical/High remote-control issues existed; these close the verified DoS/recon/supply-chain gaps.

- **L2 (agent):** remove CORS headers — native app + WS don't use CORS; ACAO:* let a malicious LAN browser tab read responses cross-origin (recon + version fingerprint). JSON fields unchanged.
- **L1 (agent):** cap concurrent connections at 128 (reject+close over cap) — blocks a LAN connection-flood DoS; WS-slot aware.
- **M1 (win agent):** authorize + size-cap the request body BEFORE reading (parity with the Linux agent) — closes a pre-auth memory-exhaustion DoS.
- **H1-B (install.sh):** verify Couchside.tar.gz against a published SHA256SUMS before extracting the root-adjacent Decky panel.

Companion changes in couchside-decky (already pushed): **L3** — resolve the sudo-grant user via DECKY_USER/loginctl and *refuse to guess* (was: first /home user → privesc on multi-user boxes); **H1-A** — the root backend installs the vendored, release-current agent with a no-downgrade check instead of fetching unreviewed code from main; the release now publishes SHA256SUMS.

**Still yours to do (the only full H1 closure):** enable branch protection on `couchside` `main` (require PR review, block force-push) so one commit can't auto-propagate; optionally sign releases (minisign/cosign) for true authenticity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)