### PR TITLE
release: v2.8.3 (iOS build 33, Android versionCode 19)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "32",
+      "buildNumber": "33",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 18
+      "versionCode": 19
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Carries #36: hold-OK joystick, REMOTE no-bounce, keyboard-bar swipe mode switching, HIDE pill above the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)