### PR TITLE
fix(win): silence ms-gamebar popup from the Guide button

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -111,6 +111,14 @@ function Uninstall-Couchside {
         Where-Object { $_.CommandLine -like '*couchside-tray.pyw*' } |
         ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
     if (Test-Path $StartupLnk) { Remove-Item -Force $StartupLnk -ErrorAction SilentlyContinue }
+    # Remove our ms-gamebar no-op handlers, but only if they are still OURS
+    # (command == systray.exe): never clobber a real Game Bar the user may have
+    # reinstalled since.
+    foreach ($s in 'ms-gamebar','ms-gamebarservices','ms-gamingoverlay') {
+        $b = "HKCU:\Software\Classes\$s"
+        $cmd = (Get-ItemProperty "$b\shell\open\command" -Name '(default)' -ErrorAction SilentlyContinue).'(default)'
+        if ($cmd -eq 'systray.exe') { Remove-Item $b -Recurse -Force -ErrorAction SilentlyContinue }
+    }
     if (Test-Path $InstallDir) { Remove-Item -Recurse -Force $InstallDir }
     Write-Host "Left in place (delete manually to unpair phones): $DataDir"
     Write-Host 'Note: if install disabled hibernation, restore it with `powercfg /hibernate on`.'
@@ -313,6 +321,27 @@ if tgz:
     }
     if (Test-Path $dllDest) { Write-Host 'Virtual gamepad ready (ViGEmBus + client DLL).' }
     else { Write-Host 'Gamepad driver step incomplete; the pad may be unavailable (everything else works).' }
+
+    # Silence the "Get an app to open this 'ms-gamebar' link" popup. Windows
+    # globally binds the Xbox *Guide* button to Xbox Game Bar; the app's Guide
+    # button drives that bit on the virtual pad, so on a box where Game Bar has
+    # been uninstalled every Guide press dead-ends in that dialog. Point the
+    # Game Bar URI schemes at a no-op (systray.exe exits instantly) so Windows
+    # opens nothing instead. Written to HKCU of the installing user, which is
+    # the agent's target user ($env:USERNAME — same identity the scheduled task
+    # below runs as); no effect on other accounts, reversible on --uninstall,
+    # no reboot. Steam Big Picture still intercepts Guide first while it is
+    # running, so this only changes the "nothing else handled Guide" case.
+    foreach ($s in 'ms-gamebar','ms-gamebarservices','ms-gamingoverlay') {
+        try {
+            $b = "HKCU:\Software\Classes\$s"
+            New-Item "$b\shell\open\command" -Force | Out-Null
+            Set-ItemProperty $b '(default)'    "URL:$s"
+            Set-ItemProperty $b 'URL Protocol' ''
+            Set-ItemProperty "$b\shell\open\command" '(default)' 'systray.exe'
+        } catch { }
+    }
+    Write-Host 'Silenced the Xbox Game Bar (ms-gamebar) popup for the Guide button.'
 }
 
 # --- 3. token (kept across reinstalls so paired phones keep working) ---------


### PR DESCRIPTION
## Symptom
Resuming control from the app on a Windows box pops up **"Get an app to open this 'ms-gamebar' link"** (screenshot: user's living-room TV).

## Root cause
Windows globally binds the Xbox **Guide** button to Xbox Game Bar. The app's Guide/Steam button sets that bit (`0x0400`) on the ViGEm virtual pad (`agent/win/couchsided-win.py:3171`), so every Guide press is routed to Game Bar via the `ms-gamebar:` URI. On a box where Game Bar has been uninstalled, that URI has no handler → the dialog. It shows on resume because tapping Guide is how you wake control.

Confirmed the client does **not** auto-send Guide on reconnect (`lib/gamepad.ts`) and the win agent doesn't emit it on connect — it's the button itself.

## Fix
`install.ps1` registers no-op HKCU handlers for `ms-gamebar` / `ms-gamebarservices` / `ms-gamingoverlay` (command = `systray.exe`, exits instantly) so Windows opens nothing instead of the popup. Chosen over dropping the Guide bit because it **preserves Guide → Steam Big Picture** (Steam intercepts Guide first while BPM is running); only the "nothing else handled Guide" case changes. Written to the installing user's hive (`$env:USERNAME`, the agent's target user). `--uninstall` removes the keys only while they're still ours.

## Immediate box fix (no reinstall)
Paste into a normal PowerShell:
```powershell
foreach ($s in 'ms-gamebar','ms-gamebarservices','ms-gamingoverlay') {
  $b = "HKCU:\Software\Classes\$s"
  New-Item "$b\shell\open\command" -Force | Out-Null
  Set-ItemProperty $b '(default)' "URL:$s"; Set-ItemProperty $b 'URL Protocol' ''
  Set-ItemProperty "$b\shell\open\command" '(default)' 'systray.exe'
}
```

## Verification
No CI covers install.ps1 (win CI only py_compiles the agent). Parse-reviewed manually; not runnable on the Mac (no pwsh). Needs a smoke on EMERY-PC after merge — key-based SSH to that box is unavailable, so it's a manual paste-and-run check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)