### PR TITLE
feat(setup): "Set up a box" guide link + app version on Account tab

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -817,6 +817,20 @@ function SetupBody() {
               No boxes yet. Pair your first machine below: enter its host, port,
               and token, or scan a QR from the agent.
             </Text>
+            {/* The box needs the agent installed before it can be paired at
+                all — surface the setup guide right where a new user gets stuck. */}
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                void Linking.openURL(SETUP_GUIDE_URL);
+              }}
+              style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
+              <Ionicons name="hardware-chip-outline" size={15} color={theme.blue} />
+              <Text style={styles.emptyLinkText}>
+                Haven&apos;t installed the agent? Setup guide
+              </Text>
+              <Ionicons name="open-outline" size={13} color={theme.blue} />
+            </Pressable>
           </View>
         ) : (
           boxes.map((box) => {
@@ -1407,6 +1421,13 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+  emptyLink: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginTop: 12,
+  },
+  emptyLinkText: { color: theme.blue, fontSize: 13, fontWeight: '600' },
   boxCard: {
     backgroundColor: theme.card,
     borderColor: theme.cardBorder,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1,4 +1,6 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import Constants from 'expo-constants';
+import * as Linking from 'expo-linking';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import React, { useCallback, useEffect, useState } from 'react';
 import {
@@ -66,6 +68,21 @@ function pairingUrl(box: Box): string {
  * silently fails on native, which is exactly the "Could not render QR" bug.
  */
 const QR_SIZE = 232;
+
+// About-row app version. `expoConfig` is embedded in store builds, so it
+// reflects the installed binary: the marketing version plus the native build
+// number (iOS buildNumber / Android versionCode).
+const APP_VERSION = Constants.expoConfig?.version ?? '—';
+const APP_BUILD =
+  Platform.OS === 'ios'
+    ? Constants.expoConfig?.ios?.buildNumber ?? ''
+    : Constants.expoConfig?.android?.versionCode != null
+      ? String(Constants.expoConfig.android.versionCode)
+      : '';
+
+// couchside.tv setup guide — how to install the agent on a box. New users who
+// grabbed the app from a store land here with no idea a box-side agent exists.
+const SETUP_GUIDE_URL = 'https://couchside.tv/#how';
 
 function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void }) {
   return (
@@ -1239,6 +1256,33 @@ function SetupBody() {
               <Ionicons name="open-outline" size={16} color={theme.textDim} />
             </Pressable>
 
+            {/* First-run lifeline: the app is useless without the box-side agent,
+                and a store download gives no hint one exists. Links to the
+                install/setup guide on couchside.tv. */}
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                void Linking.openURL(SETUP_GUIDE_URL);
+              }}
+              style={({ pressed }) => [styles.rateRow, pressed && styles.pressed]}>
+              <Ionicons name="hardware-chip-outline" size={18} color={theme.blue} />
+              <View style={styles.rateBody}>
+                <Text style={styles.rateTitle}>Set up a box</Text>
+                <Text style={styles.rateSub}>
+                  Install the agent — instructions at couchside.tv.
+                </Text>
+              </View>
+              <Ionicons name="open-outline" size={16} color={theme.textDim} />
+            </Pressable>
+
+            <View style={styles.aboutRow}>
+              <Ionicons name="information-circle-outline" size={16} color={theme.textDim} />
+              <Text style={styles.aboutText}>
+                Couchside v{APP_VERSION}
+                {APP_BUILD ? ` (${Platform.OS === 'ios' ? 'build' : 'vc'} ${APP_BUILD})` : ''}
+              </Text>
+            </View>
+
             <Text style={styles.hint}>
               Each agent listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
               /api/ping require the bearer token.
@@ -1488,6 +1532,14 @@ const styles = StyleSheet.create({
   rateBody: { flex: 1 },
   rateTitle: { color: theme.text, fontSize: 14, fontWeight: '700' },
   rateSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
+  aboutRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+    paddingHorizontal: 2,
+  },
+  aboutText: { color: theme.textDim, fontSize: 12 },
   unlockRow: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
## What

Additions to the Setup screen, both requested after noticing gaps for freshly-onboarded users:

1. **Setup-guide link → `couchside.tv/#how`** ("Three steps to flight", which contains the agent install command). A store download gives no hint that a box-side agent is even required. Placed in **two** spots so people find it regardless of where they look:
   - The **Boxes** empty state ("No boxes yet…") — where a brand-new user with nothing paired actually hits the wall.
   - The **Account** tab, as a "Set up a box" row (mirrors the existing "Rate Couchside" row).
2. **About / version line** on the Account tab — shows the installed app version, read live from `expo-constants` (marketing version + iOS `buildNumber` / Android `versionCode`). Previously there was no way to tell which build was installed.

## Where

`app/app/(tabs)/setup.tsx` — new module constants `APP_VERSION` / `APP_BUILD` / `SETUP_GUIDE_URL`; empty-state link + Account "Set up a box" row + version line.

## Verify

- `tsc --noEmit` clean.
- Web preview (Metro restarted to pick up the version bump):
  - Account tab shows **"Set up a box → Install the agent — instructions at couchside.tv."** and **"Couchside v2.8.5"** (on device the version appends `(build 36)` on iOS / `(vc 21)` on Android).
  - Boxes empty state shows **"Haven't installed the agent? Setup guide ↗"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)