### PR TITLE
release: v2.7.0 (iOS build 29, Android versionCode 15)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.6.0",
+    "version": "2.7.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "25",
+      "buildNumber": "29",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 14
+      "versionCode": 15
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Version bump for the 2.7.0 release. `autoIncrement` wrote the build numbers during the EAS cloud build.

| | |
|---|---|
| `version` | 2.6.0 → **2.7.0** |
| `ios.buildNumber` | 28 → **29** |
| `android.versionCode` | 14 → **15** |

## Shipped

**Android — LIVE.** Google Play production, versionCode 15, 100% rollout, verified via the Play Developer API. This is the **first Android build without the entitlement fail-open**, which was live in production: a flaky Google Play Billing call made the app declare itself `'purchased'` and hide the Buy *and* Restore buttons from real customers. Also brings the unlock row on Setup, trial nudges, the Rate row, and the calm box-less empty states.

**iOS — parked.** Build 29 is on TestFlight, added to the Public Beta group with "What to Test", and submitted for Beta App Review. Its **App Store** submission waits for 2.6.0 to clear — ASC returns `409: You cannot create a new version of the App in the current state` while a version is in review.

## Follow-ups when 2.6.0 is approved

- Create the 2.7.0 App Store version, attach build 29, submit.
- **Refresh the review notes.** Guideline 2.3.1(a) requires new features be described with specificity — the reviewer will see a "Rate Couchside" row and trial banners that did not exist in 2.6.0. Note that the Rate row *links out* to the store and never calls `requestReview()`.
- **Fix the IAP `reviewNote`.** It still claims the paywall only appears after the trial, which is what sent the last reviewer looking in the wrong place. Left alone deliberately: editing a `WAITING_FOR_REVIEW` product risked bouncing it out of the in-flight review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)