### PR TITLE
feat(win): desktop shortcut buttons — Win, Alt+Tab, Lock, Task Manager

### DIFF
--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -1580,11 +1580,15 @@ VK_BACK, VK_TAB, VK_RETURN, VK_SHIFT, VK_ESCAPE, VK_SPACE = (
 VK_END, VK_HOME = 0x23, 0x24
 VK_LEFT, VK_UP, VK_RIGHT, VK_DOWN = 0x25, 0x26, 0x27, 0x28
 VK_VOLUME_MUTE, VK_VOLUME_DOWN, VK_VOLUME_UP = 0xAD, 0xAE, 0xAF
+# Modifier + Windows-key virtual codes, for the system-shortcut chords below.
+VK_LWIN, VK_LCONTROL, VK_LMENU = 0x5B, 0xA2, 0xA4
+VK_L = 0x4C  # letter L, for Win+L (lock)
 
 # E0-prefixed extended keys: SendInput needs KEYEVENTF_EXTENDEDKEY or their
-# scan codes alias onto the numpad for raw-input consumers.
+# scan codes alias onto the numpad for raw-input consumers. LWIN is E0-prefixed
+# too; without the flag Win+L / the Start menu can misfire.
 EXTENDED_VKS = frozenset((VK_LEFT, VK_UP, VK_RIGHT, VK_DOWN, VK_HOME, VK_END,
-                          VK_VOLUME_MUTE, VK_VOLUME_DOWN, VK_VOLUME_UP))
+                          VK_VOLUME_MUTE, VK_VOLUME_DOWN, VK_VOLUME_UP, VK_LWIN))
 
 # named special key -> virtual-key code (same protocol names as Linux)
 SPECIAL_KEYS = {
@@ -1599,6 +1603,18 @@ SPECIAL_KEYS = {
     "right": VK_RIGHT,
     "home": VK_HOME,
     "end": VK_END,
+}
+
+# System-shortcut chords (Windows desktop). One protocol name -> an ordered VK
+# sequence pressed down in order then released in reverse (see Keyboard.emit).
+# Ctrl+Alt+Del is deliberately absent: it is the Secure Attention Sequence, which
+# SendInput cannot generate by design (only the kernel/SendSAS can). These are
+# all plain injectable keystrokes.
+KEY_CHORDS = {
+    "win": (VK_LWIN,),                                # Start menu
+    "alt-tab": (VK_LMENU, VK_TAB),                    # switch window
+    "lock": (VK_LWIN, VK_L),                          # Win+L, lock the session
+    "taskmgr": (VK_LCONTROL, VK_SHIFT, VK_ESCAPE),    # Ctrl+Shift+Esc
 }
 
 if IS_WINDOWS:
@@ -3421,6 +3437,13 @@ class WinKeyboard:
                 vk = SPECIAL_KEYS[ev[1]]
                 inputs.append(_key_input(vk, True))
                 inputs.append(_key_input(vk, False))
+            elif kind == "chord":
+                # Press modifiers/keys in order, release in reverse — the
+                # standard hotkey shape (e.g. Alt down, Tab down, Tab up, Alt up).
+                for vk in ev[1]:
+                    inputs.append(_key_input(vk, True))
+                for vk in reversed(ev[1]):
+                    inputs.append(_key_input(vk, False))
         _send_inputs(inputs)
 
     def destroy(self):
@@ -3546,6 +3569,8 @@ def keyboard_events(msg):
         return [("text", text)]
     if t == "k":
         key = msg.get("key")
+        if key in KEY_CHORDS:
+            return [("chord", KEY_CHORDS[key])]
         if key not in SPECIAL_KEYS:
             raise ValueError("unknown special key %r" % (key,))
         return [("key", key)]

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -34,7 +34,7 @@ import { Gated } from '@/components/Gated';
 import { RemoteView } from '@/components/RemoteView';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
-import { ButtonKey, GamepadClient, GamepadStatus, StickKey, TriggerKey } from '@/lib/gamepad';
+import { ButtonKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -692,6 +692,14 @@ function PadScreen() {
   // auto-releases, so one tap opens the ⋯ panel where Decky / plugins live.
   const qam = useCallback(() => client.qamChord(), [client]);
 
+  // Windows desktop shortcuts (Start / Alt+Tab / Lock / Task Manager). Only a
+  // ViGEm (Windows) box maps these; the row that uses them is gated on that.
+  const isWindows = dev === 'ViGEm X360 pad';
+  const sys = useCallback(
+    (name: SystemChord) => () => client.sendSystemChord(name),
+    [client],
+  );
+
   const trig = useCallback(
     (k: TriggerKey) => ({
       onDown: () => client.sendTrigger(k, 255),
@@ -899,6 +907,19 @@ function PadScreen() {
               fontSize={22}
             />
           </View>
+          {/* Windows desktop shortcuts — one-shot chords, ViGEm boxes only. */}
+          {isWindows && (
+            <View style={styles.swipeBtnRow}>
+              <PadButton label="⊞ WIN" onDown={sys('win')} onUp={NOOP}
+                style={[styles.tpBtn, styles.tpBtnWide]} fontSize={12} />
+              <PadButton label="ALT+TAB" onDown={sys('alt-tab')} onUp={NOOP}
+                style={[styles.tpBtn, styles.tpBtnWide]} fontSize={11} />
+              <PadButton label="LOCK" onDown={sys('lock')} onUp={NOOP}
+                style={styles.tpBtn} fontSize={11} />
+              <PadButton label="TASK" onDown={sys('taskmgr')} onUp={NOOP}
+                style={styles.tpBtn} fontSize={11} />
+            </View>
+          )}
           {keyboardBar}
         </>
       ) : landscape ? (

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -45,6 +45,9 @@ export type ButtonKey =
   | 'du'
   | 'dd';
 
+/** Windows desktop system shortcuts (one-shot chords the agent expands). */
+export type SystemChord = 'win' | 'alt-tab' | 'lock' | 'taskmgr';
+
 export type TriggerKey = 'lt' | 'rt';
 export type StickKey = 'l' | 'r';
 
@@ -388,6 +391,17 @@ export class GamepadClient {
   /** A single special key press+release (backspace, enter, arrows, …). */
   sendKey(key: SpecialKey): void {
     this.sendRaw({ t: 'k', key });
+  }
+
+  /**
+   * Fire a one-shot Windows system shortcut (Start / Alt+Tab / Lock / Task
+   * Manager). Rides the same {t:'k'} channel — the agent maps the name to a
+   * key-chord and presses/releases it. Windows-only (the buttons that call this
+   * only render for a ViGEm box); a Linux agent rejects the unknown name and
+   * drops the frame.
+   */
+  sendSystemChord(name: SystemChord): void {
+    this.sendRaw({ t: 'k', key: name });
   }
 
   // ---------- internals ----------


### PR DESCRIPTION
## What
A **SYSTEM** row in the Pad → Trackpad view (the desktop-driving surface), one-tap Windows shortcuts, shown only when connected to a ViGEm (Windows) box:

| Button | Sends |
|---|---|
| ⊞ WIN | Start menu (`LWIN`) |
| ALT+TAB | switch window (`LMENU`+`Tab`) |
| LOCK | lock session (`Win+L`) |
| TASK | Task Manager (`Ctrl+Shift+Esc`) |

## Why no Ctrl+Alt+Del
CAD is the **Secure Attention Sequence** — SendInput cannot generate it by design (only the kernel / `SendSAS` can, which needs a group-policy change + elevation and still no-ops on hardened boxes). Lock + Task Manager are what CAD is actually used for on a couch box, and they're plain reliable SendInput. Per the user's choice: reliable set, skip true CAD.

## How
- Rides the existing `{t:'k'}` keyboard channel — no new message type.
- Win agent: `KEY_CHORDS` map + a `chord` event kind in `Keyboard.emit` (press in order, release in reverse). `keyboard_events` routes chord names before the single-key path and still rejects unknown names. `LWIN` added to `EXTENDED_VKS`.
- App: `GamepadClient.sendSystemChord()`, `SystemChord` type; row gated on `dev === 'ViGEm X360 pad'` (the real Windows device name, already the `textCaps` signal).

## Verification
- Agent: `keyboard_events` unit-tested for all four chords + normal key + unknown-rejected; VK sequences correct (`win→0x5b`, `alt-tab→0xa4,0x09`, `lock→0x5b,0x4c`, `taskmgr→0xa2,0x10,0x1b`). `py_compile` OK.
- App: `tsc --noEmit` clean.
- **Not** verifiable headlessly: real SendInput firing on Windows (no key-based SSH to the box) and the row rendering (mock reports `dev="mock"`, so the gate hides it under `--mock`). Needs an on-box smoke, same as the ms-gamebar fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)