### PR TITLE
feat(couch-mode): real display picker on Bazzite + optimistic button

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1123,6 +1123,20 @@ def _couchmode_session():
         return "desktop"
 
 
+def _output_forcing_supported():
+    """True when this box's gamescope session honors $OUTPUT_CONNECTOR (so the
+    app's display picker is AUTHORITATIVE, not advisory). Bazzite's
+    gamescope-session-plus reads it into --prefer-output; SteamOS's session
+    hardcodes its preference and ignores the env. Detected from the session
+    script itself rather than a distro name, so it tracks reality."""
+    try:
+        with open("/usr/share/gamescope-session-plus/"
+                  "gamescope-session-plus") as f:
+            return "OUTPUT_CONNECTOR" in f.read()
+    except OSError:
+        return False
+
+
 def couchmode_info():
     """Payload for GET /api/displays: the connected outputs, which are TV
     candidates (external) to offer as the game display, and the current session
@@ -1138,6 +1152,10 @@ def couchmode_info():
         # to the first external one in the app's picker.
         "game_outputs": [o["name"] for o in outs if not o["internal"]],
         "session": _couchmode_session(),
+        # Whether the picker's choice is actually honored (see helper). The app
+        # hides the picker when this is False — a dead control is worse than
+        # no control.
+        "output_forcing": _output_forcing_supported(),
     }
 
 
@@ -5273,7 +5291,8 @@ class Handler(BaseHTTPRequestHandler):
                          "outputs": [{"name": "DP-1", "internal": False},
                                      {"name": "eDP-1", "internal": True}],
                          "game_outputs": ["DP-1"],
-                         "session": "desktop"} if self.mock
+                         "session": "desktop",
+                         "output_forcing": True} if self.mock
                         else couchmode_info())
                 if info is None:
                     self._send(404, {"error": "not found"}, started)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1264,14 +1264,48 @@ def _session_to_desktop():
     ])
 
 
+_ENVD_OUTPUT_CONF = os.path.expanduser(
+    "~/.config/environment.d/95-couchside-couchmode.conf")
+
+
+def _set_preferred_output(output):
+    """Make the app's display picker REAL where the platform allows it.
+
+    Bazzite's gamescope-session-plus sources ~/.config/environment.d/*.conf and
+    feeds $OUTPUT_CONNECTOR to gamescope's --prefer-output (verified on a
+    bazzite-deck box). Write the chosen connector there, with the platform's
+    own fallbacks after it, so an unplugged monitor degrades instead of
+    blanking. SteamOS's session hardcodes its preference and ignores this file
+    — harmless there, picker stays advisory.
+
+    SECURITY: `output` is client-supplied and lands in a file systemd parses —
+    accept it only if it exactly matches a CONNECTED DRM connector name.
+    Returns a step dict."""
+    if not output:
+        return {"skipped": True}
+    if output not in {o["name"] for o in _connected_outputs()}:
+        return {"ok": False, "exit_code": 1, "stdout": "",
+                "stderr": "unknown output %r" % (output,)}
+    try:
+        os.makedirs(os.path.dirname(_ENVD_OUTPUT_CONF), exist_ok=True)
+        with open(_ENVD_OUTPUT_CONF, "w") as f:
+            f.write("# Written by couchside couch-mode (app display picker).\n"
+                    "OUTPUT_CONNECTOR=%s,*,eDP-1\n" % output)
+        return {"ok": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    except OSError as e:
+        return {"ok": False, "exit_code": 1, "stdout": "",
+                "stderr": "envd write: %s" % e}
+
+
 def couchmode_start(output, hdr=False):
     """Fling the box into Game Mode on the TV. Steps, all best-effort except the
     session switch: (0) TV power-on + input-to-box where the box can drive the
     panel/CEC (inert otherwise), (1) move audio to the TV's HDMI sink, (2)
-    transient switch to Game Mode. gamescope lands on the external output on its
-    own (see the section header); `output` is recorded but not forced. The switch
-    tears down the desktop session — the agent (system service) survives, so the
-    app reads session=gamescope on its next /api/displays poll."""
+    transient switch to Game Mode. On platforms whose session honors
+    $OUTPUT_CONNECTOR (Bazzite) the chosen `output` is FORCED via an
+    environment.d drop-in; elsewhere gamescope picks its own external. The
+    switch tears down the desktop session — the agent (system service)
+    survives, so the app reads session=gamescope on its next poll."""
     steps = {}
     # (0) Fold in TV power + input. tv_send returns None when no backend exists.
     pwr = tv_send("power_on", False)
@@ -1282,7 +1316,9 @@ def couchmode_start(output, hdr=False):
     sink = _tv_audio_sink()
     steps["audio"] = (_couch_run(["pactl", "set-default-sink", sink])
                       if sink else {"skipped": True})
-    # (2) Enter Game Mode (the one step that must succeed).
+    # (2) Honor the display picker where the platform allows it.
+    steps["output"] = _set_preferred_output(output)
+    # (3) Enter Game Mode (the one step that must succeed).
     sw = _session_to_game()
     steps["session"] = sw
     return {"ok": sw["ok"], "output": output, "hdr": bool(hdr),

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -34,6 +34,10 @@ export function CouchModeSheet({
 }) {
   const inGameMode = displays?.session === 'gamescope';
   const outputs = displays?.game_outputs ?? [];
+  // Show the picker only where the choice is actually honored (the agent
+  // reports whether the session reads $OUTPUT_CONNECTOR). false = advisory-only
+  // box (e.g. SteamOS): hide it. undefined = older agent: keep prior behavior.
+  const canPickOutput = outputs.length > 1 && displays?.output_forcing !== false;
   const [output, setOutput] = useState<string>(outputs[0] ?? '');
   const [busy, setBusy] = useState(false);
 
@@ -106,7 +110,7 @@ export function CouchModeSheet({
                 hand over. Tap Back to Desktop to return.
               </Text>
 
-              {outputs.length > 1 && (
+              {canPickOutput && (
                 <>
                   <Text style={styles.sub}>GAME DISPLAY</Text>
                   <View style={styles.pills}>

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -26,7 +26,10 @@ export function CouchModeSheet({
   visible: boolean;
   settings: ConnSettings;
   displays: Displays | null;
-  onChanged: () => void;
+  /** Fired after a successful switch with the session the box is entering —
+      the caller shows it optimistically (the box goes briefly unreachable
+      mid-switch, so waiting on a poll leaves the UI stale). */
+  onChanged: (session: 'gamescope' | 'desktop') => void;
   onClose: () => void;
 }) {
   const inGameMode = displays?.session === 'gamescope';
@@ -51,7 +54,7 @@ export function CouchModeSheet({
     try {
       await api.couchModeStart(settings, output);
       hapticSuccess();
-      onChanged();
+      onChanged('gamescope');
       onClose();
     } catch {
       hapticError();
@@ -67,7 +70,7 @@ export function CouchModeSheet({
     try {
       await api.desktopMode(settings);
       hapticSuccess();
-      onChanged();
+      onChanged('desktop');
       onClose();
     } catch {
       hapticError();

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -254,6 +254,17 @@ export function RemotePowerBar() {
   );
   const displays = reachable ? displaysPoll.data ?? null : null;
   const [couchOpen, setCouchOpen] = React.useState(false);
+  // Optimistic session: the couch-mode POST response already says which
+  // session the box is entering, and the box goes briefly unreachable during
+  // the switch (Game Mode can drop .local resolution), so waiting on the poll
+  // left the button stale. Show the known target now; the next successful
+  // displays poll is the source of truth again.
+  const [sessionOverride, setSessionOverride] =
+    React.useState<'gamescope' | 'desktop' | null>(null);
+  const polledSession = displaysPoll.data?.session;
+  React.useEffect(() => {
+    if (polledSession != null) setSessionOverride(null);
+  }, [polledSession]);
 
   // Suspend-action availability, once per connect (agent >= 2.6 with the rule).
   const [hasSuspend, setHasSuspend] = React.useState(false);
@@ -507,7 +518,7 @@ export function RemotePowerBar() {
     ? 'moon'
     : 'tv-outline';
 
-  const inGameMode = displays?.session === 'gamescope';
+  const inGameMode = (sessionOverride ?? displays?.session) === 'gamescope';
 
   return (
     <>
@@ -777,7 +788,10 @@ export function RemotePowerBar() {
         visible={couchOpen}
         settings={settings}
         displays={displays}
-        onChanged={displaysPoll.refresh}
+        onChanged={(session) => {
+          setSessionOverride(session);
+          displaysPoll.refresh();
+        }}
         onClose={() => setCouchOpen(false)}
       />
     </>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -125,6 +125,10 @@ export type Displays = {
   game_outputs: string[];
   /** Current session: 'gamescope' when already in Game Mode, else 'desktop'. */
   session: 'gamescope' | 'desktop';
+  /** Whether the box's session honors the chosen output (Bazzite: yes; SteamOS
+      hardcodes its preference: no). false hides the picker — a dead control is
+      worse than none. undefined (older agent) keeps the picker visible. */
+  output_forcing?: boolean;
 };
 
 /** GET/POST /api/screensaver state (agent >= 2.8.4). */


### PR DESCRIPTION
Picker writes OUTPUT_CONNECTOR via ~/.config/environment.d (validated live: gamescope relaunched with --prefer-output DP-1,*,eDP-1 on the two-monitor box); Couch button updates optimistically from the switch response instead of waiting out the box's mid-switch network drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)