### PR TITLE
fix(iap): never hide the unlock behind a store hiccup; calm the box-less tabs

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -61,10 +61,14 @@ function ActionsScreen() {
   const { settings, ready } = useSettings();
   const [run, setRun] = useState<RunRecord | null>(null);
 
+  // No host yet (fresh install): don't poll, and show the pairing hint instead
+  // of a red "Box unreachable" banner retrying every 2s against http://:8787.
+  const configured = settings.host.trim().length > 0;
+
   const actions = usePoll<{ actions: ActionInfo[] }>(
     () => api.actions(settings),
     30000,
-    ready,
+    ready && configured,
     hostKey(settings), // clear the previous box's actions on switch
   );
 
@@ -119,7 +123,17 @@ function ActionsScreen() {
     <View style={[styles.screen, { paddingTop: 12 }]}>
       <Text style={styles.title}>Actions</Text>
       <ScrollView style={styles.list} contentContainerStyle={{ paddingBottom: 12 }}>
-        {actions.error != null && !actions.data && (
+        {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
+        {!configured && (
+          <View style={styles.emptyCard}>
+            <Text style={styles.emptyTitle}>No box configured</Text>
+            <Text style={styles.emptyText}>
+              Open the Setup tab to pair with the Couchside agent on your media center or Steam
+              machine.
+            </Text>
+          </View>
+        )}
+        {configured && actions.error != null && !actions.data && (
           <View style={styles.errBox}>
             <Text style={styles.errText}>{actions.error.message}</Text>
             <Pressable
@@ -129,7 +143,7 @@ function ActionsScreen() {
             </Pressable>
           </View>
         )}
-        {!actions.data && actions.error == null && (
+        {configured && !actions.data && actions.error == null && (
           <Text style={styles.dim}>loading…</Text>
         )}
         {groups.map((g) => (
@@ -224,6 +238,16 @@ const styles = StyleSheet.create({
   badgeText: { color: '#0b1220', fontSize: 11, fontWeight: '800' },
   cardDesc: { color: theme.textDim, fontSize: 13, lineHeight: 18 },
   pressed: { opacity: 0.7 },
+  emptyCard: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  emptyTitle: { color: theme.text, fontSize: 16, fontWeight: '700', marginBottom: 6 },
+  emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
   errBox: {
     backgroundColor: theme.redDeep,
     borderColor: theme.red,

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -321,11 +321,15 @@ function LaunchScreen() {
   // Bumped on pull-to-refresh so tiles retry any cover that failed to load.
   const [retryKey, setRetryKey] = useState(0);
 
+  // No host yet (fresh install): don't poll, and show the pairing hint instead
+  // of a red "Box unreachable" banner retrying every 2s against http://:8787.
+  const configured = settings.host.trim().length > 0;
+
   const boxKey = hostKey(settings); // resetKey: clear stale data on box switch
   const list = usePoll<{ launchers: Launcher[] }>(
     () => api.launchers(settings),
     30000,
-    ready,
+    ready && configured,
     boxKey,
   );
 
@@ -339,7 +343,7 @@ function LaunchScreen() {
   // and flipped by the effect below; poll fast while something is downloading.
   const [active, setActive] = useState(false);
   const dl = usePoll<Downloads | null>(
-    () => api.downloads(settings), active ? 5000 : 20000, ready, boxKey);
+    () => api.downloads(settings), active ? 5000 : 20000, ready && configured, boxKey);
   const downloads = useMemo(() => dl.data?.downloads ?? [], [dl.data]);
   const dlByAppid = useMemo(() => new Map(downloads.map((d) => [d.appid, d])), [downloads]);
 
@@ -443,15 +447,18 @@ function LaunchScreen() {
     <View style={styles.screen}>
       <View style={styles.header}>
         <Text style={styles.title}>Launch</Text>
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            setAddOpen(true);
-          }}
-          style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}>
-          <Ionicons name="add" size={18} color={theme.blue} />
-          <Text style={styles.addBtnText}>Add</Text>
-        </Pressable>
+        {/* Nothing to add a launcher to until a box is paired. */}
+        {configured && (
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setAddOpen(true);
+            }}
+            style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}>
+            <Ionicons name="add" size={18} color={theme.blue} />
+            <Text style={styles.addBtnText}>Add</Text>
+          </Pressable>
+        )}
       </View>
 
       <ScrollView
@@ -467,8 +474,20 @@ function LaunchScreen() {
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
         <DownloadsSection downloads={downloads} />
 
+        {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
+        {!configured && (
+          <View style={styles.emptyCard}>
+            <Ionicons name="rocket" size={40} color={theme.textFaint} />
+            <Text style={styles.emptyTitle}>No box configured</Text>
+            <Text style={styles.emptyText}>
+              Open the Setup tab to pair with the Couchside agent on your media center or Steam
+              machine.
+            </Text>
+          </View>
+        )}
+
         {/* Error (no data yet) */}
-        {list.error != null && !list.data && (
+        {configured && list.error != null && !list.data && (
           <View style={styles.errBox}>
             <Text style={styles.errText}>{list.error.message}</Text>
             <Pressable
@@ -480,7 +499,7 @@ function LaunchScreen() {
         )}
 
         {/* Loading */}
-        {!list.data && list.error == null && (
+        {configured && !list.data && list.error == null && (
           <View style={styles.center}>
             <ActivityIndicator color={theme.textDim} />
             <Text style={styles.dim}>loading launchers…</Text>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -20,9 +20,10 @@ import { QrView } from '@/components/QrView';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, ApiError } from '@/lib/api';
-import { recordPurchaseDate } from '@/lib/entitlement';
+import { isGenuinelyPurchased, recordPurchaseDate } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
 import {
+  hapticLight,
   hapticSelection,
   hapticSuccess,
   setHapticsEnabled,
@@ -137,18 +138,19 @@ function StepRow({ label, step }: { label: string; step: StepState }) {
 function EntitlementPill() {
   const { entitlement, ready } = useEntitlement();
   if (!ready) return null;
-  const label =
-    entitlement.state === 'purchased'
-      ? 'Unlocked, thank you'
-      : entitlement.state === 'trial'
-        ? `Trial: ${entitlement.trialDaysLeft} day${entitlement.trialDaysLeft === 1 ? '' : 's'} left`
-        : 'Trial ended';
-  const color =
-    entitlement.state === 'purchased'
-      ? theme.green
-      : entitlement.state === 'trial'
-        ? theme.amber
-        : theme.red;
+  // A store-unreachable fail-open must not claim "Unlocked": report the real
+  // trial clock it still carries, so the Buy button beside it makes sense.
+  const purchased = isGenuinelyPurchased(entitlement);
+  const label = purchased
+    ? 'Unlocked, thank you'
+    : entitlement.trialDaysLeft > 0
+      ? `Trial: ${entitlement.trialDaysLeft} day${entitlement.trialDaysLeft === 1 ? '' : 's'} left`
+      : 'Trial ended';
+  const color = purchased
+    ? theme.green
+    : entitlement.trialDaysLeft > 0
+      ? theme.amber
+      : theme.red;
   return (
     <View style={[styles.pill, { borderColor: color }]}>
       <Text style={[styles.pillText, { color }]}>{label}</Text>
@@ -726,6 +728,31 @@ function SetupBody() {
       <View style={styles.header}>
         <CategoryTabs tab={tab} onTab={setTab} />
       </View>
+      {/* The unlock is a one-time purchase buried under the Account category,
+          and during the trial nothing else points at it — App Review could not
+          find it at all (2.1(b), build 27). This row is the signpost: always on
+          screen while unpurchased, on whichever category is open. */}
+      {!isGenuinelyPurchased(entitlement) && tab !== 'account' && (
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            setTab('account');
+          }}
+          style={({ pressed }) => [styles.unlockRow, pressed && styles.pressed]}>
+          <Ionicons name="lock-open-outline" size={18} color={theme.blue} />
+          <View style={styles.unlockRowBody}>
+            <Text style={styles.unlockRowTitle}>Unlock Couchside — {price ?? '$4.99'}</Text>
+            <Text style={styles.unlockRowSub}>
+              {entitlement.trialDaysLeft > 0
+                ? `Trial: ${entitlement.trialDaysLeft} day${
+                    entitlement.trialDaysLeft === 1 ? '' : 's'
+                  } left · one-time purchase, no subscription`
+                : 'Trial ended · one-time purchase, no subscription'}
+            </Text>
+          </View>
+          <Ionicons name="chevron-forward" size={18} color={theme.textDim} />
+        </Pressable>
+      )}
       {/* Logs hosts its own FlatList and must not live inside a ScrollView.
           Gated like the old top-level Logs tab (the journal is a paid surface;
           Setup itself stays un-gated so purchase/restore is always reachable). */}
@@ -1073,7 +1100,7 @@ function SetupBody() {
             </View>
             <View style={styles.card}>
               <CardHeader icon="card-outline" label="PURCHASE" />
-              {entitlement.state !== 'purchased' && (
+              {!isGenuinelyPurchased(entitlement) && (
                 <Pressable
                   onPress={onBuy}
                   disabled={buying || restoring}
@@ -1096,7 +1123,7 @@ function SetupBody() {
                   {restoreMsg.text}
                 </Text>
               )}
-              {entitlement.state !== 'purchased' && (
+              {!isGenuinelyPurchased(entitlement) && (
                 <Text style={styles.purchaseHint}>
                   One-time unlock · no subscription, no account, no tracking.
                 </Text>
@@ -1334,6 +1361,22 @@ const styles = StyleSheet.create({
   btnTestText: { color: theme.blue, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   btnSave: { backgroundColor: theme.blue },
   btnSaveText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  unlockRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginHorizontal: 14,
+    marginTop: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: theme.card,
+    borderColor: theme.blue,
+    borderWidth: 1,
+    borderRadius: 12,
+  },
+  unlockRowBody: { flex: 1 },
+  unlockRowTitle: { color: theme.text, fontSize: 14, fontWeight: '800' },
+  unlockRowSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
   btnBuy: {
     backgroundColor: theme.blue,
     borderRadius: 8,

--- a/app/lib/EntitlementContext.tsx
+++ b/app/lib/EntitlementContext.tsx
@@ -68,7 +68,12 @@ type EntitlementContextValue = {
 };
 
 const EntitlementContext = createContext<EntitlementContextValue>({
-  entitlement: { state: 'trial', trialDaysLeft: TRIAL_DAYS, isEarlyAdopter: false },
+  entitlement: {
+    state: 'trial',
+    trialDaysLeft: TRIAL_DAYS,
+    isEarlyAdopter: false,
+    unlockedByFallback: false,
+  },
   ready: false,
   refresh: async () => {},
   recordPurchase: async () => {},
@@ -79,6 +84,7 @@ export function EntitlementProvider({ children }: { children: React.ReactNode })
     state: 'trial',
     trialDaysLeft: TRIAL_DAYS,
     isEarlyAdopter: false,
+    unlockedByFallback: false,
   });
   const [ready, setReady] = useState(false);
 

--- a/app/lib/entitlement.ts
+++ b/app/lib/entitlement.ts
@@ -29,6 +29,14 @@ export type Entitlement = {
    * adopter cutoff. Conservative: unknown purchase date => false.
    */
   isEarlyAdopter: boolean;
+  /**
+   * True when 'purchased' was granted by the fail-open below (unreachable store
+   * / unfetchable product) rather than by an actual purchase. The gate honours
+   * it, but the Setup > Account purchase UI must NOT: hiding the only Buy
+   * button behind a transient store hiccup is what got build 26/27 rejected
+   * under 2.1(b) ("we cannot locate the In-App Purchases").
+   */
+  unlockedByFallback: boolean;
 };
 
 export const TRIAL_DAYS = 7;
@@ -57,7 +65,19 @@ const BETA_ENTITLEMENT: Entitlement = {
   state: 'purchased',
   trialDaysLeft: 0,
   isEarlyAdopter: false,
+  unlockedByFallback: false,
 };
+
+/**
+ * True only for a real, owned unlock — never for the store-unreachable
+ * fail-open. The Setup > Account purchase UI keys off this (not off
+ * `state === 'purchased'`) so the Buy/Restore buttons stay on screen when the
+ * store is having a bad day. The feature gate deliberately does NOT use this:
+ * a fail-open build stays unlocked.
+ */
+export function isGenuinelyPurchased(e: Entitlement): boolean {
+  return e.state === 'purchased' && !e.unlockedByFallback;
+}
 
 /** True iff a known purchase timestamp falls before the early-adopter cutoff. */
 function earlyAdopterFromDate(purchaseDateMs: number | null): boolean {
@@ -155,6 +175,7 @@ export async function getEntitlement(): Promise<Entitlement> {
         state: 'purchased',
         trialDaysLeft: 0,
         isEarlyAdopter: earlyAdopterFromDate(await purchaseDateMs()),
+        unlockedByFallback: false,
       };
     }
   } catch {
@@ -163,8 +184,8 @@ export async function getEntitlement(): Promise<Entitlement> {
   const elapsedMs = Date.now() - (await firstLaunchMs());
   const daysLeft = Math.max(0, Math.ceil((TRIAL_DAYS * DAY_MS - elapsedMs) / DAY_MS));
   return daysLeft > 0
-    ? { state: 'trial', trialDaysLeft: daysLeft, isEarlyAdopter: false }
-    : { state: 'expired', trialDaysLeft: 0, isEarlyAdopter: false };
+    ? { state: 'trial', trialDaysLeft: daysLeft, isEarlyAdopter: false, unlockedByFallback: false }
+    : { state: 'expired', trialDaysLeft: 0, isEarlyAdopter: false, unlockedByFallback: false };
 }
 
 /**
@@ -209,10 +230,16 @@ export async function revalidateWithStore(local: Entitlement): Promise<Entitleme
       state: 'purchased',
       trialDaysLeft: 0,
       isEarlyAdopter: earlyAdopterFromDate(result.purchaseDateMs ?? null),
+      unlockedByFallback: false,
     };
   }
   if (result.state === 'unavailable') {
-    return { state: 'purchased', trialDaysLeft: local.trialDaysLeft, isEarlyAdopter: false };
+    return {
+      state: 'purchased',
+      trialDaysLeft: local.trialDaysLeft,
+      isEarlyAdopter: false,
+      unlockedByFallback: true,
+    };
   }
   if (result.state === 'none' && (await getProduct()) == null) {
     // The store connected but couchpilot_unlock is not fetchable: this is a
@@ -220,7 +247,12 @@ export async function revalidateWithStore(local: Entitlement): Promise<Entitleme
     // listing) that cannot possibly sell the unlock: treat like
     // 'unavailable' so such builds are never locked out. NOT cached, so an
     // official store build (which can always fetch the product) still gates.
-    return { state: 'purchased', trialDaysLeft: local.trialDaysLeft, isEarlyAdopter: false };
+    return {
+      state: 'purchased',
+      trialDaysLeft: local.trialDaysLeft,
+      isEarlyAdopter: false,
+      unlockedByFallback: true,
+    };
   }
   return local;
 }


### PR DESCRIPTION
## Why

App Review rejected **v2.6.0 build 27** under **Guideline 2.1(b) — Information Needed**:

> We have started the review of the app, but we are not able to continue because we cannot locate the In-App Purchases, such as **Couchside Forever Unlock**, within the app at this time.

Reviewed on an iPad Air 11-inch (M3), with no Couchside agent anywhere on Apple's network.

## Root cause

`resolveEntitlement()` **fails open**. Both a store it can't reach and a product it can't fetch return `state: 'purchased'`:

```ts
if (result.state === 'unavailable') return { state: 'purchased', ... };
if (result.state === 'none' && (await getProduct()) == null) return { state: 'purchased', ... };
```

…and `setup.tsx` rendered the `UNLOCK $4.99` button **only when `state !== 'purchased'`**. So one flaky sandbox `fetchProducts` on the reviewer's device and the app shows a green "Unlocked, thank you" pill with **no purchase button anywhere in the app** — while the store listing advertises a $4.99 unlock.

Failing open is correct for the *gate* (a self-compiled source-available build must not lock the user out). It is wrong for the *purchase UI*.

Two things compounded it: the purchase lived two levels deep (Setup → **Account** sub-tab), and the 7-day trial suppresses the paywall entirely on a fresh install — so nothing in the app ever pointed at the unlock.

## Changes

- **`lib/entitlement.ts`** — mark the fail-open with `unlockedByFallback`; add `isGenuinelyPurchased()`. The gate still fails open; the purchase UI keys off the helper, so Buy/Restore can never vanish. The pill no longer claims "Unlocked, thank you" when nothing was bought.
- **`(tabs)/setup.tsx`** — persistent **"Unlock Couchside — $4.99"** row above the category tabs while unpurchased, jumping straight to the purchase. Reviewers don't go spelunking into sub-tabs.
- **`(tabs)/actions.tsx`, `(tabs)/launch.tsx`** — gate the polls on a configured host. With no box they fetched `http://:8787`, failed, and painted **"Box unreachable: network error"** with a 2s retry loop forever; a reviewer with no hardware saw a broken app. Now they show the same "No box configured" card as Console. Launch's Add button is hidden until a box exists (it fired at the empty host too).

## Verification

`tsc` clean. Verified on the Expo web build, where StoreKit is absent — which reproduces the exact fail-open path that hid the button on the reviewer's iPad:

- Setup → Account: **`UNLOCK $4.99`** and **`RESTORE PURCHASES`** both render (previously: neither).
- Pill reads **"Trial: 7 days left"** (previously: a false "Unlocked, thank you").
- Setup lands on the unlock row; tapping it opens the PURCHASE card.
- Actions and Launch show "No box configured" instead of a red error banner. No console errors.

Ships as **build 28**, replacing the rejected build 27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)