### PR TITLE
fix(2.8.6): Fleet settle + agent 2.9.4 downloads active/queued (recovered)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -40,7 +40,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.3"
+VERSION = "2.9.4"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1742,6 +1742,15 @@ DL_COMMITTING = 4194304
 DL_ACTIVE_OP = (DL_UPDATE_RUNNING | DL_UPDATE_STARTED | DL_UPDATE_STOPPING
                 | DL_VALIDATING | DL_PREALLOCATING | DL_DOWNLOADING
                 | DL_STAGING | DL_COMMITTING)
+# Bits that mean bytes/work are ACTUALLY MOVING (transfer or install), as
+# opposed to the update-state-machine bits (UPDATE_RUNNING/STARTED/STOPPING)
+# which Steam also sets on QUEUED updates and leaves for days without moving a
+# byte. "Currently downloading" uses these + the downloading/ folder, so the
+# app stops showing idle queue entries as stuck live downloads.
+DL_TRANSFER = (DL_DOWNLOADING | DL_PREALLOCATING | DL_VALIDATING
+               | DL_STAGING | DL_COMMITTING)
+# Update-state-machine bits: set on queued/scheduled updates that aren't moving.
+DL_UPDATE_ANY = DL_UPDATE_RUNNING | DL_UPDATE_STARTED | DL_UPDATE_STOPPING
 
 
 def _steam_root():
@@ -1959,18 +1968,32 @@ def _acf_int(s):
 
 
 def _download_state(flags):
-    """Map StateFlags to a coarse, user-facing operation label."""
+    """Map StateFlags to a coarse, user-facing label for an ACTIVELY-moving app
+    (caller has already established a real transfer is in progress)."""
     if flags & (DL_DOWNLOADING | DL_PREALLOCATING):
         return "downloading"
     if flags & DL_VALIDATING:
         return "validating"
     if flags & (DL_STAGING | DL_COMMITTING):
         return "finalizing"
-    if flags & (DL_UPDATE_RUNNING | DL_UPDATE_STARTED | DL_UPDATE_STOPPING):
-        return "updating"
-    # Incomplete bytes with no active-op bit: paused and queued look identical
-    # in the appmanifest, so report the more useful "paused".
-    return "paused"
+    # An UPDATE_* bit but no transfer bit, yet the caller proved it's moving
+    # (present in the downloading/ folder): it IS downloading.
+    return "downloading"
+
+
+def _downloading_appids(steamapps):
+    """Appids Steam is ACTIVELY transferring right now: the digit-named subdirs
+    under steamapps/downloading/. This is ground truth for "moving now" — the
+    appmanifest StateFlags alone leave queued updates marked started/stopping
+    for days with zero bytes moving. Best-effort; never raises."""
+    ids = set()
+    try:
+        for name in os.listdir(os.path.join(steamapps, "downloading")):
+            if name.isdigit():
+                ids.add(name)
+    except OSError:
+        pass
+    return ids
 
 
 def steam_downloads():
@@ -1995,6 +2018,8 @@ def steam_downloads():
                 manifests = glob.glob(os.path.join(steamapps, "appmanifest_*.acf"))
             except Exception:
                 continue
+            # Ground truth for "moving now" in THIS library.
+            active_ids = _downloading_appids(steamapps)
             for mf in manifests:
                 try:
                     with open(mf, "r", encoding="utf-8", errors="replace") as f:
@@ -2015,22 +2040,42 @@ def steam_downloads():
                 if flags & DL_UNINSTALLING:
                     continue  # uninstall in progress, not a download
                 incomplete = total > 0 and done < total
-                if not (flags & DL_ACTIVE_OP) and not incomplete:
-                    # Fully installed, or a stale flags==6 pending-update entry
-                    # whose byte counters are equal: nothing is moving.
+                # ACTUALLY moving right now: a transfer/install bit is set, or
+                # Steam has a chunk dir open for it. NOT the update-* bits alone.
+                active = bool(flags & DL_TRANSFER) or appid in active_ids
+                # Queued: Steam has an update pending (update-* bit or unfinished
+                # bytes) but isn't transferring it — the "downloads for days"
+                # backlog. Reported as its own state so the app can dim/section
+                # it instead of showing a stuck live download.
+                pending = bool(flags & DL_UPDATE_ANY) or incomplete
+                if not active and not pending:
+                    continue  # fully installed, nothing to do
+                if not active and not incomplete:
+                    # Queued but every byte is already present (stale 100%
+                    # "updating" ghost, e.g. an update applied but the flag not
+                    # cleared): nothing left to download — drop it.
                     continue
                 percent = (
                     int(max(0, min(100, round(done * 100.0 / total)))) if total > 0 else 0
                 )
+                if active:
+                    state = _download_state(flags)
+                    if state == "downloading" and total > 0 and done >= total:
+                        state = "finalizing"  # bytes done, Steam is installing
+                else:
+                    state = "queued"
                 found[appid] = {
                     "appid": int(appid),
                     "name": name,
-                    "state": _download_state(flags),
+                    "state": state,
+                    "active": active,
                     "bytes_total": total,
                     "bytes_downloaded": done,
                     "percent": percent,
                 }
-        order = {"downloading": 0, "paused": 1}
+        order = {
+            "downloading": 0, "validating": 1, "finalizing": 2, "queued": 3,
+        }
         items = list(found.values())
         items.sort(key=lambda d: (order.get(d["state"], 2), d["name"].lower(), d["appid"]))
         return items
@@ -2158,18 +2203,22 @@ _MOCK_DL_PCT = 0
 
 
 def mock_downloads():
-    """--mock stand-in: one advancing download (0->100%, +7% per poll so the
-    progress bar visibly moves) and one paused entry. No real Steam needed."""
+    """--mock stand-in: one advancing ACTIVE download (0->100%, +7% per poll so
+    the bar visibly moves) plus two QUEUED updates (pending, not moving) — the
+    common real shape. No real Steam needed."""
     global _MOCK_DL_PCT
     _MOCK_DL_PCT = (_MOCK_DL_PCT + 7) % 101
     total = 42_000_000_000
     done = int(total * _MOCK_DL_PCT / 100)
     return [
         {"appid": 1091500, "name": "Cyberpunk 2077", "state": "downloading",
-         "bytes_total": total, "bytes_downloaded": done, "percent": _MOCK_DL_PCT},
-        {"appid": 570, "name": "Dota 2", "state": "paused",
-         "bytes_total": 18_000_000_000, "bytes_downloaded": 5_400_000_000,
-         "percent": 30},
+         "active": True, "bytes_total": total, "bytes_downloaded": done,
+         "percent": _MOCK_DL_PCT},
+        {"appid": 570, "name": "Dota 2", "state": "queued", "active": False,
+         "bytes_total": 18_000_000_000, "bytes_downloaded": 0, "percent": 0},
+        {"appid": 1245620, "name": "Elden Ring", "state": "queued",
+         "active": False, "bytes_total": 3_100_000_000, "bytes_downloaded": 0,
+         "percent": 0},
     ]
 
 

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -26,7 +26,15 @@ import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { api, Downloads, hostKey, ImageSource, Launcher, SteamDownload } from '@/lib/api';
+import {
+  api,
+  Downloads,
+  hostKey,
+  ImageSource,
+  isActiveDownload,
+  Launcher,
+  SteamDownload,
+} from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, theme } from '@/lib/theme';
@@ -115,7 +123,7 @@ function LauncherTile({
         </View>
       )}
 
-      {download && (
+      {download && isActiveDownload(download) && (
         <View style={styles.tilePill}>
           <Ionicons
             name={download.state === 'paused' ? 'pause' : 'cloud-download'}
@@ -123,6 +131,12 @@ function LauncherTile({
             color={download.state === 'paused' ? theme.amber : theme.blue}
           />
           <Text style={styles.tilePillText}>{download.percent}%</Text>
+        </View>
+      )}
+      {download && !isActiveDownload(download) && (
+        <View style={[styles.tilePill, styles.tilePillQueued]}>
+          <Ionicons name="time-outline" size={11} color={theme.textDim} />
+          <Text style={[styles.tilePillText, { color: theme.textDim }]}>queued</Text>
         </View>
       )}
 
@@ -172,18 +186,67 @@ function DownloadRow({ d }: { d: SteamDownload }) {
   );
 }
 
-/** Active Steam downloads, shown above the launcher grid. Hidden when empty. */
+/** A queued (pending, not-moving) update — compact, dimmed, no fake progress. */
+function QueuedRow({ d }: { d: SteamDownload }) {
+  return (
+    <View style={styles.qRow}>
+      <Text style={styles.qName} numberOfLines={1}>
+        {d.name}
+      </Text>
+      {d.bytes_total > 0 && <Text style={styles.qSize}>{fmtGB(d.bytes_total)} GB</Text>}
+    </View>
+  );
+}
+
+/**
+ * Steam downloads above the launcher grid. Splits what's ACTUALLY transferring
+ * now (full progress rows) from Steam's queued/pending-update backlog (compact,
+ * collapsed by default) — the backlog otherwise reads as downloads stuck for
+ * days. Hidden when nothing is downloading or queued.
+ */
 function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
+  const [showQueue, setShowQueue] = useState(false);
   if (downloads.length === 0) return null;
+  const active = downloads.filter(isActiveDownload);
+  const queued = downloads.filter((d) => !isActiveDownload(d));
   return (
     <View style={styles.dlCard}>
-      <View style={styles.dlHeader}>
-        <Ionicons name="cloud-download" size={14} color={theme.blue} />
-        <Text style={styles.dlHeaderText}>DOWNLOADS</Text>
-      </View>
-      {downloads.map((d) => (
-        <DownloadRow key={d.appid} d={d} />
-      ))}
+      {active.length > 0 && (
+        <>
+          <View style={styles.dlHeader}>
+            <Ionicons name="cloud-download" size={14} color={theme.blue} />
+            <Text style={styles.dlHeaderText}>DOWNLOADING</Text>
+          </View>
+          {active.map((d) => (
+            <DownloadRow key={d.appid} d={d} />
+          ))}
+        </>
+      )}
+      {queued.length > 0 && (
+        <>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setShowQueue((v) => !v);
+            }}
+            style={({ pressed }) => [
+              styles.dlHeader,
+              active.length > 0 && styles.dlHeaderGap,
+              pressed && styles.pressed,
+            ]}>
+            <Ionicons name="time-outline" size={13} color={theme.textDim} />
+            <Text style={[styles.dlHeaderText, { color: theme.textDim }]}>
+              QUEUED · {queued.length}
+            </Text>
+            <Ionicons
+              name={showQueue ? 'chevron-up' : 'chevron-down'}
+              size={14}
+              color={theme.textDim}
+            />
+          </Pressable>
+          {showQueue && queued.map((d) => <QueuedRow key={d.appid} d={d} />)}
+        </>
+      )}
     </View>
   );
 }
@@ -352,10 +415,14 @@ function LaunchScreen() {
   const prevDl = useRef<Map<number, SteamDownload>>(new Map());
   const observedDl = useRef<Set<number>>(new Set());
   useEffect(() => {
-    setActive(downloads.length > 0);
+    // Poll fast only while something is genuinely transferring — a static queue
+    // of pending updates shouldn't hammer the box every 5s.
+    setActive(downloads.some(isActiveDownload));
     const curIds = new Set(downloads.map((d) => d.appid));
     for (const d of downloads) {
-      if (d.state === 'downloading' || d.state === 'paused') observedDl.current.add(d.appid);
+      // Only track truly-active downloads for the "finished" toast; a queued
+      // entry vanishing is a cancel/dequeue, not a completion.
+      if (isActiveDownload(d)) observedDl.current.add(d.appid);
     }
     for (const [appid, prev] of prevDl.current) {
       if (!curIds.has(appid) && observedDl.current.has(appid)) {
@@ -598,6 +665,12 @@ const styles = StyleSheet.create({
     gap: 12,
   },
   dlHeader: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dlHeaderGap: {
+    marginTop: 4,
+    borderTopColor: theme.cardBorder,
+    borderTopWidth: 1,
+    paddingTop: 12,
+  },
   dlHeaderText: {
     color: theme.textDim,
     fontSize: 11,
@@ -605,6 +678,10 @@ const styles = StyleSheet.create({
     fontFamily: mono,
     letterSpacing: 1,
   },
+  // Queued (pending, not-moving) update rows: compact + dimmed.
+  qRow: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingLeft: 19 },
+  qName: { color: theme.textDim, fontSize: 13, flex: 1, fontFamily: mono },
+  qSize: { color: theme.textFaint, fontSize: 11, fontFamily: mono },
   dlRow: { gap: 6 },
   dlTop: { flexDirection: 'row', alignItems: 'center' },
   dlName: { color: theme.text, fontSize: 14, fontWeight: '600', flex: 1, fontFamily: mono },
@@ -634,6 +711,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 7,
   },
   tilePillText: { color: theme.text, fontSize: 11, fontWeight: '700', fontFamily: mono },
+  tilePillQueued: { backgroundColor: 'rgba(0,0,0,0.55)' },
 
   tile: {
     borderRadius: 14,

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -228,15 +228,26 @@ export type SteamDownloadState =
   | 'finalizing'
   | 'updating';
 
-/** One Steam app with an active download/update/validation operation. */
+/** One Steam app with a download/update/validation operation. */
 export type SteamDownload = {
   appid: number;
   name: string;
   state: SteamDownloadState;
+  /**
+   * True when bytes/install work are ACTUALLY moving right now (agent >= 2.9.4),
+   * vs a queued/pending update Steam hasn't started. Absent on older agents —
+   * treat undefined as active so their behavior is unchanged.
+   */
+  active?: boolean;
   bytes_total: number;
   bytes_downloaded: number;
   percent: number;
 };
+
+/** True when this entry is genuinely transferring/installing (not just queued). */
+export function isActiveDownload(d: SteamDownload): boolean {
+  return d.active !== false && d.state !== 'queued';
+}
 
 export type Downloads = { downloads: SteamDownload[] };
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -561,24 +561,40 @@ async function attempt(
 ): Promise<Response> {
   const { method = 'GET', auth = true, timeoutMs = TIMEOUT_MS, body } = opts;
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const abortTimer = setTimeout(() => controller.abort(), timeoutMs);
+  // Hard deadline INDEPENDENT of fetch + AbortController. On Android, a fetch
+  // whose DNS is stuck resolving a `.local` mDNS name can ignore
+  // controller.abort() and never settle its promise — which froze callers (the
+  // Fleet tab stuck forever at "probing…", and raceGet's Promise.any waiting on
+  // a hostname path that never rejects). This timer guarantees the JS promise
+  // always settles, so a stuck lookup degrades to a clean timeout + retry.
+  let hardTimer: ReturnType<typeof setTimeout> | undefined;
+  const hardDeadline = new Promise<never>((_, reject) => {
+    hardTimer = setTimeout(
+      () => reject(new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`)),
+      timeoutMs + 1000,
+    );
+  });
   try {
     const headers: Record<string, string> = {};
     if (auth) headers.Authorization = `Bearer ${settings.token}`;
     if (body !== undefined) headers['Content-Type'] = 'application/json';
-    return await fetch(`${baseUrl({ host, port: settings.port })}${path}`, {
+    const fetchPromise = fetch(`${baseUrl({ host, port: settings.port })}${path}`, {
       method,
       headers,
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: controller.signal,
     });
+    return await Promise.race([fetchPromise, hardDeadline]);
   } catch (e: unknown) {
+    if (e instanceof ApiError) throw e; // hard-deadline timeout, already shaped
     if (e instanceof Error && e.name === 'AbortError') {
       throw new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`);
     }
     throw new ApiError('unreachable', 'Box unreachable: network error');
   } finally {
-    clearTimeout(timer);
+    clearTimeout(abortTimer);
+    if (hardTimer) clearTimeout(hardTimer);
   }
 }
 


### PR DESCRIPTION
These three commits were authored for the 2.8.6 release but never pushed before #48 was squash-merged (which only captured the version bump). Recovering them onto main so the shipped code matches the sideloaded/deployed builds.

- **fix(api)**: guarantee every fetch settles — Fleet no longer hangs at "probing…" on Android (`.local` mDNS + raceGet Promise.any hang).
- **feat(agent) 2.9.4**: separate ACTIVE downloads from Steam's queued backlog (downloading/-folder truth).
- **feat(launch)**: DOWNLOADING vs collapsed QUEUED·N split in the app.

All already validated on hardware (both boxes on 2.9.4, Razr on the rebuilt 2.8.6, web-preview UI) and tsc-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)