### PR TITLE
security: Ed25519 release signature verification (full H1 closure)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,14 @@ PLUGIN_URL="https://github.com/emerytech/couchside-decky/releases/latest/downloa
 # — a signing key + branch protection would be needed to prove the release itself
 # wasn't produced maliciously (out of scope here).
 PLUGIN_SUMS_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/SHA256SUMS"
+PLUGIN_SIG_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/SHA256SUMS.sig"
+# Ed25519 public key for verifying that SHA256SUMS was signed by the maintainer.
+# The matching SECRET key is held OFFLINE (never in CI), so a compromised
+# repo/CI/account cannot forge a signature. This half is public — safe to embed.
+# Signed with: openssl pkeyutl -sign -rawin (see scripts/sign-release.sh).
+RELEASE_PUBKEY_PEM='-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEA+9aBnheHC7N3J9JNfkP2PoBf89SCkBxmqlZ/2lrcwGA=
+-----END PUBLIC KEY-----'
 
 PORT_DEFAULT=8787
 INSTALL_DIR="${HOME}/.local/opt/couchside"
@@ -903,13 +911,14 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
     # Decky's plugin dir is root-owned (same as a store install), so place the
     # files with sudo and let plugin_loader load them on restart.
     #
-    # Supply-chain integrity gate: fetch SHA256SUMS from the SAME release and
-    # verify Couchside.tar.gz against it before extracting. This catches a
-    # corrupted/truncated download, transport tampering, or a swapped-in tarball
-    # asset. It is NOT full authenticity — the sums file is from the same release,
-    # so proving the release itself is genuine would need branch protection +
-    # release signing (out of scope here). A mismatch or missing checksum aborts
-    # only the panel install (non-fatal: the agent is already installed above).
+    # Supply-chain gate: verify the release is (1) SIGNED by the maintainer's
+    # offline Ed25519 key and (2) matches its SHA256SUMS, before extracting. The
+    # signature proves authenticity even against a repo/CI/account compromise (the
+    # secret key is never in CI); the checksum catches corruption/transport
+    # tampering. A present-but-invalid signature or a checksum mismatch aborts the
+    # panel install (non-fatal: the agent is already installed above). An older,
+    # UNSIGNED release, or a box whose openssl lacks Ed25519, falls back to
+    # checksum-only with a warning rather than breaking the install.
     decky_verify_ok() {
         curl -fsSL "$PLUGIN_URL" -o "${decky_tmp}/Couchside.tar.gz" || {
             note "couldn't download the panel tarball (skipping)."
@@ -919,6 +928,26 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
             note "couldn't download SHA256SUMS for the panel; refusing to install unverified (skipping)."
             return 1
         }
+        # (1) Authenticity: verify SHA256SUMS.sig against the embedded public key.
+        # openssl's own words distinguish a real bad signature ("Verification
+        # Failure" -> abort) from an openssl that can't do Ed25519 -rawin (any
+        # other output -> fall back to checksum-only).
+        if curl -fsSL "$PLUGIN_SIG_URL" -o "${decky_tmp}/SHA256SUMS.sig" 2>/dev/null; then
+            printf '%s\n' "$RELEASE_PUBKEY_PEM" > "${decky_tmp}/couchside-release.pub"
+            sig_out="$(openssl pkeyutl -verify -pubin -inkey "${decky_tmp}/couchside-release.pub" \
+                        -rawin -in "${decky_tmp}/SHA256SUMS" \
+                        -sigfile "${decky_tmp}/SHA256SUMS.sig" 2>&1 || true)"
+            if printf '%s' "$sig_out" | grep -qi 'Verified Successfully'; then
+                note "release signature: verified (maintainer offline key)."
+            elif printf '%s' "$sig_out" | grep -qi 'Verification Failure'; then
+                note "release signature INVALID — refusing to install the panel (skipping)."
+                return 1
+            else
+                note "can't verify release signature (openssl lacks Ed25519); checksum only."
+            fi
+        else
+            note "no release signature found (older/unsigned release); checksum only."
+        fi
         # Verify only our tarball's line. `-c` checks entries whose filename
         # exists in the cwd, so run it from the temp dir. Prefer sha256sum, fall
         # back to `shasum -a 256` (present on Bazzite / most distros).

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# sign-release.sh <tag> [secret-key]
+#
+# Sign a couchside-decky release's SHA256SUMS with the maintainer's OFFLINE
+# Ed25519 key and upload SHA256SUMS.sig to that release. install.sh verifies it
+# against the public key embedded there.
+#
+# Run this LOCALLY after a release is cut — never in CI. The whole point is that
+# the secret key never touches GitHub, so a compromised repo/CI/account cannot
+# forge a release. Requires: gh (authenticated) and an openssl with Ed25519
+# (macOS system LibreSSL 3.3+ works; else `brew install openssl@3`).
+#
+#   scripts/sign-release.sh v0.2.6
+#
+set -euo pipefail
+
+REPO="emerytech/couchside-decky"
+tag="${1:-}"
+key="${2:-$HOME/couchside-release.key}"
+
+[ -n "$tag" ] || { echo "usage: $0 <tag> [secret-key]   e.g. $0 v0.2.6" >&2; exit 2; }
+[ -f "$key" ] || { echo "error: secret key not found: $key" >&2; exit 2; }
+command -v gh >/dev/null 2>&1 || { echo "error: gh (GitHub CLI) not found / not authenticated" >&2; exit 2; }
+
+# Pick an openssl that supports Ed25519 one-shot signing (-rawin): try the one on
+# PATH, then Homebrew's openssl@3.
+ossl="openssl"
+if ! "$ossl" pkeyutl -help 2>&1 | grep -q -- '-rawin'; then
+    if command -v brew >/dev/null 2>&1; then
+        cand="$(brew --prefix openssl@3 2>/dev/null)/bin/openssl"
+        [ -x "$cand" ] && ossl="$cand"
+    fi
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "==> downloading SHA256SUMS from $REPO $tag"
+gh release download "$tag" --repo "$REPO" --pattern SHA256SUMS --dir "$tmp" --clobber
+
+echo "==> signing with $key (via $ossl)"
+"$ossl" pkeyutl -sign -inkey "$key" -rawin -in "$tmp/SHA256SUMS" -out "$tmp/SHA256SUMS.sig"
+
+# Sanity: verify our own signature with the public half before uploading, so we
+# never publish a signature install.sh would reject.
+"$ossl" pkey -in "$key" -pubout -out "$tmp/pub.pem"
+if ! "$ossl" pkeyutl -verify -pubin -inkey "$tmp/pub.pem" -rawin \
+        -in "$tmp/SHA256SUMS" -sigfile "$tmp/SHA256SUMS.sig" >/dev/null 2>&1; then
+    echo "error: self-verification failed — not uploading" >&2
+    exit 1
+fi
+
+echo "==> uploading SHA256SUMS.sig to $tag"
+gh release upload "$tag" "$tmp/SHA256SUMS.sig" --repo "$REPO" --clobber
+
+echo "OK: signed + uploaded SHA256SUMS.sig for $tag"
+echo "    (verify the embedded key matches: openssl pkey -in $key -pubout)"


### PR DESCRIPTION
Completes H1: branch protection + offline-key signatures mean a compromised repo/CI/account can't forge a release. install.sh verifies SHA256SUMS.sig against the embedded Ed25519 pubkey before trusting the checksum + extracting the Decky panel (invalid=abort; unsigned/incapable=checksum-only fallback). scripts/sign-release.sh = maintainer's per-release signing (offline key, never CI). Validated; bash -n clean.