### PR TITLE
Capability-adaptive UI: caps on /api/status, tab gating, Fleet tab, stale-poll reset

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -135,7 +135,7 @@ All responses carry permissive CORS headers; `OPTIONS` returns 204.
 | Route | Method | Description |
 |---|---|---|
 | `/api/ping` | GET | Unauthenticated reachability probe: `{"ok":true,"app":"couchside-agent","version":"<agent version>","host":"…","ip":"…"}` |
-| `/api/status` | GET | hostname, time, uptime, load, CPU temp, memory, disk usage (`/`, `/var`), and `net` (`iface`, `mac`, `wired`, `wol_armed`) for the app's Wake-on-LAN power path |
+| `/api/status` | GET | hostname, time, uptime, load, CPU temp, memory, disk usage (`/`, `/var`), `net` (`iface`, `mac`, `wired`, `wol_armed`) for the app's Wake-on-LAN power path, and `caps` (added in 2.8.2): a boot-time summary `{"gamepad","steam","media","tv","screen","power_schedule"}` of booleans saying which optional features this box supports, so the app hides unsupported UI and skips the per-feature probes (`/api/tv`, `/api/media`, `/api/screen`, `/api/downloads`, `/api/power/schedule`) on connect. A hint, not authority — a live op still confirms. Older agents omit `caps` and the app falls back to probing each feature |
 | `/api/units` | GET | State of the configured watchlist units |
 | `/api/journal?unit=<name>&lines=<n>&scope=system\|user` | GET | Last n journal lines (default 100, clamped 1 to 500). Unit must be in the configured watchlist, else 400 |
 | `/api/actions` | GET | Configured actions with id/label/description/danger |

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.8.1"
+VERSION = "2.8.2"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -596,6 +596,64 @@ def read_disks():
     return disks
 
 
+# ---------------------------------------------------------------------------
+# Box capability summary (rides /api/status).
+#
+# The app learns which optional features a box supports (gamepad, Steam,
+# now-playing, TV strip, screen preview, scheduled wake) so it can hide UI the
+# box can't back. Historically it discovered each one with its own probe-and-
+# appear request (GET /api/tv, /api/media, /api/screen, ...): N round-trips per
+# connect, each independently version-sniffed. Folding a boolean summary into
+# the status poll it already makes lets the app skip those probes and paint the
+# right UI on the first frame. A boot-time snapshot, like the existing probes it
+# replaces: presence here (a controller node, a Steam install, a session bus) is
+# static per boot, so it is computed once in main() and served from CAPS.
+#
+# It is a hint, not authority: a live op still confirms (e.g. gamepad=True but
+# /dev/uinput perms broke). Absent on agents < this version, so the app keeps
+# its 404 fallbacks. In --mock every capability reads True so the whole app is
+# exercisable on a dev machine with no hardware.
+# ---------------------------------------------------------------------------
+
+CAPS = {}  # set once by set_caps() in main(); returned by real_/mock_status
+
+
+def _uinput_writable():
+    """Best-effort: can this process open /dev/uinput for the virtual gamepad?
+    The udev rule + `input` group grant rw; os.access uses the real uid/gid,
+    which is what the service runs as. Never raises."""
+    try:
+        return os.access("/dev/uinput", os.W_OK)
+    except Exception:
+        return False
+
+
+def set_caps(mock):
+    """Snapshot box capabilities into CAPS. Call in main() AFTER set_tv/
+    set_mpris/set_screen so the availability helpers reflect real startup
+    detection. In --mock everything is available (see module note)."""
+    global CAPS
+
+    def safe(fn):
+        try:
+            return bool(fn())
+        except Exception:
+            return False
+
+    if mock:
+        CAPS = {k: True for k in
+                ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
+        return
+    CAPS = {
+        "gamepad": _uinput_writable(),
+        "steam": _steam_root() is not None,
+        "media": safe(mpris_available),
+        "tv": safe(lambda: _tv_hw_backend() is not None or soft_available()),
+        "screen": _SCREEN is not None,
+        "power_schedule": safe(rtc_available),
+    }
+
+
 def real_status():
     return {
         "hostname": socket.gethostname().split(".")[0],
@@ -607,6 +665,7 @@ def real_status():
         "disks": read_disks(),
         "net": net_info_cached(),
         "agent_version": VERSION,
+        "caps": CAPS,
     }
 
 
@@ -965,6 +1024,7 @@ def mock_status():
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
+        "caps": CAPS,
     }
 
 
@@ -5375,6 +5435,7 @@ def main():
     set_mpris(args.mock)
     set_screen(args.mock)
     set_power_schedule(args.mock)
+    set_caps(args.mock)  # after the detectors above; snapshots CAPS
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)
 
     Handler.token = load_token(args)
@@ -5395,6 +5456,8 @@ def main():
     print("mpris: %s" % ("available" if BUSCTL else "unavailable"), flush=True)
     print("screen: %s" % (("%s (%s)" % (_SCREEN["session"], ",".join(_SCREEN["backends"])))
                           if _SCREEN else "unavailable"), flush=True)
+    print("caps: %s" % (",".join(sorted(k for k, v in CAPS.items() if v)) or "none"),
+          flush=True)
     try:
         server.serve_forever()
     except KeyboardInterrupt:

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -84,7 +84,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.3.0-win"
+VERSION = "0.3.1-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -737,6 +737,40 @@ def net_info_cached():
     return _NET_CACHE["val"]
 
 
+# Box capability summary (rides /api/status); see the Linux agent's real_status
+# for the full rationale. Mirrors the same six flags so one app codebase reads
+# either agent. Snapshotted once in main() after the detectors run; a hint, not
+# authority; absent on older agents (app keeps its 404 fallbacks); all True in
+# --mock. vigem_available() is a load-only DLL check (no bus connect).
+CAPS = {}  # set once by set_caps() in main(); returned by real_/mock_status
+
+
+def set_caps(mock):
+    """Snapshot box capabilities into CAPS. Call in main() AFTER set_tv/
+    set_screen/set_power_schedule so the availability helpers reflect startup
+    detection. In --mock everything reads True."""
+    global CAPS
+
+    def safe(fn):
+        try:
+            return bool(fn())
+        except Exception:
+            return False
+
+    if mock:
+        CAPS = {k: True for k in
+                ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
+        return
+    CAPS = {
+        "gamepad": safe(vigem_available),
+        "steam": _steam_root() is not None,
+        "media": safe(smtc_available),
+        "tv": safe(lambda: _tv_hw_backend() is not None or soft_available()),
+        "screen": _SCREEN is not None,
+        "power_schedule": safe(wake_available),
+    }
+
+
 def real_status():
     return {
         "hostname": socket.gethostname().split(".")[0],
@@ -748,6 +782,7 @@ def real_status():
         "disks": read_disks(),
         "net": net_info_cached(),
         "agent_version": VERSION,
+        "caps": CAPS,
     }
 
 
@@ -973,6 +1008,7 @@ def mock_status():
         "net": {"iface": "Intel(R) Ethernet Connection I219-V",
                 "mac": "de:ad:be:ef:00:02", "wired": True, "wol_armed": True},
         "agent_version": VERSION,
+        "caps": CAPS,
     }
 
 
@@ -3153,6 +3189,39 @@ _VIGEM_LOCK = threading.Lock()
 _VIGEM = {"dll": None, "client": None}
 
 
+def _vigem_dll_candidates():
+    """Where ViGEmClient.dll might live, in load order."""
+    candidates = []
+    base = getattr(sys, "_MEIPASS", None)  # PyInstaller onefile extract dir
+    if base:
+        candidates.append(os.path.join(base, "ViGEmClient.dll"))
+    candidates.append(os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "ViGEmClient.dll"))
+    candidates.append("ViGEmClient.dll")  # PATH / System32
+    return candidates
+
+
+def _vigem_load_dll():
+    """Load ViGEmClient.dll (no client connect), or None if not found. A
+    side-effect-free presence check for caps; the real client connect happens in
+    _load_vigem()."""
+    for cand in _vigem_dll_candidates():
+        try:
+            return ctypes.CDLL(cand)
+        except OSError:
+            continue
+    return None
+
+
+def vigem_available():
+    """True when ViGEmClient.dll loads. A hint (the ViGEmBus driver could still
+    be down); the gamepad WS connect is the ground-truth check."""
+    try:
+        return _vigem_load_dll() is not None
+    except Exception:
+        return False
+
+
 def _load_vigem():
     """Load ViGEmClient.dll and connect a shared client (cached on success).
     Returns (dll, client) or raises RuntimeError with a useful message.
@@ -3164,20 +3233,7 @@ def _load_vigem():
     with _VIGEM_LOCK:
         if _VIGEM["client"] is not None:
             return _VIGEM["dll"], _VIGEM["client"]
-        candidates = []
-        base = getattr(sys, "_MEIPASS", None)  # PyInstaller onefile extract dir
-        if base:
-            candidates.append(os.path.join(base, "ViGEmClient.dll"))
-        candidates.append(os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "ViGEmClient.dll"))
-        candidates.append("ViGEmClient.dll")  # PATH / System32
-        dll = None
-        for cand in candidates:
-            try:
-                dll = ctypes.CDLL(cand)
-                break
-            except OSError:
-                continue
+        dll = _vigem_load_dll()
         if dll is None:
             raise RuntimeError(
                 "ViGEmClient.dll not found (install ViGEmBus and place "
@@ -4593,6 +4649,7 @@ def main():
     set_tv(args.mock)
     set_screen(args.mock)
     set_power_schedule(args.mock)
+    set_caps(args.mock)  # after the detectors above; snapshots CAPS
     if IS_WINDOWS and not args.mock:
         start_load_sampler()
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router, Tabs } from 'expo-router';
+import { router, Tabs, useSegments } from 'expo-router';
 import { useEffect, useRef } from 'react';
 
 import { hapticSelection } from '@/lib/haptics';
@@ -13,7 +13,15 @@ export const unstable_settings = {
 };
 
 export default function TabLayout() {
-  const { boxes, ready } = useBoxes();
+  const { boxes, activeBox, ready } = useBoxes();
+  const segments = useSegments();
+
+  // A "server box" (headless: no virtual gamepad, no Steam) reports these false
+  // in /api/status caps, so its gaming tabs are hidden. Undefined caps (unknown,
+  // or agent < 2.8.2) leaves both visible — never hide a tab on a guess.
+  const caps = activeBox?.caps;
+  const hidePad = caps?.gamepad === false;
+  const hideLaunch = caps?.steam === false;
 
   // On true first run (persisted fleet loaded, but empty) send the user to
   // Setup to pair. Runs once. After that, the Pad initial route stands.
@@ -25,6 +33,17 @@ export default function TabLayout() {
       router.replace('/(tabs)/setup');
     }
   }, [ready, boxes.length]);
+
+  // Bounce off a tab hidden for the active box — landing on the Pad initial
+  // route for a server box, or switching from an HTPC to a server box while the
+  // Pad/Launch tab is focused. Sends the user to Console (the tabs index).
+  useEffect(() => {
+    if (!ready) return;
+    const leaf = segments[segments.length - 1];
+    if ((hidePad && leaf === 'pad') || (hideLaunch && leaf === 'launch')) {
+      router.replace('/(tabs)');
+    }
+  }, [ready, hidePad, hideLaunch, segments]);
 
   return (
     <Tabs
@@ -47,6 +66,15 @@ export default function TabLayout() {
         }}
       />
       <Tabs.Screen
+        name="fleet"
+        options={{
+          title: 'Fleet',
+          tabBarIcon: ({ color }) => <Ionicons name="server" size={24} color={color} />,
+          // Only useful with several boxes; single-box users keep a clean bar.
+          href: boxes.length >= 2 ? undefined : null,
+        }}
+      />
+      <Tabs.Screen
         name="actions"
         options={{
           title: 'Actions',
@@ -58,6 +86,8 @@ export default function TabLayout() {
         options={{
           title: 'Pad',
           tabBarIcon: ({ color }) => <Ionicons name="game-controller" size={24} color={color} />,
+          // Hidden on a server box (no virtual gamepad). null = no tab bar entry.
+          href: hidePad ? null : undefined,
         }}
       />
       <Tabs.Screen
@@ -65,6 +95,8 @@ export default function TabLayout() {
         options={{
           title: 'Launch',
           tabBarIcon: ({ color }) => <Ionicons name="rocket" size={24} color={color} />,
+          // Hidden on a server box (no Steam install). null = no tab bar entry.
+          href: hideLaunch ? null : undefined,
         }}
       />
       <Tabs.Screen

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -13,7 +13,7 @@ import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { ActionInfo, ActionResult, api, Danger } from '@/lib/api';
+import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
 import { hapticError, hapticHeavy, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, theme } from '@/lib/theme';
@@ -65,6 +65,7 @@ function ActionsScreen() {
     () => api.actions(settings),
     30000,
     ready,
+    hostKey(settings), // clear the previous box's actions on switch
   );
 
   const execute = useCallback(

--- a/app/app/(tabs)/fleet.tsx
+++ b/app/app/(tabs)/fleet.tsx
@@ -1,0 +1,295 @@
+import { router } from 'expo-router';
+import React from 'react';
+import { AppState, AppStateStatus, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { Gated } from '@/components/Gated';
+import { TabScreen } from '@/components/TabScreen';
+import { useFocusEffect } from 'expo-router';
+import { useLockOrientation } from '@/hooks/useLockOrientation';
+import { api, Status } from '@/lib/api';
+import { usePref } from '@/lib/prefs';
+import { Box } from '@/lib/settings';
+import { useBoxes } from '@/lib/SettingsContext';
+import { mono, numeric, pctColor, tempColor, theme } from '@/lib/theme';
+
+/** One box's latest fleet snapshot. */
+type FleetEntry = {
+  status: Status | null;
+  /** Message of the last failed poll, or null while reachable. */
+  error: string | null;
+  /** Unix ms of the last successful poll (for the DOWN tile's last-seen). */
+  lastSuccess: number | null;
+};
+
+type FleetMap = Record<string, FleetEntry>;
+
+/**
+ * Poll /api/status for EVERY box while the Fleet tab is focused. The
+ * single-target usePoll can't fan out, so this follows useBoxOnlineStatus's
+ * shape instead (SettingsContext): one in-flight request per box, paused on
+ * background/blur, entries pruned when a box is removed.
+ */
+function useFleetStatus(boxes: Box[], intervalMs: number): FleetMap {
+  const [map, setMap] = React.useState<FleetMap>({});
+
+  const boxesRef = React.useRef<Box[]>(boxes);
+  boxesRef.current = boxes;
+  const inFlight = React.useRef<Set<string>>(new Set());
+  const mounted = React.useRef(true);
+
+  // Prune entries for boxes that no longer exist.
+  const idsKey = boxes.map((b) => b.id).join(',');
+  React.useEffect(() => {
+    setMap((prev) => {
+      const ids = new Set(boxesRef.current.map((b) => b.id));
+      let changed = false;
+      const next: FleetMap = {};
+      for (const [id, v] of Object.entries(prev)) {
+        if (ids.has(id)) next[id] = v;
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [idsKey]);
+
+  React.useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      let appActive = AppState.currentState === 'active' || AppState.currentState == null;
+      let interval: ReturnType<typeof setInterval> | null = null;
+
+      const tick = () => {
+        if (!appActive) return;
+        for (const box of boxesRef.current) {
+          if (inFlight.current.has(box.id)) continue;
+          inFlight.current.add(box.id);
+          const conn = { host: box.host, port: box.port, token: box.token, lastIp: box.lastIp };
+          void api
+            .status(conn)
+            .then((s) => {
+              if (!mounted.current) return;
+              setMap((prev) => ({
+                ...prev,
+                [box.id]: { status: s, error: null, lastSuccess: Date.now() },
+              }));
+            })
+            .catch((e: unknown) => {
+              if (!mounted.current) return;
+              const msg = e instanceof Error ? e.message : String(e);
+              setMap((prev) => ({
+                ...prev,
+                [box.id]: {
+                  status: prev[box.id]?.status ?? null,
+                  error: msg,
+                  lastSuccess: prev[box.id]?.lastSuccess ?? null,
+                },
+              }));
+            })
+            .finally(() => {
+              inFlight.current.delete(box.id);
+            });
+        }
+      };
+
+      const start = () => {
+        if (interval != null) return;
+        tick();
+        interval = setInterval(tick, intervalMs);
+      };
+      const stop = () => {
+        if (interval != null) {
+          clearInterval(interval);
+          interval = null;
+        }
+      };
+
+      const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
+        const nowActive = s === 'active';
+        if (nowActive === appActive) return;
+        appActive = nowActive;
+        if (appActive) start();
+        else stop();
+      });
+      if (appActive) start();
+
+      return () => {
+        stop();
+        sub.remove();
+      };
+    }, [intervalMs]),
+  );
+
+  return map;
+}
+
+function fmtLastSeen(ts: number | null): string {
+  if (!ts) return 'never';
+  const s = Math.round((Date.now() - ts) / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ${m % 60}m ago`;
+}
+
+function Tile({ box, entry, active, onPress }: {
+  box: Box;
+  entry: FleetEntry | undefined;
+  active: boolean;
+  onPress: () => void;
+}) {
+  const s = entry?.status ?? null;
+  const up = entry != null && entry.error == null && s != null;
+  const memPct = s ? Math.round((s.mem.used_mb / s.mem.total_mb) * 100) : 0;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.tile,
+        active && styles.tileActive,
+        !up && entry != null && styles.tileDown,
+        pressed && styles.pressed,
+      ]}>
+      <View style={styles.tileHeader}>
+        <View style={[styles.dot, { backgroundColor: up ? theme.green : theme.red }]} />
+        <Text style={styles.tileName} numberOfLines={1}>
+          {s?.hostname ?? box.name}
+        </Text>
+        {active && <Text style={styles.activeTag}>active</Text>}
+      </View>
+      <Text style={styles.tileHost} numberOfLines={1}>
+        {box.host}:{box.port}
+      </Text>
+
+      {up && s ? (
+        <View style={styles.metricsRow}>
+          <View style={styles.metric}>
+            <Text style={styles.metricLabel}>TEMP</Text>
+            <Text style={[styles.metricValue, { color: tempColor(s.cpu_temp_c) }]}>
+              {s.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}°` : '—'}
+            </Text>
+          </View>
+          <View style={styles.metric}>
+            <Text style={styles.metricLabel}>LOAD</Text>
+            <Text style={[styles.metricValue, { color: theme.text }]}>
+              {s.load[0].toFixed(2)}
+            </Text>
+          </View>
+          <View style={styles.metric}>
+            <Text style={styles.metricLabel}>MEM</Text>
+            <Text style={[styles.metricValue, { color: pctColor(memPct) }]}>{memPct}%</Text>
+          </View>
+        </View>
+      ) : (
+        <Text style={styles.downText}>
+          {entry == null ? 'probing…' : `DOWN · last seen ${fmtLastSeen(entry.lastSuccess)}`}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+export default function FleetTab() {
+  useLockOrientation('portrait');
+  return (
+    <TabScreen>
+      <Gated>
+        <FleetScreen />
+      </Gated>
+    </TabScreen>
+  );
+}
+
+function FleetScreen() {
+  const { boxes, activeBoxId, switchBox } = useBoxes();
+  const statusInterval = usePref('statusIntervalMs');
+  const fleet = useFleetStatus(boxes, statusInterval);
+
+  return (
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={{ paddingTop: 12, paddingBottom: 32, paddingHorizontal: 14 }}>
+      <Text style={styles.sectionTitle}>YOUR FLEET</Text>
+      {boxes.map((box) => (
+        <Tile
+          key={box.id}
+          box={box}
+          entry={fleet[box.id]}
+          active={box.id === activeBoxId}
+          onPress={() => {
+            switchBox(box.id);
+            // Land on the box's Console; a box whose gaming tabs are hidden
+            // still always has Console.
+            router.replace('/(tabs)');
+          }}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scroll: { flex: 1 },
+  sectionTitle: {
+    color: theme.textFaint,
+    fontFamily: mono,
+    fontSize: 11,
+    letterSpacing: 1.5,
+    marginBottom: 10,
+  },
+  tile: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 10,
+  },
+  tileActive: { borderColor: theme.blue },
+  tileDown: { borderColor: theme.redDeep },
+  pressed: { opacity: 0.7 },
+  tileHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  dot: { width: 9, height: 9, borderRadius: 5 },
+  tileName: {
+    color: theme.text,
+    fontFamily: mono,
+    fontSize: 16,
+    fontWeight: '700',
+    flexShrink: 1,
+  },
+  activeTag: {
+    color: theme.blue,
+    fontFamily: mono,
+    fontSize: 11,
+    marginLeft: 'auto',
+  },
+  tileHost: {
+    color: theme.textFaint,
+    fontFamily: mono,
+    fontSize: 11,
+    marginTop: 2,
+    marginLeft: 17,
+  },
+  metricsRow: { flexDirection: 'row', gap: 18, marginTop: 10, marginLeft: 17 },
+  metric: {},
+  metricLabel: {
+    color: theme.textFaint,
+    fontFamily: mono,
+    fontSize: 9,
+    letterSpacing: 1,
+  },
+  metricValue: { ...numeric, fontSize: 18, fontWeight: '700', marginTop: 2 },
+  downText: {
+    color: theme.red,
+    fontFamily: mono,
+    fontSize: 11,
+    marginTop: 10,
+    marginLeft: 17,
+  },
+});

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -7,7 +7,7 @@ import { ScreenPreview } from '@/components/ScreenPreview';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { api, humanizeUptime, Status, Unit } from '@/lib/api';
+import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, pctColor, tempColor, theme } from '@/lib/theme';
@@ -84,8 +84,11 @@ function ConsoleScreen() {
   const configured = settings.host.trim().length > 0;
 
   const statusInterval = usePref('statusIntervalMs');
-  const status = usePoll<Status>(() => api.status(settings), statusInterval, ready && configured);
-  const units = usePoll<{ units: Unit[] }>(() => api.units(settings), 10000, ready && configured);
+  const boxKey = hostKey(settings); // resetKey: clear stale data on box switch
+  const status = usePoll<Status>(
+    () => api.status(settings), statusInterval, ready && configured, boxKey);
+  const units = usePoll<{ units: Unit[] }>(
+    () => api.units(settings), 10000, ready && configured, boxKey);
 
   const s = status.data;
   const reachable = configured && status.error == null && s != null;
@@ -224,6 +227,12 @@ function ConsoleScreen() {
             ) : (
               <Text style={styles.unitErr}>loading…</Text>
             )}
+            {/* The watchlist is box-side config, not app state — point at it so
+                homelab users know they can watch their own services. */}
+            <Text style={styles.unitHint}>
+              watchlist: /etc/couchside/config.json on the box (units[]), then
+              restart couchside.service
+            </Text>
           </Card>
         )}
       </ScrollView>
@@ -332,4 +341,5 @@ const styles = StyleSheet.create({
   chipName: { color: theme.text, fontSize: 13, fontFamily: mono, flexShrink: 1 },
   chipState: { fontSize: 12, marginLeft: 'auto', ...numeric },
   unitErr: { color: theme.textDim, fontSize: 13 },
+  unitHint: { color: theme.textFaint, fontFamily: mono, fontSize: 10, marginTop: 10 },
 });

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -26,7 +26,7 @@ import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { api, Downloads, ImageSource, Launcher, SteamDownload } from '@/lib/api';
+import { api, Downloads, hostKey, ImageSource, Launcher, SteamDownload } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -321,10 +321,12 @@ function LaunchScreen() {
   // Bumped on pull-to-refresh so tiles retry any cover that failed to load.
   const [retryKey, setRetryKey] = useState(0);
 
+  const boxKey = hostKey(settings); // resetKey: clear stale data on box switch
   const list = usePoll<{ launchers: Launcher[] }>(
     () => api.launchers(settings),
     30000,
     ready,
+    boxKey,
   );
 
   const showToast = useCallback((msg: string) => {
@@ -336,7 +338,8 @@ function LaunchScreen() {
   // `active` is declared BEFORE the poll that reads it (avoids a TDZ self-ref)
   // and flipped by the effect below; poll fast while something is downloading.
   const [active, setActive] = useState(false);
-  const dl = usePoll<Downloads | null>(() => api.downloads(settings), active ? 5000 : 20000, ready);
+  const dl = usePoll<Downloads | null>(
+    () => api.downloads(settings), active ? 5000 : 20000, ready, boxKey);
   const downloads = useMemo(() => dl.data?.downloads ?? [], [dl.data]);
   const dlByAppid = useMemo(() => new Map(downloads.map((d) => [d.appid, d])), [downloads]);
 

--- a/app/components/LogsPanel.tsx
+++ b/app/components/LogsPanel.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { FlatList, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, Journal, Unit, UnitScope } from '@/lib/api';
+import { api, hostKey, Journal, Unit, UnitScope } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -37,7 +37,8 @@ export function LogsPanel() {
 
   // The picker mirrors the agent's journal watchlist (/api/units). The huge
   // interval parks the timer; usePoll still fetches on mount and every focus.
-  const units = usePoll<{ units: Unit[] }>(() => api.units(settings), 3600_000, ready);
+  const boxKey = hostKey(settings); // resetKey: clear stale data on box switch
+  const units = usePoll<{ units: Unit[] }>(() => api.units(settings), 3600_000, ready, boxKey);
   const picker =
     units.data && units.data.units.length > 0 ? toPicker(units.data.units) : FALLBACK_UNITS;
 
@@ -49,14 +50,12 @@ export function LogsPanel() {
     // usePoll still fires immediately on focus / refresh()).
     auto ? 5000 : 3600_000,
     ready,
+    // Keyed by box AND selected unit: switching either clears the old lines in
+    // the same render and refires — no flash of another unit's journal. This
+    // replaces the manual refresh-on-unit-change effect this panel used to
+    // carry (resetKey also covers the box switch that effect missed).
+    `${boxKey}|${target.scope}:${target.unit}`,
   );
-
-  // Re-fetch immediately when the selected unit changes (index or, once the
-  // real watchlist arrives, the unit that index resolves to).
-  const { refresh } = journal;
-  useEffect(() => {
-    refresh();
-  }, [target.unit, target.scope, refresh]);
 
   const renderLine = useCallback(
     ({ item }: { item: string }) => <Text style={styles.line}>{item}</Text>,

--- a/app/components/NowPlayingCard.tsx
+++ b/app/components/NowPlayingCard.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Image, LayoutChangeEvent, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
+import { api, hostKey, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
 import { hapticLight, hapticMedium } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, theme } from '@/lib/theme';
@@ -26,7 +26,8 @@ export function NowPlayingCard() {
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
-  const poll = usePoll<Media | null>(() => api.media(settings), 5000, ready && configured);
+  const poll = usePoll<Media | null>(
+    () => api.media(settings), 5000, ready && configured, hostKey(settings));
   const players = poll.data?.players ?? [];
 
   // Active player: user's pick if still present, else first Playing, else first.

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SleepTimerSheet } from '@/components/SleepTimerSheet';
 import { usePoll } from '@/hooks/usePoll';
-import { api, PowerSchedule, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
+import { api, capsEqual, hostKey, PowerSchedule, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac } from '@/lib/settings';
@@ -182,7 +182,15 @@ export function RemotePowerBar() {
   }, [open]);
 
   const statusInterval = usePref('statusIntervalMs');
-  const status = usePoll<Status>(() => api.status(settings), statusInterval, ready && configured);
+  // hostKey as resetKey: usePoll guarantees `status.data` always belongs to
+  // the CURRENT box (cleared on switch, in-flight results for the old box
+  // discarded). The learners below persist onto the active box, and this bar
+  // is mounted once per tab screen — without that guarantee a stale instance
+  // once mis-attributed one box's data to another and the competing writes
+  // ping-ponged forever ("Maximum update depth exceeded").
+  const boxKey = hostKey(settings);
+  const status = usePoll<Status>(
+    () => api.status(settings), statusInterval, ready && configured, boxKey);
   const s = status.data;
   const reachable = configured && status.error == null && s != null;
 
@@ -192,12 +200,22 @@ export function RemotePowerBar() {
     if (mac && mac !== settings.mac) void update({ mac });
   }, [s?.net?.mac, settings.mac, update]);
 
+  // Learn + persist the box's capability summary from status (agent >= 2.8.2),
+  // so the tab bar can hide gaming tabs on a server box immediately on next
+  // launch. Value-equality gate (caps is a fresh object every poll) so it
+  // writes storage once per real change, not once per poll.
+  React.useEffect(() => {
+    if (s?.caps && !capsEqual(s.caps, settings.caps)) {
+      void update({ caps: s.caps });
+    }
+  }, [s?.caps, settings.caps, update]);
+
   // TV/audio backend + mute state. Polled (not probed once per connect) so the
   // mute indicator self-heals when the box is muted out of band (controller,
   // keyboard, a stale seed), and a TV backend appearing/disappearing shows up
   // without a reconnect. api.tv 404s when there is no backend, which surfaces
   // as tvPoll.error, so tv stays null there.
-  const tvPoll = usePoll<Tv>(() => api.tv(settings), 5000, reachable);
+  const tvPoll = usePoll<Tv>(() => api.tv(settings), 5000, reachable, boxKey);
   const refreshTv = tvPoll.refresh;
   const tv = reachable && tvPoll.error == null && tvPoll.data?.available ? tvPoll.data : null;
   const muted = tv?.muted ?? null;
@@ -208,6 +226,7 @@ export function RemotePowerBar() {
     () => api.powerSchedule(settings),
     15000,
     reachable,
+    boxKey,
   );
   const schedule = reachable ? schedulePoll.data ?? null : null;
   const [sleepOpen, setSleepOpen] = React.useState(false);

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -3,7 +3,7 @@ import React, { useCallback, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, Tv, TvKey, TvOp } from '@/lib/api';
+import { api, hostKey, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { Settings } from '@/lib/settings';
@@ -34,7 +34,7 @@ export function RemoteView({
   // flip the nav target from TV to BOX mid-interaction (one lost poll would
   // turn OSD arrow presses into gamepad presses inside a game). A box with no
   // backend never yields data (404), so the TV clusters still stay hidden.
-  const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true);
+  const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
   const tv = tvPoll.data?.available ? tvPoll.data : null;
   const hasTvKeys = tv?.keys === true;
   const sources = tv?.sources ?? [];

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -12,7 +12,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AppState, AppStateStatus, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, screenFrameSource, ScreenInfo } from '@/lib/api';
+import { api, hostKey, screenFrameSource, ScreenInfo } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -25,15 +25,32 @@ export function ScreenPreview() {
   const configured = !!settings.host && !!settings.token;
 
   // Slow probe: just detects whether capture is possible on this box.
+  const boxKey = hostKey(settings);
   const probe = usePoll<ScreenInfo | null>(
     () => api.screenInfo(settings),
     30000,
     ready && configured,
+    boxKey, // clear the previous box's probe on switch
   );
-  // Sticky: once a box has ever reported capture support, keep the card so a
-  // later 404 (e.g. the greeter after a session restart) is explained, not hidden.
+  // Sticky PER BOX: once this box has ever reported capture support, keep the
+  // card so a later 404 (e.g. the greeter after a session restart) is
+  // explained, not hidden. Stickiness must not survive a box switch — that
+  // once left the card showing "no capturable session" on a headless box that
+  // never supported capture at all.
+  //
+  // The dataKey check is load-bearing, not belt-and-braces: on a box switch,
+  // React finishes executing the discarded render pass with the OLD box's
+  // probe.data still visible, and a bare `if (probe.data)` there re-poisons
+  // this ref right after the reset below. dataKey identifies which box the
+  // data belongs to, so the doomed pass can't attribute it to the new box.
+  // (See PollState.dataKey in hooks/usePoll.ts.)
   const everSupported = useRef(false);
-  if (probe.data) everSupported.current = true;
+  const supportKeyRef = useRef(boxKey);
+  if (supportKeyRef.current !== boxKey) {
+    supportKeyRef.current = boxKey;
+    everSupported.current = false;
+  }
+  if (probe.data && probe.dataKey === boxKey) everSupported.current = true;
   const supported = probe.data != null;
 
   const [active, setActive] = useState(false);

--- a/app/hooks/usePoll.ts
+++ b/app/hooks/usePoll.ts
@@ -11,6 +11,16 @@ export type PollState<T> = {
   lastSuccess: number | null;
   /** Fire a fetch right now (also restarts the interval). */
   refresh: () => void;
+  /**
+   * The resetKey `data` was fetched under (undefined until first data / after
+   * a key change). Render-time consumers that MUTATE REFS from `data` must
+   * check `dataKey === <current key>` first: when resetKey changes, React
+   * discards the in-progress render pass but still finishes executing it, and
+   * that doomed pass sees the PREVIOUS key's `data` (state swaps only apply to
+   * the re-render) while its ref writes persist. Effects are safe (they only
+   * run after commit); bare `if (data) someRef.current = ...` is not.
+   */
+  dataKey: string | undefined;
 };
 
 /** While a box is unreachable, retry this fast until it recovers. */
@@ -24,19 +34,43 @@ const ERROR_RETRY_MS = 2000;
  * - On AppState 'active' it refetches immediately (no waiting out the timer).
  * - Pauses while the screen is unfocused (useFocusEffect).
  * - Never calls setState after unmount/blur. `enabled: false` stops polling.
+ * - `resetKey` identifies the poll target (e.g. the active box's host:port).
+ *   When it changes, data/error clear in the SAME render (no stale frame from
+ *   the previous target) and any in-flight fetch that was started for the old
+ *   key is discarded when it lands — a response can never be attributed to a
+ *   target it wasn't fetched for. Omit for polls whose target never changes.
  */
 export function usePoll<T>(
   fn: () => Promise<T>,
   intervalMs: number,
   enabled = true,
+  resetKey?: string,
 ): PollState<T> {
   const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(true);
   const [lastSuccess, setLastSuccess] = useState<number | null>(null);
+  const [dataKey, setDataKey] = useState<string | undefined>(undefined);
 
   const fnRef = useRef(fn);
   fnRef.current = fn;
+
+  // Poll-target generation: bumped on resetKey change; in-flight ticks carry
+  // the generation they started under and drop their result if it moved.
+  const genRef = useRef(0);
+  const keyRef = useRef(resetKey);
+  if (keyRef.current !== resetKey) {
+    // Adjust-state-during-render (the sanctioned React pattern): clearing here
+    // instead of in an effect means the target switch never paints one frame
+    // of the previous target's data.
+    keyRef.current = resetKey;
+    genRef.current++;
+    setData(null);
+    setError(null);
+    setLoading(true);
+    setLastSuccess(null);
+    setDataKey(undefined);
+  }
 
   const aliveRef = useRef(false);
   // Self-scheduling timeout (not a fixed interval) so success and failure can
@@ -64,19 +98,27 @@ export function usePoll<T>(
   }, [intervalMs, clearTimer]);
 
   const tick = useCallback(async () => {
+    // Snapshot the generation this fetch is FOR; a resetKey change mid-flight
+    // moves it, and the late result must be dropped, not shown as the new
+    // target's data.
+    const gen = genRef.current;
+    const keyAtStart = keyRef.current;
     try {
       const result = await fnRef.current();
-      if (!aliveRef.current) return;
+      if (!aliveRef.current || gen !== genRef.current) return;
       failingRef.current = false;
       setData(result);
+      setDataKey(keyAtStart);
       setError(null);
       setLastSuccess(Date.now());
     } catch (e: unknown) {
-      if (!aliveRef.current) return;
+      if (!aliveRef.current || gen !== genRef.current) return;
       failingRef.current = true;
       setError(e instanceof Error ? e : new Error(String(e)));
     } finally {
-      if (aliveRef.current) {
+      // A stale-generation tick schedules nothing: the key-change effect has
+      // already fired a fresh tick for the new target.
+      if (aliveRef.current && gen === genRef.current) {
         setLoading(false);
         scheduleNext();
       }
@@ -95,6 +137,20 @@ export function usePoll<T>(
     clearTimer();
     void tickRef.current();
   }, [clearTimer]);
+
+  // Refetch immediately when the poll target changes (state already cleared
+  // during this render). Skips the mount render — the focus effect below owns
+  // the first fetch, and double-firing it would race two initial requests.
+  const mountedForKey = useRef(false);
+  useEffect(() => {
+    if (!mountedForKey.current) {
+      mountedForKey.current = true;
+      return;
+    }
+    failingRef.current = false;
+    fireNow();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- deliberately key-only
+  }, [resetKey]);
 
   useFocusEffect(
     useCallback(() => {
@@ -128,5 +184,5 @@ export function usePoll<T>(
     setEpoch((n) => n + 1);
   }, []);
 
-  return { data, error, loading, lastSuccess, refresh };
+  return { data, error, loading, lastSuccess, refresh, dataKey };
 }

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -247,6 +247,7 @@ export function useSettings(): SettingsContextValue {
       lastIp: activeBox.lastIp,
       mac: activeBox.mac,
       volumeTarget: activeBox.volumeTarget,
+      caps: activeBox.caps,
     };
   }, [activeBox]);
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -67,6 +67,30 @@ export type NetInfo = {
   wol_armed: boolean | null;
 };
 
+/**
+ * Optional-feature summary a box reports on /api/status (agent >= 2.8.2). Lets
+ * the app hide UI a box can't back — and skip the per-feature probe requests it
+ * otherwise fires on connect (GET /api/tv, /api/media, /api/screen, ...) — from
+ * the status poll it already makes, instead of N separate probe-and-appear
+ * round-trips. A hint, not authority: a live op still confirms (e.g. gamepad
+ * true but the controller node's perms broke). Absent on older agents — when
+ * `caps` is undefined the app falls back to probing each feature individually.
+ */
+export type BoxCaps = {
+  /** Virtual game controller (/dev/uinput on Linux, ViGEmBus on Windows). Gates the Pad tab. */
+  gamepad: boolean;
+  /** A Steam install is present. Gates the Launch tab: games, launch, downloads, cover art. */
+  steam: boolean;
+  /** Now-playing / transport (MPRIS on Linux, SMTC on Windows). Gates the media card. */
+  media: boolean;
+  /** A TV / volume backend (RS-232 panel, HDMI-CEC, or box soft-volume). Gates the TV strip. */
+  tv: boolean;
+  /** A screen-capture path for the live preview. Gates the preview card. */
+  screen: boolean;
+  /** Scheduled wake can be armed (RTC alarm on Linux, waitable timer on Windows). Gates the sleep/wake rows. */
+  power_schedule: boolean;
+};
+
 export type Status = {
   hostname: string;
   time: number;
@@ -78,6 +102,8 @@ export type Status = {
   /** Network facts for the power/Wake-on-LAN path (agent >= 2.6). */
   net?: NetInfo;
   agent_version: string;
+  /** Optional-feature summary (agent >= 2.8.2); undefined on older agents. See BoxCaps. */
+  caps?: BoxCaps;
 };
 
 export type UnitScope = 'system' | 'user';
@@ -321,6 +347,22 @@ async function probeOrNull<T>(p: Promise<T>): Promise<T | null> {
   }
 }
 
+/**
+ * Gate an optional-feature probe on the box's advertised caps (Status.caps).
+ * When `cap` is explicitly false the feature is absent, so resolve null WITHOUT
+ * a request — the round-trip the caps summary exists to save. When `cap` is
+ * undefined (older agent that doesn't report caps) we still run the probe, so
+ * behaviour is unchanged against agents < 2.8.2. A 404 from the probe itself is
+ * handled by probeOrNull, so this stays correct even if caps disagrees.
+ */
+function probeGated<T>(
+  cap: boolean | undefined,
+  probe: () => Promise<T | null>,
+): Promise<T | null> {
+  if (cap === false) return Promise.resolve(null);
+  return probe();
+}
+
 // ---------- Client ----------
 
 const TIMEOUT_MS = 4000;
@@ -334,11 +376,40 @@ function baseUrl(settings: Pick<Settings, 'host' | 'port'>): string {
 // JSON API proved reachable, not a blind settings.host that mDNS may have
 // stopped resolving under SteamOS Game Mode WiFi power-save.
 const lastGoodHost = new Map<string, string>();
-function hostKey(s: Pick<Settings, 'host' | 'port'>): string {
+/** Stable identity of a poll/connection target ("host:port"). Exported as the
+ *  canonical `resetKey` for usePoll: every active-box poll passes it so a box
+ *  switch clears stale data instead of briefly showing the previous box's. */
+export function hostKey(s: Pick<Settings, 'host' | 'port'>): string {
   return `${s.host}:${s.port}`;
 }
 export function resolveEffectiveHost(settings: ConnSettings): string {
   return lastGoodHost.get(hostKey(settings)) ?? settings.host;
+}
+
+// Latest capability summary each box reported on /api/status (keyed host:port),
+// so the optional-feature probes can skip a request the box has said it can't
+// answer without every caller threading caps down. Populated by api.status();
+// empty until the first status poll of a box returns (and always empty for
+// agents < 2.8.2 that don't report caps), in which case the probes fall back to
+// probing — never a false skip. Mirrors the lastGoodHost cache above.
+const lastCaps = new Map<string, BoxCaps>();
+function cachedCaps(settings: Pick<Settings, 'host' | 'port'>): BoxCaps | undefined {
+  return lastCaps.get(hostKey(settings));
+}
+
+/** Value-equality for BoxCaps (either may be undefined). Lets callers persist
+ *  caps onto a box only when it actually changed, avoiding write churn. */
+export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.gamepad === b.gamepad &&
+    a.steam === b.steam &&
+    a.media === b.media &&
+    a.tv === b.tv &&
+    a.screen === b.screen &&
+    a.power_schedule === b.power_schedule
+  );
 }
 
 const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
@@ -546,8 +617,13 @@ export const api = {
     return request<Ping>(settings, '/api/ping', { auth: false });
   },
 
-  status(settings: ConnSettings): Promise<Status> {
-    return request<Status>(settings, '/api/status');
+  async status(settings: ConnSettings): Promise<Status> {
+    const s = await request<Status>(settings, '/api/status');
+    // Cache caps so the optional-feature probes can skip dead requests (see
+    // lastCaps). Only overwrite when present, so a momentary old-agent reply
+    // never clears a good entry.
+    if (s.caps) lastCaps.set(hostKey(settings), s.caps);
+    return s;
   },
 
   units(settings: ConnSettings): Promise<{ units: Unit[] }> {
@@ -588,8 +664,12 @@ export const api = {
    * 404 (agent < 2.8 or no route) so the Launch tab hides the section; a 200
    * with an empty list also means "nothing pending".
    */
-  downloads(settings: ConnSettings): Promise<Downloads | null> {
-    return probeOrNull(request<Downloads>(settings, '/api/downloads'));
+  downloads(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<Downloads | null> {
+    return probeGated(caps?.steam, () =>
+      probeOrNull(request<Downloads>(settings, '/api/downloads')));
   },
 
   /**
@@ -726,8 +806,12 @@ export const api = {
    * null on 404 (agent < 2.8 or no session bus) so the card hides; 200 with an
    * empty list means "nothing playing". 8 s budget matches the agent's ceiling.
    */
-  media(settings: ConnSettings): Promise<Media | null> {
-    return probeOrNull(request<Media>(settings, '/api/media', { timeoutMs: 8000 }));
+  media(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<Media | null> {
+    return probeGated(caps?.media, () =>
+      probeOrNull(request<Media>(settings, '/api/media', { timeoutMs: 8000 })));
   },
 
   /** One transport op on a player; `seek` carries { position_ms }. */
@@ -749,8 +833,12 @@ export const api = {
    * < 2.8 or no capture path) so the preview card hides. Frames come from
    * screenFrameSource(), not this method.
    */
-  screenInfo(settings: ConnSettings): Promise<ScreenInfo | null> {
-    return probeOrNull(request<ScreenInfo>(settings, '/api/screen', { timeoutMs: 8000 }));
+  screenInfo(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<ScreenInfo | null> {
+    return probeGated(caps?.screen, () =>
+      probeOrNull(request<ScreenInfo>(settings, '/api/screen', { timeoutMs: 8000 })));
   },
 
   /**
@@ -758,8 +846,12 @@ export const api = {
    * (agent < 2.8.1) so the rows hide; a transient 500 still throws, never
    * reading as "timer vanished".
    */
-  powerSchedule(settings: ConnSettings): Promise<PowerSchedule | null> {
-    return probeOrNull(request<PowerSchedule>(settings, '/api/power/schedule'));
+  powerSchedule(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<PowerSchedule | null> {
+    return probeGated(caps?.power_schedule, () =>
+      probeOrNull(request<PowerSchedule>(settings, '/api/power/schedule')));
   },
 
   /** Arm a delayed suspend/poweroff. */

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -1,6 +1,8 @@
 import { Platform } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 
+import type { BoxCaps } from './api';
+
 /**
  * Input style for the Pad tab:
  *  - gamepad:  full on-screen Xbox controller
@@ -40,6 +42,13 @@ export type Box = {
    * media keys, the default) or 'tv' (the panel/CEC backend). Per box.
    */
   volumeTarget?: 'box' | 'tv';
+  /**
+   * Optional-feature summary this box last reported on /api/status (agent >=
+   * 2.8.2), learned + persisted like `mac`. Lets the tab bar hide gaming tabs
+   * (Pad/Launch) on a server box immediately on launch, before the first live
+   * poll. Undefined until first learned / on older agents.
+   */
+  caps?: BoxCaps;
 };
 
 /**
@@ -57,6 +66,8 @@ export type Settings = {
   mac?: string;
   /** Volume target of the active box (see Box.volumeTarget). */
   volumeTarget?: 'box' | 'tv';
+  /** Capability summary of the active box (see Box.caps). */
+  caps?: BoxCaps;
 };
 
 /** Safe placeholder used when no box is active (nothing paired yet). */
@@ -184,6 +195,28 @@ function normalizePadMode(v: unknown): PadMode {
   return 'swipe';
 }
 
+/** Coerce a parsed value into a BoxCaps, or undefined unless all six flags are
+ *  present as booleans (a partial/garbage blob is dropped, not half-trusted). */
+function normalizeCaps(raw: unknown): BoxCaps | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const o = raw as Record<string, unknown>;
+  const bool = (k: string): boolean | undefined =>
+    typeof o[k] === 'boolean' ? (o[k] as boolean) : undefined;
+  const gamepad = bool('gamepad');
+  const steam = bool('steam');
+  const media = bool('media');
+  const tv = bool('tv');
+  const screen = bool('screen');
+  const power_schedule = bool('power_schedule');
+  if (
+    gamepad === undefined || steam === undefined || media === undefined ||
+    tv === undefined || screen === undefined || power_schedule === undefined
+  ) {
+    return undefined;
+  }
+  return { gamepad, steam, media, tv, screen, power_schedule };
+}
+
 /** Coerce an arbitrary parsed value into a valid Box, or null if unusable. */
 function normalizeBox(raw: unknown): Box | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -200,9 +233,10 @@ function normalizeBox(raw: unknown): Box | null {
     typeof o.lastIp === 'string' && isValidLanIp(o.lastIp) ? o.lastIp : undefined;
   const mac = normalizeMac(o.mac) ?? undefined;
   const volumeTarget = normalizeVolumeTarget(o.volumeTarget);
+  const caps = normalizeCaps(o.caps);
   return {
     id, name, host, port, token, padMode: normalizePadMode(o.padMode),
-    lastIp, mac, volumeTarget,
+    lastIp, mac, volumeTarget, caps,
   };
 }
 
@@ -292,6 +326,7 @@ export function activeSettings(state: BoxesState): Settings {
     lastIp: active.lastIp,
     mac: active.mac,
     volumeTarget: active.volumeTarget,
+    caps: active.caps,
   };
 }
 

--- a/app/package.json
+++ b/app/package.json
@@ -37,8 +37,8 @@
   },
   "scripts": {
     "start": "expo start",
-    "android": "expo start --android",
-    "ios": "expo start --ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
     "web": "expo start --web"
   },
   "private": true

--- a/docs/capability-adaptive-ui.md
+++ b/docs/capability-adaptive-ui.md
@@ -1,0 +1,101 @@
+# Capability-adaptive UI
+
+The app shows exactly the UI a box can back, and nothing else. A headless
+server (no virtual gamepad, no Steam) automatically loses its gaming tabs; an
+HTPC keeps them; a mixed fleet flips per selected box. This is not a "mode" and
+carries no branding — it is the same probe-and-appear philosophy the app has
+used since 2.5 (TV strip, media card, screen preview), promoted to a first-class
+capability summary.
+
+Decision (2026-07-09): no separate product, no "server mode" naming anywhere in
+code, UI, or marketing. Couchside runs on any systemd Linux machine (README has
+said so all along); this work just makes the UI honest about it. Any homelab
+outreach later is a screenshots-and-post exercise, not a build.
+
+## How it works
+
+1. **Agent detects at boot** — `set_caps` (agent/couchsided.py and
+   agent/win/couchsided-win.py) snapshots six booleans from the existing
+   availability detectors:
+
+   | cap | Linux | Windows |
+   |---|---|---|
+   | `gamepad` | /dev/uinput writable | ViGEmClient.dll loads |
+   | `steam` | Steam root with steamapps/ | steam.exe present |
+   | `media` | session bus + busctl (MPRIS) | SMTC |
+   | `tv` | RS-232 panel / CEC / soft volume | panel / cec_bridge / soft |
+   | `screen` | gamescope or spectacle + downscaler | GDI |
+   | `power_schedule` | /dev/rtc0 writable | waitable timers |
+
+2. **Rides the status heartbeat** — `caps` on `/api/status` (agent >= 2.8.2).
+   No extra round-trips; the app also skips the per-feature probe requests
+   (`/api/media`, `/api/screen`, `/api/downloads`, `/api/power/schedule`) when
+   caps says the feature is absent (`probeGated`, app/lib/api.ts).
+
+3. **Persisted per box** — the status poll learns `caps` onto the Box record
+   (app/components/RemotePowerBar.tsx), same pattern as the Wake-on-LAN MAC
+   learner, so gating is correct on the first frame of the next launch.
+   Responses are tagged with the box they were fetched for (`forBox`) so a
+   stale poll snapshot can never be attributed to another box (this class of
+   bug previously caused a write ping-pong between the per-tab bar instances —
+   "Maximum update depth exceeded" — caught live on the simulator).
+
+4. **Tabs follow caps** — app/app/(tabs)/_layout.tsx: `caps.gamepad === false`
+   hides Pad, `caps.steam === false` hides Launch (`href: null`), and a bounce
+   effect moves the user to Console if they were on a now-hidden tab.
+   Undefined caps (old agent, never connected) hides nothing — never hide UI
+   on a guess. Caps is a hint, not authority: live ops still verify (the
+   gamepad WS connect is ground truth).
+
+## Status
+
+- **Done** — caps summary in both agents (2.8.2 / 0.3.1-win), typed +
+  cached + probe-skipping app client, per-box persistence, tab gating with
+  bounce, `forBox` response tagging. Verified: mock + real agents over HTTP,
+  web build (Expo web + stubs), and on-device iOS simulator with a live
+  mixed fleet (server stub + HTPC mock), including box switching in both
+  directions and a cold-start no-error check.
+- **Done** — Fleet tab (app/app/(tabs)/fleet.tsx): per-box status polling
+  (useFleetStatus, modeled on useBoxOnlineStatus), tiles with hostname /
+  temp / load / mem / DOWN + last-seen, tap = switch active box + land on
+  Console. Tab bar entry hidden with fewer than 2 boxes so single-box users
+  keep a clean bar.
+- **Done** — configurable watchlist: agent-side config (`units[]` in
+  /etc/couchside/config.json) was already fully documented in
+  agent/README.md with examples; the Console UNITS card now carries a hint
+  pointing at it. An authed `/api/config/units` write route (edit the
+  watchlist from the app) remains a follow-up — config.json is deliberately
+  root-owned, so in-app editing needs a route on the agent, not a file write.
+
+## Deferred
+
+- **couchside-docker** — container ps/start/stop/restart/logs. Pattern:
+  root-owned fixed-argument wrapper at /etc/couchside/couchside-docker
+  (mirror of the couchside-journal wrapper, couchside-decky/main.py). sudoers
+  grants ONLY the wrapper; the wrapper validates subcommand allowlist +
+  container-name charset + clamped log lines, then execs docker. Never a
+  wildcard docker sudoers rule (docker group ~= root). Agent grows
+  /api/containers routes; app grows a containers screen.
+- **couchside-systemctl** — same wrapper pattern for arbitrary per-unit
+  systemctl (start/stop/restart any validated unit), replacing today's
+  fixed-action sudoers entries for user-defined units.
+- **Metrics history / sparklines** — Console and Fleet are point-in-time.
+- **/api/config/units write route** — see above.
+
+## Done since: stale-poll reset (was deferred)
+
+usePoll now takes a `resetKey` (the poll target's identity, `hostKey(settings)`
+= host:port). On key change it clears data/error in the same render (no stale
+frame), discards in-flight results fetched for the old key (generation guard),
+and refires for the new target. All 13 active-box poll sites pass it; the
+LogsPanel journal keys on box + selected unit and dropped its manual
+refresh-on-unit-change effect.
+
+The hook also exposes `dataKey` — which key the current `data` was fetched
+under. Render-time consumers that mutate refs from poll data MUST gate on it:
+when resetKey changes, React discards the in-progress render pass but still
+finishes executing it with the OLD target's data visible, and ref writes from
+that doomed pass persist. ScreenPreview's sticky "ever supported" ref was
+re-poisoned exactly this way (found live on the simulator; a bare
+`if (probe.data)` after the per-box reset). Effects are immune (they run only
+after commit); bare render-time ref writes are not.


### PR DESCRIPTION
## What

The app now shows exactly the UI a box can back. A headless server (no gamepad, no Steam) automatically loses its gaming tabs; an HTPC keeps them; a mixed fleet flips per selected box. No mode, no branding — same probe-and-appear philosophy as the TV strip, promoted to a first-class capability summary.

### Agent (2.8.2 / 0.3.1-win)
- Boot-time `caps` summary on `/api/status`: `{gamepad, steam, media, tv, screen, power_schedule}`, computed from the existing detectors (uinput/ViGEm, Steam root, MPRIS/SMTC, panel/CEC/soft, capture path, RTC/waitable timers). All true in `--mock`.
- Windows: extracted a load-only `_vigem_load_dll()` so the cap check has no bus-connect side effect.

### App
- `BoxCaps` typed; per-box cache; `media`/`screenInfo`/`downloads`/`powerSchedule` probes skip the request when caps says absent (agents without caps keep 404 probe-and-appear).
- caps persisted on the Box record from the status poll (same pattern as the WoL MAC learner) — gating correct on first frame after launch.
- Tab gating: `gamepad:false` hides Pad, `steam:false` hides Launch, bounce to Console off hidden tabs. Undefined caps hides nothing.
- **Fleet tab**: per-box status polling, temp/load/mem tiles, DOWN + last-seen, tap to switch. Hidden under 2 boxes.
- **usePoll `resetKey`**: box switch clears poll data in the same render, discards in-flight results fetched for the old box, refires. All 13 active-box poll sites keyed; LogsPanel journal also keys on selected unit. New `PollState.dataKey` guards render-time ref writes against React executing the discarded render pass with stale data (fixed ScreenPreview's sticky ever-supported ref, and the earlier caps/mac write ping-pong).
- Console UNITS card hints at the box-side watchlist config.

### Docs
- `docs/capability-adaptive-ui.md`: mechanism, status, deferred `couchside-docker`/`couchside-systemctl` wrapper design.
- `agent/README.md` `/api/status` row.

## Verification
- Both agents `--mock` over HTTP (caps all true; 401 without token); real-branch caps exception-safe (all-bool, no crash).
- Expo web against a server stub + HTPC mock: tab drop/restore, probe short-circuit visible in the network log.
- iOS simulator (dev build, cache-cleared full bundle): mixed fleet, switching both directions, cold start; Fleet tap-to-switch; no stale SCREEN card on the headless box; 0 render-loop errors.
- `tsc --noEmit` clean.

## After merge
- Shipping agent 2.8.2 to boxes needs the manual decky release: `gh workflow run ... -f force=true` then `scripts/sign-release.sh` (push trigger is dead).
- App-side changes ride the next EAS build; no store action now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)