### PR TITLE
feat: box-side update check + opt-in app-triggered update (agent 2.9.5)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -30,6 +30,7 @@ import tempfile
 import termios
 import threading
 import time
+import urllib.request
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, unquote
@@ -40,7 +41,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.4"
+VERSION = "2.9.5"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -169,6 +170,13 @@ ACTIONS = dict(DEFAULT_ACTIONS)
 ACTION_ORDER = list(DEFAULT_ACTION_ORDER)
 CONFIG_PORT = None  # optional "port" from config.json
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
+# When true, the app may trigger a box-side agent update via POST
+# /api/update/apply. OFF BY DEFAULT: enabling it lets any holder of the bearer
+# token cause a (signature-verified) install + restart, so it is opt-in and can
+# only be turned on ON THE BOX (`couchside allow-updates on`, or config.json),
+# never by the app itself. The app just reads the state and shows/hides its
+# Update button accordingly.
+ALLOW_APP_UPDATE = False
 LAUNCHERS = []  # list of {"id","label","cmd":[...]}, custom launchers only
 CONFIG_PATH = DEFAULT_CONFIG_PATH  # remembered by load_config() for rewrites
 CONFIG_LOCK = threading.Lock()  # serializes launcher config rewrites
@@ -336,11 +344,15 @@ def _parse_config(raw):
 def load_config(path):
     """Load config.json into the module globals; fall back to defaults."""
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
-    global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL
+    global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, ALLOW_APP_UPDATE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
             raw = json.load(f)
+        # Read the app-update flag FIRST, independent of the rest of the config:
+        # it must be honored even if _parse_config later rejects some other field.
+        if isinstance(raw, dict):
+            ALLOW_APP_UPDATE = bool(raw.get("allow_app_update", False))
         units, actions, order, port, launchers, panel = _parse_config(raw)
     except FileNotFoundError:
         print("warning: config %s not found, using built-in generic defaults"
@@ -656,6 +668,102 @@ def set_caps(mock):
         "couchmode": safe(couchmode_available),
         "desktop": safe(desktop_available),
     }
+
+
+# ---------------------------------------------------------------------------
+# Update check (/api/update/check).
+#
+# PRIVACY: this is the ONLY thing that reaches the public internet on the app's
+# behalf, and it lives on the BOX — which already talks to GitHub to fetch its
+# own updates — NOT in the phone app. The app reads the result over the LAN, so
+# the app itself never leaves your network. GitHub sees the box's IP (a read of
+# a public repo); nothing about the user is sent to us. The check runs only when
+# asked (the app polls this route) and is CACHED, so GitHub is contacted at most
+# once every few hours. It compares the installed agent version to the newest
+# SIGNED release (the same assets install.sh verifies), so nothing here can be
+# spoofed into recommending a malicious build.
+# ---------------------------------------------------------------------------
+_UPDATE_LATEST_VER_URL = \
+    "https://github.com/emerytech/couchside/releases/latest/download/agent-version.txt"
+_UPDATE_RELEASE_API = "https://api.github.com/repos/emerytech/couchside/releases/latest"
+_UPDATE_TTL_S = 6 * 3600
+_update_cache = {"at": 0.0, "data": None}
+_update_lock = threading.Lock()
+
+
+def _http_text(url, timeout=8):
+    """GET a small text/JSON body from GitHub. GitHub requires a User-Agent."""
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "couchside-agent/%s" % VERSION,
+        "Accept": "application/vnd.github+json",
+    })
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        return r.read(1_000_000).decode("utf-8", "replace")
+
+
+def _ver_tuple(s):
+    out = []
+    for p in (s or "").strip().split("."):
+        digits = "".join(ch for ch in p if ch.isdigit())
+        out.append(int(digits) if digits else 0)
+    return tuple(out) or (0,)
+
+
+def update_check(force=False):
+    """Whether a newer SIGNED agent release exists. Cached (6h) so the app can
+    poll cheaply — the box contacts GitHub only on a cache miss. Never raises;
+    a network failure returns available:false with an error string."""
+    now = time.monotonic()
+    with _update_lock:
+        c = _update_cache
+        if not force and c["data"] is not None and now - c["at"] < _UPDATE_TTL_S:
+            return c["data"]
+    installed = VERSION
+    try:
+        latest = _http_text(_UPDATE_LATEST_VER_URL).strip().split()[0]
+        meta = json.loads(_http_text(_UPDATE_RELEASE_API))
+        data = {
+            "available": _ver_tuple(latest) > _ver_tuple(installed),
+            "installed": installed,
+            "latest": latest,
+            "tag": meta.get("tag_name") or None,
+            "notes": (meta.get("body") or "").strip() or None,
+            "checked_at": int(time.time()),
+        }
+    except Exception as e:
+        data = {"available": False, "installed": installed, "latest": None,
+                "tag": None, "notes": None, "error": str(e)[:200],
+                "checked_at": int(time.time())}
+    with _update_lock:
+        _update_cache["at"] = now
+        _update_cache["data"] = data
+    return data
+
+
+def mock_update_check():
+    return {"available": True, "installed": VERSION, "latest": "2.9.9",
+            "tag": "v2.8.9",
+            "notes": "## Mock update 2.9.9\n- A shiny new thing\n- A small fix",
+            "checked_at": int(time.time())}
+
+
+def update_apply():
+    """Spawn a DETACHED box-side update (the signed installer) so it survives
+    this agent's own restart, and return immediately. The caller MUST have
+    verified ALLOW_APP_UPDATE first. The installer verifies the release
+    signature before installing, so a triggered update can only ever install an
+    authentic release — never arbitrary code."""
+    log = "/tmp/couchside-update.log"
+    # start_new_session detaches the child into its own session/process group:
+    # when the installer restarts couchside.service and kills this agent, the
+    # update keeps running to completion.
+    subprocess.Popen(
+        ["bash", "-c",
+         "curl -fsSL 'https://couchside.tv/install.sh' | bash > %s 2>&1" % log],
+        stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL, start_new_session=True)
+    print("[update] app-triggered update started (log: %s)" % log, flush=True)
+    return {"started": True, "log": log}
 
 
 # ---------------------------------------------------------------------------
@@ -5410,6 +5518,17 @@ class Handler(BaseHTTPRequestHandler):
                 # 404 -> the app hides the section (probe-and-appear via 404->null).
                 downloads = mock_downloads() if self.mock else steam_downloads()
                 self._send(200, {"downloads": downloads}, started)
+            elif path == "/api/update/check":
+                # Box-side update check (agent >= 2.9.5). The app reads this over
+                # the LAN so the app never touches the internet; the box (already
+                # internet-facing for updates) does the cached GitHub read. Old
+                # agents 404 -> the app shows no banner (probe-and-appear).
+                force = parse_qs(parsed.query).get("force", ["0"])[0] == "1"
+                data = mock_update_check() if self.mock else update_check(force=force)
+                # apply_enabled is read live (not from the cache) so the app
+                # reflects the box-side toggle without waiting out the TTL.
+                data = dict(data, apply_enabled=bool(ALLOW_APP_UPDATE))
+                self._send(200, data, started)
             elif path.startswith("/api/steam/") and path.endswith("/cover"):
                 appid = path[len("/api/steam/"):-len("/cover")]
                 self._handle_steam_cover(appid, started)
@@ -5598,6 +5717,23 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 result = (mock_action(action_id) if self.mock
                           else real_action(action_id))
+                self._send(200, result, started)
+                return
+
+            # POST /api/update/apply: app-triggered box-side update. Gated by
+            # ALLOW_APP_UPDATE (off by default, box-side opt-in only): 403 when
+            # disabled so the capability doesn't exist for boxes that didn't
+            # opt in. The installer verifies the release signature, so even an
+            # authorized trigger can only install an authentic release.
+            if path == "/api/update/apply":
+                if not ALLOW_APP_UPDATE:
+                    self._send(403, {"ok": False, "error":
+                                     "app updates are disabled on this box "
+                                     "(enable with: couchside allow-updates on)"},
+                               started)
+                    return
+                result = ({"started": True, "log": "/tmp/couchside-update.log"}
+                          if self.mock else update_apply())
                 self._send(200, result, started)
                 return
 

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -17,6 +17,7 @@ import {
   View,
 } from 'react-native';
 
+import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
@@ -1214,6 +1215,7 @@ function SetupBody() {
 
         {tab === 'account' && (
           <>
+            <AgentUpdateBanner />
             <View style={styles.accountBadges}>
               <EarlyAdopterBadge />
               <EntitlementPill />

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -1,0 +1,169 @@
+/**
+ * Box-side agent update banner.
+ *
+ * PRIVACY: the check happens on the BOX (agent >= 2.9.5 /api/update/check) — the
+ * box does the GitHub read; the app only reads the result over the LAN, so the
+ * app itself never touches the internet. Shows what's new; the [Update] button
+ * appears only when the box owner opted in on the box (`couchside allow-updates
+ * on`), and even then the install is signature-verified by the box. 404 on older
+ * agents -> the banner is hidden.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useCallback, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, UpdateCheck } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, theme } from '@/lib/theme';
+
+const POLL_MS = 30 * 60 * 1000; // twice an hour; the box caches for ~6h anyway
+
+export function AgentUpdateBanner() {
+  const { settings } = useSettings();
+  const configured = settings.host.trim().length > 0;
+  const poll = usePoll<UpdateCheck | null>(
+    () => api.updateCheck(settings),
+    POLL_MS,
+    configured,
+    hostKey(settings),
+  );
+  const check = poll.data;
+
+  const [expanded, setExpanded] = useState(false);
+  const [dismissed, setDismissed] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const applyingRef = useRef(false);
+
+  const apply = useCallback(async () => {
+    if (applyingRef.current || !check?.latest) return;
+    applyingRef.current = true;
+    setApplying(true);
+    setMsg('Starting the update on your box…');
+    try {
+      await api.applyUpdate(settings);
+      setMsg('Updating — your box will restart. This can take a minute.');
+      const target = check.latest;
+      let done = false;
+      for (let i = 0; i < 40 && !done; i++) {
+        await new Promise((r) => setTimeout(r, 3000));
+        try {
+          const p = await api.ping(settings);
+          if (p.version === target) {
+            setMsg(`Updated to ${target}. `);
+            poll.refresh();
+            done = true;
+          }
+        } catch {
+          // box restarting — keep polling
+        }
+      }
+      if (!done) setMsg('Update started — it may still be finishing. Check the version shortly.');
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      setMsg(`Couldn't start the update (${detail}). You can run \`couchside update\` on the box.`);
+    } finally {
+      setApplying(false);
+      applyingRef.current = false;
+    }
+  }, [check?.latest, poll, settings]);
+
+  if (!check || !check.available) return null;
+  if (dismissed && dismissed === check.latest) return null;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Ionicons name="arrow-up-circle" size={18} color={theme.blue} />
+        <Text style={styles.title} numberOfLines={1}>
+          Agent update available{check.latest ? ` — ${check.latest}` : ''}
+        </Text>
+        {!applying && (
+          <Pressable
+            hitSlop={8}
+            onPress={() => {
+              hapticLight();
+              setDismissed(check.latest);
+            }}>
+            <Ionicons name="close" size={16} color={theme.textDim} />
+          </Pressable>
+        )}
+      </View>
+
+      <Text style={styles.sub}>
+        installed {check.installed}
+        {check.tag ? ` · ${check.tag}` : ''}
+      </Text>
+
+      {check.notes ? (
+        <>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setExpanded((v) => !v);
+            }}
+            style={styles.notesToggle}>
+            <Ionicons
+              name={expanded ? 'chevron-up' : 'chevron-down'}
+              size={14}
+              color={theme.blue}
+            />
+            <Text style={styles.notesToggleText}>What's new</Text>
+          </Pressable>
+          {expanded && <Text style={styles.notes}>{check.notes}</Text>}
+        </>
+      ) : null}
+
+      {msg ? (
+        <Text style={styles.msg}>{msg}</Text>
+      ) : check.apply_enabled ? (
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            void apply();
+          }}
+          disabled={applying}
+          style={({ pressed }) => [styles.btn, pressed && styles.btnPressed]}>
+          <Text style={styles.btnText}>{applying ? 'Updating…' : 'Update now'}</Text>
+        </Pressable>
+      ) : (
+        <Text style={styles.hint}>
+          To update, run <Text style={styles.code}>couchside update</Text> on the box — or
+          enable in-app updates there with <Text style={styles.code}>couchside allow-updates on</Text>.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.card,
+    borderColor: theme.blue,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 14,
+    gap: 8,
+  },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  title: { color: theme.text, fontSize: 14, fontWeight: '700', flex: 1 },
+  sub: { color: theme.textDim, fontSize: 12, fontFamily: mono },
+  notesToggle: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  notesToggleText: { color: theme.blue, fontSize: 13, fontWeight: '600' },
+  notes: { color: theme.textDim, fontSize: 12, lineHeight: 18, fontFamily: mono },
+  btn: {
+    backgroundColor: theme.blue,
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+    marginTop: 2,
+  },
+  btnPressed: { opacity: 0.85 },
+  btnText: { color: '#0b1220', fontSize: 14, fontWeight: '700' },
+  msg: { color: theme.text, fontSize: 13, lineHeight: 19 },
+  hint: { color: theme.textDim, fontSize: 12, lineHeight: 18 },
+  code: { fontFamily: mono, color: theme.text },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -251,6 +251,29 @@ export function isActiveDownload(d: SteamDownload): boolean {
 
 export type Downloads = { downloads: SteamDownload[] };
 
+/**
+ * Box-side update check (agent >= 2.9.5), read over the LAN. The BOX contacts
+ * GitHub (it already does that to update itself) and caches the result; the app
+ * only ever talks to the box, so the app itself never leaves your network. See
+ * the agent's /api/update/check for the privacy rationale. Absent on older
+ * agents (404 -> null -> no banner).
+ */
+export type UpdateCheck = {
+  available: boolean;
+  installed: string;
+  latest: string | null;
+  tag: string | null;
+  notes: string | null;
+  checked_at: number;
+  /**
+   * True only if the box was opted in (on the box: `couchside allow-updates on`)
+   * to let the app trigger an update via applyUpdate(). Off by default, so the
+   * app shows a working [Update] button only where the owner enabled it.
+   */
+  apply_enabled?: boolean;
+  error?: string;
+};
+
 /** MPRIS transport op, POSTed as /api/media/<player>/<op>. */
 export type MediaOp = 'play' | 'pause' | 'play_pause' | 'next' | 'previous' | 'stop' | 'seek';
 
@@ -811,6 +834,26 @@ export const api = {
   ): Promise<Downloads | null> {
     return probeGated(caps?.steam, () =>
       probeOrNull(request<Downloads>(settings, '/api/downloads')));
+  },
+
+  /**
+   * Box-side agent update check (agent >= 2.9.5). The box does the GitHub read
+   * (cached); the app just reads the result over the LAN, so the app never
+   * touches the internet. 404 -> null on older agents (no banner shown).
+   */
+  updateCheck(settings: ConnSettings): Promise<UpdateCheck | null> {
+    return probeOrNull(request<UpdateCheck>(settings, '/api/update/check'));
+  },
+
+  /**
+   * Trigger a box-side agent update (agent >= 2.9.5, only when the box opted in
+   * — 403 otherwise). The box runs the SIGNATURE-VERIFIED installer detached and
+   * restarts, so the connection drops; poll ping/status for the new version.
+   */
+  applyUpdate(settings: ConnSettings): Promise<{ started: boolean; log?: string }> {
+    return request<{ started: boolean; log?: string }>(settings, '/api/update/apply', {
+      method: 'POST',
+    });
   },
 
   /**

--- a/install.sh
+++ b/install.sh
@@ -868,14 +868,49 @@ except Exception:
     systemctl --user status couchside.service 2>/dev/null \
       || systemctl status couchside.service 2>/dev/null || true
     ;;
+  allow-updates)
+    # Opt-in: let the phone app trigger an update (POST /api/update/apply).
+    # OFF by default. Must be set HERE on the box (not by the app), so the
+    # capability only exists when you consciously enable it. Edits config.json
+    # (root-owned) + restarts the agent.
+    case "${2:-}" in
+      on|off)
+        val="false"; [ "$2" = "on" ] && val="true"
+        sudo python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
+import json, os, sys
+p = "/etc/couchside/config.json"
+val = sys.argv[1] == "true"
+try:
+    with open(p) as f: d = json.load(f)
+    if not isinstance(d, dict): d = {}
+except Exception:
+    d = {}
+d["allow_app_update"] = val
+os.makedirs(os.path.dirname(p), exist_ok=True)
+tmp = p + ".tmp"
+with open(tmp, "w") as f: json.dump(d, f, indent=2)
+os.replace(tmp, p)
+PY
+        sudo systemctl restart couchside 2>/dev/null \
+          || systemctl --user restart couchside 2>/dev/null || true
+        echo "App-triggered updates: ${2}"
+        ;;
+      ""|status)
+        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /etc/couchside/config.json 2>/dev/null \
+          && echo "App-triggered updates: on" || echo "App-triggered updates: off"
+        ;;
+      *) echo "usage: couchside allow-updates on|off" >&2; exit 2 ;;
+    esac
+    ;;
   help|-h|--help|"")
     cat <<USAGE
 couchside — manage the Couchside agent on this box
-  couchside update       show the release notes, then update on confirm
-  couchside update -y    update without the prompt
-  couchside pair         show the pairing QR on this box's screen
-  couchside version      print the installed agent version
-  couchside status       show the agent service status
+  couchside update          show the release notes, then update on confirm
+  couchside update -y       update without the prompt
+  couchside allow-updates on|off   let (or stop) the phone app trigger updates
+  couchside pair            show the pairing QR on this box's screen
+  couchside version         print the installed agent version
+  couchside status          show the agent service status
 USAGE
     ;;
   *)

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -50,6 +50,15 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 for f in "${files[@]}"; do cp "$agent/$f" "$tmp/$f"; done
 
+# agent-version.txt: the agent VERSION string, so the box-side update check
+# (/api/update/check) can compare cheaply without downloading the whole daemon.
+# Signed alongside everything else (it's covered by SHA256SUMS below).
+agent_ver="$(grep -m1 '^VERSION' "$agent/couchsided.py" | cut -d'"' -f2)"
+[ -n "$agent_ver" ] || { echo "error: couldn't read agent VERSION" >&2; exit 2; }
+printf '%s\n' "$agent_ver" > "$tmp/agent-version.txt"
+files+=(agent-version.txt)
+echo "==> agent version: $agent_ver"
+
 echo "==> generating SHA256SUMS over ${#files[@]} agent files"
 ( cd "$tmp" && { command -v sha256sum >/dev/null 2>&1 \
     && sha256sum "${files[@]}" \
@@ -77,9 +86,10 @@ if ! gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
 fi
 
 echo "==> uploading signed agent assets to $tag"
-gh release upload "$tag" --repo "$REPO" --clobber \
-    "$tmp/couchsided.py" "$tmp/couchside.service" "$tmp/qr.py" \
-    "$tmp/couchside-screensaver.sh" "$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig"
+uploads=()
+for f in "${files[@]}"; do uploads+=("$tmp/$f"); done
+uploads+=("$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig")
+gh release upload "$tag" --repo "$REPO" --clobber "${uploads[@]}"
 
 echo "OK: signed agent published to $REPO $tag"
 echo "    install.sh fetches these from releases/latest/download/ and verifies the sig."


### PR DESCRIPTION
"Agent update available" in the app **without the app ever touching the internet** — the box does the check (it already talks to GitHub for its own updates), the app reads the result over the LAN.

**Agent 2.9.5**
- `GET /api/update/check` — installed vs newest **signed** release, cached 6h. Returns `{available, installed, latest, tag, notes, apply_enabled}`.
- `POST /api/update/apply` — app-triggered update, **gated by `allow_app_update` (off by default)** → 403 when disabled. When on, spawns the signature-verified installer detached (survives the agent restart). Can only ever install an authentic release.

**Installer**
- `couchside allow-updates on|off` — box-side opt-in toggle (not app-controllable, by design).
- `release-agent.sh` publishes a signed `agent-version.txt` for the check.

**App**
- `AgentUpdateBanner` (Setup › Account): update + notes over the LAN; an **[Update now]** button only when the box opted in, else instructions to run `couchside update` on the box.

**Verified:** check (mock + real reachability), apply gating (403 off / 200 on), CLI toggle, both banner states in the web preview (screenshots).

Note: the agent side (2.9.5) ships via a release + Decky + couchside.tv; the app banner rides the next app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)