### PR TITLE
perf: kill the cold-path input stalls (mDNS-first dial + in-loop uinput settle)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4768,16 +4768,33 @@ def _wsend_op(entry, opcode, payload=b""):
 
 
 def _release_devices(entry):
-    """Destroy a session's virtual input devices (idempotent) but LEAVE its
-    socket open — used when demoting a holder that stays connected as a waiter."""
-    for slot in ("device", "mouse", "keyboard"):
-        dev = entry.get(slot)
-        if dev is not None:
+    """Demote a session that stays connected as a waiter: destroy its gamepad
+    (one pad per holder — the new holder brings its own) but KEEP the mouse and
+    keyboard. Their frames are gated on entry["held"] anyway, and keeping them
+    makes regaining control instant — re-creating them restarted the 0.5s
+    enumeration-settle window, so the first swipe after a pass-back stalled
+    ~500ms (measured). Mouse buttons are defensively released (a drag could be
+    mid-press at demote; keyboard frames always pair press+release, so keys
+    can never be left held)."""
+    dev = entry.get("device")
+    if dev is not None:
+        try:
+            dev.destroy()
+        except Exception:
+            pass
+        entry["device"] = None
+    mouse = entry.get("mouse")
+    if mouse is not None:
+        # Skip if the device is still inside its settle window: nothing can
+        # have been pressed through it yet, and emit() would block this (the
+        # granter's) thread for the remainder.
+        ready = getattr(mouse, "_ready_at", 0) <= time.monotonic()
+        if ready:
             try:
-                dev.destroy()
+                mouse.emit([(EV_KEY, code, 0)
+                            for code in MOUSE_BTN_CODES.values()])
             except Exception:
                 pass
-            entry[slot] = None
 
 
 def _make_holder(entry, mock):
@@ -5986,6 +6003,21 @@ class Handler(BaseHTTPRequestHandler):
         else:  # waiting: tell me, and prompt the holder
             _wsend_json(entry, {"t": "waiting", "holder": holder.get("name")})
             _wsend_json(holder, {"t": "control_request", "name": name})
+            # Pre-create mouse/keyboard NOW: the settle window burns while the
+            # holder decides (human seconds), so a grant hands over devices
+            # that are already past it — first input after a pass measured
+            # 524ms with create-at-grant, ~7ms with create-at-wait. Input
+            # stays gated on entry["held"]; a create failure just falls back
+            # to the lazy path on first use.
+            for slot, factory in (
+                    ("mouse", MockMouse if self.mock else UInputMouse),
+                    ("keyboard", MockKeyboard if self.mock else UInputKeyboard)):
+                if entry.get(slot) is None:
+                    try:
+                        entry[slot] = factory()
+                    except Exception as e:
+                        print("[gamepad] waiter %s pre-create failed: %s"
+                              % (slot, e), flush=True)
             print("[gamepad] %s waiting (holder %s)"
                   % (name, holder.get("name")), flush=True)
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.2"
+VERSION = "2.9.3"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4148,6 +4148,12 @@ class UInputMediaKeys:
 # are silently dropped. 0.5s is comfortably past the observed race on SteamOS
 # (verified live: a Meta tap fired immediately after create never reached KWin;
 # the same tap after a settle opened the launcher every time).
+#
+# The wait is a DEADLINE, not an inline sleep: __init__ stamps ready-at and
+# emit() sleeps only the remainder. Devices are pre-created at hello
+# (_make_holder), so the window has normally elapsed by the first real gesture
+# and the wait is zero — measured 508ms first-frame stall -> ~7ms. A frame that
+# does arrive early still waits out the remainder, preserving the guarantee.
 _UINPUT_SETTLE_S = 0.5
 
 
@@ -4181,13 +4187,17 @@ class UInputMouse:
             os.close(fd)
             raise
         self.fd = fd
-        # Settle before first emit — see UInputKeyboard (same enumeration race:
-        # the first click/move of a fresh session would be dropped).
-        time.sleep(_UINPUT_SETTLE_S)
+        # Settle deadline before first emit — see UInputKeyboard (same
+        # enumeration race: the first click/move of a fresh session would be
+        # dropped). emit() waits out whatever remains of this window.
+        self._ready_at = time.monotonic() + _UINPUT_SETTLE_S
 
     def emit(self, events):
         if self.fd is None:
             return
+        wait = self._ready_at - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
         _emit_events(self.fd, events)
 
     def destroy(self):
@@ -4232,16 +4242,19 @@ class UInputKeyboard:
             os.close(fd)
             raise
         self.fd = fd
-        # Settle: the X server / compositor needs a beat to enumerate a fresh
-        # uinput device before it delivers events from it. The keyboard is
-        # created lazily on the FIRST key frame — without this, that first
-        # press (a typed char, or the Start-menu Meta tap, verified live on
-        # SteamOS) is silently dropped. One-time cost per session.
-        time.sleep(_UINPUT_SETTLE_S)
+        # Settle deadline: the X server / compositor needs a beat to enumerate
+        # a fresh uinput device before it delivers events from it — without
+        # the wait, the first press (a typed char, or the Start-menu Meta tap,
+        # verified live on SteamOS) is silently dropped. Stamped here, waited
+        # out in emit(); pre-created at hello so the wait is normally zero.
+        self._ready_at = time.monotonic() + _UINPUT_SETTLE_S
 
     def emit(self, events):
         if self.fd is None:
             return
+        wait = self._ready_at - time.monotonic()
+        if wait > 0:
+            time.sleep(wait)
         _emit_events(self.fd, events)
 
     def destroy(self):
@@ -4771,8 +4784,16 @@ def _make_holder(entry, mock):
     """Give `entry` the gamepad device and mark it holder, then send hello.
     A session only ever receives hello on becoming the holder (waiters get
     'waiting' instead), so hello IS the "you have control now" signal. Returns
-    False (and closes the session) if uinput fails. Mouse/keyboard stay lazy —
-    created on first use by this now-held session."""
+    False (and closes the session) if uinput fails.
+
+    Mouse/keyboard are pre-created here too: instantiation is a few ioctls
+    (the enumeration settle is a deadline waited out in emit(), not a sleep in
+    __init__), so by the time a human makes their first gesture the settle
+    window has elapsed and the frame emits immediately. Previously they were
+    created lazily on first use, which stalled the recv loop ~0.5s on the
+    first swipe / keypress of EVERY session (measured 508/525ms). A create
+    failure here is non-fatal — the slot stays None and the lazy path in
+    _handle_frame retries on first use, reporting the error to the client."""
     try:
         entry["device"] = MockGamepad() if mock else UInputGamepad()
     except Exception as e:
@@ -4784,6 +4805,14 @@ def _make_holder(entry, mock):
     entry["requested"] = False
     _wsend_json(entry, {"t": "hello", "dev": entry["device"].name,
                         "text": _text_caps(mock)})
+    for slot, factory in (("mouse", MockMouse if mock else UInputMouse),
+                          ("keyboard", MockKeyboard if mock else UInputKeyboard)):
+        if entry.get(slot) is None:
+            try:
+                entry[slot] = factory()
+            except Exception as e:
+                print("[gamepad] %s pre-create failed (lazy path will retry):"
+                      " %s" % (slot, e), flush=True)
     print("[gamepad] control -> %s" % entry["name"], flush=True)
     return True
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -585,6 +585,59 @@ async function attempt(
 const PROBE_TIMEOUT_MS = 2500;
 
 /**
+ * Head start given to the cached-IP path before the hostname attempt joins the
+ * race (see raceGet). Android mDNS resolution was measured at ~1.6s, the
+ * probe + request on a live cached IP at ~40ms — so when the IP is good the
+ * hostname fetch never even starts.
+ */
+const GET_RACE_STAGGER_MS = 250;
+
+/**
+ * Happy-Eyeballs for idempotent GETs: race the cached IP (identity-probed
+ * first, so the bearer token still never goes to an unproven address) against
+ * the configured hostname, staggered so the fast path usually wins alone.
+ * Safe only for GETs — a double-send of a POST could run an action twice.
+ * Returns the first success; if both fail, throws the hostname path's error
+ * (it matches what the single-attempt flow would have reported).
+ */
+async function raceGet(
+  settings: ConnSettings,
+  path: string,
+  opts: { method?: 'GET' | 'POST' | 'DELETE'; auth?: boolean; timeoutMs?: number; body?: unknown },
+  fallbackIp: string,
+): Promise<{ res: Response; usedHost: string }> {
+  let settled = false;
+  const ipPath = (async () => {
+    if (!(await probeTarget(fallbackIp, settings))) {
+      throw new ApiError('unreachable', 'cached IP did not answer as this box');
+    }
+    const res = await attempt(fallbackIp, settings, path, opts);
+    return { res, usedHost: fallbackIp };
+  })();
+  const hostPath = (async () => {
+    await new Promise((r) => setTimeout(r, GET_RACE_STAGGER_MS));
+    if (settled) {
+      // The IP already won; don't fire a redundant fetch.
+      throw new ApiError('unreachable', 'cached IP path won');
+    }
+    const res = await attempt(settings.host, settings, path, opts);
+    return { res, usedHost: settings.host };
+  })();
+  // Swallow the loser's eventual rejection so it can't surface as unhandled.
+  ipPath.catch(() => {});
+  hostPath.catch(() => {});
+  try {
+    const winner = await Promise.any([ipPath, hostPath]);
+    settled = true;
+    return winner;
+  } catch {
+    settled = true;
+    // Both paths failed. Re-throw the hostname error for a familiar message.
+    return await hostPath;
+  }
+}
+
+/**
  * Unauthenticated identity probe: does `host` answer /api/ping AS this box
  * (see pingMatchesBox)? Never sends the bearer token. False on any failure.
  */
@@ -622,24 +675,17 @@ async function request<T>(
 
   let res: Response;
   let usedHost = settings.host;
-  if (method === 'GET' || !fallback) {
-    try {
-      res = await attempt(settings.host, settings, path, opts);
-    } catch (e: unknown) {
-      // Only idempotent GETs may re-send after a transport failure. React
-      // Native's fetch reports "connection lost after the request was
-      // delivered" identically to "never connected", so a re-sent POST could
-      // run an action (reboot!) twice.
-      const retriable =
-        e instanceof ApiError && (e.kind === 'unreachable' || e.kind === 'timeout');
-      if (retriable && fallback && method === 'GET' && (await probeTarget(fallback, settings))) {
-        usedHost = fallback;
-        res = await attempt(fallback, settings, path, opts);
-        usedHost = fallback;
-      } else {
-        throw e;
-      }
-    }
+  if (method === 'GET' && fallback) {
+    // Idempotent + a cached IP known: race both addresses (IP-first, see
+    // raceGet). Double-delivery is harmless for a GET, and this removes the
+    // ~1.6s mDNS resolution from every status poll / list fetch.
+    ({ res, usedHost } = await raceGet(settings, path, opts, fallback));
+  } else if (method === 'GET' || !fallback) {
+    // Single known address (or non-GET without a fallback): one plain attempt.
+    // No retry here: React Native's fetch reports "connection lost after the
+    // request was delivered" identically to "never connected", so a re-sent
+    // POST could run an action (reboot!) twice.
+    res = await attempt(settings.host, settings, path, opts);
   } else {
     // Non-idempotent (POST/DELETE): pick the working target FIRST with cheap
     // ping probes, then send the request EXACTLY ONCE, never retried.

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -129,7 +129,21 @@ const QAM_CHORD_HOLD_MS = 120;
  * so hold Guide alone briefly first.
  */
 const QAM_GUIDE_LEAD_MS = 60;
-const BACKOFF_MS = [1000, 2000, 4000];
+/**
+ * First retry is near-immediate: a WS drop is usually a WiFi blip or an agent
+ * restart, and a 150ms retry against the cached IP reconnects before the user
+ * notices. Later steps back off normally for a genuinely-down box.
+ */
+const BACKOFF_MS = [150, 1000, 2000, 4000];
+/**
+ * Abort a socket stuck in CONNECTING. React Native's WebSocket has no connect
+ * timeout of its own: dialing a stale cached IP (DHCP moved the box) emits no
+ * error until the OS gives up (30s+ of frozen "connecting…"). 4s comfortably
+ * covers the slow path that actually works — mDNS resolution was measured at
+ * ~1.6s on Android — while cutting dead-target hangs short so the reconnect
+ * alternation can try the other address.
+ */
+const CONNECT_TIMEOUT_MS = 4000;
 
 export type GamepadStatusListener = (status: GamepadStatus, dev: string | null) => void;
 
@@ -177,15 +191,20 @@ export class GamepadClient {
   private conn: Conn | null = null;
   private attempt = 0;
   /**
-   * When true, open() dials conn.lastIp instead of conn.host. Failed attempts
-   * alternate this so a box whose .local name has gone dark (SteamOS Game
-   * Mode mDNS) is reached via its cached IP on the next try. Sticky while the
-   * target stays the same, so a working fallback keeps being used.
+   * When true, open() dials the ALTERNATE address (the mDNS hostname) instead
+   * of the primary (the cached IP). The cached IP is primary because it was
+   * measured ~9ms to connect where Android mDNS resolution takes ~1.6s — with
+   * hostname-first, every reconnect stalled the remote for that long. Failed
+   * attempts alternate this so a box whose IP moved (DHCP) is still reached
+   * via its .local name on the next try. Sticky while the target stays the
+   * same, so a working path keeps being used.
    */
   private useFallback = false;
 
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Aborts a socket stuck in CONNECTING (see CONNECT_TIMEOUT_MS). */
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
 
   private stickLastSent: Record<StickKey, number> = { l: 0, r: 0 };
   private stickPending: Record<StickKey, { x: number; y: number } | null> = {
@@ -502,7 +521,12 @@ export class GamepadClient {
     // raised asynchronously, off the JS thread) and which crashes the whole app.
     const cleanHost = (host || '').trim();
     const cleanIp = (lastIp || '').trim();
-    const target = this.useFallback && cleanIp ? cleanIp : cleanHost || cleanIp;
+    // IP-first: the cached LAN IP connects in ~9ms where Android mDNS takes
+    // ~1.6s, so it is the primary; the hostname is the alternate for when the
+    // IP goes stale. With a single known address there is nothing to alternate.
+    const primary = cleanIp || cleanHost;
+    const alternate = cleanIp && cleanHost && cleanHost !== cleanIp ? cleanHost : '';
+    const target = this.useFallback && alternate ? alternate : primary;
     if (!target || !port) {
       // Nothing dialable yet (box not paired, no address). Stay quietly errored;
       // connect() re-runs when host/port/token change, so pairing recovers this.
@@ -523,6 +547,25 @@ export class GamepadClient {
       return;
     }
     this.ws = ws;
+
+    // Connect watchdog: a dead target (stale cached IP) leaves the socket in
+    // CONNECTING with no error for 30s+. Cut it short so scheduleReconnect can
+    // flip to the alternate address. Cleared on onopen / teardown.
+    this.clearConnectWatchdog();
+    this.connectTimer = setTimeout(() => {
+      this.connectTimer = null;
+      if (ws !== this.ws || ws.readyState !== 0 /* CONNECTING */) return;
+      this.teardownSocket(false);
+      if (this.active) {
+        this.setStatus('error', null);
+        this.scheduleReconnect();
+      }
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      if (ws !== this.ws) return;
+      this.clearConnectWatchdog();
+    };
 
     ws.onmessage = (ev: WebSocketMessageEvent) => {
       // A reconnect can replace this.ws while this socket's callbacks are still
@@ -634,6 +677,13 @@ export class GamepadClient {
     }
   }
 
+  private clearConnectWatchdog(): void {
+    if (this.connectTimer != null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
   private startPing(): void {
     this.stopPing();
     this.pingTimer = setInterval(() => {
@@ -650,6 +700,7 @@ export class GamepadClient {
 
   private teardownSocket(sendClose: boolean): void {
     this.stopPing();
+    this.clearConnectWatchdog();
     for (const k of ['l', 'r'] as StickKey[]) {
       const timer = this.stickTimer[k];
       if (timer) {

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -109,7 +109,14 @@ export const BUTTON_KEYS: ButtonKey[] = [
   'dd',
 ];
 
-const PING_INTERVAL_MS = 20_000;
+/**
+ * Keepalive ping cadence. 5s (was 20s) doubles as a radio-wake trickle for
+ * SteamOS handhelds: their WiFi power-save lets the radio doze between sparse
+ * packets, adding 20–90ms of jitter to the first inputs after an idle gap
+ * (measured on a Legion Go — WS RTT p50 was LOWER under load than idle).
+ * ~30 bytes every 5s is free; the phone's radio is already up (screen on).
+ */
+const PING_INTERVAL_MS = 5_000;
 /** Per-stick send throttle: ~50 Hz. */
 const STICK_INTERVAL_MS = 20;
 /**

--- a/scripts/ws-latency-test.py
+++ b/scripts/ws-latency-test.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Tokened WS latency test against a Couchside agent's /ws/gamepad endpoint.
+
+Measures, from this machine, using a raw RFC6455 stdlib client (no deps):
+  1. TCP connect + WS upgrade + hello latency (xN cold connects)
+  2. Idle ping->pong RTT distribution (xN)
+  3. FIRST mouse-move penalty: move + ping, time to pong
+     (expected to expose the in-loop UI_DEV_CREATE + _UINPUT_SETTLE_S=0.5 stall)
+  4. Sustained 90 Hz mouse moves with interleaved pings: RTT under load
+  5. Burst: 300 back-to-back moves then ping: queue-drain time
+  6. First keyboard-frame penalty (second lazy device create)
+
+Usage: ws_latency_test.py <host> <port> <token>
+"""
+import base64
+import json
+import os
+import socket
+import struct
+import sys
+import time
+
+
+def ws_connect(host: str, port: int, token: str, timeout: float = 8.0):
+    """Open TCP + upgrade. Returns (sock, t_tcp_ms, t_upgrade_ms, t_hello_ms, hello)."""
+    t0 = time.perf_counter()
+    s = socket.create_connection((host, port), timeout=timeout)
+    t_tcp = time.perf_counter()
+    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    key = base64.b64encode(os.urandom(16)).decode()
+    path = ("/ws/gamepad?token=%s&handoff=takeover&name=latency-test" % token)
+    req = (
+        "GET %s HTTP/1.1\r\n"
+        "Host: %s:%d\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Key: %s\r\n"
+        "Sec-WebSocket-Version: 13\r\n\r\n" % (path, host, port, key)
+    )
+    s.sendall(req.encode())
+    # Read HTTP response headers.
+    buf = b""
+    while b"\r\n\r\n" not in buf:
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("closed during upgrade: %r" % buf[:200])
+        buf += chunk
+    head, rest = buf.split(b"\r\n\r\n", 1)
+    if b" 101 " not in head.split(b"\r\n", 1)[0]:
+        raise RuntimeError("upgrade refused: %r" % head.split(b"\r\n", 1)[0])
+    t_up = time.perf_counter()
+    # Wait for the hello frame.
+    frame, rest = read_frame(s, rest)
+    t_hello = time.perf_counter()
+    hello = json.loads(frame)
+    return (
+        s,
+        rest,
+        (t_tcp - t0) * 1000,
+        (t_up - t0) * 1000,
+        (t_hello - t0) * 1000,
+        hello,
+    )
+
+
+def send_text(s: socket.socket, obj: dict) -> None:
+    payload = json.dumps(obj, separators=(",", ":")).encode()
+    mask = os.urandom(4)
+    n = len(payload)
+    if n < 126:
+        header = struct.pack("!BB", 0x81, 0x80 | n)
+    elif n < 65536:
+        header = struct.pack("!BBH", 0x81, 0x80 | 126, n)
+    else:
+        header = struct.pack("!BBQ", 0x81, 0x80 | 127, n)
+    masked = bytes(b ^ mask[i % 4] for i, b in enumerate(payload))
+    s.sendall(header + mask + masked)
+
+
+def read_frame(s: socket.socket, buf: b"") -> tuple:
+    """Read one complete server frame (unmasked text). Returns (payload, leftover)."""
+    buf = bytes(buf)
+    while True:
+        # Parse what we have.
+        if len(buf) >= 2:
+            b1, b2 = buf[0], buf[1]
+            opcode = b1 & 0x0F
+            ln = b2 & 0x7F
+            off = 2
+            if ln == 126:
+                if len(buf) >= 4:
+                    ln = struct.unpack("!H", buf[2:4])[0]
+                    off = 4
+                else:
+                    ln = None
+            elif ln == 127:
+                if len(buf) >= 10:
+                    ln = struct.unpack("!Q", buf[2:10])[0]
+                    off = 10
+                else:
+                    ln = None
+            if ln is not None and len(buf) >= off + ln:
+                payload = buf[off : off + ln]
+                leftover = buf[off + ln :]
+                if opcode == 0x8:
+                    raise RuntimeError("server close: %r" % payload[:120])
+                if opcode in (0x1, 0x2):
+                    return payload, leftover
+                # ping/pong/continuation: skip
+                buf = leftover
+                continue
+        chunk = s.recv(4096)
+        if not chunk:
+            raise RuntimeError("connection closed")
+        buf += chunk
+
+
+def wait_pong(s, buf) -> tuple:
+    """Read frames until {"t":"pong"}; returns (ms_from_call, leftover)."""
+    t0 = time.perf_counter()
+    while True:
+        payload, buf = read_frame(s, buf)
+        try:
+            msg = json.loads(payload)
+        except ValueError:
+            continue
+        if msg.get("t") == "pong":
+            return (time.perf_counter() - t0) * 1000, buf
+        # ignore hello/waiting/etc
+
+
+def pct(sorted_vals, p):
+    if not sorted_vals:
+        return float("nan")
+    idx = min(len(sorted_vals) - 1, int(round(p / 100 * (len(sorted_vals) - 1))))
+    return sorted_vals[idx]
+
+
+def dist(name, vals):
+    v = sorted(vals)
+    print(
+        "%-34s n=%-4d min=%6.1f p50=%6.1f p90=%6.1f p99=%6.1f max=%7.1f (ms)"
+        % (name, len(v), v[0], pct(v, 50), pct(v, 90), pct(v, 99), v[-1])
+    )
+
+
+def main():
+    host, port, token = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+
+    # ---- 1. cold connect x8 ----
+    tcp_ms, up_ms, hello_ms = [], [], []
+    for i in range(8):
+        s, buf, t_tcp, t_up, t_hello, hello = ws_connect(host, port, token)
+        tcp_ms.append(t_tcp)
+        up_ms.append(t_up)
+        hello_ms.append(t_hello)
+        if i == 0:
+            print("hello frame: %s" % hello)
+        s.close()
+        time.sleep(0.15)
+    dist("1. TCP connect", tcp_ms)
+    dist("1. WS upgrade (from t0)", up_ms)
+    dist("1. hello received (from t0)", hello_ms)
+
+    # ---- fresh session for the rest ----
+    s, buf, _, _, _, _ = ws_connect(host, port, token)
+
+    # ---- 2. idle ping RTT x200 ----
+    rtts = []
+    for _ in range(200):
+        send_text(s, {"t": "ping"})
+        ms, buf = wait_pong(s, buf)
+        rtts.append(ms)
+        time.sleep(0.01)
+    dist("2. idle ping->pong RTT", rtts)
+
+    # ---- 3. FIRST mouse move penalty (lazy device create in recv loop) ----
+    t0 = time.perf_counter()
+    send_text(s, {"t": "m", "dx": 1, "dy": 0})
+    send_text(s, {"t": "ping"})
+    first_move_ms, buf = wait_pong(s, buf)
+    print("3. FIRST mouse frame -> pong flush: %.1f ms   <-- lazy create + settle" % first_move_ms)
+
+    # second move for contrast
+    send_text(s, {"t": "m", "dx": -1, "dy": 0})
+    send_text(s, {"t": "ping"})
+    warm_move_ms, buf = wait_pong(s, buf)
+    print("3. warm mouse frame -> pong flush: %.1f ms" % warm_move_ms)
+
+    # ---- 4. sustained 90 Hz moves for 5 s, ping every 100 ms ----
+    load_rtts = []
+    t_end = time.perf_counter() + 5.0
+    next_ping = time.perf_counter()
+    moves = 0
+    while time.perf_counter() < t_end:
+        send_text(s, {"t": "m", "dx": 1 if moves % 2 else -1, "dy": 0})
+        moves += 1
+        now = time.perf_counter()
+        if now >= next_ping:
+            send_text(s, {"t": "ping"})
+            ms, buf = wait_pong(s, buf)
+            load_rtts.append(ms)
+            next_ping = now + 0.1
+        time.sleep(0.011)
+    dist("4. RTT under 90Hz move load", load_rtts)
+    print("   (moves sent: %d over 5s = %.0f Hz)" % (moves, moves / 5.0))
+
+    # ---- 5. burst drain: 300 back-to-back moves then ping ----
+    t0 = time.perf_counter()
+    for i in range(300):
+        send_text(s, {"t": "m", "dx": 1 if i % 2 else -1, "dy": 0})
+    send_text(s, {"t": "ping"})
+    drain_ms, buf = wait_pong(s, buf)
+    print("5. 300-move burst -> drained in: %.1f ms (%.2f ms/frame)" % (drain_ms, drain_ms / 300))
+
+    # ---- 6. first keyboard frame penalty ----
+    send_text(s, {"t": "k", "key": "end"})
+    send_text(s, {"t": "ping"})
+    first_key_ms, buf = wait_pong(s, buf)
+    print("6. FIRST key frame -> pong flush: %.1f ms   <-- second lazy create" % first_key_ms)
+
+    send_text(s, {"t": "k", "key": "end"})
+    send_text(s, {"t": "ping"})
+    warm_key_ms, buf = wait_pong(s, buf)
+    print("6. warm key frame -> pong flush: %.1f ms" % warm_key_ms)
+
+    s.close()
+    print("DONE")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The "stick", measured on hardware

Live measurements (Razr over WiFi + a raw-WS test client vs bazzite & Legion Go boxes; throwaway agent instances, no prod tokens touched):

| Path | Before | After |
|---|---|---|
| Connect by mDNS hostname (Android) | 1.62 s | — |
| Connect by cached IP | 9 ms | (now primary) |
| First mouse frame of a WS session | 508 ms | **6.4 ms** |
| First key frame of a WS session | 525 ms | **6.3 ms** |
| First input after a control handoff | 524 ms | **7.0 ms** |
| First input after auto-promote | 501 ms | **6.3 ms** |
| Warm frame / ping RTT | 6–8 ms | unchanged |

Two compounding cold-path stalls; everything warm was already Apple-TV-class.

## Agent 2.9.3

- **First-input stall:** lazy uinput create slept `_UINPUT_SETTLE_S` (0.5s) inline in the recv loop. Now a deadline waited out in `emit()` (guarantee preserved — an early frame still waits the remainder, verified), and mouse+kbd are pre-created at hello (~1ms without the sleep).
- **Handoff instant-input:** waiters pre-create devices while the holder decides; demote keeps the mouse/keyboard (only the gamepad is destroyed) so a pass-back doesn't restart the settle window. Held mouse buttons defensively released on demote.

## App

- `gamepad.ts`: cached IP is the **primary** WS dial target (hostname = alternate). 4s connect watchdog (RN WebSocket has no connect timeout). First reconnect backoff 1s → 150ms. Keepalive 20s → 5s (doubles as a SteamOS WiFi-radio wake trickle — Legion Go idle RTT was *worse* than under load).
- `api.ts`: Happy-Eyeballs for idempotent GETs — race cached IP (identity-probed before the token is sent) vs hostname, 250ms stagger. POST/DELETE single-send flow untouched.

## Validation

- Agent + handoff fixes validated on **bazzite** AND **SteamOS/Legion Go** (the platform the 0.5s settle was originally calibrated on): first-frame stall gone on both, 200× reconnect churn = zero fd/RSS/device leaks, full 8-step consent protocol green ×2, input survives a live Couch-Mode session switch (3.7ms/8.2ms post-switch).
- `tsc` clean; app IP-first path verified in web preview (bogus hostname + good lastIp connects instantly, zero requests to the bad name).
- **Render-path audit (pad.tsx / RemoteView.tsx / useTrackpad.ts / contexts): already clean** — all per-move state in refs + Animated, 90Hz move coalescing, no per-frame haptics, timers cleaned up, onLayout guarded, context values memoized. No render changes needed; the cold-path fixes are the complete answer.

New in-repo tool: `scripts/ws-latency-test.py` for future regression measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)