### PR TITLE
security(installer): signed + pinned agent, partial-download guard

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,16 +14,34 @@
 #   --help         this text
 set -euo pipefail
 
-# Raw file sources (used when not running from a git checkout)
-DAEMON_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/couchsided.py"
-UNIT_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/couchside.service"
+# Partial-download guard: the ENTIRE installer runs inside this brace group, so
+# `curl … | bash` must have received the closing brace — i.e. the whole file —
+# before bash executes a single command. A connection dropped mid-download fails
+# to parse (no closing brace) and runs NOTHING, instead of executing a truncated,
+# half-configured install. The matching `}` is the last line of this file.
+{
+
+# Agent file sources (used when not running from a git checkout). These are the
+# maintainer-SIGNED release assets — NOT mutable `main` — so `couchside update`
+# fetches a pinned, authenticated agent. releases/latest resolves to the newest
+# published release; each carries these files + a SHA256SUMS signed with the
+# offline key (see scripts/release-agent.sh). install.sh verifies the signature
+# (against RELEASE_PUBKEY_PEM below) AND each file's hash before installing.
+AGENT_BASE="https://github.com/emerytech/couchside/releases/latest/download"
+DAEMON_URL="${AGENT_BASE}/couchsided.py"
+UNIT_URL="${AGENT_BASE}/couchside.service"
 # Pure-stdlib terminal QR renderer, so the installer can draw the pairing QR
 # without qrencode (immutable distros like Bazzite rarely ship it). Optional:
 # a failed fetch just falls back to printing the URL.
-QR_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/qr.py"
+QR_URL="${AGENT_BASE}/qr.py"
 # Aerial-screensaver player script (agent's /api/screensaver launches it via a
 # Steam shortcut). Optional: a failed fetch just means the feature stays absent.
-SCREENSAVER_URL="https://raw.githubusercontent.com/emerytech/couchside/main/agent/couchside-screensaver.sh"
+SCREENSAVER_URL="${AGENT_BASE}/couchside-screensaver.sh"
+# Signature + checksums for the agent files above, published as sibling assets
+# in the SAME release. install.sh verifies the sig (authenticity) + hashes
+# (integrity) before installing any fetched agent file.
+AGENT_SUMS_URL="${AGENT_BASE}/SHA256SUMS"
+AGENT_SIG_URL="${AGENT_BASE}/SHA256SUMS.sig"
 # Built Decky Loader plugin, shipped as a tarball because the compiled frontend
 # (dist/) isn't checked into git, so raw source wouldn't give a working panel.
 PLUGIN_URL="https://github.com/emerytech/couchside-decky/releases/latest/download/Couchside.tar.gz"
@@ -357,14 +375,55 @@ else
     curl -fsSL "$QR_URL" -o "$WORK_DIR/qr.py" 2>/dev/null || true
     # Optional aerial-screensaver player, same policy.
     curl -fsSL "$SCREENSAVER_URL" -o "$WORK_DIR/couchside-screensaver.sh" 2>/dev/null || true
+
+    # --- Supply-chain gate (FAIL CLOSED): the fetched agent must be SIGNED by
+    # the maintainer's offline Ed25519 key AND match its SHA256SUMS before we
+    # install it. The signature proves authenticity even against a
+    # repo/CI/account compromise (the secret key is never in CI); the hashes
+    # catch corruption/transport tampering. Same gate the Decky panel uses below.
+    curl -fsSL "$AGENT_SUMS_URL" -o "$WORK_DIR/SHA256SUMS" \
+        || die "couldn't fetch the agent SHA256SUMS — refusing to install unverified."
+    if curl -fsSL "$AGENT_SIG_URL" -o "$WORK_DIR/SHA256SUMS.sig" 2>/dev/null \
+       && command -v openssl >/dev/null 2>&1; then
+        printf '%s\n' "$RELEASE_PUBKEY_PEM" > "$WORK_DIR/couchside-release.pub"
+        # openssl's own words distinguish a real bad signature ("Verification
+        # Failure" -> abort) from an openssl too old for Ed25519 -rawin (any
+        # other output -> fall back to checksum-only integrity).
+        sig_out="$(openssl pkeyutl -verify -pubin -inkey "$WORK_DIR/couchside-release.pub" \
+                    -rawin -in "$WORK_DIR/SHA256SUMS" \
+                    -sigfile "$WORK_DIR/SHA256SUMS.sig" 2>&1 || true)"
+        if printf '%s' "$sig_out" | grep -qi 'Verified Successfully'; then
+            note "agent signature: verified (maintainer offline key)."
+        elif printf '%s' "$sig_out" | grep -qi 'Verification Failure'; then
+            die "agent signature INVALID — refusing to install (possible tampering)."
+        else
+            note "can't verify agent signature (openssl lacks Ed25519); checksum only."
+        fi
+    else
+        note "no agent signature available; checksum only."
+    fi
+    # Hash every fetched file against SHA256SUMS. Build the check list from only
+    # the files that actually landed (the optional ones may not have), but the
+    # two REQUIRED files must be present + listed, else fail closed.
+    (
+        cd "$WORK_DIR" || exit 1
+        : > SUMS.check
+        while read -r h f; do
+            [ -n "$f" ] && [ -f "$f" ] && printf '%s  %s\n' "$h" "$f" >> SUMS.check
+        done < SHA256SUMS
+        grep -qF ' couchsided.py' SUMS.check && grep -qF ' couchside.service' SUMS.check || exit 1
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c SUMS.check >/dev/null 2>&1
+        elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 -c SUMS.check >/dev/null 2>&1
+        else
+            exit 1
+        fi
+    ) || die "agent checksum verification FAILED (corrupt/tampered/missing) — refusing to install."
 fi
-# Integrity / sanity gate (FAIL CLOSED): never install code we just fetched
-# without first checking it parses. py_compile catches a truncated download or an
-# HTML error page served in place of the .py, so a half-written daemon can't be
-# installed and left crash-looping. This is a SANITY gate, not authentication.
-# TODO (stronger follow-up): pin DAEMON_URL/UNIT_URL to a tagged release and
-# verify a published SHA256SUMS (curl the sums + `sha256sum -c`) so a
-# compromised or MITM'd raw.githubusercontent.com response is rejected too.
+# Secondary sanity gate: even a correctly-signed file must actually parse (a
+# git-checkout install skips the crypto above, and this catches a bad local
+# tree too). py_compile also rejects a truncated read or an HTML error page.
 python3 -m py_compile "$WORK_DIR/couchsided.py" || die "downloaded couchsided.py does not compile, aborting."
 # The unit is not Python; sanity-check it's a non-empty [Service] file so a
 # failed/HTML fetch can't be installed as the systemd unit.
@@ -1167,3 +1226,5 @@ echo "To re-show the pairing QR later without a terminal: launch the"
 echo "'Couchside — Pair Phone' tile from your Steam library (Game Mode included"
 echo ", it opens in Steam's built-in browser). If the tile isn't there yet,"
 echo "restart Steam once, or add $PAIR_SCRIPT via Steam > Add a Non-Steam Game."
+
+} # end partial-download guard — see the matching `{` near the top

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# release-agent.sh <tag> [secret-key]
+#
+# Publish the raw agent files as SIGNED assets on the couchside GitHub release
+# <tag>, so install.sh (and `couchside update`) can fetch a PINNED, MAINTAINER-
+# SIGNED agent instead of mutable `main`. Mirrors scripts/sign-release.sh (which
+# does the same for the Decky plugin's release), reusing the same offline
+# Ed25519 key and the public half embedded in install.sh.
+#
+# Run LOCALLY after tagging a release — the secret key never touches CI, so a
+# compromised repo/CI/account cannot forge a release.
+#
+#   scripts/release-agent.sh v2.8.6
+#
+# Uploads to the release: couchsided.py, couchside.service, qr.py,
+# couchside-screensaver.sh, SHA256SUMS, SHA256SUMS.sig.
+set -euo pipefail
+
+REPO="emerytech/couchside"
+tag="${1:-}"
+key="${2:-$HOME/couchside-release.key}"
+
+[ -n "$tag" ] || { echo "usage: $0 <tag> [secret-key]   e.g. $0 v2.8.6" >&2; exit 2; }
+[ -f "$key" ] || { echo "error: secret key not found: $key" >&2; exit 2; }
+command -v gh >/dev/null 2>&1 || { echo "error: gh (GitHub CLI) not found / not authenticated" >&2; exit 2; }
+
+# Repo root = parent of this script's dir.
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+agent="$root/agent"
+
+# The exact files install.sh fetches. couchsided.py + couchside.service are
+# REQUIRED; qr.py + couchside-screensaver.sh are optional at install time but
+# always shipped + signed here.
+files=(couchsided.py couchside.service qr.py couchside-screensaver.sh)
+for f in "${files[@]}"; do
+    [ -f "$agent/$f" ] || { echo "error: missing agent/$f" >&2; exit 2; }
+done
+
+# Pick an openssl that supports Ed25519 one-shot signing (-rawin).
+ossl="openssl"
+if ! "$ossl" pkeyutl -help 2>&1 | grep -q -- '-rawin'; then
+    if command -v brew >/dev/null 2>&1; then
+        cand="$(brew --prefix openssl@3 2>/dev/null)/bin/openssl"
+        [ -x "$cand" ] && ossl="$cand"
+    fi
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+for f in "${files[@]}"; do cp "$agent/$f" "$tmp/$f"; done
+
+echo "==> generating SHA256SUMS over ${#files[@]} agent files"
+( cd "$tmp" && { command -v sha256sum >/dev/null 2>&1 \
+    && sha256sum "${files[@]}" \
+    || shasum -a 256 "${files[@]}"; } > SHA256SUMS )
+cat "$tmp/SHA256SUMS"
+
+echo "==> signing SHA256SUMS with $key (via $ossl)"
+"$ossl" pkeyutl -sign -inkey "$key" -rawin -in "$tmp/SHA256SUMS" -out "$tmp/SHA256SUMS.sig"
+
+# Self-verify with the public half before uploading — never publish a signature
+# install.sh would reject.
+"$ossl" pkey -in "$key" -pubout -out "$tmp/pub.pem"
+if ! "$ossl" pkeyutl -verify -pubin -inkey "$tmp/pub.pem" -rawin \
+        -in "$tmp/SHA256SUMS" -sigfile "$tmp/SHA256SUMS.sig" >/dev/null 2>&1; then
+    echo "error: self-verification failed — not uploading" >&2
+    exit 1
+fi
+echo "    signature self-verified OK"
+
+# Ensure a release exists for the tag (create from the tag if not).
+if ! gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
+    echo "==> creating release $tag"
+    gh release create "$tag" --repo "$REPO" --title "$tag" \
+        --notes "Signed agent assets for install.sh / \`couchside update\`."
+fi
+
+echo "==> uploading signed agent assets to $tag"
+gh release upload "$tag" --repo "$REPO" --clobber \
+    "$tmp/couchsided.py" "$tmp/couchside.service" "$tmp/qr.py" \
+    "$tmp/couchside-screensaver.sh" "$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig"
+
+echo "OK: signed agent published to $REPO $tag"
+echo "    install.sh fetches these from releases/latest/download/ and verifies the sig."


### PR DESCRIPTION
Hardens `couchside update` / the curl one-liner per the three gaps flagged in review.

1. **Signed agent** — installs from the maintainer-signed GitHub **release** assets (`releases/latest/download`) instead of mutable `main`, and verifies a SHA256SUMS signed with the **offline Ed25519 key** (same key + embedded pubkey already used for the Decky plugin) before installing. Bad sig aborts; every file's hash is checked. Closes the code's own "SANITY gate, NOT authentication" TODO. New `scripts/release-agent.sh` publishes + signs the assets.
2. **Pinned, not mutable main** — `releases/latest` resolves to the newest published release, so a bad/malicious main commit can't auto-deploy.
3. **Partial-download guard** — whole installer wrapped in a brace group, so `curl … | bash` must receive the entire file before executing anything.

Older openssl (no Ed25519) falls back to checksum-only integrity with a warning, same as the Decky path — never breaks the install.

**Verified:** end-to-end on a box (`agent signature: verified (maintainer offline key)`, agent back up at 2.9.4); negative tests — tampered agent → hash reject, tampered SHA256SUMS → signature reject; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)