### PR TITLE
feat(control): consent-based controller handoff

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.1"
+VERSION = "2.9.2"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4721,13 +4721,42 @@ def ws_send_json(conn, obj):
     ws_send(conn, WS_OP_TEXT, json.dumps(obj).encode("utf-8"))
 
 
-# Single active gamepad connection: a new valid connection replaces the old
-# one (old uinput device destroyed first, then its socket closed).
+# Controller sessions. Multiple phones may be CONNECTED at once, but only one
+# HOLDS the virtual input devices at a time. A joining phone either grabs
+# control (handoff=takeover, the default and the pre-2.9.2 behavior) or asks
+# the current holder to pass it (handoff=ask): the holder is prompted and taps
+# Pass/Keep, and a demoted phone can Request control back. If the holder never
+# answers, the waiter can Force after a client-side timeout. All state changes
+# happen under GAMEPAD_LOCK; each entry carries its own SEND lock ("slock")
+# because control frames (granted/released/…) are sent to a socket from a
+# DIFFERENT thread than the one running that session's recv loop, and two
+# threads writing one socket unsynchronised would interleave WS frames.
 GAMEPAD_LOCK = threading.Lock()
-GAMEPAD_ACTIVE = None  # {"conn": socket, "device": gamepad-or-None}
+GAMEPAD_HOLDER = None      # the entry that currently owns input devices, or None
+GAMEPAD_SESSIONS = []      # every live entry (holder + waiters)
 
 
-def _gamepad_teardown(entry):
+def _wsend_json(entry, obj):
+    """Send one JSON text frame to a session, serialised per-socket. Never raises."""
+    with entry["slock"]:
+        try:
+            ws_send_json(entry["conn"], obj)
+        except OSError:
+            pass
+
+
+def _wsend_op(entry, opcode, payload=b""):
+    """Send one raw WS frame to a session, serialised per-socket. Never raises."""
+    with entry["slock"]:
+        try:
+            ws_send(entry["conn"], opcode, payload)
+        except OSError:
+            pass
+
+
+def _release_devices(entry):
+    """Destroy a session's virtual input devices (idempotent) but LEAVE its
+    socket open — used when demoting a holder that stays connected as a waiter."""
     for slot in ("device", "mouse", "keyboard"):
         dev = entry.get(slot)
         if dev is not None:
@@ -4735,14 +4764,28 @@ def _gamepad_teardown(entry):
                 dev.destroy()
             except Exception:
                 pass
+            entry[slot] = None
+
+
+def _make_holder(entry, mock):
+    """Give `entry` the gamepad device and mark it holder, then send hello.
+    A session only ever receives hello on becoming the holder (waiters get
+    'waiting' instead), so hello IS the "you have control now" signal. Returns
+    False (and closes the session) if uinput fails. Mouse/keyboard stay lazy —
+    created on first use by this now-held session."""
     try:
-        entry["conn"].shutdown(socket.SHUT_RDWR)
-    except OSError:
-        pass
-    try:
-        entry["conn"].close()
-    except OSError:
-        pass
+        entry["device"] = MockGamepad() if mock else UInputGamepad()
+    except Exception as e:
+        print("[gamepad] device create failed: %s" % e, flush=True)
+        _wsend_json(entry, {"t": "err", "msg": "uinput unavailable: %s" % e})
+        _wsend_op(entry, WS_OP_CLOSE)
+        return False
+    entry["held"] = True
+    entry["requested"] = False
+    _wsend_json(entry, {"t": "hello", "dev": entry["device"].name,
+                        "text": _text_caps(mock)})
+    print("[gamepad] control -> %s" % entry["name"], flush=True)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -5873,46 +5916,52 @@ class Handler(BaseHTTPRequestHandler):
                   % (e.__class__.__name__, e), flush=True)
 
     def _gamepad_session(self):
-        global GAMEPAD_ACTIVE
+        global GAMEPAD_HOLDER
         conn = self.connection
-        entry = {"conn": conn, "device": None, "mouse": None, "keyboard": None}
+        q = parse_qs(urlparse(self.path).query)
+        name = (q.get("name", [""])[0] or "A device")[:40]
+        # 'ask' = request control from the holder; anything else (incl. old
+        # clients that send no param) = grab it, the pre-2.9.2 behavior.
+        ask = q.get("handoff", ["takeover"])[0] == "ask"
+        entry = {"conn": conn, "device": None, "mouse": None, "keyboard": None,
+                 "name": name, "held": False, "requested": False,
+                 "slock": threading.Lock()}
 
-        # One active gamepad connection: replace (and tear down) the old one.
+        # ---- decide this session's initial role -------------------------------
+        demoted = None      # a holder we bumped (takeover): notify after unlock
         with GAMEPAD_LOCK:
-            old, GAMEPAD_ACTIVE = GAMEPAD_ACTIVE, entry
-        if old is not None:
-            print("[gamepad] replacing previous connection", flush=True)
-            # Tell the loser WHY before the socket dies. Without this the other
-            # phone treated the drop as a network blip and auto-reconnected,
-            # kicking THIS connection — two paired phones fought in a reconnect
-            # war forever. A client that sees code=replaced stops reconnecting
-            # and offers an explicit take-over instead.
-            try:
-                ws_send_json(old["conn"], {
-                    "t": "err", "code": "replaced",
-                    "msg": "another device took control"})
-            except OSError:
-                pass
-            _gamepad_teardown(old)
+            GAMEPAD_SESSIONS.append(entry)
+            holder = GAMEPAD_HOLDER
+            if holder is None:
+                GAMEPAD_HOLDER = entry
+                entry["held"] = True
+                role = "hold"
+            elif ask:
+                entry["requested"] = True
+                role = "wait"
+            else:  # takeover
+                holder["held"] = False
+                demoted = holder
+                GAMEPAD_HOLDER = entry
+                entry["held"] = True
+                role = "hold"
 
-        mine = True
-        try:
-            try:
-                device = MockGamepad() if self.mock else UInputGamepad()
-            except Exception as e:
-                print("[gamepad] device create failed: %s" % e, flush=True)
-                try:
-                    ws_send_json(conn, {"t": "err",
-                                        "msg": "uinput unavailable: %s" % e})
-                    ws_send(conn, WS_OP_CLOSE)
-                except OSError:
-                    pass
+        if demoted is not None:
+            _release_devices(demoted)
+            _wsend_json(demoted, {"t": "released", "by": name})
+        if role == "hold":
+            if not _make_holder(entry, self.mock):
+                # uinput failed; drop this session, promote a waiter if any.
+                self._gamepad_cleanup(entry)
                 return
-            entry["device"] = device
-            print("[gamepad] connected (%s)" % device.name, flush=True)
-            ws_send_json(conn, {"t": "hello", "dev": device.name,
-                                "text": _text_caps(self.mock)})
+        else:  # waiting: tell me, and prompt the holder
+            _wsend_json(entry, {"t": "waiting", "holder": holder.get("name")})
+            _wsend_json(holder, {"t": "control_request", "name": name})
+            print("[gamepad] %s waiting (holder %s)"
+                  % (name, holder.get("name")), flush=True)
 
+        # ---- recv loop --------------------------------------------------------
+        try:
             conn.settimeout(60.0)
             buf = bytearray()
             while True:
@@ -5920,50 +5969,61 @@ class Handler(BaseHTTPRequestHandler):
                     frame = ws_recv_frame(conn, buf)
                 except ValueError as e:
                     print("[gamepad] protocol violation: %s" % e, flush=True)
-                    try:
-                        ws_send(conn, WS_OP_CLOSE)
-                    except OSError:
-                        pass
+                    _wsend_op(entry, WS_OP_CLOSE)
                     return
                 if frame is None:  # EOF / timeout / socket error -> dead
                     return
                 opcode, payload = frame
                 try:
                     if opcode == WS_OP_CLOSE:
-                        ws_send(conn, WS_OP_CLOSE, payload[:2])
+                        _wsend_op(entry, WS_OP_CLOSE, payload[:2])
                         return
                     if opcode == WS_OP_PING:
-                        ws_send(conn, WS_OP_PONG, payload)
+                        _wsend_op(entry, WS_OP_PONG, payload)
                         continue
                     if opcode != WS_OP_TEXT:
                         continue  # ignore binary / stray pong
-                    if not self._gamepad_message(conn, entry, device, payload):
+                    if not self._gamepad_message(conn, entry, payload):
                         return
                 except OSError:
                     return
         finally:
+            self._gamepad_cleanup(entry)
+
+    def _gamepad_cleanup(self, entry):
+        """Remove a dead session; if it held control, promote a waiter (prefer
+        one that requested). Runs from the session's own thread on exit."""
+        global GAMEPAD_HOLDER
+        promote = None
+        with GAMEPAD_LOCK:
+            was_holder = GAMEPAD_HOLDER is entry
+            if entry in GAMEPAD_SESSIONS:
+                GAMEPAD_SESSIONS.remove(entry)
+            if was_holder:
+                GAMEPAD_HOLDER = None
+                waiters = [s for s in GAMEPAD_SESSIONS]
+                promote = next((s for s in waiters if s.get("requested")), None) \
+                    or (waiters[0] if waiters else None)
+                if promote is not None:
+                    GAMEPAD_HOLDER = promote
+            # Destroy OUR devices under nothing (destroy is idempotent); grab
+            # refs while we hold the lock so a concurrent promote can't race.
+            devices = [entry.get("device"), entry.get("mouse"),
+                       entry.get("keyboard")]
+        for dev in devices:
+            if dev is not None:
+                try:
+                    dev.destroy()
+                except Exception:
+                    pass
+        if promote is not None and not _make_holder(promote, self.mock):
+            # promotion failed (uinput gone): leave no holder.
             with GAMEPAD_LOCK:
-                mine = GAMEPAD_ACTIVE is entry
-                if mine:
-                    GAMEPAD_ACTIVE = None
-                # Always destroy ALL of OUR devices (destroy() is idempotent):
-                # if a replacer tore us down while our gamepad was still being
-                # created, it saw device=None and only closed the socket.
-                # Without this, that freshly created uinput device (and fd)
-                # would leak as a phantom pad until service restart. The lazily
-                # created mouse/keyboard are torn down here too.
-                devices = [entry.get("device"), entry.get("mouse"),
-                           entry.get("keyboard")]
-            for dev in devices:
-                if dev is not None:
-                    try:
-                        dev.destroy()
-                    except Exception:
-                        pass
-            if mine:
-                print("[gamepad] disconnected", flush=True)
-            # socket itself is closed by the http.server machinery
-            # (close_connection is set), or already closed by a replacer.
+                if GAMEPAD_HOLDER is promote:
+                    GAMEPAD_HOLDER = None
+        if was_holder:
+            print("[gamepad] holder %s disconnected" % entry.get("name"),
+                  flush=True)
 
     # Message-type prefixes routed to the mouse / keyboard virtual devices.
     _MOUSE_TYPES = frozenset(("m", "mb", "mw"))
@@ -5980,8 +6040,8 @@ class Handler(BaseHTTPRequestHandler):
         """
         text = msg.get("text")
         if not isinstance(text, str):
-            ws_send_json(conn, {"t": "err", "msg": "kt text must be a string"})
-            ws_send(conn, WS_OP_CLOSE)
+            _wsend_json(entry, {"t": "err", "msg": "kt text must be a string"})
+            _wsend_op(entry, WS_OP_CLOSE)
             return False
         if not text:
             return True
@@ -6014,24 +6074,82 @@ class Handler(BaseHTTPRequestHandler):
                 clipboard_paste(chunk, kbd, self.mock, entry)
         return True
 
-    def _gamepad_message(self, conn, entry, device, payload):
+    # Control frames (holder handoff) — handled regardless of hold state.
+    _CONTROL_TYPES = frozenset(("grant", "deny", "request", "force"))
+
+    def _handle_control(self, entry, t):
+        """Holder-handoff control frame. grant/deny come from the HOLDER;
+        request/force come from a WAITER. Returns True (session continues)."""
+        global GAMEPAD_HOLDER
+        demoted = None
+        promote = None
+        notify_holder = None
+        deny = None
+        with GAMEPAD_LOCK:
+            holder = GAMEPAD_HOLDER
+            if t in ("grant", "deny") and entry is not holder:
+                return True  # only the holder may grant/deny
+            if t == "grant":
+                target = next((s for s in GAMEPAD_SESSIONS
+                               if s.get("requested") and s is not entry), None)
+                if target is not None:
+                    entry["held"] = False
+                    demoted = entry
+                    target["held"] = True  # provisional; device made below
+                    GAMEPAD_HOLDER = target
+                    promote = target
+            elif t == "deny":
+                deny = next((s for s in GAMEPAD_SESSIONS
+                             if s.get("requested") and s is not entry), None)
+                if deny is not None:
+                    deny["requested"] = False
+            elif t == "request":
+                if holder is not None and entry is not holder:
+                    entry["requested"] = True
+                    notify_holder = holder
+            elif t == "force":
+                if holder is not None and entry is not holder:
+                    holder["held"] = False
+                    demoted = holder
+                    entry["held"] = True
+                    GAMEPAD_HOLDER = entry
+                    promote = entry
+        if demoted is not None:
+            _release_devices(demoted)
+            _wsend_json(demoted, {"t": "released",
+                                  "by": (promote or {}).get("name")})
+        if promote is not None:
+            _make_holder(promote, self.mock)
+        if notify_holder is not None:
+            _wsend_json(notify_holder, {"t": "control_request",
+                                        "name": entry.get("name")})
+        if deny is not None:
+            _wsend_json(deny, {"t": "denied"})
+        return True
+
+    def _gamepad_message(self, conn, entry, payload):
         """Handle one text frame. Returns False when the session must end.
 
-        Gamepad messages drive the always-present pad. Mouse (m/mb/mw) and
-        keyboard (kt/k) messages drive virtual devices created lazily on first
-        use and tracked in `entry` for teardown on disconnect.
+        Control frames run regardless of hold state; INPUT frames (pad/mouse/
+        keyboard) are dropped unless this session currently holds control, so a
+        connected-but-waiting phone can never move the pointer.
         """
         try:
             msg = json.loads(payload.decode("utf-8"))
             if not isinstance(msg, dict):
                 raise ValueError("message must be a JSON object")
         except (ValueError, UnicodeDecodeError):
-            ws_send_json(conn, {"t": "err", "msg": "invalid JSON message"})
-            ws_send(conn, WS_OP_CLOSE)
+            _wsend_json(entry, {"t": "err", "msg": "invalid JSON message"})
+            _wsend_op(entry, WS_OP_CLOSE)
             return False
         t = msg.get("t")
         if t == "ping":
-            ws_send_json(conn, {"t": "pong"})
+            _wsend_json(entry, {"t": "pong"})
+            return True
+        if t in self._CONTROL_TYPES:
+            return self._handle_control(entry, t)
+        # Input frames only from the holder; a waiter's input is ignored.
+        if not entry.get("held"):
             return True
         if t == "kt":
             # Text passthrough is handled here, BEFORE the decode table, so it
@@ -6047,38 +6165,37 @@ class Handler(BaseHTTPRequestHandler):
             decode, slot = keyboard_events, "keyboard"
             factory = MockKeyboard if self.mock else UInputKeyboard
         else:
-            decode, slot, factory = gamepad_events, None, None
+            decode, slot, factory = gamepad_events, "device", None
 
         try:
             events = decode(msg)
         except ValueError as e:
-            ws_send_json(conn, {"t": "err", "msg": str(e)})
-            ws_send(conn, WS_OP_CLOSE)
+            _wsend_json(entry, {"t": "err", "msg": str(e)})
+            _wsend_op(entry, WS_OP_CLOSE)
             return False
 
-        if slot is None:
-            target = device
-        else:
-            target = entry.get(slot)
-            if target is None:
-                try:
-                    target = factory()
-                except Exception as e:
-                    print("[gamepad] %s device create failed: %s"
-                          % (slot, e), flush=True)
-                    ws_send_json(conn, {"t": "err",
-                                        "msg": "%s unavailable: %s" % (slot, e)})
-                    ws_send(conn, WS_OP_CLOSE)
-                    return False
-                entry[slot] = target
-                print("[gamepad] %s device created (%s)"
-                      % (slot, target.name), flush=True)
+        target = entry.get(slot)
+        if target is None:
+            if factory is None:
+                return True  # gamepad device gone (mid-teardown): drop frame
+            try:
+                target = factory()
+            except Exception as e:
+                print("[gamepad] %s device create failed: %s"
+                      % (slot, e), flush=True)
+                _wsend_json(entry, {"t": "err",
+                                    "msg": "%s unavailable: %s" % (slot, e)})
+                _wsend_op(entry, WS_OP_CLOSE)
+                return False
+            entry[slot] = target
+            print("[gamepad] %s device created (%s)"
+                  % (slot, target.name), flush=True)
 
         try:
             target.emit(events)
         except OSError as e:
-            ws_send_json(conn, {"t": "err", "msg": "uinput write failed: %s" % e})
-            ws_send(conn, WS_OP_CLOSE)
+            _wsend_json(entry, {"t": "err", "msg": "uinput write failed: %s" % e})
+            _wsend_op(entry, WS_OP_CLOSE)
             return False
         return True
 

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -511,7 +511,14 @@ const STATUS_COLOR: Record<GamepadStatus, string> = {
   error: theme.red,
   closed: theme.red,
   replaced: theme.amber,
+  waiting: theme.amber,
+  released: theme.amber,
 };
+
+/** This phone's label sent to the box so the holder's "wants control" prompt
+ *  can name it. A platform label (no native device-name dependency). */
+const DEVICE_LABEL =
+  Platform.OS === 'ios' ? 'iPhone' : Platform.OS === 'android' ? 'Android phone' : 'A device';
 
 function statusLabel(status: GamepadStatus, dev: string | null): string {
   switch (status) {
@@ -521,6 +528,10 @@ function statusLabel(status: GamepadStatus, dev: string | null): string {
       return 'connecting…';
     case 'replaced':
       return 'another device has control · tap to take over';
+    case 'waiting':
+      return dev ? `waiting for ${dev} to pass control` : 'waiting for control';
+    case 'released':
+      return dev ? `${dev} has control · tap to request` : 'tap to request control';
     default:
       return 'disconnected, tap to retry';
   }
@@ -568,6 +579,15 @@ function PadScreen() {
   // Non-null when the box is refusing input injection (locked / not the active
   // desktop / an elevated window has focus); the string is the hint to show.
   const [inputBlocked, setInputBlocked] = useState<string | null>(null);
+  // Controller handoff (agent >= 2.9.2). askToSwitch: when another phone joins
+  // a box we control, ask before passing (vs let it grab). controlReq: the
+  // requesting device's name while a Pass/Keep prompt is up. canForce: a waiter
+  // has waited long enough with no answer to force takeover.
+  const askToSwitch = usePref('askToSwitchControl');
+  const askToSwitchRef = useRef(askToSwitch);
+  askToSwitchRef.current = askToSwitch;
+  const [controlReq, setControlReq] = useState<string | null>(null);
+  const [canForce, setCanForce] = useState(false);
 
   const clientRef = useRef<GamepadClient | null>(null);
   if (clientRef.current == null) {
@@ -600,15 +620,21 @@ function PadScreen() {
     client.onStatus((s, d) => {
       setStatus(s);
       setDev(d);
+      if (s !== 'waiting') setCanForce(false);
     });
 
     client.onInputBlocked((blocked, msg) => {
       setInputBlocked(blocked ? (msg ?? 'Input paused — unlock the box.') : null);
     });
 
+    client.onControlRequest((name) => setControlReq(name));
+
     const connect = () => {
       focusedRef.current = true;
-      client.connect(settingsRef.current);
+      client.connect(settingsRef.current, {
+        handoffAsk: askToSwitchRef.current,
+        deviceName: DEVICE_LABEL,
+      });
       if (Platform.OS !== 'web') {
         // Honor the "keep screen awake on Pad" pref; if it was turned off while
         // focused, this re-connect path also releases a prior lock.
@@ -645,6 +671,7 @@ function PadScreen() {
       disconnect();
       client.onStatus(null);
       client.onInputBlocked(null);
+      client.onControlRequest(null);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- connection
     // identity only; settingsRef carries the rest without re-running.
@@ -673,12 +700,27 @@ function PadScreen() {
     }
   }, [client, ready, settings.lastIp]);
 
+  // Waiting with no answer for 20s -> allow forcing control (the holder walked
+  // away or its app is backgrounded). Reset whenever we leave the waiting state.
+  useEffect(() => {
+    if (status !== 'waiting') return undefined;
+    const t = setTimeout(() => setCanForce(true), 20_000);
+    return () => clearTimeout(t);
+  }, [status]);
+
+  // The status pill's tap does the right thing per state: request/force control
+  // during a handoff, otherwise reconnect.
   const retry = useCallback(() => {
-    if (status !== 'connected') {
-      haptic();
-      client.connect(settings);
+    haptic();
+    if (status === 'released') {
+      client.requestControl();
+    } else if (status === 'waiting') {
+      if (canForce) client.forceControl();
+      else client.requestControl();
+    } else if (status !== 'connected') {
+      client.connect(settings, { handoffAsk: askToSwitch, deviceName: DEVICE_LABEL });
     }
-  }, [client, settings, status]);
+  }, [client, settings, status, canForce, askToSwitch]);
 
   const btn = useCallback(
     (k: ButtonKey) => ({
@@ -832,7 +874,9 @@ function PadScreen() {
         <Pressable onPress={retry} style={styles.pill} hitSlop={8}>
           <View style={[styles.pillDot, { backgroundColor: STATUS_COLOR[status] }]} />
           <Text style={styles.pillText} numberOfLines={1}>
-            {statusLabel(status, dev)}
+            {status === 'waiting' && canForce
+              ? 'no response · tap to take control'
+              : statusLabel(status, dev)}
           </Text>
         </Pressable>
         <View style={styles.modeToggle}>
@@ -856,6 +900,39 @@ function PadScreen() {
             {'⚠  '}
             {inputBlocked}
           </Text>
+        </View>
+      )}
+
+      {/* Handoff prompt: another phone wants control of this box. */}
+      {controlReq != null && (
+        <View style={styles.handoffBar}>
+          <Text style={styles.handoffText} numberOfLines={2}>
+            {controlReq} wants control
+          </Text>
+          <View style={styles.handoffBtns}>
+            <Pressable
+              onPress={() => {
+                haptic();
+                client.denyControl();
+                setControlReq(null);
+              }}
+              style={({ pressed }) => [styles.handoffBtn, pressed && styles.btnPressed]}>
+              <Text style={styles.handoffBtnText}>KEEP</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => {
+                haptic();
+                client.grantControl();
+                setControlReq(null);
+              }}
+              style={({ pressed }) => [
+                styles.handoffBtn,
+                styles.handoffBtnPass,
+                pressed && styles.btnPressed,
+              ]}>
+              <Text style={[styles.handoffBtnText, styles.handoffBtnPassText]}>PASS</Text>
+            </Pressable>
+          </View>
         </View>
       )}
 
@@ -1383,6 +1460,38 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 12,
   },
+  handoffBar: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    backgroundColor: 'rgba(96,165,250,0.12)',
+    borderColor: theme.blue,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  handoffText: { flex: 1, color: theme.text, fontSize: 13, fontWeight: '600' },
+  handoffBtns: { flexDirection: 'row', gap: 8 },
+  handoffBtn: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: theme.cardBorder,
+    backgroundColor: theme.card,
+  },
+  handoffBtnPass: { backgroundColor: theme.blue, borderColor: theme.blue },
+  handoffBtnText: {
+    color: theme.textDim,
+    fontFamily: mono,
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 1,
+  },
+  handoffBtnPassText: { color: '#0b1220' },
   inputBlockedText: {
     color: theme.amber,
     fontFamily: mono,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -581,6 +581,7 @@ function SetupBody() {
   const padWinShortcuts = usePref('padWinShortcuts');
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
+  const askToSwitchControl = usePref('askToSwitchControl');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -1164,6 +1165,15 @@ function SetupBody() {
                 value={padHints}
                 onValueChange={(v) => {
                   void setPref('padHints', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Ask before switching control"
+                sub="When another phone joins a box you're controlling, it asks and you tap Pass — instead of taking over instantly. Needs agent 2.9.2+."
+                value={askToSwitchControl}
+                onValueChange={(v) => {
+                  void setPref('askToSwitchControl', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -31,10 +31,17 @@ export type GamepadStatus =
   | 'connected'
   | 'error'
   | 'closed'
-  /** Another device took the controller (agent >= 2.9.1 sends code=replaced).
+  /** Another device took the controller (old agent 2.9.1 sends code=replaced).
       Deliberately NOT auto-reconnected — that caused two paired phones to kick
       each other in an endless war. The user takes back control explicitly. */
-  | 'replaced';
+  | 'replaced'
+  /** Connected but WAITING for the current holder to pass control (agent >=
+      2.9.2, our handoff pref = ask). Socket stays open; can force after a
+      timeout. `dev` carries the holder's name. */
+  | 'waiting'
+  /** We held control and it was passed/taken (agent >= 2.9.2). Socket stays
+      open; can request it back. `dev` carries the new holder's name. */
+  | 'released';
 
 export type ButtonKey =
   | 'a'
@@ -155,6 +162,16 @@ export class GamepadClient {
     | ((blocked: boolean, msg: string | null) => void)
     | null = null;
 
+  // Controller handoff (agent >= 2.9.2). When this phone HOLDS control and
+  // another asks for it, the agent sends control_request{name}; the UI prompts
+  // Pass/Keep. controlRequest holds the pending requester name (or null).
+  private controlRequest: string | null = null;
+  private controlReqListener: ((name: string | null) => void) | null = null;
+  /** Ask-to-pass vs grab-control, read from prefs at connect() time. */
+  private handoffAsk = true;
+  /** This device's label, sent so the holder's prompt can name the requester. */
+  private deviceName = 'A device';
+
   /** True between connect() and close(): reconnect on failure while set. */
   private active = false;
   private conn: Conn | null = null;
@@ -192,6 +209,41 @@ export class GamepadClient {
     if (fn) fn(this.status, this.dev);
   }
 
+  /** Register the (single) control-request listener; fires immediately. Gets
+   *  the requesting device's name while a handoff is pending, else null. */
+  onControlRequest(fn: ((name: string | null) => void) | null): void {
+    this.controlReqListener = fn;
+    if (fn) fn(this.controlRequest);
+  }
+
+  private setControlRequest(name: string | null): void {
+    if (this.controlRequest === name) return;
+    this.controlRequest = name;
+    if (this.controlReqListener) this.controlReqListener(name);
+  }
+
+  /** Holder taps "Pass control": hand off to the waiting device. */
+  grantControl(): void {
+    this.sendRaw({ t: 'grant' });
+    this.setControlRequest(null);
+  }
+
+  /** Holder taps "Keep control": refuse the pending request. */
+  denyControl(): void {
+    this.sendRaw({ t: 'deny' });
+    this.setControlRequest(null);
+  }
+
+  /** Waiter/released device asks the current holder to pass control. */
+  requestControl(): void {
+    this.sendRaw({ t: 'request' });
+  }
+
+  /** Waiter takes control when the holder never answered (post-timeout). */
+  forceControl(): void {
+    this.sendRaw({ t: 'force' });
+  }
+
   /**
    * Register the (single) input-blocked listener; fires immediately with the
    * current state. Fires with `true` when the server reports input injection
@@ -215,7 +267,9 @@ export class GamepadClient {
    * StrictMode double-invokes, and repeated focus events can't tear down a
    * healthy socket.
    */
-  connect(conn: Conn): void {
+  connect(conn: Conn, opts?: { handoffAsk?: boolean; deviceName?: string }): void {
+    if (opts?.handoffAsk != null) this.handoffAsk = opts.handoffAsk;
+    if (opts?.deviceName) this.deviceName = opts.deviceName;
     const same =
       this.conn != null &&
       this.conn.host === conn.host &&
@@ -455,7 +509,10 @@ export class GamepadClient {
       this.setStatus('error', null);
       return;
     }
-    const url = `ws://${target}:${port}/ws/gamepad?token=${encodeURIComponent(token)}`;
+    const url =
+      `ws://${target}:${port}/ws/gamepad?token=${encodeURIComponent(token)}` +
+      `&handoff=${this.handoffAsk ? 'ask' : 'takeover'}` +
+      `&name=${encodeURIComponent(this.deviceName)}`;
 
     let ws: WebSocket;
     try {
@@ -472,7 +529,10 @@ export class GamepadClient {
       // pending, so ignore events from a socket we have already superseded.
       // (Same guard in onerror/onclose below.)
       if (ws !== this.ws) return;
-      let msg: { t?: string; dev?: string; msg?: string; text?: string; code?: string };
+      let msg: {
+        t?: string; dev?: string; msg?: string; text?: string;
+        code?: string; name?: string; holder?: string; by?: string;
+      };
       try {
         msg = JSON.parse(String(ev.data));
       } catch {
@@ -480,6 +540,7 @@ export class GamepadClient {
       }
       if (msg.t === 'hello') {
         this.attempt = 0;
+        this.setControlRequest(null); // any pending prompt is moot now
         this.dev = typeof msg.dev === 'string' ? msg.dev : null;
         // Text capability: an explicit hello field wins; otherwise default by
         // device — old Windows agents (ViGEm) already type full unicode via
@@ -492,11 +553,29 @@ export class GamepadClient {
               : 'ascii';
         this.setStatus('connected', this.dev);
         this.startPing();
+      } else if (msg.t === 'waiting') {
+        // Agent >= 2.9.2: connected but a WAITER — another phone holds control
+        // and we asked to take over. Socket stays open; the UI shows a wait +
+        // force-after-timeout affordance. Do NOT reconnect.
+        this.dev = typeof msg.holder === 'string' ? msg.holder : null;
+        this.setStatus('waiting', this.dev);
+        this.startPing();
+      } else if (msg.t === 'control_request') {
+        // We HOLD control and another device wants it — prompt Pass/Keep.
+        this.setControlRequest(typeof msg.name === 'string' ? msg.name : 'A device');
+      } else if (msg.t === 'released') {
+        // We were the holder; control passed/taken away. Socket stays open so
+        // we can request it back without reconnecting.
+        this.dev = typeof msg.by === 'string' ? msg.by : null;
+        this.setControlRequest(null);
+        this.setStatus('released', this.dev);
+      } else if (msg.t === 'denied') {
+        // Our request to take control was refused — still a connected waiter.
+        this.setStatus('waiting', this.dev);
       } else if (msg.t === 'err') {
         if (msg.code === 'replaced') {
-          // Another device took the controller (agent >= 2.9.1). STOP
-          // reconnecting — auto-retry here is what made two phones kick each
-          // other in a war. The UI offers an explicit take-over (connect()).
+          // Old agent (2.9.1) forced-takeover path: it closes the socket. STOP
+          // reconnecting; the UI offers an explicit take-over (connect()).
           this.active = false;
           this.setStatus('replaced', null);
           return;
@@ -520,6 +599,7 @@ export class GamepadClient {
       if (ws !== this.ws) return;
       this.ws = null;
       this.stopPing();
+      this.setControlRequest(null);
       if (this.active) {
         this.setStatus('error', null);
         this.scheduleReconnect();

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -42,6 +42,9 @@ export type Prefs = {
   padKeyboardBar: boolean;
   /** Gesture hint text on the swipe/trackpad surfaces. */
   padHints: boolean;
+  /** When another phone joins a box you're controlling, ask before handing
+      over (true) vs let it grab control immediately (false). Agent >= 2.9.2. */
+  askToSwitchControl: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -58,6 +61,7 @@ export const DEFAULTS: Prefs = {
   padWinShortcuts: true,
   padKeyboardBar: true,
   padHints: true,
+  askToSwitchControl: true,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -133,6 +137,7 @@ function normalize(raw: unknown): Prefs {
     padWinShortcuts: bool(o.padWinShortcuts, DEFAULTS.padWinShortcuts),
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
+    askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
   };
 }
 


### PR DESCRIPTION
New phone asks; holder taps Pass/Keep; demoted phone can request back or force after 20s. Opt-out pref 'Ask before switching control' (default on). Agent 2.9.2, full protocol mock-tested; app banner + states preview-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)