### PR TITLE
fix: Couch Mode on single-display desktops + unmissable keyboard dismiss

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -2,10 +2,12 @@
   "version": "0.0.1",
   "configurations": [
     {
-      "name": "couchside-static",
-      "runtimeExecutable": "python3",
-      "runtimeArgs": ["-m", "http.server", "8993", "-d", "/private/tmp/claude-501/-Users-temery-Developer-rescue-remote/fabee38d-fd9f-4dab-86b0-372e275ad4ed/scratchpad/site-preview"],
-      "port": 8993
+      "name": "couchside-app-web",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["expo", "start", "--web", "--port", "8097"],
+      "cwd": "app",
+      "port": 8097,
+      "autoPort": false
     }
   ]
 }

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1096,13 +1096,15 @@ def _connected_outputs():
 
 def couchmode_available():
     """True when this box can do the desktop→TV Game Mode handoff: SteamOS/Bazzite,
-    the session tools present, and 2+ connected outputs (so there's a TV to fling
-    Game Mode onto, distinct from the built-in panel)."""
+    the session tools present, and at least one EXTERNAL output (a TV/monitor to
+    fling Game Mode onto). A desktop tower or mini-PC with a single wired display
+    counts — the handoff is desktop→Game Mode on that display. A bare handheld
+    (internal panel only, nothing plugged in) stays hidden."""
     if not _is_steamos_like():
         return False
     if not all(shutil.which(t) for t in _COUCHMODE_TOOLS):
         return False
-    return len(_connected_outputs()) >= 2
+    return any(not o["internal"] for o in _connected_outputs())
 
 
 def _couchmode_session():

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -386,6 +386,19 @@ function KeyboardBar({ onText, onBackspace, onEnter }: KeyboardBarProps) {
           </Pressable>
         )}
       </View>
+      {/* Floating dismiss, pinned to the TOP of the screen while typing. The
+          in-layout DONE gets covered by the raised keyboard and the iOS
+          InputAccessoryView Done bar stopped rendering under newer iOS SDKs
+          (build 30), which left the keyboard stuck open — this one cannot be
+          covered and depends on nothing keyboard-related. */}
+      {open && (
+        <Pressable
+          onPress={dismiss}
+          hitSlop={10}
+          style={({ pressed }) => [styles.kbFloatDone, pressed && styles.btnPressed]}>
+          <Text style={styles.kbDoneText}>⌨ ✕ HIDE</Text>
+        </Pressable>
+      )}
       <TextInput
         ref={inputRef}
         value={value}
@@ -1209,6 +1222,23 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '800',
     letterSpacing: 1,
+  },
+  // Floating keyboard dismiss: top-right of the screen, above everything, so
+  // it stays reachable no matter how tall the keyboard is.
+  kbFloatDone: {
+    position: 'absolute',
+    top: 6,
+    right: 12,
+    zIndex: 60,
+    elevation: 6,
+    backgroundColor: theme.blue,
+    borderRadius: 999,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.35,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
   },
   kbBarText: {
     color: theme.textDim,

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -161,6 +161,11 @@ export function RemoteView({
     <ScrollView
       style={styles.root}
       contentContainerStyle={styles.content}
+      // While the nav circle is a trackpad, the page must not scroll: the
+      // ScrollView was stealing the drag (page moved, pointer stuttered).
+      // The responder also refuses termination (useTrackpad), but disabling
+      // the scroll entirely is what makes the surface feel solid.
+      scrollEnabled={!trackpad}
       showsVerticalScrollIndicator={false}>
       {/* Nav target toggle — only meaningful with an RS-232 panel */}
       {hasTvKeys && (

--- a/app/hooks/useTrackpad.ts
+++ b/app/hooks/useTrackpad.ts
@@ -61,6 +61,11 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: () => true,
+      // Inside a ScrollView (the RemoteView nav circle) the scroll container
+      // asks to take over mid-drag — which scrolled the page and killed the
+      // pointer gesture. Refuse: once the trackpad owns the touch, it keeps it.
+      onPanResponderTerminationRequest: () => false,
+      onShouldBlockNativeResponder: () => true,
       onPanResponderGrant: (evt) => {
         const touches = evt.nativeEvent.touches.length || 1;
         st.current = {


### PR DESCRIPTION
Field fixes from testing 2.8.0 on a work Bazzite box:

1. **Couch Mode gate**: required 2+ connected outputs (handheld+TV assumption) — a desktop tower with one wired monitor never showed the button. Now requires ≥1 EXTERNAL output; bare handhelds stay hidden.
2. **Keyboard stuck open (iOS build 30)**: the InputAccessoryView Done bar stopped rendering on newer-iOS-SDK builds and the in-layout DONE is covered by the keyboard. New floating "⌨ ✕ HIDE" pill pinned top-of-screen while typing — can't be covered, no keyboard plumbing. Verified in web preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)