### PR TITLE
fix(controller): stop two paired phones fighting for control

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.0"
+VERSION = "2.9.1"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -5882,6 +5882,17 @@ class Handler(BaseHTTPRequestHandler):
             old, GAMEPAD_ACTIVE = GAMEPAD_ACTIVE, entry
         if old is not None:
             print("[gamepad] replacing previous connection", flush=True)
+            # Tell the loser WHY before the socket dies. Without this the other
+            # phone treated the drop as a network blip and auto-reconnected,
+            # kicking THIS connection — two paired phones fought in a reconnect
+            # war forever. A client that sees code=replaced stops reconnecting
+            # and offers an explicit take-over instead.
+            try:
+                ws_send_json(old["conn"], {
+                    "t": "err", "code": "replaced",
+                    "msg": "another device took control"})
+            except OSError:
+                pass
             _gamepad_teardown(old)
 
         mine = True

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -510,6 +510,7 @@ const STATUS_COLOR: Record<GamepadStatus, string> = {
   connecting: theme.amber,
   error: theme.red,
   closed: theme.red,
+  replaced: theme.amber,
 };
 
 function statusLabel(status: GamepadStatus, dev: string | null): string {
@@ -518,6 +519,8 @@ function statusLabel(status: GamepadStatus, dev: string | null): string {
       return dev ?? 'connected';
     case 'connecting':
       return 'connecting…';
+    case 'replaced':
+      return 'another device has control · tap to take over';
     default:
       return 'disconnected, tap to retry';
   }

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -26,7 +26,15 @@
  */
 import { Settings } from './settings';
 
-export type GamepadStatus = 'connecting' | 'connected' | 'error' | 'closed';
+export type GamepadStatus =
+  | 'connecting'
+  | 'connected'
+  | 'error'
+  | 'closed'
+  /** Another device took the controller (agent >= 2.9.1 sends code=replaced).
+      Deliberately NOT auto-reconnected — that caused two paired phones to kick
+      each other in an endless war. The user takes back control explicitly. */
+  | 'replaced';
 
 export type ButtonKey =
   | 'a'
@@ -464,7 +472,7 @@ export class GamepadClient {
       // pending, so ignore events from a socket we have already superseded.
       // (Same guard in onerror/onclose below.)
       if (ws !== this.ws) return;
-      let msg: { t?: string; dev?: string; msg?: string; text?: string };
+      let msg: { t?: string; dev?: string; msg?: string; text?: string; code?: string };
       try {
         msg = JSON.parse(String(ev.data));
       } catch {
@@ -485,7 +493,15 @@ export class GamepadClient {
         this.setStatus('connected', this.dev);
         this.startPing();
       } else if (msg.t === 'err') {
-        // Server reports the failure then closes; onclose handles reconnect.
+        if (msg.code === 'replaced') {
+          // Another device took the controller (agent >= 2.9.1). STOP
+          // reconnecting — auto-retry here is what made two phones kick each
+          // other in a war. The UI offers an explicit take-over (connect()).
+          this.active = false;
+          this.setStatus('replaced', null);
+          return;
+        }
+        // Other server failures close the socket; onclose handles reconnect.
         this.setStatus('error', null);
       } else if (msg.t === 'blocked') {
         this.setInputBlocked(true, typeof msg.msg === 'string' ? msg.msg : null);
@@ -507,7 +523,9 @@ export class GamepadClient {
       if (this.active) {
         this.setStatus('error', null);
         this.scheduleReconnect();
-      } else {
+      } else if (this.status !== 'replaced') {
+        // 'replaced' must survive the close that follows it — it carries the
+        // take-over affordance in the UI.
         this.setStatus('closed', null);
       }
     };


### PR DESCRIPTION
Agent 2.9.1 notifies the replaced session (code=replaced); the app stops auto-reconnecting on it and offers an explicit take-over via the status pill. Mock-agent + stubbed-socket verified: one connection attempt after a kick, no reconnect war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)