### PR TITLE
release: v2.8.6 (iOS build 37, Android versionCode 22)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.5",
+    "version": "2.8.6",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "36",
+      "buildNumber": "37",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 21
+      "versionCode": 22
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Version bump for 2.8.6. Ships everything merged since 2.8.5:

- **#46** responsiveness: agent 2.9.3 (first-input 508ms→6ms, handoff instant), app IP-first WS dial + connect watchdog + Happy-Eyeballs GETs + 5s keepalive. Hardware-validated on bazzite + SteamOS.
- **#47** double-tap-drag marquee select (kernel-proven).
- **#45** Setup "Set up a box" link + app version line.

iOS build 37 / Android versionCode 22. Builds via local runner (EAS quota exhausted for July) + gandalf; store submission gated on hands-on Razr validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)