### PR TITLE
release: v2.8.5 (iOS build 36, Android versionCode 21)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.4",
+    "version": "2.8.5",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "35",
+      "buildNumber": "36",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 20
+      "versionCode": 21
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Consent controller handoff (Pass/Keep + request back, agent 2.9.2) + elastic no-scroll RemoteView.

🤖 Generated with [Claude Code](https://claude.com/claude-code)