### PR TITLE
feat(trial): warn before the paywall; broaden and surface the review ask

### DIFF
--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
@@ -10,6 +10,7 @@ import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
+import { noteBoxReachable } from '@/lib/review';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, pctColor, tempColor, theme } from '@/lib/theme';
 
@@ -94,6 +95,12 @@ function ConsoleScreen() {
   const s = status.data;
   const reachable = configured && status.error == null && s != null;
   const memPct = s ? Math.round((s.mem.used_mb / s.mem.total_mb) * 100) : 0;
+
+  // The app did its job: a paired box answered. Counted at most once per launch
+  // (noteBoxReachable guards); at EARNED_SESSIONS it earns a review ask.
+  useEffect(() => {
+    if (reachable) void noteBoxReachable();
+  }, [reachable]);
 
   return (
     <View style={styles.screen}>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1,4 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   Alert,
@@ -22,6 +23,7 @@ import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, ApiError } from '@/lib/api';
 import { isGenuinelyPurchased, recordPurchaseDate } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
+import { openWriteReview } from '@/lib/review';
 import {
   hapticLight,
   hapticSelection,
@@ -721,6 +723,18 @@ function SetupBody() {
   // Active category tab (Boxes / Preferences / Account).
   const [tab, setTab] = useState<SetupTab>('boxes');
 
+  // Deep-link straight to the purchase: the trial nudge banner pushes
+  // /setup?tab=account. Clear the param once applied, so tapping the banner
+  // again still lands here instead of being swallowed as a no-op re-render.
+  const params = useLocalSearchParams<{ tab?: string }>();
+  const router = useRouter();
+  useEffect(() => {
+    if (params.tab === 'account') {
+      setTab('account');
+      router.setParams({ tab: undefined });
+    }
+  }, [params.tab, router]);
+
   return (
     <KeyboardAvoidingView
       style={styles.screen}
@@ -1130,6 +1144,26 @@ function SetupBody() {
               )}
             </View>
 
+            {/* User-initiated, always available. This LINKS OUT to the store's
+                write-review page — it must never call requestReview(): Apple
+                does not allow the native sheet to be summoned by a tap. The
+                app-triggered sheet lives in components/ReviewPrompt.tsx. */}
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                void openWriteReview();
+              }}
+              style={({ pressed }) => [styles.rateRow, pressed && styles.pressed]}>
+              <Ionicons name="star-outline" size={18} color={theme.amber} />
+              <View style={styles.rateBody}>
+                <Text style={styles.rateTitle}>Rate Couchside</Text>
+                <Text style={styles.rateSub}>
+                  A quick review helps other people find it.
+                </Text>
+              </View>
+              <Ionicons name="open-outline" size={16} color={theme.textDim} />
+            </Pressable>
+
             <Text style={styles.hint}>
               Each agent listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
               /api/ping require the bearer token.
@@ -1361,6 +1395,24 @@ const styles = StyleSheet.create({
   btnTestText: { color: theme.blue, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   btnSave: { backgroundColor: theme.blue },
   btnSaveText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  rateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginTop: 12,
+    // `hint` below carries no margin of its own — it leans on the preceding
+    // block's bottom margin, so this row has to provide it.
+    marginBottom: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+  },
+  rateBody: { flex: 1 },
+  rateTitle: { color: theme.text, fontSize: 14, fontWeight: '700' },
+  rateSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
   unlockRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -3,6 +3,8 @@ import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
 import { ReviewPrompt } from '@/components/ReviewPrompt';
+import { ReviewToast } from '@/components/ReviewToast';
+import { TrialEndsToast } from '@/components/TrialEndsToast';
 import { UnlockToast } from '@/components/UnlockToast';
 import { DeepLinkHandler } from '@/lib/DeepLink';
 import { EntitlementProvider } from '@/lib/EntitlementContext';
@@ -39,8 +41,12 @@ export default function RootLayout() {
           </Stack>
           {/* Global overlay: survives the Paywall unmount on unlock (see UnlockToast). */}
           <UnlockToast />
-          {/* One-shot store-review ask a few seconds after the unlock toast. */}
+          {/* Last word before the paywall lands: one-shot, on the trial's final day. */}
+          <TrialEndsToast />
+          {/* Decides whether to ask for a review, and how. Asks once, ever. */}
           <ReviewPrompt />
+          {/* The fallback invite ReviewPrompt falls back to when the OS sheet can't run. */}
+          <ReviewToast />
         </ThemeProvider>
       </EntitlementProvider>
     </SettingsProvider>

--- a/app/components/ReviewPrompt.tsx
+++ b/app/components/ReviewPrompt.tsx
@@ -1,54 +1,90 @@
 import { useEffect } from 'react';
 import { Platform } from 'react-native';
-import * as SecureStore from 'expo-secure-store';
 
 import { subscribeUnlocked } from '@/lib/EntitlementContext';
+import {
+  emitReviewInvite,
+  hasAskedForReview,
+  markReviewAsked,
+  subscribeReviewEarned,
+} from '@/lib/review';
 
 /**
- * One-shot in-app review request, fired off the unlock signal — the happiest
- * moment in the app's life (the user just paid and everything works). Waits a
- * few seconds so it never collides with the UnlockToast, asks the OS review
- * controller once, and never asks again (persisted flag). The OS keeps its own
- * quota on top (Apple shows the sheet at most ~3×/year and only outside
- * TestFlight), so this is a polite request, not a guarantee — which is exactly
- * the App Store rule.
+ * Decides IF and HOW to ask for a review. Asks at most once, ever.
+ *
+ * Two earned moments trigger it:
+ *   - the unlock — the happiest moment in the app's life (the user just paid
+ *     and everything works), and
+ *   - the app simply having done its job: EARNED_SESSIONS launches in which a
+ *     paired box was reachable (see lib/review.ts). This is what lets a trial
+ *     user who loves the app be asked too; before, only purchasers ever were.
+ *
+ * How: the native OS sheet, which is app-triggered and never wired to a button
+ * (that is Apple's rule, and the reason there is no "Rate" button that calls
+ * it). The OS keeps its own quota on top (~3×/year, and never in TestFlight),
+ * so this is a polite request, not a guarantee.
+ *
+ * If the sheet cannot run — no `hasAction()`, web, a build without the native
+ * module — we fall back to ReviewToast, which links OUT to the store's
+ * write-review page instead. Both paths share ONE asked-flag, so a user is
+ * never hit by both, and whichever fires first retires the other forever.
  *
  * Mounted at the root layout next to UnlockToast for the same reason it is:
  * the unlock signal fires the instant the Paywall unmounts, so anything living
  * inside the Paywall would die before it could act.
  */
-const ASKED_KEY = 'couchside.reviewAsked.v1';
 const REVIEW_DELAY_MS = 4000;
 
 export function ReviewPrompt() {
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
-    const unsub = subscribeUnlocked(() => {
+    // In-memory guard: both triggers can fire in one launch (buy the unlock on
+    // your third good session). Only ever queue one ask.
+    let queued = false;
+
+    const ask = () => {
+      if (queued) return;
+      queued = true;
       timer = setTimeout(() => {
         void (async () => {
-          try {
-            if (Platform.OS === 'web') return;
-            if ((await SecureStore.getItemAsync(ASKED_KEY)) === '1') return;
-            // Lazy require, NOT a top-level import: expo-store-review is a
-            // native module, and a top-level import crashes the entire app at
-            // bundle-eval time on any binary built without it (dev builds,
-            // web). Review is best-effort — resolve it only at the moment of
-            // use, inside the try.
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            const StoreReview = require('expo-store-review') as typeof import('expo-store-review');
-            if (!(await StoreReview.hasAction())) return;
-            // Mark BEFORE requesting: if the OS shows the sheet and the app is
-            // killed mid-flow, better to never ask again than to double-ask.
-            await SecureStore.setItemAsync(ASKED_KEY, '1');
-            await StoreReview.requestReview();
-          } catch {
-            // Review is best-effort by definition; never surface a failure.
+          // Re-check at fire time, not at schedule time.
+          if (await hasAskedForReview()) return;
+
+          if (Platform.OS !== 'web') {
+            try {
+              // Lazy require, NOT a top-level import: expo-store-review is a
+              // native module, and a top-level import crashes the entire app
+              // at bundle-eval time on any binary built without it (dev
+              // builds, web). Resolve it only at the moment of use.
+              // eslint-disable-next-line @typescript-eslint/no-require-imports
+              const StoreReview = require('expo-store-review') as typeof import('expo-store-review');
+              if (await StoreReview.hasAction()) {
+                // Mark BEFORE requesting: if the OS shows the sheet and the
+                // app is killed mid-flow, better to never ask again than to
+                // double-ask.
+                await markReviewAsked();
+                await StoreReview.requestReview();
+                return;
+              }
+            } catch {
+              // fall through to the toast
+            }
           }
+
+          // No native sheet here: invite via the toast, which links out to the
+          // store rather than summoning the sheet from a tap.
+          await markReviewAsked();
+          emitReviewInvite();
         })();
       }, REVIEW_DELAY_MS);
-    });
+    };
+
+    const unsubUnlock = subscribeUnlocked(ask);
+    const unsubEarned = subscribeReviewEarned(ask);
+
     return () => {
-      unsub();
+      unsubUnlock();
+      unsubEarned();
       if (timer) clearTimeout(timer);
     };
   }, []);

--- a/app/components/ReviewToast.tsx
+++ b/app/components/ReviewToast.tsx
@@ -1,0 +1,112 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { hapticLight } from '@/lib/haptics';
+import { openWriteReview, subscribeReviewInvite } from '@/lib/review';
+import { mono, theme } from '@/lib/theme';
+
+const TOAST_MS = 8000;
+
+/**
+ * The fallback review invite: a dismissible toast that links OUT to the App
+ * Store's write-review page.
+ *
+ * This exists because the native review sheet is not always available (the OS
+ * declines, TestFlight, web, a build without the module). ReviewPrompt decides
+ * — native sheet first, this toast only if the sheet cannot run — and both
+ * share one asked-flag, so this never doubles up on the OS prompt.
+ *
+ * It links out rather than calling requestReview() because Apple does not allow
+ * the native sheet to be summoned by a tap. Tapping "Rate" opens the store; the
+ * user writes the review there.
+ *
+ * Longer-lived than the other toasts (8s): this one asks for something, so it
+ * has to be readable and reachable, not just glanceable.
+ */
+export function ReviewToast() {
+  const insets = useSafeAreaInsets();
+  const [shown, setShown] = useState(false);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = subscribeReviewInvite(() => {
+      setShown(true);
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => setShown(false), TOAST_MS);
+    });
+    return () => {
+      unsub();
+      if (timer) clearTimeout(timer);
+    };
+  }, []);
+
+  const onRate = useCallback(() => {
+    hapticLight();
+    setShown(false);
+    void openWriteReview();
+  }, []);
+
+  const onDismiss = useCallback(() => {
+    hapticLight();
+    setShown(false);
+  }, []);
+
+  if (!shown) return null;
+
+  return (
+    <View style={[styles.wrap, { bottom: insets.bottom + 76 }]}>
+      <View style={styles.toast}>
+        <Text style={styles.title}>Enjoying Couchside?</Text>
+        <Text style={styles.sub}>A quick review helps other people find it.</Text>
+        <View style={styles.actions}>
+          <Pressable
+            onPress={onDismiss}
+            style={({ pressed }) => [styles.btn, pressed && styles.pressed]}>
+            <Text style={styles.btnText}>NOT NOW</Text>
+          </Pressable>
+          <Pressable
+            onPress={onRate}
+            style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+            <Text style={styles.btnPrimaryText}>RATE</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { position: 'absolute', left: 0, right: 0, alignItems: 'center' },
+  toast: {
+    maxWidth: '92%',
+    backgroundColor: theme.card,
+    borderColor: theme.blue,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  title: {
+    color: theme.text,
+    fontFamily: mono,
+    fontSize: 13,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  sub: { color: theme.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 12 },
+  btn: {
+    flex: 1,
+    paddingVertical: 9,
+    borderRadius: 8,
+    alignItems: 'center',
+    backgroundColor: theme.inset,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  btnText: { color: theme.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  btnPrimary: { backgroundColor: theme.blue, borderColor: theme.blue },
+  btnPrimaryText: { color: '#0b1220', fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  pressed: { opacity: 0.7 },
+});

--- a/app/components/TabScreen.tsx
+++ b/app/components/TabScreen.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { BoxSwitcher } from '@/components/BoxSwitcher';
+import { TrialNudge } from '@/components/TrialNudge';
 import { IS_BETA_BUILD } from '@/lib/entitlement';
 import { mono, theme } from '@/lib/theme';
 
@@ -15,6 +16,9 @@ export function TabScreen({ children }: { children: React.ReactNode }) {
   return (
     <View style={styles.root}>
       <BoxSwitcher />
+      {/* Near the end of the trial only, and never on Setup (which already
+          carries the permanent unlock row). Self-hides otherwise. */}
+      <TrialNudge />
       <View style={styles.body}>{children}</View>
       {IS_BETA_BUILD && (
         <View pointerEvents="none" style={styles.betaBadge}>

--- a/app/components/TrialEndsToast.tsx
+++ b/app/components/TrialEndsToast.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { isGenuinelyPurchased } from '@/lib/entitlement';
+import { useEntitlement } from '@/lib/EntitlementContext';
+import { mono, theme } from '@/lib/theme';
+import { lastDayToastShown, markLastDayToastShown } from '@/lib/trialNudge';
+
+const TOAST_MS = 3200;
+
+/**
+ * One-shot "Trial ends today" toast, on the final day of the trial.
+ *
+ * The banner (TrialNudge) is easy to scroll past; this is the last, unmissable
+ * word before the paywall lands — and it is deliberately the ONLY interrupting
+ * thing in the whole trial. Fires once per install, then never again.
+ *
+ * Mounted at the root layout, like UnlockToast, so it is not tied to whichever
+ * tab happens to be mounted.
+ */
+export function TrialEndsToast() {
+  const insets = useSafeAreaInsets();
+  const { entitlement, ready } = useEntitlement();
+  const [shown, setShown] = useState(false);
+
+  // Exactly one day left. Not `state === 'trial'` (the store-unreachable
+  // fail-open reports 'purchased' over a still-running clock), and not `<= 1`
+  // (0 means the trial is already over and the paywall is up — too late to
+  // warn).
+  const lastDay =
+    ready && !isGenuinelyPurchased(entitlement) && entitlement.trialDaysLeft === 1;
+
+  useEffect(() => {
+    if (!lastDay) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
+    void (async () => {
+      if (await lastDayToastShown()) return;
+      await markLastDayToastShown();
+      if (cancelled) return;
+      setShown(true);
+      timer = setTimeout(() => setShown(false), TOAST_MS);
+    })();
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [lastDay]);
+
+  if (!shown) return null;
+
+  return (
+    <View pointerEvents="none" style={[styles.wrap, { bottom: insets.bottom + 76 }]}>
+      <View style={styles.toast}>
+        <Text style={styles.title}>Trial ends today</Text>
+        <Text style={styles.sub}>Setup › Account to unlock — one-time, no subscription.</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: { position: 'absolute', left: 0, right: 0, alignItems: 'center' },
+  toast: {
+    maxWidth: '90%',
+    backgroundColor: theme.card,
+    borderColor: theme.amber,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+  },
+  title: {
+    color: theme.amber,
+    fontFamily: mono,
+    fontSize: 13,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  sub: { color: theme.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
+});

--- a/app/components/TrialNudge.tsx
+++ b/app/components/TrialNudge.tsx
@@ -1,0 +1,119 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { usePathname, useRouter } from 'expo-router';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { isGenuinelyPurchased } from '@/lib/entitlement';
+import { useEntitlement } from '@/lib/EntitlementContext';
+import { hapticLight } from '@/lib/haptics';
+import { theme } from '@/lib/theme';
+import {
+  dismissNudge,
+  isNudgeDismissed,
+  nudgeCopy,
+  subscribeNudgeDismissed,
+  thresholdFor,
+  type NudgeThreshold,
+} from '@/lib/trialNudge';
+
+/**
+ * Slim, dismissible banner shown near the end of the trial so the paywall on
+ * day 7 is never a surprise. Lives inside TabScreen, so it rides above every
+ * tab's content — except Setup, where the permanent "Unlock Couchside" row
+ * already says the same thing and a banner would just be noise.
+ *
+ * Tapping it goes straight to the purchase (Setup > Account). Dismissing it is
+ * permanent for that threshold: see lib/trialNudge.ts for the once-only rules.
+ */
+export function TrialNudge() {
+  const { entitlement, ready } = useEntitlement();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const [threshold, setThreshold] = useState<NudgeThreshold | null>(null);
+
+  const onSetup = pathname?.startsWith('/setup') ?? false;
+  // Not `state === 'trial'`: the store-unreachable fail-open reports
+  // 'purchased' while the trial clock keeps running underneath (see
+  // entitlement.ts). Such a user WILL be gated once the store recovers, so
+  // they still deserve the warning. `trialDaysLeft > 0` also keeps the banner
+  // away from an already-expired user, who is looking at the paywall anyway.
+  const inTrial =
+    ready && !isGenuinelyPurchased(entitlement) && entitlement.trialDaysLeft > 0;
+  const candidate = inTrial ? thresholdFor(entitlement.trialDaysLeft) : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    if (candidate == null) {
+      setThreshold(null);
+      return;
+    }
+    void (async () => {
+      const dismissed = await isNudgeDismissed(candidate);
+      if (!cancelled) setThreshold(dismissed ? null : candidate);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [candidate]);
+
+  // Every mounted tab has its own TrialNudge; a dismissal on one must clear
+  // them all, or an already-mounted sibling keeps showing the banner.
+  useEffect(() => subscribeNudgeDismissed(() => setThreshold(null)), []);
+
+  const onDismiss = useCallback(() => {
+    if (threshold == null) return;
+    hapticLight();
+    void dismissNudge(threshold);
+    setThreshold(null);
+  }, [threshold]);
+
+  const onPress = useCallback(() => {
+    hapticLight();
+    router.push('/setup?tab=account');
+  }, [router]);
+
+  if (threshold == null || onSetup) return null;
+
+  const { title, sub } = nudgeCopy(entitlement.trialDaysLeft);
+  const urgent = entitlement.trialDaysLeft <= 1;
+  const accent = urgent ? theme.amber : theme.blue;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [styles.row, { borderColor: accent }, pressed && styles.pressed]}>
+      <Ionicons name="lock-open-outline" size={16} color={accent} />
+      <View style={styles.body}>
+        <Text style={[styles.title, { color: accent }]}>{title}</Text>
+        <Text style={styles.sub}>{sub}</Text>
+      </View>
+      <Pressable
+        onPress={onDismiss}
+        hitSlop={10}
+        style={({ pressed }) => [styles.close, pressed && styles.pressed]}>
+        <Ionicons name="close" size={16} color={theme.textDim} />
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    marginHorizontal: 12,
+    marginTop: 8,
+    paddingVertical: 9,
+    paddingHorizontal: 12,
+    backgroundColor: theme.card,
+    borderWidth: 1,
+    borderRadius: 10,
+  },
+  body: { flex: 1 },
+  title: { fontSize: 13, fontWeight: '800' },
+  sub: { color: theme.textDim, fontSize: 11, marginTop: 1 },
+  close: { padding: 2 },
+  pressed: { opacity: 0.7 },
+});

--- a/app/lib/entitlement.ts
+++ b/app/lib/entitlement.ts
@@ -111,7 +111,7 @@ export async function recordPurchaseDate(ms: number): Promise<void> {
  * (and on iOS typically app reinstalls), which is as durable as a
  * client-only trial clock can reasonably be.
  */
-async function storageGet(key: string): Promise<string | null> {
+export async function storageGet(key: string): Promise<string | null> {
   if (Platform.OS === 'web') {
     try {
       return typeof window !== 'undefined' && window.localStorage
@@ -124,7 +124,7 @@ async function storageGet(key: string): Promise<string | null> {
   return SecureStore.getItemAsync(key);
 }
 
-async function storageSet(key: string, value: string): Promise<void> {
+export async function storageSet(key: string, value: string): Promise<void> {
   if (Platform.OS === 'web') {
     try {
       if (typeof window !== 'undefined' && window.localStorage) {

--- a/app/lib/review.ts
+++ b/app/lib/review.ts
@@ -1,0 +1,139 @@
+/**
+ * Store-review plumbing. The "have we already asked?" rule lives here, in ONE
+ * place, because there are two ways a review gets requested and a user must
+ * never be hit by both:
+ *
+ *   1. The native OS sheet (`StoreReview.requestReview`). App-triggered, on an
+ *      earned moment. Best conversion, and it must NEVER be wired to a button:
+ *      Apple's rule is that the sheet is requested by the app, not summoned by
+ *      a tap. (components/ReviewPrompt.tsx)
+ *   2. A dismissible in-app toast that links OUT to the App Store write-review
+ *      page. This is the fallback for when the native sheet isn't available
+ *      (no `hasAction()`, web, unsupported build). (components/ReviewToast.tsx)
+ *
+ * Both share ASKED_KEY, so whichever fires first retires the other forever.
+ *
+ * The "Rate Couchside" row in Setup > Account is deliberately OUTSIDE this
+ * machinery: it is user-initiated, always available, unflagged, and it links
+ * out to the store — it never calls requestReview(). That is what keeps it
+ * legal.
+ *
+ * "Earned moment" = the app actually did its job. We count launches in which a
+ * paired box was reachable (at most one per launch); at EARNED_SESSIONS we
+ * consider the app to have proven itself. Buying the unlock is also an earned
+ * moment, and a happier one — that signal comes from EntitlementContext.
+ */
+import { Linking, Platform } from 'react-native';
+
+import { storageGet, storageSet } from './entitlement';
+
+/** Shared with the pre-existing ReviewPrompt flag: users already asked stay asked. */
+const ASKED_KEY = 'couchside.reviewAsked.v1';
+const GOOD_SESSIONS_KEY = 'couchside.goodSessions.v1';
+
+/** Launches-with-a-reachable-box before we consider a review earned. */
+export const EARNED_SESSIONS = 3;
+
+const IOS_APP_ID = '6786884115';
+const ANDROID_PACKAGE = 'com.ets3d.rescueremote';
+
+/** True once either the native sheet or the toast has asked. Never ask twice. */
+export async function hasAskedForReview(): Promise<boolean> {
+  try {
+    return (await storageGet(ASKED_KEY)) === '1';
+  } catch {
+    // An unreadable flag must not turn into a nag loop: assume we asked.
+    return true;
+  }
+}
+
+export async function markReviewAsked(): Promise<void> {
+  try {
+    await storageSet(ASKED_KEY, '1');
+  } catch {
+    // Best effort. Worst case the user sees one extra invite, never a loop
+    // within a launch (the in-memory guard below covers that).
+  }
+}
+
+/**
+ * Open the store's own write-review page. This is the ONLY thing a tap is
+ * allowed to do — see the header note about requestReview().
+ */
+export async function openWriteReview(): Promise<void> {
+  const url =
+    Platform.OS === 'ios'
+      ? `itms-apps://apps.apple.com/app/id${IOS_APP_ID}?action=write-review`
+      : `market://details?id=${ANDROID_PACKAGE}`;
+  const web =
+    Platform.OS === 'ios'
+      ? `https://apps.apple.com/app/id${IOS_APP_ID}?action=write-review`
+      : `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE}`;
+  try {
+    if (await Linking.canOpenURL(url)) {
+      await Linking.openURL(url);
+      return;
+    }
+  } catch {
+    // fall through to the https form, which always resolves to something
+  }
+  try {
+    await Linking.openURL(web);
+  } catch {
+    // Nothing sensible left to do; never crash over a review link.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Earned-moment signal
+// ---------------------------------------------------------------------------
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+/** Guards against counting the same launch twice (polls fire repeatedly). */
+let notedThisLaunch = false;
+
+/**
+ * Subscribe to "the app has proven itself" — fired once, when the good-session
+ * count crosses EARNED_SESSIONS. Returns an unsubscribe.
+ */
+export function subscribeReviewEarned(fn: Listener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+// ---------------------------------------------------------------------------
+// Fallback-invite signal (native sheet unavailable -> show the toast instead)
+// ---------------------------------------------------------------------------
+
+const inviteListeners = new Set<Listener>();
+
+/** ReviewToast subscribes; ReviewPrompt emits when the OS sheet can't run. */
+export function subscribeReviewInvite(fn: Listener): () => void {
+  inviteListeners.add(fn);
+  return () => inviteListeners.delete(fn);
+}
+
+export function emitReviewInvite(): void {
+  inviteListeners.forEach((l) => l());
+}
+
+/**
+ * Call when a paired box is confirmed reachable. Counts at most once per app
+ * launch; emits the earned signal the moment the threshold is crossed.
+ */
+export async function noteBoxReachable(): Promise<void> {
+  if (notedThisLaunch) return;
+  notedThisLaunch = true;
+  if (await hasAskedForReview()) return;
+  let n = 0;
+  try {
+    n = Number(await storageGet(GOOD_SESSIONS_KEY)) || 0;
+  } catch {
+    return;
+  }
+  n += 1;
+  await storageSet(GOOD_SESSIONS_KEY, String(n)).catch(() => {});
+  if (n >= EARNED_SESSIONS) listeners.forEach((l) => l());
+}

--- a/app/lib/trialNudge.ts
+++ b/app/lib/trialNudge.ts
@@ -1,0 +1,99 @@
+/**
+ * Trial nudges: the ramp that stops day 7 being a cliff.
+ *
+ * Today the app runs a silent 7-day countdown and then, with no warning,
+ * replaces five of six tabs with a paywall. This softens that: a dismissible
+ * banner when the trial is nearly out, and a toast on the final day, so the
+ * wall is never a surprise.
+ *
+ * Rules, deliberately gentle:
+ *   - Nothing at all until the trial has NUDGE_DAYS (3) or fewer left.
+ *   - Each threshold shows AT MOST ONCE, ever, and stays dismissed (persisted).
+ *     Crossing into the next threshold is a new, separate nudge.
+ *   - Dismissing is permanent for that threshold. No re-nagging on every launch.
+ *   - Purchasing retires all of it (the banner keys off `state === 'trial'`).
+ */
+import { storageGet, storageSet } from './entitlement';
+
+/** Days-left thresholds that earn a nudge, high to low. */
+export const NUDGE_THRESHOLDS = [3, 1] as const;
+export type NudgeThreshold = (typeof NUDGE_THRESHOLDS)[number];
+
+const DISMISSED_KEY = (t: number) => `couchside.trialNudge.v1.${t}`;
+const LAST_DAY_TOAST_KEY = 'couchside.trialLastDayToast.v1';
+
+/**
+ * The threshold a given days-left falls into, or null when the trial still has
+ * room. 2 days left is still the "3" nudge — it does not re-fire — but 1 day
+ * left crosses into its own.
+ */
+export function thresholdFor(daysLeft: number): NudgeThreshold | null {
+  for (const t of [...NUDGE_THRESHOLDS].sort((a, b) => a - b)) {
+    if (daysLeft <= t) return t;
+  }
+  return null;
+}
+
+export async function isNudgeDismissed(t: NudgeThreshold): Promise<boolean> {
+  try {
+    return (await storageGet(DISMISSED_KEY(t))) === '1';
+  } catch {
+    // Unreadable flag: assume dismissed rather than risk nagging every launch.
+    return true;
+  }
+}
+
+/**
+ * Every mounted tab renders its own TrialNudge, each holding its own state, so
+ * a dismissal has to be broadcast: without this, dismissing on Console leaves
+ * the already-mounted Actions instance still showing the banner when you
+ * switch back to it — the flag is persisted, but the live component never
+ * re-read it.
+ */
+type DismissListener = () => void;
+const dismissListeners = new Set<DismissListener>();
+
+export function subscribeNudgeDismissed(fn: DismissListener): () => void {
+  dismissListeners.add(fn);
+  return () => dismissListeners.delete(fn);
+}
+
+export async function dismissNudge(t: NudgeThreshold): Promise<void> {
+  try {
+    await storageSet(DISMISSED_KEY(t), '1');
+  } catch {
+    // best effort
+  }
+  dismissListeners.forEach((l) => l());
+}
+
+/** The final-day toast is one-shot for the life of the install. */
+export async function lastDayToastShown(): Promise<boolean> {
+  try {
+    return (await storageGet(LAST_DAY_TOAST_KEY)) === '1';
+  } catch {
+    return true;
+  }
+}
+
+export async function markLastDayToastShown(): Promise<void> {
+  try {
+    await storageSet(LAST_DAY_TOAST_KEY, '1');
+  } catch {
+    // best effort
+  }
+}
+
+/** Copy for the banner, by threshold. */
+export function nudgeCopy(daysLeft: number): { title: string; sub: string } {
+  if (daysLeft <= 1) {
+    return {
+      title: 'Trial ends today',
+      sub: 'Unlock Couchside to keep the console, pad, and launcher.',
+    };
+  }
+  return {
+    title: `${daysLeft} days left in your trial`,
+    sub: 'One-time unlock · no subscription, no account.',
+  };
+}


### PR DESCRIPTION
## Trial nudges

The trial ran a **silent** countdown and then, on day 7, replaced five of six tabs with a paywall. No warning at any point. This adds a ramp:

- A **dismissible banner** at **3 days** and again at **1 day** left, riding above the tab content — never on Setup, which already carries the permanent unlock row.
- A one-shot **"Trial ends today" toast** on the final day.

Each threshold shows at most once and stays dismissed (persisted). Tapping either goes straight to the purchase via a new `?tab=account` param on Setup.

**Two subtleties the gate forced:**

1. **It keys off `!isGenuinelyPurchased() && trialDaysLeft > 0`, not `state === 'trial'`.** The store-unreachable fail-open in `entitlement.ts` reports `'purchased'` over a still-running clock — that user *will* be gated once the store recovers, so they still deserve the warning. The `> 0` also keeps the banner away from an already-expired user, who is staring at the paywall anyway (`thresholdFor(0)` would otherwise return `1`).

2. **Dismissal is broadcast.** Every mounted tab renders its own `TrialNudge` with its own state. Without `subscribeNudgeDismissed`, dismissing on Console leaves the already-mounted Actions instance still showing the banner when you switch back — the flag is persisted, but the live component never re-reads it. Caught this in the DOM during verification.

## Review ask

Previously **only purchasers were ever asked**, and only on unlock. Now the ask also fires when the app has simply done its job — `EARNED_SESSIONS` launches with a reachable box — so a trial user who loves it gets asked too.

`lib/review.ts` owns the single asked-flag both paths share, so nobody is nagged twice:

- **`ReviewPrompt`** tries the native OS sheet. It stays **app-triggered and is never wired to a button** — that's Apple's rule, and the reason there is no "Rate" button that summons it.
- If the sheet can't run (no `hasAction()`, web, a build without the native module), it falls back to **`ReviewToast`**, which **links out** to the store's write-review page.
- The new **"Rate Couchside" row** in Setup → Account is user-initiated, always available, unflagged — and links out. It must never call `requestReview()`.

## Verification

`tsc` clean. Driven on the web build by winding the trial clock back:

| | |
|---|---|
| 2 days left | blue banner, "2 days left in your trial", on Console/Actions — absent on Setup ✓ |
| 1 day left | amber banner, "Trial ends today" + the one-shot toast (flag set) ✓ |
| Dismiss | persists (`couchside.trialNudge.v1.3=1`) **and** clears the already-mounted sibling tab ✓ |
| Setup → Account | "Rate Couchside" row renders below the purchase card ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)