### PR TITLE
feat: aerial screensaver — agent 2.8.4 /api/screensaver + app theme picker

### DIFF
--- a/agent/couchside-screensaver.sh
+++ b/agent/couchside-screensaver.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# couchside-screensaver: Apple-TV-style aerial screensaver for Couchside boxes.
+# Launched THROUGH STEAM (registered as a non-Steam shortcut) because gamescope
+# only surfaces windows Steam focuses. Plays shuffled Apple aerials fullscreen
+# with ffplay until killed (the agent's screensaver stop TERMs the pidfile pid;
+# the trap below forwards that to the current ffplay child).
+#
+# Playlist: Apple's public aerial catalog (entries.json inside resources.tar).
+# Cached for 7 days; refreshed best-effort. 1080p H264 tier: every box decodes
+# it, streams light. No key, no account.
+set -u
+# Steam launches non-Steam shortcuts inside its runtime: LD_LIBRARY_PATH /
+# LD_PRELOAD point at Steam's bundled libs, which breaks OS binaries (curl,
+# tar, python3, ffplay all link the wrong libraries and die). Shed that env —
+# we want the plain OS toolchain; gamescope still surfaces the window fine.
+unset LD_LIBRARY_PATH LD_PRELOAD
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/couchside"
+CATALOG="$CACHE_DIR/aerials.json"
+CATALOG_URL="https://sylvan.apple.com/Aerials/resources-15.tar"
+PIDFILE="$CACHE_DIR/screensaver.pid"
+mkdir -p "$CACHE_DIR"
+
+# Single instance: a stale pidfile whose pid is dead is overwritten.
+if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+    exit 0
+fi
+echo "$$" > "$PIDFILE"
+# Steam's reaper owns our process group, so a stopper can't signal the pgid —
+# it kills THIS pid (the pidfile), and we forward to the current ffplay child.
+CUR=""
+stop() { [ -n "$CUR" ] && kill "$CUR" 2>/dev/null; rm -f "$PIDFILE"; exit 0; }
+trap stop TERM INT
+trap 'rm -f "$PIDFILE"' EXIT
+
+fresh() {
+    [ -f "$CATALOG" ] || return 1
+    local age=$(( $(date +%s) - $(stat -c %Y "$CATALOG" 2>/dev/null || echo 0) ))
+    [ "$age" -lt 604800 ]
+}
+
+if ! fresh; then
+    tmp=$(mktemp -d)
+    # Verified TLS first. Fedora's CA bundle can't build Apple's sylvan chain
+    # (missing intermediate, AIA-only), so fall back to unverified — the parser
+    # below hard-whitelists https://*.apple.com URLs, and ffmpeg's own TLS does
+    # not verify either, so this is no weaker than playback itself. Video
+    # content only; nothing from this file is executed.
+    if ! curl -fsSL -m 60 -o "$tmp/resources.tar" "$CATALOG_URL" 2>/dev/null; then
+        curl -fsSLk -m 60 -o "$tmp/resources.tar" "$CATALOG_URL" 2>/dev/null
+    fi
+    if [ -s "$tmp/resources.tar" ] \
+       && tar -xf "$tmp/resources.tar" -C "$tmp" entries.json 2>/dev/null; then
+        mv "$tmp/entries.json" "$CATALOG"
+    fi
+    rm -rf "$tmp"
+fi
+[ -f "$CATALOG" ] || exit 1
+
+# Conf (~/.config/couchside/screensaver.conf), both optional:
+#   TIER=1080-H264 (default; every box decodes it) | 1080-SDR | 4K-SDR | 4K-HDR
+#   THEME=all (default) | space | landscapes | cities | underwater
+#         (comma-separable, e.g. THEME=space,underwater — Apple TV's categories)
+CONF="${XDG_CONFIG_HOME:-$HOME/.config}/couchside/screensaver.conf"
+TIER="1080-H264"
+THEME="all"
+# shellcheck disable=SC1090
+[ -f "$CONF" ] && . "$CONF"
+
+# Shuffled URL list, one per line. Re-shuffled each full pass.
+urls() {
+    TIER="$TIER" THEME="$THEME" python3 - "$CATALOG" <<'PY'
+import json, os, random, sys
+from urllib.parse import urlparse
+d = json.load(open(sys.argv[1]))
+tier = "url-" + os.environ.get("TIER", "1080-H264")
+# Theme names -> category ids, matched against AerialCategory<Name> keys at
+# runtime so a future catalog reshuffle of UUIDs keeps working.
+want = {t.strip().lower() for t in os.environ.get("THEME", "all").split(",") if t.strip()}
+cat_ids = None
+if want and "all" not in want:
+    cat_ids = {c["id"] for c in d.get("categories", [])
+               if c.get("localizedNameKey", "").lower().removeprefix("aerialcategory") in want}
+u = []
+for a in d.get("assets", []):
+    if cat_ids is not None and not (set(a.get("categories", [])) & cat_ids):
+        continue
+    x = a.get(tier) or a.get("url-1080-H264")
+    if not x:
+        continue
+    # Whitelist: https + apple.com hosts only. The catalog fetch may have been
+    # unverified (see above), so never let it point the player anywhere else.
+    p = urlparse(x)
+    if p.scheme == "https" and (p.hostname or "").endswith(".apple.com"):
+        u.append(x)
+# An unmatched theme name would yield an empty list — fall back to everything
+# rather than a black screen.
+if not u:
+    u = [a.get(tier) or a.get("url-1080-H264") for a in d.get("assets", [])]
+    u = [x for x in u if x and urlparse(x).scheme == "https"
+         and (urlparse(x).hostname or "").endswith(".apple.com")]
+random.shuffle(u)
+print("\n".join(u))
+PY
+}
+
+while :; do
+    while IFS= read -r url; do
+        ffplay -fs -an -loglevel quiet -autoexit "$url" &
+        CUR=$!
+        wait "$CUR"
+        rc=$?
+        CUR=""
+        # 0 = video finished, play the next; anything else = ffplay was killed
+        # (Steam's Stop, our stop(), or a decode failure) — exit cleanly.
+        [ "$rc" -eq 0 ] || exit 0
+    done < <(urls)
+done

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.8.3"
+VERSION = "2.8.4"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -642,7 +642,8 @@ def set_caps(mock):
 
     if mock:
         CAPS = {k: True for k in
-                ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
+                ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
+                 "screensaver")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -651,7 +652,204 @@ def set_caps(mock):
         "tv": safe(lambda: _tv_hw_backend() is not None or soft_available()),
         "screen": _SCREEN is not None,
         "power_schedule": safe(rtc_available),
+        "screensaver": safe(screensaver_available),
     }
+
+
+# ---------------------------------------------------------------------------
+# Aerial screensaver (/api/screensaver).
+#
+# Apple-TV-style flyover screensaver. The heavy lifting lives in the installed
+# couchside-screensaver.sh (deployed by install.sh / the Decky plugin next to
+# this agent): it caches Apple's public aerial catalog, filters by THEME, picks
+# a quality TIER, and loops shuffled videos with ffplay. This agent only
+# manages it:
+#   - it must be launched THROUGH STEAM (gamescope surfaces only what Steam
+#     focuses — the atom tricks were tested and do not work), so first start
+#     registers it as a non-Steam shortcut via steamos-add-to-steam and
+#     launches it with steam://rungameid/<id>;
+#   - stop kills the pid from the script's pidfile (NOT the pgid — Steam's
+#     reaper owns the process group);
+#   - theme/tier are written to the script's conf before each start.
+# ---------------------------------------------------------------------------
+
+SCREENSAVER_SCRIPT = os.path.expanduser(
+    "~/.local/opt/couchside/couchside-screensaver.sh")
+SCREENSAVER_CONF = os.path.expanduser("~/.config/couchside/screensaver.conf")
+SCREENSAVER_PIDFILE = os.path.expanduser("~/.cache/couchside/screensaver.pid")
+SCREENSAVER_THEMES = ("all", "landscapes", "cities", "space", "underwater")
+SCREENSAVER_TIERS = ("1080-H264", "1080-SDR", "1080-HDR", "4K-SDR", "4K-HDR")
+# How long to wait for steamos-add-to-steam's async registration to land in
+# shortcuts.vdf, and the gap between the double rungameid fire on a fresh
+# registration (the first open only shows the shortcut's page).
+SS_REGISTER_WAIT_S = 10
+SS_FIRST_LAUNCH_GAP_S = 4
+
+SS_MOCK = False
+_SS_MOCK = {"running": False, "theme": "all", "tier": "1080-H264"}
+_SS_LOCK = threading.Lock()   # one start/stop mutation at a time
+
+
+def set_screensaver(mock):
+    global SS_MOCK
+    SS_MOCK = mock
+
+
+def screensaver_available():
+    """Script deployed + the Steam-launch toolchain present. Boot-time hint
+    (rides caps); GET /api/screensaver is the live authority."""
+    return (os.path.isfile(SCREENSAVER_SCRIPT)
+            and shutil.which("ffplay") is not None
+            and shutil.which("steam") is not None
+            and shutil.which("steamos-add-to-steam") is not None)
+
+
+def _ss_running():
+    try:
+        with open(SCREENSAVER_PIDFILE) as f:
+            pid = int(f.read().strip())
+        os.kill(pid, 0)
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _ss_conf_read():
+    """(theme, tier) from the script's conf, defaults when absent/partial."""
+    theme, tier = "all", "1080-H264"
+    try:
+        with open(SCREENSAVER_CONF) as f:
+            for line in f:
+                line = line.strip()
+                if line.startswith("THEME="):
+                    theme = line.split("=", 1)[1].strip() or theme
+                elif line.startswith("TIER="):
+                    tier = line.split("=", 1)[1].strip() or tier
+    except OSError:
+        pass
+    return theme, tier
+
+
+def _ss_conf_write(theme, tier):
+    os.makedirs(os.path.dirname(SCREENSAVER_CONF), exist_ok=True)
+    with open(SCREENSAVER_CONF, "w") as f:
+        f.write("TIER=%s\nTHEME=%s\n" % (tier, theme))
+
+
+def _ss_validate(theme, tier):
+    """Validated (theme, tier), raising ValueError on junk. theme may be a
+    comma list of known themes ("space,underwater")."""
+    parts = [t.strip().lower() for t in str(theme).split(",") if t.strip()]
+    if not parts:
+        parts = ["all"]
+    for t in parts:
+        if t not in SCREENSAVER_THEMES:
+            raise ValueError("unknown theme %r" % t)
+    if tier not in SCREENSAVER_TIERS:
+        raise ValueError("unknown tier %r" % tier)
+    return ",".join(parts), tier
+
+
+def _ss_appid():
+    """The registered shortcut's appid from shortcuts.vdf, or None. Matched by
+    exe path so a rename of the tile doesn't break the lookup."""
+    for p in glob.glob(os.path.expanduser(
+            "~/.steam/steam/userdata/*/config/shortcuts.vdf")):
+        try:
+            with open(p, "rb") as f:
+                data = f.read()
+        except OSError:
+            continue
+        i = data.find(b"couchside-screensaver.sh")
+        if i < 0:
+            continue
+        # The appid field precedes the exe/appname block of the same entry.
+        seg = data[max(0, i - 300):i]
+        j = seg.rfind(b"\x02appid\x00")
+        if j >= 0 and j + 12 <= len(seg):
+            return struct.unpack("<I", seg[j + 8:j + 12])[0]
+    return None
+
+
+def _ss_gameid(appid):
+    """steam://rungameid id for a non-Steam shortcut."""
+    return (appid << 32) | 0x02000000
+
+
+def _ss_fire(gameid):
+    subprocess.Popen(
+        ["steam", "steam://rungameid/%d" % gameid],
+        env=_user_env(), start_new_session=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def screensaver_info():
+    if SS_MOCK:
+        return {"available": True, "running": _SS_MOCK["running"],
+                "theme": _SS_MOCK["theme"], "tier": _SS_MOCK["tier"],
+                "themes": list(SCREENSAVER_THEMES),
+                "tiers": list(SCREENSAVER_TIERS)}
+    theme, tier = _ss_conf_read()
+    return {"available": screensaver_available(), "running": _ss_running(),
+            "theme": theme, "tier": tier,
+            "themes": list(SCREENSAVER_THEMES),
+            "tiers": list(SCREENSAVER_TIERS)}
+
+
+def screensaver_start(theme, tier):
+    """Write conf and launch via Steam. Registration (first ever start) and
+    the fresh-registration double-fire run in a background thread — the POST
+    returns immediately and the app watches `running` flip via GET."""
+    theme, tier = _ss_validate(theme, tier)
+    if SS_MOCK:
+        _SS_MOCK.update(running=True, theme=theme, tier=tier)
+        return {"ok": True, "running": True}
+    if not screensaver_available():
+        raise RuntimeError("screensaver not installed on this box")
+    with _SS_LOCK:
+        _ss_conf_write(theme, tier)
+        if _ss_running():
+            # Restart with the new theme/tier: kill, then relaunch below.
+            screensaver_stop()
+        appid = _ss_appid()
+
+    def launch():
+        aid = appid
+        fresh = aid is None
+        if fresh:
+            subprocess.run(
+                ["steamos-add-to-steam", SCREENSAVER_SCRIPT],
+                env=_user_env(), timeout=30,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            deadline = time.monotonic() + SS_REGISTER_WAIT_S
+            while aid is None and time.monotonic() < deadline:
+                time.sleep(1)
+                aid = _ss_appid()
+            if aid is None:
+                print("[screensaver] registration did not appear in shortcuts.vdf",
+                      flush=True)
+                return
+        _ss_fire(_ss_gameid(aid))
+        if fresh:
+            # A shortcut's very first rungameid only opens its page.
+            time.sleep(SS_FIRST_LAUNCH_GAP_S)
+            _ss_fire(_ss_gameid(aid))
+
+    threading.Thread(target=launch, daemon=True).start()
+    return {"ok": True, "starting": True}
+
+
+def screensaver_stop():
+    if SS_MOCK:
+        _SS_MOCK["running"] = False
+        return {"ok": True, "running": False}
+    try:
+        with open(SCREENSAVER_PIDFILE) as f:
+            pid = int(f.read().strip())
+        os.kill(pid, 15)  # SIGTERM; the script forwards it to its ffplay child
+    except (OSError, ValueError):
+        pass  # not running = already stopped; stop is idempotent
+    return {"ok": True, "running": False}
 
 
 # ---------------------------------------------------------------------------
@@ -4763,6 +4961,15 @@ class Handler(BaseHTTPRequestHandler):
                 # Always 200: reports the (volatile) sleep timer + the RTC wake
                 # alarm read from hardware. Old agents 404 -> app hides the rows.
                 self._send(200, power_schedule_info(), started)
+            elif path == "/api/screensaver":
+                # Probe-and-appear like /api/tv: 404 when the script/toolchain
+                # is absent so the app hides the feature (and old apps that
+                # never ask are unaffected).
+                info = screensaver_info()
+                if info["available"]:
+                    self._send(200, info, started)
+                else:
+                    self._send(404, {"error": "screensaver not installed"}, started)
             else:
                 self._send(404, {"error": "not found"}, started)
         except BrokenPipeError:
@@ -4992,6 +5199,37 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "unknown player"}, started)
                     return
                 self._send(200, result, started)
+                return
+
+            # POST /api/screensaver: {"op":"start","theme"?,"tier"?} | {"op":"stop"}
+            if path == "/api/screensaver":
+                if not (SS_MOCK or screensaver_available()):
+                    self._send(404, {"error": "screensaver not installed"}, started)
+                    return
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError
+                    op = req.get("op")
+                except (ValueError, UnicodeDecodeError):
+                    self._send(400, {"error": "json body with op required"}, started)
+                    return
+                cur_theme, cur_tier = _ss_conf_read()
+                if op == "start":
+                    try:
+                        r = screensaver_start(req.get("theme", cur_theme),
+                                              req.get("tier", cur_tier))
+                    except ValueError as e:
+                        self._send(400, {"error": str(e)}, started)
+                        return
+                    except RuntimeError as e:
+                        self._send(409, {"error": str(e)}, started)
+                        return
+                    self._send(200, r, started)
+                elif op == "stop":
+                    self._send(200, screensaver_stop(), started)
+                else:
+                    self._send(400, {"error": "op must be start|stop"}, started)
                 return
 
             # POST /api/power/sleep: arm a delayed suspend/poweroff.
@@ -5486,6 +5724,7 @@ def main():
     set_mpris(args.mock)
     set_screen(args.mock)
     set_power_schedule(args.mock)
+    set_screensaver(args.mock)
     set_caps(args.mock)  # after the detectors above; snapshots CAPS
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)
 

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -84,7 +84,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.3.2-win"
+VERSION = "0.3.3-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -758,8 +758,11 @@ def set_caps(mock):
             return False
 
     if mock:
+        # screensaver stays False even in mock: it is a gamescope/Steam-shortcut
+        # feature the Windows agent does not implement (see the Linux agent).
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
+        CAPS["screensaver"] = False
         return
     CAPS = {
         "gamepad": safe(vigem_available),
@@ -768,6 +771,7 @@ def set_caps(mock):
         "tv": safe(lambda: _tv_hw_backend() is not None or soft_available()),
         "screen": _SCREEN is not None,
         "power_schedule": safe(wake_available),
+        "screensaver": False,
     }
 
 

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -3,9 +3,10 @@ import React from 'react';
 import { Alert, Modal, PanResponder, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { ScreensaverSheet } from '@/components/ScreensaverSheet';
 import { SleepTimerSheet } from '@/components/SleepTimerSheet';
 import { usePoll } from '@/hooks/usePoll';
-import { api, capsEqual, hostKey, PowerSchedule, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
+import { api, capsEqual, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac } from '@/lib/settings';
@@ -230,6 +231,17 @@ export function RemotePowerBar() {
   );
   const schedule = reachable ? schedulePoll.data ?? null : null;
   const [sleepOpen, setSleepOpen] = React.useState(false);
+
+  // Aerial screensaver (agent >= 2.8.4, gamescope boxes). Probe-and-appear:
+  // null hides the row; caps.screensaver === false skips the request entirely.
+  const saverPoll = usePoll<Screensaver | null>(
+    () => api.screensaver(settings),
+    15000,
+    reachable,
+    boxKey,
+  );
+  const saver = reachable ? saverPoll.data ?? null : null;
+  const [saverOpen, setSaverOpen] = React.useState(false);
 
   // Suspend-action availability, once per connect (agent >= 2.6 with the rule).
   const [hasSuspend, setHasSuspend] = React.useState(false);
@@ -456,6 +468,7 @@ export function RemotePowerBar() {
   const canBlankScreen = reachable && tv?.screen_toggle === true;
   const canSuspend = reachable && hasSuspend;
   const canWake = !reachable && !!settings.mac && wolAvailable;
+  const hasSaver = reachable && saver?.available === true;
 
   // Nothing to control on this box right now.
   if (
@@ -465,6 +478,7 @@ export function RemotePowerBar() {
     !hasTvPower &&
     !canSourceBox &&
     !canBlankScreen &&
+    !hasSaver &&
     sources.length === 0
   )
     return null;
@@ -539,6 +553,21 @@ export function RemotePowerBar() {
                     </Text>
                   )}
                 </View>
+              )}
+
+              {/* Aerial screensaver (agent >= 2.8.4, gamescope boxes) */}
+              {hasSaver && (
+                <Pressable
+                  onPress={() => {
+                    setOpen(false);
+                    setSaverOpen(true);
+                  }}
+                  style={({ pressed }) => [styles.bigBtn, pressed && styles.pressed]}>
+                  <Ionicons name="film-outline" size={22} color={theme.text} />
+                  <Text style={styles.bigLabel}>
+                    {saver?.running ? 'Screensaver · playing' : 'Screensaver'}
+                  </Text>
+                </Pressable>
               )}
 
               {/* Sleep timer / wake schedule (agent >= 2.8.1) */}
@@ -694,6 +723,13 @@ export function RemotePowerBar() {
         schedule={schedule}
         onChanged={schedulePoll.refresh}
         onClose={() => setSleepOpen(false)}
+      />
+      <ScreensaverSheet
+        visible={saverOpen}
+        settings={settings}
+        saver={saver}
+        onChanged={saverPoll.refresh}
+        onClose={() => setSaverOpen(false)}
       />
     </>
   );

--- a/app/components/ScreensaverSheet.tsx
+++ b/app/components/ScreensaverSheet.tsx
@@ -1,0 +1,238 @@
+/**
+ * Aerial screensaver sheet (opened from the power menu). Apple-TV-style theme
+ * picker + quality toggle + start/stop. State is read from the box
+ * (api.screensaver), so the running flag reflects reality: stopping it from
+ * the TV side (Steam's Exit) shows up on the next poll.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { api, ConnSettings, Screensaver } from '@/lib/api';
+import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { mono, theme } from '@/lib/theme';
+
+/** Display labels for the agent's theme ids (order = display order). */
+const THEME_LABELS: Record<string, string> = {
+  all: 'All',
+  landscapes: 'Landscapes',
+  cities: 'Cities',
+  space: 'Space',
+  underwater: 'Underwater',
+};
+
+/** UI keeps the tier choice binary; the conf accepts more but these two are
+ *  the ones that matter (H264 = every box decodes it; 4K SDR = the showcase). */
+const TIER_CHOICES = [
+  { id: '1080-H264', label: '1080p' },
+  { id: '4K-SDR', label: '4K' },
+] as const;
+
+export function ScreensaverSheet({
+  visible,
+  settings,
+  saver,
+  onChanged,
+  onClose,
+}: {
+  visible: boolean;
+  settings: ConnSettings;
+  saver: Screensaver | null;
+  onChanged: () => void;
+  onClose: () => void;
+}) {
+  // Selected themes as a set; "all" is exclusive with the rest.
+  const [picked, setPicked] = useState<Set<string>>(new Set(['all']));
+  const [tier, setTier] = useState<string>('1080-H264');
+  const [busy, setBusy] = useState(false);
+
+  // Seed the picker from the box's current conf when the sheet OPENS — and
+  // only then. Keying on `saver` too would re-seed on every background poll
+  // (new object identity each tick) and silently wipe a selection the user is
+  // mid-way through making.
+  const wasVisible = React.useRef(false);
+  useEffect(() => {
+    const opening = visible && !wasVisible.current;
+    wasVisible.current = visible;
+    if (!opening || !saver) return;
+    const parts = saver.theme.split(',').map((t) => t.trim()).filter(Boolean);
+    setPicked(new Set(parts.length ? parts : ['all']));
+    setTier(saver.tier === '4K-SDR' ? '4K-SDR' : '1080-H264');
+  }, [visible, saver]);
+
+  const toggleTheme = useCallback((id: string) => {
+    hapticLight();
+    setPicked((prev) => {
+      if (id === 'all') return new Set(['all']);
+      const next = new Set(prev);
+      next.delete('all');
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      // Nothing left selected reads as "all" — never an empty screensaver.
+      return next.size ? next : new Set(['all']);
+    });
+  }, []);
+
+  const start = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    hapticLight();
+    try {
+      const themeStr = picked.has('all') ? 'all' : [...picked].join(',');
+      await api.screensaverOp(settings, 'start', { theme: themeStr, tier });
+      hapticSuccess();
+      onChanged();
+      onClose();
+    } catch {
+      hapticError();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, picked, tier, settings, onChanged, onClose]);
+
+  const stop = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    hapticLight();
+    try {
+      await api.screensaverOp(settings, 'stop');
+      onChanged();
+    } catch {
+      hapticError();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, settings, onChanged]);
+
+  const themes = saver?.themes?.length ? saver.themes : Object.keys(THEME_LABELS);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.sheet} onPress={() => {}}>
+          <Text style={styles.title}>AERIAL SCREENSAVER</Text>
+
+          {saver?.running && (
+            <View style={styles.armedRow}>
+              <Text style={styles.armedText}>Playing on the TV</Text>
+              <Pressable onPress={stop} style={styles.cancelBtn} disabled={busy}>
+                <Text style={styles.cancelText}>STOP</Text>
+              </Pressable>
+            </View>
+          )}
+
+          <Text style={styles.sub}>THEMES</Text>
+          <View style={styles.pills}>
+            {themes.map((id) => {
+              const on = picked.has(id);
+              return (
+                <Pressable
+                  key={id}
+                  onPress={() => toggleTheme(id)}
+                  style={[styles.pill, on && styles.pillOn]}>
+                  <Text style={[styles.pillText, on && styles.pillTextOn]}>
+                    {THEME_LABELS[id] ?? id}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <Text style={styles.sub}>QUALITY</Text>
+          <View style={styles.seg}>
+            {TIER_CHOICES.map((t) => (
+              <Pressable
+                key={t.id}
+                onPress={() => {
+                  hapticLight();
+                  setTier(t.id);
+                }}
+                style={[styles.segBtn, tier === t.id && styles.segOn]}>
+                <Text style={[styles.segText, tier === t.id && styles.segTextOn]}>{t.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+
+          <Pressable
+            disabled={busy}
+            onPress={start}
+            style={({ pressed }) => [styles.startBtn, pressed && styles.pressed]}>
+            <Text style={styles.startText}>
+              {busy ? 'Starting…' : saver?.running ? 'Restart with these settings' : 'Start screensaver'}
+            </Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: theme.card,
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    padding: 20,
+    paddingBottom: 32,
+    gap: 10,
+  },
+  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  sub: { color: theme.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
+
+  pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
+  pill: {
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    backgroundColor: theme.inset,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+  },
+  pillOn: { borderColor: theme.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
+  pillText: { color: theme.textDim, fontSize: 14, fontWeight: '600' },
+  pillTextOn: { color: theme.blue },
+  pressed: { opacity: 0.7 },
+
+  seg: { flexDirection: 'row', gap: 6, marginTop: 4 },
+  segBtn: {
+    flex: 1,
+    alignItems: 'center',
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+  },
+  segOn: { backgroundColor: theme.inset, borderColor: theme.textDim },
+  segText: { color: theme.textDim, fontSize: 14, fontWeight: '600' },
+  segTextOn: { color: theme.text },
+
+  startBtn: {
+    marginTop: 12,
+    alignItems: 'center',
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: theme.blue,
+  },
+  startText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+
+  armedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    padding: 12,
+  },
+  armedText: { color: theme.text, fontSize: 15 },
+  cancelBtn: {
+    borderColor: theme.red,
+    borderWidth: 1,
+    borderRadius: 999,
+    paddingVertical: 5,
+    paddingHorizontal: 12,
+  },
+  cancelText: { color: theme.red, fontSize: 12, fontWeight: '700', fontFamily: mono },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -89,6 +89,23 @@ export type BoxCaps = {
   screen: boolean;
   /** Scheduled wake can be armed (RTC alarm on Linux, waitable timer on Windows). Gates the sleep/wake rows. */
   power_schedule: boolean;
+  /**
+   * Aerial screensaver (Steam-shortcut launched, Linux/gamescope boxes only).
+   * Optional: absent on agents < 2.8.4, so undefined must read as "unknown,
+   * probe" — only an explicit false skips the probe.
+   */
+  screensaver?: boolean;
+};
+
+/** GET/POST /api/screensaver state (agent >= 2.8.4). */
+export type Screensaver = {
+  available: boolean;
+  running: boolean;
+  /** Current theme ("all" or comma list, e.g. "space,underwater"). */
+  theme: string;
+  tier: string;
+  themes: string[];
+  tiers: string[];
 };
 
 /**
@@ -422,7 +439,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.media === b.media &&
     a.tv === b.tv &&
     a.screen === b.screen &&
-    a.power_schedule === b.power_schedule
+    a.power_schedule === b.power_schedule &&
+    a.screensaver === b.screensaver
   );
 }
 
@@ -866,6 +884,31 @@ export const api = {
   ): Promise<PowerSchedule | null> {
     return probeGated(caps?.power_schedule, () =>
       probeOrNull(request<PowerSchedule>(settings, '/api/power/schedule')));
+  },
+
+  /**
+   * Aerial screensaver state. Probe-and-appear: null on 404 (agent < 2.8.4 or
+   * script not installed) so the row hides. caps.screensaver === false skips
+   * the request outright; undefined (older agent) still probes.
+   */
+  screensaver(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<Screensaver | null> {
+    return probeGated(caps?.screensaver, () =>
+      probeOrNull(request<Screensaver>(settings, '/api/screensaver')));
+  },
+
+  /** Start the screensaver (optionally switching theme/tier) or stop it. */
+  screensaverOp(
+    settings: ConnSettings,
+    op: 'start' | 'stop',
+    opts: { theme?: string; tier?: string } = {},
+  ): Promise<{ ok: boolean; running?: boolean; starting?: boolean }> {
+    return request(settings, '/api/screensaver', {
+      method: 'POST',
+      body: { op, ...opts },
+    });
   },
 
   /** Arm a delayed suspend/poweroff. */

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -214,7 +214,10 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   ) {
     return undefined;
   }
-  return { gamepad, steam, media, tv, screen, power_schedule };
+  // screensaver arrived later (agent 2.8.4): optional, so caps persisted from
+  // a 2.8.2/2.8.3 box still round-trip. undefined = unknown -> the app probes.
+  const screensaver = bool('screensaver');
+  return { gamepad, steam, media, tv, screen, power_schedule, screensaver };
 }
 
 /** Coerce an arbitrary parsed value into a valid Box, or null if unusable. */

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,9 @@ UNIT_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/couch
 # without qrencode (immutable distros like Bazzite rarely ship it). Optional:
 # a failed fetch just falls back to printing the URL.
 QR_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/qr.py"
+# Aerial-screensaver player script (agent's /api/screensaver launches it via a
+# Steam shortcut). Optional: a failed fetch just means the feature stays absent.
+SCREENSAVER_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/couchside-screensaver.sh"
 # Built Decky Loader plugin, shipped as a tarball because the compiled frontend
 # (dist/) isn't checked into git, so raw source wouldn't give a working panel.
 PLUGIN_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/Couchside.tar.gz"
@@ -338,6 +341,9 @@ if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/agent/couchsided.py" ]; then
     cp "$SCRIPT_DIR/agent/couchside.service" "$WORK_DIR/couchside.service"
     # Optional QR helper: present in a checkout, harmless if not.
     [ -f "$SCRIPT_DIR/agent/qr.py" ] && cp "$SCRIPT_DIR/agent/qr.py" "$WORK_DIR/qr.py"
+    # Optional aerial-screensaver player (the agent's /api/screensaver drives it).
+    [ -f "$SCRIPT_DIR/agent/couchside-screensaver.sh" ] && \
+        cp "$SCRIPT_DIR/agent/couchside-screensaver.sh" "$WORK_DIR/couchside-screensaver.sh"
 else
     command -v curl >/dev/null 2>&1 || die "curl not found (needed to fetch the agent files)."
     say "Fetching agent files from GitHub"
@@ -347,6 +353,8 @@ else
     curl -fsSL "$UNIT_URL" -o "$WORK_DIR/couchside.service"
     # Optional: don't abort the install if only the QR helper fails to fetch.
     curl -fsSL "$QR_URL" -o "$WORK_DIR/qr.py" 2>/dev/null || true
+    # Optional aerial-screensaver player, same policy.
+    curl -fsSL "$SCREENSAVER_URL" -o "$WORK_DIR/couchside-screensaver.sh" 2>/dev/null || true
 fi
 # Integrity / sanity gate (FAIL CLOSED): never install code we just fetched
 # without first checking it parses. py_compile catches a truncated download or an
@@ -368,6 +376,13 @@ fi
 say "Installing daemon to $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 install -m 0755 "$WORK_DIR/couchsided.py" "$INSTALL_DIR/couchsided.py"
+# The aerial-screensaver player is optional: install only if it fetched and
+# parses (bash -n), so a failed/HTML fetch can't land as an executable script.
+if [ -f "$WORK_DIR/couchside-screensaver.sh" ] \
+   && bash -n "$WORK_DIR/couchside-screensaver.sh" 2>/dev/null \
+   && head -1 "$WORK_DIR/couchside-screensaver.sh" | grep -q '^#!'; then
+    install -m 0755 "$WORK_DIR/couchside-screensaver.sh" "$INSTALL_DIR/couchside-screensaver.sh"
+fi
 # The QR helper is optional: install it only if it fetched and compiles, so the
 # terminal pairing QR works without qrencode. Its absence just prints the URL.
 if [ -f "$WORK_DIR/qr.py" ] && python3 -m py_compile "$WORK_DIR/qr.py" 2>/dev/null; then


### PR DESCRIPTION
## What
Apple-TV-style aerial screensaver, controlled from the phone. Power menu gains a **Screensaver** row (probe-and-appear) opening a sheet with **theme chips** (All / Landscapes / Cities / Space / Underwater — Apple's own catalog categories, multi-selectable), a 1080p/4K toggle, and start/restart/stop.

## How it works (proven on the living-room box before this code)
gamescope surfaces only what Steam focuses — the atom routes are conclusively dead — so the player runs as a **non-Steam shortcut**:
- `agent/couchside-screensaver.sh` (vendored from the box-tested copy): sheds Steam's runtime env, caches Apple's aerial catalog, THEME/TIER conf, shuffled ffplay loop, pidfile+TERM-forward stop
- Agent 2.8.4: `GET/POST /api/screensaver`; start writes the conf and fires `steam://rungameid/<id>` (first-ever start self-registers via `steamos-add-to-steam`, reads the appid from shortcuts.vdf by exe match, double-fires past the page-only first open); `screensaver` cap on status; win agent 0.3.3 reports false
- install.sh + (decky repo, pushed separately) deploy the script

## Bugs caught by live verification
1. Power bar's "nothing to control" gate didn't count the screensaver → feature unreachable on TV-less boxes
2. Sheet re-seeded from the box conf on every 15s poll → wiped mid-selection picks (fixed: seed on open only)

## Verification
Mock route matrix (start/stop/validation/401) · Expo web vs a stateful stub: row, running label, seeding, multi-select surviving poll ticks, `theme=space,underwater tier=4K-SDR` landing, stop landing · tsc/py_compile/bash -n clean.

## After merge
- Decky repo changes (defaults bundle + workflow sync + main.py deploy) already pushed to couchside-decky master
- Boxes need agent 2.8.4 (decky v0.2.10 cut+sign, or install.sh) for the phone-driven flow; the living-room box's existing tile keeps working regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)