### PR TITLE
Couch Mode + Plasma desktop nav (2.8.0 / agent 2.9.0)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -643,7 +643,7 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver")}
+                 "screensaver", "couchmode")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -653,6 +653,7 @@ def set_caps(mock):
         "screen": _SCREEN is not None,
         "power_schedule": safe(rtc_available),
         "screensaver": safe(screensaver_available),
+        "couchmode": safe(couchmode_available),
     }
 
 
@@ -1018,6 +1019,93 @@ def real_action(action_id):
         "stdout": r.stdout,
         "stderr": r.stderr,
         "duration_ms": int((time.monotonic() - start) * 1000),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Couch Mode (/api/displays, /api/couch-mode, /api/desktop-mode).
+#
+# For a box run as a DESKTOP (Plasma) that also has a TV wired in: one tap flings
+# it into Game Mode on the TV. The desktop→couch handoff, phone-triggered.
+#
+# The reliable output mechanism (learned from a real multi-monitor setup): don't
+# fight gamescope's session args to inject --prefer-output — instead make the
+# chosen TV output PRIMARY first (kscreen-doctor), THEN switch to Game Mode, and
+# gamescope lands on the primary. Desktop Mode reverses the session.
+#
+# SteamOS/Bazzite only (shared tooling: gamescope, steamos-session-select,
+# kscreen-doctor, wpctl). Gated to boxes with 2+ connected outputs, so a
+# single-display box (a handheld with nothing plugged in, or a dedicated Game
+# Mode box) never shows the button. Outputs are read from DRM sysfs, which works
+# regardless of the current session (kscreen-doctor only answers inside Plasma).
+#
+# This section is the read-only half: enumerate outputs + report the capability.
+# The switch orchestration (audio move + set-primary + session switch, chained
+# with the existing TV power/HDMI-input control) is a separate step.
+# ---------------------------------------------------------------------------
+
+# DRM connector name prefixes that are a built-in panel, not a TV/monitor.
+_INTERNAL_OUTPUT_PREFIXES = ("eDP", "LVDS", "DSI")
+# The session tools Couch Mode drives; all must be present to offer it.
+_COUCHMODE_TOOLS = ("gamescope", "steamos-session-select", "kscreen-doctor", "wpctl")
+
+
+def _is_steamos_like():
+    """True on SteamOS or Bazzite — the only platforms Couch Mode targets."""
+    try:
+        rel = open("/etc/os-release").read().lower()
+    except OSError:
+        return False
+    return "steamos" in rel or "bazzite" in rel
+
+
+def _connected_outputs():
+    """Connected DRM outputs as [{name, internal}], newest-sorted by connector.
+
+    Read straight from /sys/class/drm/*/status so it works in ANY session
+    (Plasma, Game Mode, or the bare login state) — kscreen-doctor only answers
+    while a KWin session is up.
+    """
+    outs = []
+    for path in sorted(glob.glob("/sys/class/drm/card*-*")):
+        try:
+            if open(os.path.join(path, "status")).read().strip() != "connected":
+                continue
+        except OSError:
+            continue
+        # cardN-DP-2 -> DP-2 ; cardN-eDP-1 -> eDP-1
+        name = os.path.basename(path).split("-", 1)[1]
+        outs.append({
+            "name": name,
+            "internal": name.startswith(_INTERNAL_OUTPUT_PREFIXES),
+        })
+    return outs
+
+
+def couchmode_available():
+    """True when this box can do the desktop→TV Game Mode handoff: SteamOS/Bazzite,
+    the session tools present, and 2+ connected outputs (so there's a TV to fling
+    Game Mode onto, distinct from the built-in panel)."""
+    if not _is_steamos_like():
+        return False
+    if not all(shutil.which(t) for t in _COUCHMODE_TOOLS):
+        return False
+    return len(_connected_outputs()) >= 2
+
+
+def couchmode_info():
+    """Payload for GET /api/displays: the connected outputs and which are TV
+    candidates (external) to offer as the game display. None when unavailable, so
+    the route 404s and the app hides the Couch Mode control (probe-and-appear)."""
+    if not couchmode_available():
+        return None
+    outs = _connected_outputs()
+    return {
+        "available": True,
+        "outputs": outs,
+        # External (non-panel) outputs are the game-display candidates. Default
+        # to the first external one in the app's picker.
+        "game_outputs": [o["name"] for o in outs if not o["internal"]],
     }
 
 
@@ -4908,6 +4996,19 @@ class Handler(BaseHTTPRequestHandler):
                 # Probe-and-appear: 404 when no TV backend so the app shows no
                 # TV strip; a body only when a backend is live.
                 info = tv_info()
+                if info is None:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, info, started)
+            elif path == "/api/displays":
+                # Probe-and-appear: 404 unless this box can do the desktop->TV
+                # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app
+                # shows no Couch Mode control otherwise.
+                info = ({"available": True,
+                         "outputs": [{"name": "DP-1", "internal": False},
+                                     {"name": "eDP-1", "internal": True}],
+                         "game_outputs": ["DP-1"]} if self.mock
+                        else couchmode_info())
                 if info is None:
                     self._send(404, {"error": "not found"}, started)
                 else:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.8.4"
+VERSION = "2.9.0"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1028,10 +1028,14 @@ def real_action(action_id):
 # For a box run as a DESKTOP (Plasma) that also has a TV wired in: one tap flings
 # it into Game Mode on the TV. The desktop→couch handoff, phone-triggered.
 #
-# The reliable output mechanism (learned from a real multi-monitor setup): don't
-# fight gamescope's session args to inject --prefer-output — instead make the
-# chosen TV output PRIMARY first (kscreen-doctor), THEN switch to Game Mode, and
-# gamescope lands on the primary. Desktop Mode reverses the session.
+# Output mechanism (verified on a real SteamOS box, 2026-07-15): the SteamOS
+# gamescope session hardcodes `-O '*',eDP-1` — prefer ANY external output, fall
+# back to the internal panel — so a box with a single external (the TV) lands
+# Game Mode on it automatically; nothing to inject. gamescope reads DRM directly
+# and ignores the X11 "primary" flag, so the old set-primary theory does nothing
+# for it. Forcing a SPECIFIC external when several are connected would need a
+# gamescope session override we don't ship yet, so `output` is advisory and the
+# app's picker (shown only with 2+ externals) is best-effort there.
 #
 # SteamOS/Bazzite only (shared tooling: gamescope, steamos-session-select,
 # kscreen-doctor, wpctl). Gated to boxes with 2+ connected outputs, so a
@@ -1039,9 +1043,12 @@ def real_action(action_id):
 # Mode box) never shows the button. Outputs are read from DRM sysfs, which works
 # regardless of the current session (kscreen-doctor only answers inside Plasma).
 #
-# This section is the read-only half: enumerate outputs + report the capability.
-# The switch orchestration (audio move + set-primary + session switch, chained
-# with the existing TV power/HDMI-input control) is a separate step.
+# The switch (couchmode_start / desktop_mode) runs entirely from the agent's own
+# service env: it's a SYSTEM service running as the desktop user with
+# XDG_RUNTIME_DIR set, which is all pactl/wpctl (audio, over the user runtime
+# socket) and steamosctl (session switch, over the system bus) need — no DISPLAY
+# or session D-Bus. Being a system service, the agent SURVIVES the session tear-
+# down, so it keeps answering and reports the new session on the next poll.
 # ---------------------------------------------------------------------------
 
 # DRM connector name prefixes that are a built-in panel, not a TV/monitor.
@@ -1095,9 +1102,14 @@ def couchmode_available():
 
 def _couchmode_session():
     """'gamescope' when this box is currently in Game Mode, else 'desktop'.
-    Lets the app show 'Back to Desktop' vs the fling-to-TV picker."""
+    Lets the app show 'Back to Desktop' vs the fling-to-TV picker.
+
+    The gamescope compositor runs with process name (comm) 'gamescope-wl' even
+    though its argv[0] is 'gamescope' — so an exact `pgrep -x gamescope` MISSES
+    it. Match either name with an anchored regex; the anchor also avoids matching
+    the 'start-gamescope-session' launcher script."""
     try:
-        r = subprocess.run(["pgrep", "-x", "gamescope"],
+        r = subprocess.run(["pgrep", "-x", "gamescope(-wl)?"],
                            capture_output=True, timeout=3)
         return "gamescope" if r.returncode == 0 else "desktop"
     except Exception:
@@ -1120,6 +1132,133 @@ def couchmode_info():
         "game_outputs": [o["name"] for o in outs if not o["internal"]],
         "session": _couchmode_session(),
     }
+
+
+def _couch_run(cmd, timeout=25, max_out=1500):
+    """Run a Couch Mode switch command from the agent's service env. The agent
+    runs as the desktop user with XDG_RUNTIME_DIR set (ensured here for safety),
+    which is all pactl/wpctl and steamosctl need. Returns a compact result dict;
+    never raises. `max_out` caps stdout/stderr (tail) for the JSON reply; pass
+    None when a caller needs to PARSE full output (e.g. `pactl list sinks`)."""
+    env = dict(os.environ)
+    env.setdefault("XDG_RUNTIME_DIR", "/run/user/%d" % os.getuid())
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True,
+                           timeout=timeout, env=env)
+        out, err = r.stdout or "", r.stderr or ""
+        if max_out is not None:
+            out, err = out[-max_out:], err[-max_out:]
+        return {"ok": r.returncode == 0, "exit_code": r.returncode,
+                "stdout": out, "stderr": err}
+    except FileNotFoundError:
+        return {"ok": False, "exit_code": 127, "stdout": "",
+                "stderr": "%s: not found" % cmd[0]}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "exit_code": 124, "stdout": "",
+                "stderr": "%s: timed out" % cmd[0]}
+    except Exception as e:  # never let a switch step crash the request
+        return {"ok": False, "exit_code": 1, "stdout": "",
+                "stderr": "%s: %s" % (cmd[0], e.__class__.__name__)}
+
+
+def _pactl_sinks():
+    """Parse `pactl list sinks` into [{name, hdmi, available}]. `available` is
+    True only when a port on the sink reports availability 'available' (an
+    HDMI/DP output with a live display), so the TV's audio sink is the one that's
+    both hdmi and available. [] when pactl is missing or errors."""
+    if not shutil.which("pactl"):
+        return []
+    r = _couch_run(["pactl", "list", "sinks"], timeout=8, max_out=None)
+    if not r["ok"]:
+        return []
+    sinks, cur = [], None
+    for raw in r["stdout"].splitlines():
+        s = raw.strip()
+        if s.startswith("Name:"):
+            cur = {"name": s.split(":", 1)[1].strip(),
+                   "hdmi": False, "available": False}
+            sinks.append(cur)
+        elif cur is not None and "type: HDMI" in s:
+            cur["hdmi"] = True
+            # port line ends "..., available)" vs "..., not available)"
+            if s.endswith("available)") and "not available)" not in s:
+                cur["available"] = True
+    return sinks
+
+
+def _tv_audio_sink():
+    """Node name of the connected TV's HDMI/DP audio sink (hdmi + available), or
+    None so the audio move no-ops rather than guessing."""
+    for s in _pactl_sinks():
+        if s["hdmi"] and s["available"]:
+            return s["name"]
+    return None
+
+
+def _internal_audio_sink():
+    """Node name of the built-in speaker/analog sink (for restoring on return)."""
+    for s in _pactl_sinks():
+        low = s["name"].lower()
+        if not s["hdmi"] and ("speaker" in low or "analog" in low
+                              or "pci" in low):
+            return s["name"]
+    return None
+
+
+def _session_to_game():
+    """Transient switch to Game Mode. Prefer steamosctl (does NOT change the
+    boot default) over the deprecated steamos-session-select wrapper (which
+    would)."""
+    if shutil.which("steamosctl"):
+        return _couch_run(["steamosctl", "switch-to-game-mode"])
+    return _couch_run(["steamos-session-select", "gamescope"])
+
+
+def _session_to_desktop():
+    """Transient switch back to the Plasma X11 desktop."""
+    if shutil.which("steamosctl"):
+        return _couch_run(["steamosctl", "switch-to-desktop-mode",
+                           "plasmax11.desktop"])
+    return _couch_run(["steamos-session-select", "plasma"])
+
+
+def couchmode_start(output, hdr=False):
+    """Fling the box into Game Mode on the TV. Steps, all best-effort except the
+    session switch: (0) TV power-on + input-to-box where the box can drive the
+    panel/CEC (inert otherwise), (1) move audio to the TV's HDMI sink, (2)
+    transient switch to Game Mode. gamescope lands on the external output on its
+    own (see the section header); `output` is recorded but not forced. The switch
+    tears down the desktop session — the agent (system service) survives, so the
+    app reads session=gamescope on its next /api/displays poll."""
+    steps = {}
+    # (0) Fold in TV power + input. tv_send returns None when no backend exists.
+    pwr = tv_send("power_on", False)
+    steps["tv_power_on"] = pwr if pwr is not None else {"skipped": True}
+    src = tv_send("source_box", False)
+    steps["tv_input"] = src if src is not None else {"skipped": True}
+    # (1) Route audio to the TV.
+    sink = _tv_audio_sink()
+    steps["audio"] = (_couch_run(["pactl", "set-default-sink", sink])
+                      if sink else {"skipped": True})
+    # (2) Enter Game Mode (the one step that must succeed).
+    sw = _session_to_game()
+    steps["session"] = sw
+    return {"ok": sw["ok"], "output": output, "hdr": bool(hdr),
+            "session": "gamescope" if sw["ok"] else _couchmode_session(),
+            "steps": steps}
+
+
+def desktop_mode():
+    """Return from Game Mode to the Plasma desktop and route audio back to the
+    built-in speaker."""
+    sw = _session_to_desktop()
+    steps = {"session": sw}
+    sink = _internal_audio_sink()
+    steps["audio"] = (_couch_run(["pactl", "set-default-sink", sink])
+                      if sink else {"skipped": True})
+    return {"ok": sw["ok"],
+            "session": "desktop" if sw["ok"] else _couchmode_session(),
+            "steps": steps}
 
 
 # ---------------------------------------------------------------------------
@@ -5345,6 +5484,41 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, screensaver_stop(), started)
                 else:
                     self._send(400, {"error": "op must be start|stop"}, started)
+                return
+
+            # POST /api/couch-mode: {"output":"DP-2","hdr":false} — fling the box
+            # into Game Mode on the TV. 404 unless the box can do the handoff.
+            if path == "/api/couch-mode":
+                if not (self.mock or couchmode_available()):
+                    self._send(404, {"error": "couch mode unavailable"}, started)
+                    return
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError
+                except (ValueError, UnicodeDecodeError):
+                    self._send(400, {"error": "json body required"}, started)
+                    return
+                output = req.get("output") or ""
+                hdr = bool(req.get("hdr", False))
+                if self.mock:
+                    self._send(200, {"ok": True, "output": output, "hdr": hdr,
+                                     "session": "gamescope",
+                                     "steps": {"session": {"ok": True}}}, started)
+                    return
+                self._send(200, couchmode_start(output, hdr), started)
+                return
+
+            # POST /api/desktop-mode: leave Game Mode back to the Plasma desktop.
+            if path == "/api/desktop-mode":
+                if not (self.mock or couchmode_available()):
+                    self._send(404, {"error": "couch mode unavailable"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "session": "desktop",
+                                     "steps": {"session": {"ok": True}}}, started)
+                    return
+                self._send(200, desktop_mode(), started)
                 return
 
             # POST /api/power/sleep: arm a delayed suspend/poweroff.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -643,7 +643,7 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver", "couchmode")}
+                 "screensaver", "couchmode", "desktop")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -654,6 +654,7 @@ def set_caps(mock):
         "power_schedule": safe(rtc_available),
         "screensaver": safe(screensaver_available),
         "couchmode": safe(couchmode_available),
+        "desktop": safe(desktop_available),
     }
 
 
@@ -908,7 +909,11 @@ def real_status():
         "disks": read_disks(),
         "net": net_info_cached(),
         "agent_version": VERSION,
-        "caps": CAPS,
+        # CAPS is a boot-time snapshot, but "desktop" is SESSION-volatile (it
+        # flips with every Game Mode <-> desktop switch), so recompute it per
+        # request — a cheap pgrep — or the app's desktop cluster would freeze
+        # at whatever session the agent booted in.
+        "caps": dict(CAPS, desktop=desktop_available()),
         "history": _history_snapshot(),
     }
 
@@ -1132,6 +1137,15 @@ def couchmode_info():
         "game_outputs": [o["name"] for o in outs if not o["internal"]],
         "session": _couchmode_session(),
     }
+
+
+def desktop_available():
+    """True on a SteamOS/Bazzite box currently in the Plasma DESKTOP session —
+    gates the app's desktop-nav cluster (Start menu / pointer / overview), which
+    only makes sense in the desktop, not in Game Mode. Session-aware so the
+    buttons appear when you're on the desktop and hide once you fling to Game
+    Mode. The keys themselves ride the existing /ws/gamepad uinput keyboard."""
+    return _is_steamos_like() and _couchmode_session() == "desktop"
 
 
 def _couch_run(cmd, timeout=25, max_out=1500):
@@ -3713,10 +3727,12 @@ KEY_J, KEY_K, KEY_L, KEY_SEMICOLON = 36, 37, 38, 39
 KEY_APOSTROPHE, KEY_GRAVE, KEY_LEFTSHIFT, KEY_BACKSLASH = 40, 41, 42, 43
 KEY_Z, KEY_X, KEY_C, KEY_V, KEY_B, KEY_N, KEY_M = 44, 45, 46, 47, 48, 49, 50
 KEY_COMMA, KEY_DOT, KEY_SLASH = 51, 52, 53
+KEY_LEFTALT = 56
 KEY_SPACE = 57
 KEY_HOME, KEY_UP = 102, 103
 KEY_LEFT, KEY_RIGHT, KEY_END, KEY_DOWN = 105, 106, 107, 108
 KEY_MUTE, KEY_VOLUMEDOWN, KEY_VOLUMEUP = 113, 114, 115
+KEY_LEFTMETA = 125  # Super/Windows key — KDE opens the app launcher (Kickoff)
 
 # Volume up/down go through the media keys so the OS shows its volume OSD. Mute
 # is NOT here: gamescope does not bind KEY_MUTE, so real_soft toggles mute via
@@ -3782,7 +3798,7 @@ def _build_char_map():
 
 CHAR_KEYMAP = _build_char_map()
 
-# named special key -> keycode
+# named special key -> keycode (one press+release)
 SPECIAL_KEYS = {
     "backspace": KEY_BACKSPACE,
     "enter": KEY_ENTER,
@@ -3795,6 +3811,15 @@ SPECIAL_KEYS = {
     "right": KEY_RIGHT,
     "home": KEY_HOME,
     "end": KEY_END,
+    # Desktop nav (KDE Plasma): a bare Meta tap opens the app launcher (Kickoff),
+    # the SteamOS/Bazzite desktop "start menu".
+    "meta": KEY_LEFTMETA,
+}
+
+# named chord -> ordered keycodes, pressed in order then released in reverse.
+# Desktop (KDE Plasma) window/overview shortcut for the app's desktop cluster.
+DESKTOP_CHORDS = {
+    "overview": (KEY_LEFTMETA, KEY_W),  # KWin "Overview" effect (Plasma 6)
 }
 
 # All KEY_* codes the virtual keyboard may emit (declared at device create).
@@ -3803,14 +3828,16 @@ SPECIAL_KEYS = {
 KEYBOARD_CODES = sorted(
     {code for code, _shift in CHAR_KEYMAP.values()}
     | set(SPECIAL_KEYS.values())
-    | {KEY_LEFTSHIFT, KEY_LEFTCTRL}
+    | {c for codes in DESKTOP_CHORDS.values() for c in codes}
+    | {KEY_LEFTSHIFT, KEY_LEFTCTRL, KEY_LEFTALT}
 )
 
 # Names for mock logging of keyboard/mouse EV_KEY events.
 _KEY_CODE_NAMES = {
     KEY_ESC: "KEY_ESC", KEY_BACKSPACE: "KEY_BACKSPACE", KEY_TAB: "KEY_TAB",
     KEY_ENTER: "KEY_ENTER", KEY_SPACE: "KEY_SPACE", KEY_LEFTSHIFT: "KEY_LEFTSHIFT",
-    KEY_LEFTCTRL: "KEY_LEFTCTRL",
+    KEY_LEFTCTRL: "KEY_LEFTCTRL", KEY_LEFTALT: "KEY_LEFTALT",
+    KEY_LEFTMETA: "KEY_LEFTMETA",
     KEY_UP: "KEY_UP", KEY_DOWN: "KEY_DOWN", KEY_LEFT: "KEY_LEFT",
     KEY_RIGHT: "KEY_RIGHT", KEY_HOME: "KEY_HOME", KEY_END: "KEY_END",
     KEY_MINUS: "KEY_MINUS", KEY_EQUAL: "KEY_EQUAL", KEY_LEFTBRACE: "KEY_LEFTBRACE",
@@ -4034,6 +4061,14 @@ class UInputMediaKeys:
         _emit_events(self.fd, [(EV_KEY, code, 0)])
 
 
+# Pause after UI_DEV_CREATE before the first emit. The X server/compositor
+# enumerates a new uinput device asynchronously; events sent before that lands
+# are silently dropped. 0.5s is comfortably past the observed race on SteamOS
+# (verified live: a Meta tap fired immediately after create never reached KWin;
+# the same tap after a settle opened the launcher every time).
+_UINPUT_SETTLE_S = 0.5
+
+
 class UInputMouse:
     """Virtual relative mouse: REL_X/REL_Y/REL_WHEEL + BTN_LEFT/RIGHT/MIDDLE."""
 
@@ -4064,6 +4099,9 @@ class UInputMouse:
             os.close(fd)
             raise
         self.fd = fd
+        # Settle before first emit — see UInputKeyboard (same enumeration race:
+        # the first click/move of a fresh session would be dropped).
+        time.sleep(_UINPUT_SETTLE_S)
 
     def emit(self, events):
         if self.fd is None:
@@ -4112,6 +4150,12 @@ class UInputKeyboard:
             os.close(fd)
             raise
         self.fd = fd
+        # Settle: the X server / compositor needs a beat to enumerate a fresh
+        # uinput device before it delivers events from it. The keyboard is
+        # created lazily on the FIRST key frame — without this, that first
+        # press (a typed char, or the Start-menu Meta tap, verified live on
+        # SteamOS) is silently dropped. One-time cost per session.
+        time.sleep(_UINPUT_SETTLE_S)
 
     def emit(self, events):
         if self.fd is None:
@@ -4283,10 +4327,15 @@ def keyboard_events(msg):
         return _type_events(text)
     if t == "k":
         key = msg.get("key")
-        if key not in SPECIAL_KEYS:
-            raise ValueError("unknown special key %r" % (key,))
-        code = SPECIAL_KEYS[key]
-        return [(EV_KEY, code, 1), (EV_KEY, code, 0)]
+        if key in SPECIAL_KEYS:
+            code = SPECIAL_KEYS[key]
+            return [(EV_KEY, code, 1), (EV_KEY, code, 0)]
+        if key in DESKTOP_CHORDS:
+            codes = DESKTOP_CHORDS[key]
+            # Press in order, release in reverse (modifiers wrap the base key).
+            return ([(EV_KEY, c, 1) for c in codes]
+                    + [(EV_KEY, c, 0) for c in reversed(codes)])
+        raise ValueError("unknown special key %r" % (key,))
     raise ValueError("unknown keyboard message type %r" % (t,))
 
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1093,10 +1093,22 @@ def couchmode_available():
     return len(_connected_outputs()) >= 2
 
 
+def _couchmode_session():
+    """'gamescope' when this box is currently in Game Mode, else 'desktop'.
+    Lets the app show 'Back to Desktop' vs the fling-to-TV picker."""
+    try:
+        r = subprocess.run(["pgrep", "-x", "gamescope"],
+                           capture_output=True, timeout=3)
+        return "gamescope" if r.returncode == 0 else "desktop"
+    except Exception:
+        return "desktop"
+
+
 def couchmode_info():
-    """Payload for GET /api/displays: the connected outputs and which are TV
-    candidates (external) to offer as the game display. None when unavailable, so
-    the route 404s and the app hides the Couch Mode control (probe-and-appear)."""
+    """Payload for GET /api/displays: the connected outputs, which are TV
+    candidates (external) to offer as the game display, and the current session
+    so the app shows enter-vs-exit. None when unavailable, so the route 404s and
+    the app hides the Couch Mode control (probe-and-appear)."""
     if not couchmode_available():
         return None
     outs = _connected_outputs()
@@ -1106,6 +1118,7 @@ def couchmode_info():
         # External (non-panel) outputs are the game-display candidates. Default
         # to the first external one in the app's picker.
         "game_outputs": [o["name"] for o in outs if not o["internal"]],
+        "session": _couchmode_session(),
     }
 
 
@@ -5007,7 +5020,8 @@ class Handler(BaseHTTPRequestHandler):
                 info = ({"available": True,
                          "outputs": [{"name": "DP-1", "internal": False},
                                      {"name": "eDP-1", "internal": True}],
-                         "game_outputs": ["DP-1"]} if self.mock
+                         "game_outputs": ["DP-1"],
+                         "session": "desktop"} if self.mock
                         else couchmode_info())
                 if info is None:
                     self._send(404, {"error": "not found"}, started)

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -758,13 +758,15 @@ def set_caps(mock):
             return False
 
     if mock:
-        # screensaver + couchmode stay False even in mock: both are
+        # screensaver + couchmode + desktop stay False even in mock: all are
         # gamescope/SteamOS features the Windows agent does not implement
-        # (see the Linux agent).
+        # (see the Linux agent). Windows has its own desktop shortcuts (the
+        # WIN/ALT-TAB cluster on a ViGEm box), not the Plasma desktop-nav cap.
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
         CAPS["screensaver"] = False
         CAPS["couchmode"] = False
+        CAPS["desktop"] = False
         return
     CAPS = {
         "gamepad": safe(vigem_available),
@@ -774,8 +776,10 @@ def set_caps(mock):
         "screen": _SCREEN is not None,
         "power_schedule": safe(wake_available),
         "screensaver": False,
-        # Desktop->TV Game Mode handoff is gamescope/SteamOS-only.
+        # Desktop->TV Game Mode handoff is gamescope/SteamOS-only, and
+        # "desktop" (the Plasma desktop-nav cluster) is Linux-only too.
         "couchmode": False,
+        "desktop": False,
     }
 
 

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -758,11 +758,13 @@ def set_caps(mock):
             return False
 
     if mock:
-        # screensaver stays False even in mock: it is a gamescope/Steam-shortcut
-        # feature the Windows agent does not implement (see the Linux agent).
+        # screensaver + couchmode stay False even in mock: both are
+        # gamescope/SteamOS features the Windows agent does not implement
+        # (see the Linux agent).
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
         CAPS["screensaver"] = False
+        CAPS["couchmode"] = False
         return
     CAPS = {
         "gamepad": safe(vigem_available),
@@ -772,6 +774,8 @@ def set_caps(mock):
         "screen": _SCREEN is not None,
         "power_schedule": safe(wake_available),
         "screensaver": False,
+        # Desktop->TV Game Mode handoff is gamescope/SteamOS-only.
+        "couchmode": False,
     }
 
 

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "29",
+      "buildNumber": "30",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 15
+      "versionCode": 16
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -34,7 +34,10 @@ import { Gated } from '@/components/Gated';
 import { RemoteView } from '@/components/RemoteView';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
-import { ButtonKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
+import { usePoll } from '@/hooks/usePoll';
+import { useTrackpad } from '@/hooks/useTrackpad';
+import { api, hostKey, Status } from '@/lib/api';
+import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -212,27 +215,16 @@ function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
     }),
   ).current;
 
+  const hints = usePref('padHints');
   return (
     <View style={styles.swipeSurface} {...responder.panHandlers}>
-      <Text style={styles.swipeHint}>swipe to move · tap to select</Text>
+      {hints && <Text style={styles.swipeHint}>swipe to move · tap to select</Text>}
     </View>
   );
 }
 
 // ---------- Trackpad surface (relative mouse, protocol v2) ----------
 
-/** Movement under this (px) still counts as a tap/click. */
-const TP_TAP_SLOP = 8;
-/** Touches longer than this aren't taps. */
-const TP_TAP_MS = 350;
-/**
- * Light acceleration: pointer delta = raw * (BASE + GAIN * speed). Slow drags
- * track 1:1-ish for precision; fast flicks cover more screen.
- */
-const TP_BASE = 1.1;
-const TP_GAIN = 0.05;
-/** Screen px of two-finger drag per wheel notch. */
-const TP_SCROLL_STEP = 18;
 /** Pointer travel (px) per haptic "texture" tick while dragging. */
 const TP_HAPTIC_PX = 56;
 
@@ -244,100 +236,23 @@ type TrackpadProps = {
 };
 
 /**
- * Relative-mouse surface:
+ * Relative-mouse surface (gesture logic shared with the RemoteView nav circle
+ * via useTrackpad):
  *  - 1-finger drag  -> sendMouseMove (with a light acceleration curve)
  *  - 1-finger tap   -> left click
  *  - 2-finger tap   -> right click
  *  - 2-finger drag  -> vertical scroll (wheel)
  */
 function Trackpad({ onMove, onLeftClick, onRightClick, onScroll }: TrackpadProps) {
-  const cb = useRef({ onMove, onLeftClick, onRightClick, onScroll });
-  cb.current = { onMove, onLeftClick, onRightClick, onScroll };
-  // Pointer speed + scroll direction, in refs so the once-created responder
-  // reads live values.
-  const feel = useRef({ sens: 1, natural: false });
-  feel.current = {
-    sens: usePref('trackpadSensitivity'),
-    natural: usePref('naturalScroll'),
-  };
-
-  const st = useRef({
-    lastX: 0,
-    lastY: 0,
-    lastT: 0,
-    moved: false,
-    t0: 0,
-    maxTouches: 1,
-    scrollAccum: 0,
-    scrollLastY: 0,
-  });
-
-  const responder = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => true,
-      onMoveShouldSetPanResponder: () => true,
-      onPanResponderGrant: (evt) => {
-        const touches = evt.nativeEvent.touches.length || 1;
-        st.current = {
-          lastX: 0,
-          lastY: 0,
-          lastT: Date.now(),
-          moved: false,
-          t0: Date.now(),
-          maxTouches: touches,
-          scrollAccum: 0,
-          scrollLastY: 0,
-        };
-      },
-      onPanResponderMove: (evt, g) => {
-        const s = st.current;
-        const touches = evt.nativeEvent.touches.length;
-        if (touches > s.maxTouches) s.maxTouches = touches;
-        if (!s.moved && Math.hypot(g.dx, g.dy) > TP_TAP_SLOP) s.moved = true;
-
-        if (s.maxTouches >= 2) {
-          // Two-finger drag -> vertical scroll. g.dy is cumulative from grant.
-          const delta = g.dy - s.scrollLastY;
-          s.scrollAccum += delta;
-          while (Math.abs(s.scrollAccum) >= TP_SCROLL_STEP) {
-            const dir = s.scrollAccum > 0 ? 1 : -1;
-            s.scrollAccum -= dir * TP_SCROLL_STEP;
-            // Drag down (dy>0) scrolls content up -> wheel down (negative).
-            // "Natural" scrolling inverts that (content follows the fingers).
-            cb.current.onScroll(feel.current.natural ? dir : -dir);
-          }
-          s.scrollLastY = g.dy;
-          return;
-        }
-
-        // One-finger drag -> relative pointer move with light acceleration.
-        const now = Date.now();
-        const rawDx = g.dx - s.lastX;
-        const rawDy = g.dy - s.lastY;
-        const dt = Math.max(1, now - s.lastT);
-        const speed = Math.hypot(rawDx, rawDy) / dt; // px/ms
-        const gain = (TP_BASE + TP_GAIN * speed * 16) * feel.current.sens; // scale speed to ~per-frame
-        s.lastX = g.dx;
-        s.lastY = g.dy;
-        s.lastT = now;
-        cb.current.onMove(rawDx * gain, rawDy * gain);
-      },
-      onPanResponderRelease: () => {
-        const s = st.current;
-        const wasTap = !s.moved && Date.now() - s.t0 < TP_TAP_MS;
-        if (wasTap) {
-          if (s.maxTouches >= 2) cb.current.onRightClick();
-          else cb.current.onLeftClick();
-        }
-      },
-    }),
-  ).current;
-
+  const responder = useTrackpad({ onMove, onLeftClick, onRightClick, onScroll });
+  const hints = usePref('padHints');
   return (
     <View style={styles.trackpadSurface} {...responder.panHandlers}>
-      <Text style={styles.swipeHint}>
-        drag to move · tap = click · two-finger tap = right-click · two-finger drag = scroll
-      </Text>
+      {hints && (
+        <Text style={styles.swipeHint}>
+          drag to move · tap = click · two-finger tap = right-click · two-finger drag = scroll
+        </Text>
+      )}
     </View>
   );
 }
@@ -700,6 +615,24 @@ function PadScreen() {
     [client],
   );
 
+  // SteamOS/Bazzite Plasma-desktop nav (Start menu / Overview / Esc). Session-
+  // aware: caps.desktop flips with each Game Mode <-> desktop switch, so poll
+  // status here like RemoteView does rather than trusting the persisted caps.
+  const deskPoll = usePoll<Status>(() => api.status(settings), 8000, true, hostKey(settings));
+  const hasDesktop = deskPoll.data?.caps?.desktop === true;
+  const desk = useCallback(
+    (name: DesktopKey | 'esc') => () =>
+      name === 'esc' ? client.sendKey('esc') : client.sendDesktopKey(name),
+    [client],
+  );
+
+  // Pad-layout prefs: every optional row/view can be hidden in Setup.
+  const showMouseRow = usePref('padMouseRow');
+  const showSteamRow = usePref('padSteamRow');
+  const showDesktopNav = usePref('padDesktopNav');
+  const showWinShortcuts = usePref('padWinShortcuts');
+  const showKeyboardBar = usePref('padKeyboardBar');
+
   const trig = useCallback(
     (k: TriggerKey) => ({
       onDown: () => client.sendTrigger(k, 255),
@@ -782,9 +715,9 @@ function PadScreen() {
   const kbBackspace = useCallback(() => client.sendKey('backspace'), [client]);
   const kbEnter = useCallback(() => client.sendKey('enter'), [client]);
 
-  const keyboardBar = (
+  const keyboardBar = showKeyboardBar ? (
     <KeyboardBar onText={kbText} onBackspace={kbBackspace} onEnter={kbEnter} />
-  );
+  ) : null;
 
   return (
     <View
@@ -869,46 +802,67 @@ function PadScreen() {
             onRightClick={tpRight}
             onScroll={tpScroll}
           />
-          <View style={styles.swipeBtnRow}>
-            <PadButton
-              label="L"
-              onDown={() => client.sendMouseButton('l', 1)}
-              onUp={() => client.sendMouseButton('l', 0)}
-              style={styles.tpBtn}
-              fontSize={14}
-            />
-            <PadButton
-              label="M"
-              onDown={() => client.sendMouseButton('m', 1)}
-              onUp={() => client.sendMouseButton('m', 0)}
-              style={styles.tpBtn}
-              fontSize={14}
-            />
-            <PadButton
-              label="R"
-              onDown={() => client.sendMouseButton('r', 1)}
-              onUp={() => client.sendMouseButton('r', 0)}
-              style={styles.tpBtn}
-              fontSize={14}
-            />
-            <PadButton
-              label="STEAM"
-              {...btn('guide')}
-              style={[styles.tpBtn, styles.tpBtnWide, styles.guideBtn]}
-              color={theme.blue}
-              fontSize={11}
-            />
-            <PadButton
-              label="⋯"
-              onDown={qam}
-              onUp={NOOP}
-              style={[styles.tpBtn, styles.guideBtn]}
-              color={theme.blue}
-              fontSize={22}
-            />
-          </View>
+          {(showMouseRow || showSteamRow) && (
+            <View style={styles.swipeBtnRow}>
+              {showMouseRow && (
+                <>
+                  <PadButton
+                    label="L"
+                    onDown={() => client.sendMouseButton('l', 1)}
+                    onUp={() => client.sendMouseButton('l', 0)}
+                    style={styles.tpBtn}
+                    fontSize={14}
+                  />
+                  <PadButton
+                    label="M"
+                    onDown={() => client.sendMouseButton('m', 1)}
+                    onUp={() => client.sendMouseButton('m', 0)}
+                    style={styles.tpBtn}
+                    fontSize={14}
+                  />
+                  <PadButton
+                    label="R"
+                    onDown={() => client.sendMouseButton('r', 1)}
+                    onUp={() => client.sendMouseButton('r', 0)}
+                    style={styles.tpBtn}
+                    fontSize={14}
+                  />
+                </>
+              )}
+              {showSteamRow && (
+                <>
+                  <PadButton
+                    label="STEAM"
+                    {...btn('guide')}
+                    style={[styles.tpBtn, styles.tpBtnWide, styles.guideBtn]}
+                    color={theme.blue}
+                    fontSize={11}
+                  />
+                  <PadButton
+                    label="⋯"
+                    onDown={qam}
+                    onUp={NOOP}
+                    style={[styles.tpBtn, styles.guideBtn]}
+                    color={theme.blue}
+                    fontSize={22}
+                  />
+                </>
+              )}
+            </View>
+          )}
+          {/* Plasma desktop nav — SteamOS/Bazzite boxes on the desktop only. */}
+          {hasDesktop && showDesktopNav && (
+            <View style={styles.swipeBtnRow}>
+              <PadButton label="START" onDown={desk('meta')} onUp={NOOP}
+                style={[styles.tpBtn, styles.tpBtnWide]} fontSize={11} />
+              <PadButton label="OVERVIEW" onDown={desk('overview')} onUp={NOOP}
+                style={[styles.tpBtn, styles.tpBtnWide]} fontSize={11} />
+              <PadButton label="ESC" onDown={desk('esc')} onUp={NOOP}
+                style={styles.tpBtn} fontSize={11} />
+            </View>
+          )}
           {/* Windows desktop shortcuts — one-shot chords, ViGEm boxes only. */}
-          {isWindows && (
+          {isWindows && showWinShortcuts && (
             <View style={styles.swipeBtnRow}>
               <PadButton label="⊞ WIN" onDown={sys('win')} onUp={NOOP}
                 style={[styles.tpBtn, styles.tpBtnWide]} fontSize={12} />
@@ -949,7 +903,8 @@ function PadScreen() {
                 </View>
                 <View style={styles.dpadRow}>
                   <PadButton label="◀" {...btn('dl')} style={styles.dpadBtn} />
-                  <View style={styles.dpadCenter} />
+                  {/* Center OK = A: opens/activates the highlighted item. */}
+                  <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={theme.green} fontSize={14} />
                   <PadButton label="▶" {...btn('dr')} style={styles.dpadBtn} />
                 </View>
                 <View style={styles.dpadRow}>
@@ -1053,7 +1008,8 @@ function PadScreen() {
               </View>
               <View style={styles.dpadRow}>
                 <PadButton label="◀" {...btn('dl')} style={styles.dpadBtn} />
-                <View style={styles.dpadCenter} />
+                {/* Center OK = A: opens/activates the highlighted item. */}
+                <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={theme.green} fontSize={14} />
                 <PadButton label="▶" {...btn('dr')} style={styles.dpadBtn} />
               </View>
               <View style={styles.dpadRow}>
@@ -1388,14 +1344,6 @@ const styles = StyleSheet.create({
   dpadBtn: {
     width: 58,
     height: 58,
-  },
-  dpadCenter: {
-    width: 58,
-    height: 58,
-    borderRadius: 12,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
-    borderWidth: 1,
   },
   dpadSpacer: {
     width: 58,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -575,6 +575,12 @@ function SetupBody() {
   const swipeSensitivity = usePref('swipeSensitivity');
   const trackpadSensitivity = usePref('trackpadSensitivity');
   const naturalScroll = usePref('naturalScroll');
+  const padMouseRow = usePref('padMouseRow');
+  const padSteamRow = usePref('padSteamRow');
+  const padDesktopNav = usePref('padDesktopNav');
+  const padWinShortcuts = usePref('padWinShortcuts');
+  const padKeyboardBar = usePref('padKeyboardBar');
+  const padHints = usePref('padHints');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -1099,6 +1105,65 @@ function SetupBody() {
                 value={naturalScroll}
                 onValueChange={(v) => {
                   void setPref('naturalScroll', v);
+                  hapticSelection();
+                }}
+              />
+            </View>
+
+            {/* Every optional Pad row/view can be hidden — declutter to taste. */}
+            <View style={styles.card}>
+              <CardHeader icon="game-controller-outline" label="PAD LAYOUT" />
+              <TogglePref
+                label="Mouse buttons"
+                sub="L / M / R click row under the trackpad."
+                value={padMouseRow}
+                onValueChange={(v) => {
+                  void setPref('padMouseRow', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Steam buttons"
+                sub="STEAM and ⋯ (Quick Access) in the trackpad row."
+                value={padSteamRow}
+                onValueChange={(v) => {
+                  void setPref('padSteamRow', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Desktop navigation"
+                sub="Start menu, Overview, and the D-pad↔trackpad toggle on SteamOS/Bazzite desktops."
+                value={padDesktopNav}
+                onValueChange={(v) => {
+                  void setPref('padDesktopNav', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Windows shortcuts"
+                sub="WIN / ALT+TAB / LOCK / TASK row on Windows boxes."
+                value={padWinShortcuts}
+                onValueChange={(v) => {
+                  void setPref('padWinShortcuts', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Keyboard bar"
+                sub="The KEYBOARD button at the bottom of the Pad tab."
+                value={padKeyboardBar}
+                onValueChange={(v) => {
+                  void setPref('padKeyboardBar', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Gesture hints"
+                sub="The helper text on swipe and trackpad surfaces."
+                value={padHints}
+                onValueChange={(v) => {
+                  void setPref('padHints', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -10,7 +10,7 @@
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Modal, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api, ConnSettings, Displays } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
@@ -32,7 +32,6 @@ export function CouchModeSheet({
   const inGameMode = displays?.session === 'gamescope';
   const outputs = displays?.game_outputs ?? [];
   const [output, setOutput] = useState<string>(outputs[0] ?? '');
-  const [hdr, setHdr] = useState(false);
   const [busy, setBusy] = useState(false);
 
   // Seed the picker from the box's current outputs when the sheet OPENS — not
@@ -50,7 +49,7 @@ export function CouchModeSheet({
     setBusy(true);
     hapticLight();
     try {
-      await api.couchModeStart(settings, output, hdr);
+      await api.couchModeStart(settings, output);
       hapticSuccess();
       onChanged();
       onClose();
@@ -59,7 +58,7 @@ export function CouchModeSheet({
     } finally {
       setBusy(false);
     }
-  }, [busy, output, hdr, settings, onChanged, onClose]);
+  }, [busy, output, settings, onChanged, onClose]);
 
   const toDesktop = useCallback(async () => {
     if (busy) return;
@@ -126,21 +125,6 @@ export function CouchModeSheet({
                 </>
               )}
 
-              <View style={styles.hdrRow}>
-                <View style={{ flex: 1 }}>
-                  <Text style={styles.hdrLabel}>HDR</Text>
-                  <Text style={styles.hdrSub}>Enable HDR on the TV (if supported).</Text>
-                </View>
-                <Switch
-                  value={hdr}
-                  onValueChange={(v) => {
-                    hapticLight();
-                    setHdr(v);
-                  }}
-                  trackColor={{ false: theme.inset, true: theme.blue }}
-                />
-              </View>
-
               <Pressable
                 disabled={busy || !output}
                 onPress={fling}
@@ -189,10 +173,6 @@ const styles = StyleSheet.create({
   pillText: { color: theme.textDim, fontSize: 14, fontWeight: '600', fontFamily: mono },
   pillTextOn: { color: theme.blue },
   pressed: { opacity: 0.7 },
-
-  hdrRow: { flexDirection: 'row', alignItems: 'center', marginTop: 8, gap: 12 },
-  hdrLabel: { color: theme.text, fontSize: 15, fontWeight: '600' },
-  hdrSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
 
   startBtn: {
     marginTop: 14,

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -1,0 +1,219 @@
+/**
+ * Couch Mode sheet (opened from the top-bar Couch button). Flings a desktop
+ * (Plasma) box into Game Mode on the TV: pick the TV output, optionally HDR,
+ * one tap. When the box is already in Game Mode, the sheet flips to a single
+ * "Back to Desktop" exit — the return path Steam itself doesn't give you.
+ *
+ * State comes from the box (api.displays -> session), so the enter/exit view
+ * reflects reality: dropping back to desktop from the box shows up on the next
+ * poll.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Modal, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
+
+import { api, ConnSettings, Displays } from '@/lib/api';
+import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { mono, theme } from '@/lib/theme';
+
+export function CouchModeSheet({
+  visible,
+  settings,
+  displays,
+  onChanged,
+  onClose,
+}: {
+  visible: boolean;
+  settings: ConnSettings;
+  displays: Displays | null;
+  onChanged: () => void;
+  onClose: () => void;
+}) {
+  const inGameMode = displays?.session === 'gamescope';
+  const outputs = displays?.game_outputs ?? [];
+  const [output, setOutput] = useState<string>(outputs[0] ?? '');
+  const [hdr, setHdr] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  // Seed the picker from the box's current outputs when the sheet OPENS — not
+  // on every background poll (which would fight a mid-selection change).
+  const wasVisible = React.useRef(false);
+  useEffect(() => {
+    const opening = visible && !wasVisible.current;
+    wasVisible.current = visible;
+    if (!opening) return;
+    setOutput((cur) => (outputs.includes(cur) ? cur : outputs[0] ?? ''));
+  }, [visible, outputs]);
+
+  const fling = useCallback(async () => {
+    if (busy || !output) return;
+    setBusy(true);
+    hapticLight();
+    try {
+      await api.couchModeStart(settings, output, hdr);
+      hapticSuccess();
+      onChanged();
+      onClose();
+    } catch {
+      hapticError();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, output, hdr, settings, onChanged, onClose]);
+
+  const toDesktop = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    hapticLight();
+    try {
+      await api.desktopMode(settings);
+      hapticSuccess();
+      onChanged();
+      onClose();
+    } catch {
+      hapticError();
+    } finally {
+      setBusy(false);
+    }
+  }, [busy, settings, onChanged, onClose]);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.sheet} onPress={() => {}}>
+          <Text style={styles.title}>COUCH MODE</Text>
+
+          {inGameMode ? (
+            <>
+              <View style={styles.armedRow}>
+                <Ionicons name="game-controller" size={18} color={theme.green} />
+                <Text style={styles.armedText}>Gaming on the TV</Text>
+              </View>
+              <Pressable
+                disabled={busy}
+                onPress={toDesktop}
+                style={({ pressed }) => [styles.startBtn, styles.exitBtn, pressed && styles.pressed]}>
+                <Ionicons name="desktop-outline" size={18} color="#fff" />
+                <Text style={styles.startText}>{busy ? 'Switching…' : 'Back to Desktop'}</Text>
+              </Pressable>
+            </>
+          ) : (
+            <>
+              <Text style={styles.blurb}>
+                Move this desktop to the TV in Game Mode — display, audio, and input all
+                hand over. Tap Back to Desktop to return.
+              </Text>
+
+              {outputs.length > 1 && (
+                <>
+                  <Text style={styles.sub}>GAME DISPLAY</Text>
+                  <View style={styles.pills}>
+                    {outputs.map((name) => {
+                      const on = name === output;
+                      return (
+                        <Pressable
+                          key={name}
+                          onPress={() => {
+                            hapticLight();
+                            setOutput(name);
+                          }}
+                          style={[styles.pill, on && styles.pillOn]}>
+                          <Text style={[styles.pillText, on && styles.pillTextOn]}>{name}</Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                </>
+              )}
+
+              <View style={styles.hdrRow}>
+                <View style={{ flex: 1 }}>
+                  <Text style={styles.hdrLabel}>HDR</Text>
+                  <Text style={styles.hdrSub}>Enable HDR on the TV (if supported).</Text>
+                </View>
+                <Switch
+                  value={hdr}
+                  onValueChange={(v) => {
+                    hapticLight();
+                    setHdr(v);
+                  }}
+                  trackColor={{ false: theme.inset, true: theme.blue }}
+                />
+              </View>
+
+              <Pressable
+                disabled={busy || !output}
+                onPress={fling}
+                style={({ pressed }) => [
+                  styles.startBtn,
+                  (pressed || busy || !output) && styles.pressed,
+                ]}>
+                <Ionicons name="tv-outline" size={18} color="#fff" />
+                <Text style={styles.startText}>{busy ? 'Switching…' : 'Fling to TV'}</Text>
+              </Pressable>
+            </>
+          )}
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
+  sheet: {
+    backgroundColor: theme.card,
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+    padding: 20,
+    paddingBottom: 32,
+    gap: 10,
+  },
+  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  sub: { color: theme.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
+  blurb: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+
+  pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
+  pill: {
+    alignItems: 'center',
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    backgroundColor: theme.inset,
+    borderColor: theme.cardBorder,
+    borderWidth: 1,
+  },
+  pillOn: { borderColor: theme.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
+  pillText: { color: theme.textDim, fontSize: 14, fontWeight: '600', fontFamily: mono },
+  pillTextOn: { color: theme.blue },
+  pressed: { opacity: 0.7 },
+
+  hdrRow: { flexDirection: 'row', alignItems: 'center', marginTop: 8, gap: 12 },
+  hdrLabel: { color: theme.text, fontSize: 15, fontWeight: '600' },
+  hdrSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
+
+  startBtn: {
+    marginTop: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 13,
+    borderRadius: 12,
+    backgroundColor: theme.blue,
+  },
+  exitBtn: { backgroundColor: theme.green },
+  startText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+
+  armedRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    padding: 12,
+  },
+  armedText: { color: theme.text, fontSize: 15 },
+});

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { Alert, Modal, PanResponder, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { CouchModeSheet } from '@/components/CouchModeSheet';
 import { ScreensaverSheet } from '@/components/ScreensaverSheet';
 import { SleepTimerSheet } from '@/components/SleepTimerSheet';
 import { usePoll } from '@/hooks/usePoll';
-import { api, capsEqual, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
+import { api, capsEqual, Displays, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac } from '@/lib/settings';
@@ -243,6 +244,17 @@ export function RemotePowerBar() {
   const saver = reachable ? saverPoll.data ?? null : null;
   const [saverOpen, setSaverOpen] = React.useState(false);
 
+  // Couch Mode displays (agent >= 2.9, SteamOS/Bazzite desktop w/ TV). Probe-
+  // and-appear: null hides the header button; caps.couchmode === false skips it.
+  const displaysPoll = usePoll<Displays | null>(
+    () => api.displays(settings),
+    15000,
+    reachable,
+    boxKey,
+  );
+  const displays = reachable ? displaysPoll.data ?? null : null;
+  const [couchOpen, setCouchOpen] = React.useState(false);
+
   // Suspend-action availability, once per connect (agent >= 2.6 with the rule).
   const [hasSuspend, setHasSuspend] = React.useState(false);
   const suspendProbedFor = React.useRef<string | null>(null);
@@ -469,8 +481,10 @@ export function RemotePowerBar() {
   const canSuspend = reachable && hasSuspend;
   const canWake = !reachable && !!settings.mac && wolAvailable;
   const hasSaver = reachable && saver?.available === true;
+  const hasCouch = reachable && displays?.available === true;
 
-  // Nothing to control on this box right now.
+  // Nothing to control on this box right now. (Couch Mode counts: it renders
+  // its own header button, so the bar must not bail when it's the only thing.)
   if (
     !canSuspend &&
     !canWake &&
@@ -479,6 +493,7 @@ export function RemotePowerBar() {
     !canSourceBox &&
     !canBlankScreen &&
     !hasSaver &&
+    !hasCouch &&
     sources.length === 0
   )
     return null;
@@ -492,8 +507,35 @@ export function RemotePowerBar() {
     ? 'moon'
     : 'tv-outline';
 
+  const inGameMode = displays?.session === 'gamescope';
+
   return (
     <>
+      {/* Couch Mode: fling this desktop box to the TV in Game Mode (or come
+          back). Fills the header's empty middle; only shows on capable boxes. */}
+      {hasCouch && (
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            setCouchOpen(true);
+          }}
+          hitSlop={8}
+          style={({ pressed }) => [
+            styles.couchBtn,
+            inGameMode && styles.couchBtnActive,
+            pressed && styles.pressed,
+          ]}>
+          <Ionicons
+            name={inGameMode ? 'game-controller' : 'tv-outline'}
+            size={16}
+            color={inGameMode ? theme.green : theme.text}
+          />
+          <Text style={[styles.couchLabel, inGameMode && { color: theme.green }]}>
+            {inGameMode ? 'On TV' : 'Couch'}
+          </Text>
+        </Pressable>
+      )}
+
       <Pressable
         onPress={() => {
           hapticLight();
@@ -731,11 +773,32 @@ export function RemotePowerBar() {
         onChanged={saverPoll.refresh}
         onClose={() => setSaverOpen(false)}
       />
+      <CouchModeSheet
+        visible={couchOpen}
+        settings={settings}
+        displays={displays}
+        onChanged={displaysPoll.refresh}
+        onClose={() => setCouchOpen(false)}
+      />
     </>
   );
 }
 
 const styles = StyleSheet.create({
+  couchBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+    backgroundColor: theme.card,
+    marginRight: 8,
+  },
+  couchBtnActive: { borderColor: theme.green, backgroundColor: 'rgba(52,211,153,0.10)' },
+  couchLabel: { color: theme.text, fontSize: 13, fontWeight: '700', fontFamily: mono },
   trigger: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -1,11 +1,13 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React, { useCallback, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { PanResponderInstance, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, hostKey, Tv, TvKey, TvOp } from '@/lib/api';
+import { useTrackpad } from '@/hooks/useTrackpad';
+import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
 import { Settings } from '@/lib/settings';
 import { mono, theme } from '@/lib/theme';
 
@@ -40,8 +42,20 @@ export function RemoteView({
   const sources = tv?.sources ?? [];
   const canBlank = tv?.screen_toggle === true;
 
+  // Desktop nav, self-polled and session-aware: the SteamOS/Bazzite desktop
+  // cluster (Start menu, trackpad, overview) appears only while the box is in
+  // the Plasma desktop, and the poll flips it off once it's flung to Game Mode.
+  const statusPoll = usePoll<Status>(() => api.status(settings), 8000, true, hostKey(settings));
+  const showDesktopNav = usePref('padDesktopNav');
+  const hasDesktop = statusPoll.data?.caps?.desktop === true && showDesktopNav;
+
   const [target, setTarget] = useState<'box' | 'tv'>('box');
   const nav = hasTvKeys ? target : 'box';
+
+  // Nav-circle input surface: the classic D-pad, or a relative-mouse trackpad
+  // (desktop only). Force back to the D-pad if the box leaves desktop mode.
+  const [surface, setSurface] = useState<'dpad' | 'track'>('dpad');
+  const trackpad = hasDesktop && surface === 'track';
 
   // ---- senders -------------------------------------------------------------
 
@@ -94,6 +108,44 @@ export function RemoteView({
     [settings],
   );
 
+  // ---- desktop nav senders (SteamOS/Bazzite Plasma, via the WS uinput) ------
+
+  const leftClick = useCallback(() => {
+    hapticLight();
+    client.sendMouseButton('l', 1);
+    setTimeout(() => client.sendMouseButton('l', 0), 40);
+  }, [client]);
+
+  const rightClick = useCallback(() => {
+    hapticLight();
+    client.sendMouseButton('r', 1);
+    setTimeout(() => client.sendMouseButton('r', 0), 40);
+  }, [client]);
+
+  const startMenu = useCallback(() => {
+    hapticLight();
+    client.sendDesktopKey('meta');
+  }, [client]);
+
+  const overview = useCallback(() => {
+    hapticLight();
+    client.sendDesktopKey('overview');
+  }, [client]);
+
+  const escKey = useCallback(() => {
+    hapticLight();
+    client.sendKey('esc');
+  }, [client]);
+
+  // The nav circle's trackpad responder. Created unconditionally (a hook); its
+  // panHandlers are only attached to the surface while `trackpad` is on.
+  const trackpadResponder = useTrackpad({
+    onMove: (dx, dy) => client.sendMouseMove(dx, dy),
+    onLeftClick: leftClick,
+    onRightClick: rightClick,
+    onScroll: (notches) => client.sendWheel(notches),
+  });
+
   // Nav cluster routing: BOX = virtual gamepad, TV = factory-remote serial keys.
   const navUp = () => (nav === 'tv' ? tvKey('up') : padTap('du'));
   const navDown = () => (nav === 'tv' ? tvKey('down') : padTap('dd'));
@@ -136,20 +188,48 @@ export function RemoteView({
         </View>
       )}
 
-      {/* Corner keys + D-pad */}
+      {/* Nav-circle surface toggle: D-pad vs trackpad (desktop boxes only) */}
+      {hasDesktop && (
+        <View style={styles.surfaceSeg}>
+          {(['dpad', 'track'] as const).map((s) => (
+            <Pressable
+              key={s}
+              onPress={() => {
+                hapticLight();
+                setSurface(s);
+              }}
+              style={[styles.seg, surface === s && styles.segActive]}>
+              <Ionicons
+                name={s === 'dpad' ? 'apps' : 'move'}
+                size={14}
+                color={surface === s ? theme.blue : theme.textDim}
+              />
+              <Text style={[styles.segText, surface === s && styles.segTextActive]}>
+                {s === 'dpad' ? 'D-PAD' : 'TRACKPAD'}
+              </Text>
+            </Pressable>
+          ))}
+        </View>
+      )}
+
+      {/* Corner keys + D-pad / trackpad */}
       <View style={styles.navBlock}>
         <View style={styles.cornerRow}>
           <CornerBtn icon="menu" label="MENU" onPress={navMenu} />
           <CornerBtn icon="settings-outline" label={nav === 'tv' ? 'SETTINGS' : 'VIEW'} onPress={navSettings} />
         </View>
 
-        <Dpad
-          onUp={navUp}
-          onDown={navDown}
-          onLeft={navLeft}
-          onRight={navRight}
-          onOk={navOk}
-        />
+        {trackpad ? (
+          <NavTrackpad responder={trackpadResponder} />
+        ) : (
+          <Dpad
+            onUp={navUp}
+            onDown={navDown}
+            onLeft={navLeft}
+            onRight={navRight}
+            onOk={navOk}
+          />
+        )}
 
         <View style={styles.cornerRow}>
           <CornerBtn icon="arrow-undo" label="BACK" onPress={navBack} />
@@ -160,6 +240,17 @@ export function RemoteView({
           />
         </View>
       </View>
+
+      {/* Desktop cluster: Plasma start menu, overview, esc, explicit clicks */}
+      {hasDesktop && (
+        <View style={styles.deskCluster}>
+          <DeskBtn icon="grid" label="START" onPress={startMenu} />
+          <DeskBtn icon="copy-outline" label="OVERVIEW" onPress={overview} />
+          <DeskBtn icon="close" label="ESC" onPress={escKey} />
+          <DeskBtn icon="ellipse-outline" label="L-CLICK" onPress={leftClick} />
+          <DeskBtn icon="ellipse" label="R-CLICK" onPress={rightClick} />
+        </View>
+      )}
 
       {/* Rockers + center stack (vol | mute/blank | brightness) */}
       <View style={styles.rockerRow}>
@@ -267,6 +358,40 @@ function Dpad({
   );
 }
 
+/**
+ * Trackpad face of the nav circle: same footprint as the D-pad, but the whole
+ * disc is a relative-mouse surface (drag=pointer, tap=click, two-finger tap=
+ * right-click, two-finger drag=scroll).
+ */
+function NavTrackpad({ responder }: { responder: PanResponderInstance }) {
+  const hints = usePref('padHints');
+  return (
+    <View style={[styles.dpad, styles.navTrack]} {...responder.panHandlers}>
+      <Ionicons name="move" size={28} color="rgba(11,18,32,0.35)" />
+      {hints && (
+        <Text style={styles.navTrackHint}>drag · tap = click{'\n'}2-finger: right / scroll</Text>
+      )}
+    </View>
+  );
+}
+
+function DeskBtn({
+  icon,
+  label,
+  onPress,
+}: {
+  icon: IoniconName;
+  label: string;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [styles.desk, pressed && styles.pressed]}>
+      <Ionicons name={icon} size={17} color={theme.text} />
+      <Text style={styles.deskText}>{label}</Text>
+    </Pressable>
+  );
+}
+
 function Rocker({
   label,
   onPlus,
@@ -330,7 +455,24 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: theme.cardBorder,
   },
-  seg: { flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center' },
+  surfaceSeg: {
+    flexDirection: 'row',
+    gap: 2,
+    padding: 2,
+    borderRadius: 10,
+    backgroundColor: theme.inset,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  seg: {
+    flex: 1,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 9,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
   segActive: { backgroundColor: theme.card, borderWidth: 1, borderColor: theme.blue },
   segText: { color: theme.textDim, fontSize: 12, fontWeight: '700', fontFamily: mono },
   segTextActive: { color: theme.blue },
@@ -402,6 +544,41 @@ const styles = StyleSheet.create({
   },
   okPressed: { backgroundColor: '#cbd5e1' },
   okText: { color: '#0b1220', fontSize: 20, fontWeight: '800', fontFamily: mono },
+
+  // Trackpad face of the nav circle (same disc, different surface).
+  navTrack: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  navTrackHint: {
+    color: 'rgba(11,18,32,0.45)',
+    fontSize: 11,
+    fontFamily: mono,
+    textAlign: 'center',
+    lineHeight: 16,
+  },
+
+  // Desktop cluster (Plasma desktop boxes only).
+  deskCluster: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 8 },
+  desk: {
+    minWidth: 64,
+    alignItems: 'center',
+    gap: 3,
+    paddingVertical: 10,
+    paddingHorizontal: 10,
+    borderRadius: 12,
+    backgroundColor: theme.card,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+  },
+  deskText: {
+    color: theme.textDim,
+    fontSize: 9,
+    fontWeight: '800',
+    letterSpacing: 0.8,
+    fontFamily: mono,
+  },
 
   rockerRow: { flexDirection: 'row', justifyContent: 'center', gap: 12 },
   rocker: {

--- a/app/hooks/useTrackpad.ts
+++ b/app/hooks/useTrackpad.ts
@@ -1,0 +1,120 @@
+/**
+ * Relative-mouse trackpad gesture, as a reusable PanResponder.
+ *
+ *  - 1-finger drag  -> onMove(dx, dy) with a light acceleration curve
+ *  - 1-finger tap   -> onLeftClick
+ *  - 2-finger tap   -> onRightClick
+ *  - 2-finger drag  -> onScroll(notches), honoring the naturalScroll pref
+ *
+ * Pointer speed (trackpadSensitivity) and scroll direction (naturalScroll) are
+ * read live from prefs so a single once-created responder always uses the
+ * current values. Shared by the Pad tab's Trackpad surface and the RemoteView
+ * nav circle's trackpad toggle. Haptics are the caller's concern (wrap onMove).
+ */
+import { useRef } from 'react';
+import { PanResponder, PanResponderInstance } from 'react-native';
+
+import { usePref } from '@/lib/prefs';
+
+/** Movement under this (px) still counts as a tap/click. */
+const TP_TAP_SLOP = 8;
+/** Touches longer than this aren't taps. */
+const TP_TAP_MS = 350;
+/**
+ * Light acceleration: pointer delta = raw * (BASE + GAIN * speed). Slow drags
+ * track ~1:1 for precision; fast flicks cover more screen.
+ */
+const TP_BASE = 1.1;
+const TP_GAIN = 0.05;
+/** Screen px of two-finger drag per wheel notch. */
+const TP_SCROLL_STEP = 18;
+
+export type TrackpadCallbacks = {
+  onMove: (dx: number, dy: number) => void;
+  onLeftClick: () => void;
+  onRightClick: () => void;
+  onScroll: (notches: number) => void;
+};
+
+export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
+  const cb = useRef(cbs);
+  cb.current = cbs;
+
+  const feel = useRef({ sens: 1, natural: false });
+  feel.current = {
+    sens: usePref('trackpadSensitivity'),
+    natural: usePref('naturalScroll'),
+  };
+
+  const st = useRef({
+    lastX: 0,
+    lastY: 0,
+    lastT: 0,
+    moved: false,
+    t0: 0,
+    maxTouches: 1,
+    scrollAccum: 0,
+    scrollLastY: 0,
+  });
+
+  return useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: (evt) => {
+        const touches = evt.nativeEvent.touches.length || 1;
+        st.current = {
+          lastX: 0,
+          lastY: 0,
+          lastT: Date.now(),
+          moved: false,
+          t0: Date.now(),
+          maxTouches: touches,
+          scrollAccum: 0,
+          scrollLastY: 0,
+        };
+      },
+      onPanResponderMove: (evt, g) => {
+        const s = st.current;
+        const touches = evt.nativeEvent.touches.length;
+        if (touches > s.maxTouches) s.maxTouches = touches;
+        if (!s.moved && Math.hypot(g.dx, g.dy) > TP_TAP_SLOP) s.moved = true;
+
+        if (s.maxTouches >= 2) {
+          // Two-finger drag -> vertical scroll. g.dy is cumulative from grant.
+          const delta = g.dy - s.scrollLastY;
+          s.scrollAccum += delta;
+          while (Math.abs(s.scrollAccum) >= TP_SCROLL_STEP) {
+            const dir = s.scrollAccum > 0 ? 1 : -1;
+            s.scrollAccum -= dir * TP_SCROLL_STEP;
+            // Drag down (dy>0) scrolls content up -> wheel down (negative).
+            // "Natural" scrolling inverts that (content follows the fingers).
+            cb.current.onScroll(feel.current.natural ? dir : -dir);
+          }
+          s.scrollLastY = g.dy;
+          return;
+        }
+
+        // One-finger drag -> relative pointer move with light acceleration.
+        const now = Date.now();
+        const rawDx = g.dx - s.lastX;
+        const rawDy = g.dy - s.lastY;
+        const dt = Math.max(1, now - s.lastT);
+        const speed = Math.hypot(rawDx, rawDy) / dt; // px/ms
+        const gain = (TP_BASE + TP_GAIN * speed * 16) * feel.current.sens;
+        s.lastX = g.dx;
+        s.lastY = g.dy;
+        s.lastT = now;
+        cb.current.onMove(rawDx * gain, rawDy * gain);
+      },
+      onPanResponderRelease: () => {
+        const s = st.current;
+        const wasTap = !s.moved && Date.now() - s.t0 < TP_TAP_MS;
+        if (wasTap) {
+          if (s.maxTouches >= 2) cb.current.onRightClick();
+          else cb.current.onLeftClick();
+        }
+      },
+    }),
+  ).current;
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -101,6 +101,13 @@ export type BoxCaps = {
    * reads as "unknown, probe"; only an explicit false skips the probe.
    */
   couchmode?: boolean;
+  /**
+   * Desktop nav: a SteamOS/Bazzite box currently in the Plasma DESKTOP session.
+   * Gates the RemoteView desktop cluster (Start menu, pointer/trackpad, overview)
+   * — session-aware, so it flips off once the box is in Game Mode. Optional:
+   * absent on agents < 2.9, so undefined reads as "not a desktop box here".
+   */
+  desktop?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -464,7 +471,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.screen === b.screen &&
     a.power_schedule === b.power_schedule &&
     a.screensaver === b.screensaver &&
-    a.couchmode === b.couchmode
+    a.couchmode === b.couchmode &&
+    a.desktop === b.desktop
   );
 }
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -95,6 +95,29 @@ export type BoxCaps = {
    * probe" — only an explicit false skips the probe.
    */
   screensaver?: boolean;
+  /**
+   * Couch Mode: desktop->TV Game Mode handoff (SteamOS/Bazzite desktop with a
+   * TV wired in, 2+ outputs). Optional: absent on agents < 2.9, so undefined
+   * reads as "unknown, probe"; only an explicit false skips the probe.
+   */
+  couchmode?: boolean;
+};
+
+/** One connected display, from GET /api/displays. */
+export type Display = {
+  name: string;
+  /** True for a built-in panel (eDP/LVDS/DSI); false = an external monitor/TV. */
+  internal: boolean;
+};
+
+/** GET /api/displays state (agent >= 2.9): the box's outputs for Couch Mode. */
+export type Displays = {
+  available: boolean;
+  outputs: Display[];
+  /** External output names to offer as the game display (default = first). */
+  game_outputs: string[];
+  /** Current session: 'gamescope' when already in Game Mode, else 'desktop'. */
+  session: 'gamescope' | 'desktop';
 };
 
 /** GET/POST /api/screensaver state (agent >= 2.8.4). */
@@ -440,7 +463,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.tv === b.tv &&
     a.screen === b.screen &&
     a.power_schedule === b.power_schedule &&
-    a.screensaver === b.screensaver
+    a.screensaver === b.screensaver &&
+    a.couchmode === b.couchmode
   );
 }
 
@@ -909,6 +933,36 @@ export const api = {
       method: 'POST',
       body: { op, ...opts },
     });
+  },
+
+  /**
+   * Couch Mode displays. Probe-and-appear: null on 404 (agent < 2.9 or box
+   * can't do the handoff) so the control hides. caps.couchmode === false skips
+   * the request outright; undefined (older agent) still probes.
+   */
+  displays(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<Displays | null> {
+    return probeGated(caps?.couchmode, () =>
+      probeOrNull(request<Displays>(settings, '/api/displays')));
+  },
+
+  /** Enter Couch Mode: fling Game Mode onto `output` (HDR optional). */
+  couchModeStart(
+    settings: ConnSettings,
+    output: string,
+    hdr = false,
+  ): Promise<{ ok: boolean }> {
+    return request(settings, '/api/couch-mode', {
+      method: 'POST',
+      body: { output, hdr },
+    });
+  },
+
+  /** Exit Couch Mode: return the box to its desktop session. */
+  desktopMode(settings: ConnSettings): Promise<{ ok: boolean }> {
+    return request(settings, '/api/desktop-mode', { method: 'POST' });
   },
 
   /** Arm a delayed suspend/poweroff. */

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -48,6 +48,14 @@ export type ButtonKey =
 /** Windows desktop system shortcuts (one-shot chords the agent expands). */
 export type SystemChord = 'win' | 'alt-tab' | 'lock' | 'taskmgr';
 
+/**
+ * SteamOS/Bazzite (KDE Plasma) desktop actions the Linux agent maps on the
+ * {t:'k'} channel: 'meta' taps Super (opens the Kickoff "start menu"),
+ * 'overview' fires the KWin overview chord (Meta+W). Gated in the UI on
+ * caps.desktop; an agent that doesn't know the name drops the frame.
+ */
+export type DesktopKey = 'meta' | 'overview';
+
 export type TriggerKey = 'lt' | 'rt';
 export type StickKey = 'l' | 'r';
 
@@ -390,6 +398,17 @@ export class GamepadClient {
 
   /** A single special key press+release (backspace, enter, arrows, …). */
   sendKey(key: SpecialKey): void {
+    this.sendRaw({ t: 'k', key });
+  }
+
+  /**
+   * Fire a SteamOS/Bazzite (KDE Plasma) desktop action — the Start menu (Meta)
+   * or Overview (Meta+W). Rides the same {t:'k'} channel; the Linux agent maps
+   * the name to a key/chord and presses/releases it. Linux-desktop-only (the
+   * buttons that call this render only when caps.desktop is set); another agent
+   * rejects the unknown name and drops the frame.
+   */
+  sendDesktopKey(key: DesktopKey): void {
     this.sendRaw({ t: 'k', key });
   }
 

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -29,6 +29,19 @@ export type Prefs = {
   trackpadSensitivity: number;
   /** Invert two-finger scroll direction (macOS-style "natural" scrolling). */
   naturalScroll: boolean;
+  // ---- Pad layout: every optional button row/view can be hidden ----
+  /** L/M/R mouse-button row under the trackpad. */
+  padMouseRow: boolean;
+  /** STEAM + QAM (⋯) buttons in the trackpad button row. */
+  padSteamRow: boolean;
+  /** Desktop-nav cluster (Start/Overview/Esc…) + the D-pad↔trackpad toggle. */
+  padDesktopNav: boolean;
+  /** Windows shortcut row (WIN/ALT+TAB/LOCK/TASK) on ViGEm boxes. */
+  padWinShortcuts: boolean;
+  /** The KEYBOARD bar at the bottom of the Pad tab. */
+  padKeyboardBar: boolean;
+  /** Gesture hint text on the swipe/trackpad surfaces. */
+  padHints: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -39,6 +52,12 @@ export const DEFAULTS: Prefs = {
   swipeSensitivity: 1,
   trackpadSensitivity: 1,
   naturalScroll: false,
+  padMouseRow: true,
+  padSteamRow: true,
+  padDesktopNav: true,
+  padWinShortcuts: true,
+  padKeyboardBar: true,
+  padHints: true,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -91,6 +110,8 @@ function normalize(raw: unknown): Prefs {
   const o = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
   const num = (v: unknown, allowed: readonly number[], fallback: number): number =>
     typeof v === 'number' && allowed.includes(v) ? v : fallback;
+  const bool = (v: unknown, fallback: boolean): boolean =>
+    typeof v === 'boolean' ? v : fallback;
   const padMode: PadMode =
     o.defaultPadMode === 'gamepad' ||
     o.defaultPadMode === 'trackpad' ||
@@ -105,8 +126,13 @@ function normalize(raw: unknown): Prefs {
     journalLines: num(o.journalLines, JOURNAL_LINE_OPTIONS, DEFAULTS.journalLines),
     swipeSensitivity: num(o.swipeSensitivity, SENSITIVITY_OPTIONS, DEFAULTS.swipeSensitivity),
     trackpadSensitivity: num(o.trackpadSensitivity, SENSITIVITY_OPTIONS, DEFAULTS.trackpadSensitivity),
-    naturalScroll:
-      typeof o.naturalScroll === 'boolean' ? o.naturalScroll : DEFAULTS.naturalScroll,
+    naturalScroll: bool(o.naturalScroll, DEFAULTS.naturalScroll),
+    padMouseRow: bool(o.padMouseRow, DEFAULTS.padMouseRow),
+    padSteamRow: bool(o.padSteamRow, DEFAULTS.padSteamRow),
+    padDesktopNav: bool(o.padDesktopNav, DEFAULTS.padDesktopNav),
+    padWinShortcuts: bool(o.padWinShortcuts, DEFAULTS.padWinShortcuts),
+    padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
+    padHints: bool(o.padHints, DEFAULTS.padHints),
   };
 }
 


### PR DESCRIPTION
## Couch Mode (agent 2.9.0)
Phone-triggered desktop→TV Game Mode handoff for SteamOS/Bazzite desktops:
- Header **Couch** button (probe-and-appear on `caps.couchmode` + `/api/displays`), sheet with output picker + one-tap **Fling to TV** / **Back to Desktop**.
- `POST /api/couch-mode`: CEC TV power-on + input → audio to the TV's HDMI sink (picked by port availability) → transient `steamosctl switch-to-game-mode`. `POST /api/desktop-mode` reverses. Runs entirely from the agent's service env; the agent survives the session teardown.
- Live-validated end-to-end on a Legion Go S (SteamOS 3.8.13, 4K TV on DP-2), both directions.

## Plasma desktop nav
- RemoteView: D-PAD ↔ TRACKPAD toggle on the nav circle (whole disc = relative mouse) + START / OVERVIEW / ESC / L-CLICK / R-CLICK cluster, gated on session-aware `caps.desktop`.
- Pad TRACK mode: START / OVERVIEW / ESC row on desktop boxes; PAD-mode d-pad center is now OK (=A).
- New PAD LAYOUT prefs: every optional Pad row/view (mouse buttons, Steam buttons, desktop nav, Windows shortcuts, keyboard bar, hints) can be hidden.
- Agent: `meta` / `overview` key names (Kickoff + KWin Overview, screenshot-verified live).

## Fixes caught during live runs
- uinput settle after device create — the FIRST keypress/click of every fresh session was silently dropped (latent production bug).
- gamescope's process comm is `gamescope-wl`; session detection now matches it.
- `pactl list sinks` parse no longer truncated.
- `caps.desktop` recomputed per status request (session-volatile).

Release: app 2.8.0 (iOS build 30, Android versionCode 16), agent 2.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)