### PR TITLE
release: iOS build 34 (2.8.3 respin, #38 fixes)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "33",
+      "buildNumber": "34",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Same 2.8.3 train, build 34: Game Mode joystick, measured HIDE lift, swipe cue, unpaired mode switching. Android ships the matching vc19 AAB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)