### PR TITLE
docs: README licensing copy — source-available app, not GPLv3/open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The installer copies the agent to `~/.local/opt/couchside/`, generates a token a
 - **Android → [Google Play](https://play.google.com/store/apps/details?id=com.ets3d.rescueremote)** — available now.
 - **iPhone / iPad → [App Store](https://apps.apple.com/app/id6786884115)** — in review.
 
-Free 7-day trial with every feature unlocked, then a one-time unlock ($4.99 summer launch price). Prefer to build it yourself? The app is open source: clone this repo and run it on your own device.
+Free 7-day trial with every feature unlocked, then a one-time unlock ($4.99 summer launch price). Prefer to build it yourself? The app's full source is right here: clone this repo and run it on your own device for personal use (see [app/LICENSE](app/LICENSE)).
 
 ## Pairing
 
@@ -98,10 +98,10 @@ Mock mode serves believable fake data and never executes real commands. The HTTP
 
 ## Pricing & license
 
-**The agent is free. The app's code is free. The official app builds are a free 7-day trial, then a one-time unlock: $4.99 summer launch price, rising to $7.99 on September 1.**
+**The agent is free and open source. The app's source is public. The official app builds are a free 7-day trial, then a one-time unlock: $4.99 summer launch price, rising to $7.99 on September 1.**
 
-- **Agent, installer, brand, docs: MIT.** Use them anywhere, for anything. See [LICENSE](LICENSE).
-- **The mobile app (`app/`): GPLv3.** Clone the repo, `npx expo run:ios` / `npx expo run:android` onto your own phone, modify it, fork it. All welcome. See [app/LICENSE](app/LICENSE). The trial gate ships in this open source; self-built copies may remove it, and that's fine.
+- **Agent, installer, brand, docs: MIT.** Use them anywhere, for anything — including building your own client against the protocol. See [LICENSE](LICENSE).
+- **The mobile app (`app/`): source-available under the PolyForm Noncommercial License 1.0.0.** Read it, audit it, `npx expo run:ios` / `npx expo run:android` it onto your own phone, and modify it for personal, noncommercial use. What you can't do is sell it or redistribute it commercially. See [app/LICENSE](app/LICENSE). The trial gate ships in this public source; self-built personal copies without a store build are treated as unlocked by design, and that's fine.
 - **The official builds on the [App Store](https://apps.apple.com/app/id6786884115) and [Google Play](https://play.google.com/store/apps/details?id=com.ets3d.rescueremote) are free to download** with everything unlocked for 7 days, then a **one-time in-app unlock: $4.99 through the summer, rising to $7.99 on September 1**. No subscription, no accounts. Unlock before September 1 to keep a permanent **Early Adopter** badge. You're paying for signed, notarized, auto-updating builds and a setup that goes from `curl` to couch in under ten minutes. It's also the only funding this project has, so thank you.
 
 © 2026 Taylor Emery (ETS3D LLC).


### PR DESCRIPTION
The 2026-07-09 relicense (PolyForm Noncommercial for app/, MIT elsewhere) updated the LICENSE files but the README still called the app "open source" (line 44) and "GPLv3" (line 104). Public repo front page contradicted app/LICENSE — a one-click credibility hit for anyone checking the licensing story from launch posts.

- Get-the-app blurb: "app is open source" → app's full source is available, personal use, links app/LICENSE
- Pricing & license: GPLv3 bullet → PolyForm Noncommercial 1.0.0 with the same build-it-yourself path and the commercial-redistribution boundary spelled out
- Agent/installer/brand/docs remain described as MIT open source

🤖 Generated with [Claude Code](https://claude.com/claude-code)