### PR TITLE
release: v2.8.4 (iOS build 35, Android versionCode 20)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "34",
+      "buildNumber": "35",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 19
+      "versionCode": 20
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Carries #40: two paired phones no longer fight — replaced-notify (agent 2.9.1) + explicit take-over pill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)