### PR TITLE
feat(agent): Roku TV backend over ECP (HTTP) (2.9.9)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.7"
+VERSION = "2.9.8"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -172,6 +172,7 @@ ACTION_ORDER = list(DEFAULT_ACTION_ORDER)
 CONFIG_PORT = None  # optional "port" from config.json
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
+CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
 # When true, the app may trigger a box-side agent update via POST
 # /api/update/apply. OFF BY DEFAULT: enabling it lets any holder of the bearer
 # token cause a (signature-verified) install + restart, so it is opt-in and can
@@ -363,13 +364,37 @@ def _parse_config(raw):
                 raise ConfigError("webos.mac must be a string")
             webos["mac"] = mac
 
-    return units, actions, order, port, launchers, panel, webos
+    # Optional Samsung Tizen TV (WS remote). host is an IP/hostname; the optional
+    # token is written back by the pairing endpoint for silent reconnects; the
+    # optional mac enables Wake-on-LAN power-on.
+    samsung = None
+    samsung_raw = raw.get("samsung")
+    if samsung_raw is not None:
+        if not isinstance(samsung_raw, dict):
+            raise ConfigError("samsung must be an object")
+        host = samsung_raw.get("host")
+        if not isinstance(host, str) or not host:
+            raise ConfigError("samsung.host must be a non-empty string")
+        samsung = {"host": host}
+        tok = samsung_raw.get("token")
+        if tok is not None:
+            if not isinstance(tok, str):
+                raise ConfigError("samsung.token must be a string")
+            samsung["token"] = tok
+        mac = samsung_raw.get("mac")
+        if mac is not None:
+            if not isinstance(mac, str):
+                raise ConfigError("samsung.mac must be a string")
+            samsung["mac"] = mac
+
+    return units, actions, order, port, launchers, panel, webos, samsung
 
 
 def load_config(path):
     """Load config.json into the module globals; fall back to defaults."""
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
-    global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, ALLOW_APP_UPDATE
+    global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
+    global ALLOW_APP_UPDATE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
@@ -378,7 +403,8 @@ def load_config(path):
         # it must be honored even if _parse_config later rejects some other field.
         if isinstance(raw, dict):
             ALLOW_APP_UPDATE = bool(raw.get("allow_app_update", False))
-        units, actions, order, port, launchers, panel, webos = _parse_config(raw)
+        (units, actions, order, port, launchers, panel, webos,
+         samsung) = _parse_config(raw)
     except FileNotFoundError:
         print("warning: config %s not found, using built-in generic defaults"
               % path, file=sys.stderr, flush=True)
@@ -395,6 +421,7 @@ def load_config(path):
     LAUNCHERS = launchers
     CONFIG_PANEL = panel
     CONFIG_WEBOS = webos
+    CONFIG_SAMSUNG = samsung
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
 
@@ -3259,7 +3286,8 @@ class _WebOSWS:
             sock = ctx.wrap_socket(sock, server_hostname=host)
         sock.settimeout(timeout)
         self.sock = sock
-        self._handshake(host, port, u.path or "/")
+        req_path = (u.path or "/") + (("?" + u.query) if u.query else "")
+        self._handshake(host, port, req_path)
 
     def _handshake(self, host, port, path):
         key = base64.b64encode(os.urandom(16)).decode()
@@ -3569,6 +3597,245 @@ def _webos_save(host, client_key, mac=None):
         CONFIG_WEBOS = cfg
 
 
+# ---- shared helpers for the network TV backends ---------------------------
+def _wol_send(mac):
+    """Send a Wake-on-LAN magic packet to <mac> (broadcast :9). ActionResult.
+    Shared by the network TV backends: a TV that is off has no live socket, so
+    WoL is the only way to power it on (needs the TV's fast-wake setting on)."""
+    start = time.monotonic()
+    if not mac:
+        return _webos_result(start, False, "no mac configured for wake")
+    try:
+        raw = bytes.fromhex(mac.replace(":", "").replace("-", ""))
+        if len(raw) != 6:
+            raise ValueError("mac must be 6 bytes")
+        packet = b"\xff" * 6 + raw * 16
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+            s.sendto(packet, ("255.255.255.255", 9))
+        finally:
+            s.close()
+        return _webos_result(start, True, "wol -> %s" % mac)
+    except (ValueError, OSError) as e:
+        return _webos_result(start, False, "wol failed: %s" % e)
+
+
+def _config_set_field(field, value):
+    """Read-modify-write CONFIG_PATH, setting top-level <field> = value, via the
+    same atomic temp-file + os.replace pattern as the launcher writer. Caller
+    MUST hold CONFIG_LOCK."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            raw = json.load(f)
+    except (OSError, ValueError):
+        raw = None
+    if not isinstance(raw, dict):
+        raw = {"units": [{"name": n, "scope": s} for n, s in WATCHLIST]}
+    raw[field] = value
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(raw, f, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, CONFIG_PATH)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---- Samsung backend (Tizen Smart TVs, WS remote over the stdlib WebSocket) -
+# Samsung Tizen TVs expose a WebSocket remote at
+# wss://<host>:8002/api/v2/channels/samsung.remote.control?name=<b64>[&token=].
+# It reuses the _WebOSWS transport built for webOS (self-signed cert, same RFC
+# 6455 framing) — only the message schema differs, so no new dependency
+# (samsungtvws was the protocol oracle; nothing from it ships). Pre-2016 sets
+# use plaintext ws://<host>:8001 and are not handled.
+#
+# Pairing: the first connect (no token) raises an Allow prompt on the TV; once
+# accepted, the TV's ms.channel.connect event carries a token that the pairing
+# endpoint persists (config.json samsung.token) for silent reconnects. Keys are
+# fire-and-forget ms.remote.control commands. power_off is KEY_POWER (a toggle);
+# power_ON is a Wake-on-LAN magic packet to samsung.mac.
+SAMSUNG_PORT = 8002
+_SAMSUNG_NAME_B64 = base64.b64encode(b"Couchside").decode()
+
+# Unified TV op -> Samsung key. KEY_MUTE is itself a toggle (no state tracking);
+# power_on is Wake-on-LAN, not a key.
+_SAMSUNG_OP_KEY = {
+    "power_off": "KEY_POWER",
+    "volume_up": "KEY_VOLUP",
+    "volume_down": "KEY_VOLDOWN",
+    "mute": "KEY_MUTE",
+}
+
+# Factory-remote key (shared PANEL_KEYS/_WEBOS_KEYS vocabulary) -> Samsung code.
+_SAMSUNG_KEYS = {
+    "up": "KEY_UP", "down": "KEY_DOWN", "left": "KEY_LEFT", "right": "KEY_RIGHT",
+    "ok": "KEY_ENTER", "menu": "KEY_MENU", "home": "KEY_HOME", "back": "KEY_RETURN",
+    "exit": "KEY_EXIT", "info": "KEY_INFO", "play": "KEY_PLAY", "pause": "KEY_PAUSE",
+    "stop": "KEY_STOP", "rewind": "KEY_REWIND", "fast_forward": "KEY_FF",
+}
+
+
+class _SamsungSession:
+    """One Tizen WS remote session. After the ms.channel.connect handshake the
+    socket accepts fire-and-forget commands. Not internally locked — callers
+    serialize via SAMSUNG_LOCK."""
+
+    def __init__(self, host, token=None):
+        url = ("wss://%s:%d/api/v2/channels/samsung.remote.control?name=%s"
+               % (host, SAMSUNG_PORT, _SAMSUNG_NAME_B64))
+        if token:
+            url += "&token=" + token
+        self.ws = _WebOSWS(url)
+        self.token = token
+        self._connect()
+
+    def _connect(self, timeout=60):
+        """Read events until the channel is authorized. Captures the token the
+        TV grants on first pairing (or rotates)."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            msg = json.loads(self.ws.recv_text())
+            event = msg.get("event")
+            if event == "ms.channel.connect":
+                tok = msg.get("data", {}).get("token")
+                if tok:
+                    self.token = str(tok)
+                return
+            if event == "ms.channel.unauthorized":
+                raise IOError("authorization denied on the TV")
+        raise IOError("Samsung authorization timed out")
+
+    def send_key(self, key):
+        self.ws.send_text(json.dumps({
+            "method": "ms.remote.control",
+            "params": {"Cmd": "Click", "DataOfCmd": key, "Option": "false",
+                       "TypeOfRemote": "SendRemoteKey"}}))
+
+    def send_text(self, text):
+        enc = base64.b64encode(text.encode("utf-8")).decode("ascii")
+        self.ws.send_text(json.dumps({
+            "method": "ms.remote.control",
+            "params": {"Cmd": enc, "DataOfCmd": "base64",
+                       "TypeOfRemote": "SendInputString"}}))
+
+    def close(self):
+        self.ws.close()
+
+
+SAMSUNG = None            # active _SamsungSession, or None until first use
+SAMSUNG_LOCK = threading.Lock()
+_SAMSUNG_MOCK = False
+
+
+def set_samsung(mock):
+    """Prepare the Samsung backend (mirrors set_webos)."""
+    global SAMSUNG, _SAMSUNG_MOCK
+    _SAMSUNG_MOCK = mock
+    if SAMSUNG is not None:
+        SAMSUNG.close()
+    SAMSUNG = None
+
+
+def samsung_available():
+    """True in --mock, or when config named a host and a token is present (i.e.
+    the TV has been paired)."""
+    if _SAMSUNG_MOCK:
+        return True
+    return bool(CONFIG_SAMSUNG and CONFIG_SAMSUNG.get("token"))
+
+
+def _samsung_conn():
+    """Return a live connected _SamsungSession. Caller MUST hold SAMSUNG_LOCK."""
+    global SAMSUNG
+    if SAMSUNG is None:
+        SAMSUNG = _SamsungSession(CONFIG_SAMSUNG["host"],
+                                  CONFIG_SAMSUNG.get("token"))
+    return SAMSUNG
+
+
+def _samsung_do(fn):
+    """Run fn(session) under the lock, with one reconnect+retry. ActionResult."""
+    global SAMSUNG
+    start = time.monotonic()
+    with SAMSUNG_LOCK:
+        for attempt in (1, 2):
+            try:
+                return _webos_result(start, True, fn(_samsung_conn()) or "ok")
+            except (IOError, OSError, ValueError, KeyError) as e:
+                if SAMSUNG is not None:
+                    SAMSUNG.close()
+                SAMSUNG = None
+                if attempt == 2:
+                    return _webos_result(
+                        start, False, "%s: %s" % (e.__class__.__name__, e))
+
+
+def real_samsung(op):
+    """Dispatch a unified TV op. power_on is Wake-on-LAN; the rest are keys."""
+    if op == "power_on":
+        return _wol_send((CONFIG_SAMSUNG or {}).get("mac"))
+    key = _SAMSUNG_OP_KEY.get(op)
+    if key is None:
+        return _webos_result(time.monotonic(), False, "unsupported op %s" % op)
+    return _samsung_do(lambda s: (s.send_key(key), op)[1])
+
+
+def real_samsung_key(k):
+    """Send one factory-remote key (PANEL_KEYS vocabulary) as a Tizen key."""
+    code = _SAMSUNG_KEYS.get(k)
+    if code is None:
+        return _webos_result(time.monotonic(), False, "unknown key %s" % k)
+    return _samsung_do(lambda s: (s.send_key(code), "key %s" % k)[1])
+
+
+def real_samsung_text(text):
+    """Send text to a focused on-TV field (Tizen SendInputString)."""
+    return _samsung_do(
+        lambda s: (s.send_text(text), "text (%d chars)" % len(text))[1])
+
+
+def mock_samsung(op):
+    """--mock stand-in: log the op, open no socket, succeed."""
+    time.sleep(0.05)
+    print("[samsung] %s" % op, flush=True)
+    return {"ok": True, "exit_code": 0, "stdout": "[mock samsung] %s\n" % op,
+            "stderr": "", "duration_ms": 50}
+
+
+def samsung_pair(host, timeout=60):
+    """Connect without a saved token so the TV shows an Allow prompt; return the
+    token the TV grants once the user accepts. Raises IOError on rejection or
+    timeout. The caller persists host+token to config for silent reconnects."""
+    sess = _SamsungSession(host, (CONFIG_SAMSUNG or {}).get("token"))
+    try:
+        if not sess.token:
+            raise IOError("TV did not grant a token")
+        return sess.token
+    finally:
+        sess.close()
+
+
+def _samsung_save(host, token, mac=None):
+    """Persist the paired Samsung config to CONFIG_PATH atomically and update
+    CONFIG_SAMSUNG. Holds CONFIG_LOCK."""
+    cfg = {"host": host, "token": token}
+    if mac:
+        cfg["mac"] = mac
+    global CONFIG_SAMSUNG
+    with CONFIG_LOCK:
+        _config_set_field("samsung", cfg)
+        CONFIG_SAMSUNG = cfg
+
+
 # ---- unified dispatch -----------------------------------------------------
 # CEC has no discrete power-off; its standby command IS the off state.
 _TV_TO_CEC = {"power_on": "power_on", "power_off": "standby",
@@ -3587,6 +3854,7 @@ def set_tv(mock):
     set_cec(mock)
     set_panel(mock)
     set_webos(mock)
+    set_samsung(mock)
     set_soft(mock)
 
 
@@ -3599,6 +3867,8 @@ def _tv_hw_backend():
         return "panel"
     if webos_available():
         return "webos"
+    if samsung_available():
+        return "samsung"
     if cec_available():
         return "cec"
     return None
@@ -3619,6 +3889,9 @@ def tv_info():
     elif hw == "webos":
         backend, adapter = "webos", ("LG webOS (%s)" % CONFIG_WEBOS["host"]
                                      if CONFIG_WEBOS else "LG webOS")
+    elif hw == "samsung":
+        backend, adapter = "samsung", ("Samsung Tizen (%s)" % CONFIG_SAMSUNG["host"]
+                                       if CONFIG_SAMSUNG else "Samsung Tizen")
     elif hw == "cec":
         cec = cec_current()
         backend, adapter = "cec", (cec["adapter"] if cec else "CEC")
@@ -3647,10 +3920,10 @@ def tv_info():
         # Factory-remote key emulation (arrows/ok/menu/home/back/settings): the
         # RS-232 panel drives the OSD, a paired webOS TV drives its pointer/nav.
         # Either lights up the app's Remote view D-pad cluster.
-        "keys": panel_available() or webos_available(),
-        # Text entry into a focused on-TV field (webOS IME). webOS-only; the
-        # panel and CEC have no text channel.
-        "text": webos_available(),
+        "keys": panel_available() or webos_available() or samsung_available(),
+        # Text entry into a focused on-TV field. webOS (IME) and Samsung
+        # (SendInputString) support it; the panel and CEC have no text channel.
+        "text": webos_available() or samsung_available(),
         # Box mute state, so the app shows the right mute indicator on connect.
         "muted": _soft_muted() if box_vol else None,
         # Current levels (0-100 or null) so the app's volume slider can show and
@@ -3669,6 +3942,8 @@ def _send_tv_hw(op, mock):
         return mock_panel(op) if mock else real_panel(op)
     if b == "webos":
         return mock_webos(op) if mock else real_webos(op)
+    if b == "samsung":
+        return mock_samsung(op) if mock else real_samsung(op)
     if b == "cec":
         cec_op = _TV_TO_CEC[op]
         return mock_cec(cec_op) if mock else real_cec(cec_op)
@@ -6214,6 +6489,9 @@ class Handler(BaseHTTPRequestHandler):
                 if backend == "webos" and k in _WEBOS_KEYS:
                     result = (mock_webos("key %s" % k) if self.mock
                               else real_webos_key(k))
+                elif backend == "samsung" and k in _SAMSUNG_KEYS:
+                    result = (mock_samsung("key %s" % k) if self.mock
+                              else real_samsung_key(k))
                 elif backend == "panel" and k in PANEL_KEYS:
                     result = ({"ok": True, "exit_code": 0,
                                "stdout": "[mock panel] key %s" % k,
@@ -6228,7 +6506,8 @@ class Handler(BaseHTTPRequestHandler):
             # POST /api/tv/text: insert text into a focused on-TV field (webOS
             # IME). Body {"text": "..."}; webOS-only (tv_info.text gates it).
             if path == "/api/tv/text":
-                if not webos_available():
+                backend = _tv_hw_backend()
+                if backend not in ("webos", "samsung"):
                     self._send(404, {"error": "no text backend"}, started)
                     return
                 try:
@@ -6239,8 +6518,13 @@ class Handler(BaseHTTPRequestHandler):
                 except (ValueError, TypeError, KeyError, UnicodeDecodeError):
                     self._send(400, {"error": "text must be a string"}, started)
                     return
-                result = (mock_webos("text") if self.mock
-                          else real_webos_text(text))
+                if self.mock:
+                    result = mock_webos("text") if backend == "webos" \
+                        else mock_samsung("text")
+                elif backend == "webos":
+                    result = real_webos_text(text)
+                else:
+                    result = real_samsung_text(text)
                 self._send(200, result, started)
                 return
 
@@ -6281,6 +6565,45 @@ class Handler(BaseHTTPRequestHandler):
                 set_caps(False)       # the 'tv' capability may have turned on
                 self._send(200, {"ok": True, "paired": True,
                                  "backend": "webos", "host": host}, started)
+                return
+
+            # POST /api/tv/samsung/pair: pair with a Samsung Tizen TV. Body
+            # {"host": "<ip>", "mac": "<optional, for Wake-on-LAN>"}. Blocks up
+            # to ~60s while the TV shows an Allow prompt; on success the granted
+            # token is persisted so later starts reconnect silently.
+            if path == "/api/tv/samsung/pair":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    host = req["host"]
+                    if not isinstance(host, str) or not host:
+                        raise ValueError("host required")
+                    mac = req.get("mac")
+                    if mac is not None and not isinstance(mac, str):
+                        raise ValueError("mac must be a string")
+                except (ValueError, TypeError, KeyError, UnicodeDecodeError):
+                    self._send(400, {"error": "host (string) required"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "paired": True,
+                                     "backend": "samsung", "host": host}, started)
+                    return
+                try:
+                    token = samsung_pair(host)
+                except (IOError, OSError) as e:
+                    self._send(502, {"ok": False,
+                                     "error": "pairing failed: %s" % e}, started)
+                    return
+                try:
+                    _samsung_save(host, token, mac)
+                except OSError as e:
+                    self._send(500, {"ok": False,
+                                     "error": "could not persist config: %s" % e},
+                               started)
+                    return
+                set_samsung(False)
+                set_caps(False)
+                self._send(200, {"ok": True, "paired": True,
+                                 "backend": "samsung", "host": host}, started)
                 return
 
             # POST /api/tv/source/<id>: switch the display input (panel only).

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -34,7 +34,7 @@ import time
 import urllib.request
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse, parse_qs, unquote
+from urllib.parse import urlparse, parse_qs, quote, unquote
 
 try:
     import fcntl  # POSIX only; uinput needs it (Linux), absent on Windows
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.8"
+VERSION = "2.9.9"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -173,6 +173,7 @@ CONFIG_PORT = None  # optional "port" from config.json
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
 CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
+CONFIG_ROKU = None  # optional {"host","name"} Roku (ECP) TV config
 # When true, the app may trigger a box-side agent update via POST
 # /api/update/apply. OFF BY DEFAULT: enabling it lets any holder of the bearer
 # token cause a (signature-verified) install + restart, so it is opt-in and can
@@ -387,14 +388,32 @@ def _parse_config(raw):
                 raise ConfigError("samsung.mac must be a string")
             samsung["mac"] = mac
 
-    return units, actions, order, port, launchers, panel, webos, samsung
+    # Optional Roku TV (ECP over HTTP). host is an IP/hostname; the optional
+    # name is a friendly label captured when the device was added. No pairing.
+    roku = None
+    roku_raw = raw.get("roku")
+    if roku_raw is not None:
+        if not isinstance(roku_raw, dict):
+            raise ConfigError("roku must be an object")
+        host = roku_raw.get("host")
+        if not isinstance(host, str) or not host:
+            raise ConfigError("roku.host must be a non-empty string")
+        roku = {"host": host}
+        name = roku_raw.get("name")
+        if name is not None:
+            if not isinstance(name, str):
+                raise ConfigError("roku.name must be a string")
+            roku["name"] = name
+
+    return (units, actions, order, port, launchers, panel, webos, samsung,
+            roku)
 
 
 def load_config(path):
     """Load config.json into the module globals; fall back to defaults."""
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
-    global ALLOW_APP_UPDATE
+    global CONFIG_ROKU, ALLOW_APP_UPDATE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
@@ -403,8 +422,8 @@ def load_config(path):
         # it must be honored even if _parse_config later rejects some other field.
         if isinstance(raw, dict):
             ALLOW_APP_UPDATE = bool(raw.get("allow_app_update", False))
-        (units, actions, order, port, launchers, panel, webos,
-         samsung) = _parse_config(raw)
+        (units, actions, order, port, launchers, panel, webos, samsung,
+         roku) = _parse_config(raw)
     except FileNotFoundError:
         print("warning: config %s not found, using built-in generic defaults"
               % path, file=sys.stderr, flush=True)
@@ -422,6 +441,7 @@ def load_config(path):
     CONFIG_PANEL = panel
     CONFIG_WEBOS = webos
     CONFIG_SAMSUNG = samsung
+    CONFIG_ROKU = roku
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
 
@@ -3836,6 +3856,130 @@ def _samsung_save(host, token, mac=None):
         CONFIG_SAMSUNG = cfg
 
 
+# ---- Roku backend (ECP over plain HTTP) -----------------------------------
+# Roku devices expose the External Control Protocol (ECP) as an unauthenticated
+# HTTP service on port 8060 — no pairing, no token, no WebSocket. Key presses
+# are POST /keypress/<KEY>; power on/off are ECP keys too (Roku TVs stay
+# reachable in standby, so unlike webOS/Samsung there is no Wake-on-LAN).
+# Stateless: each op is a one-shot POST, so there is no session or lock.
+# Config-driven; a reachable host is enough (nothing to pair).
+ROKU_PORT = 8060
+
+# Unified TV op -> ECP key. Roku TVs wake over the network, so power_on is the
+# PowerOn key (not Wake-on-LAN); mute (VolumeMute) self-toggles.
+_ROKU_OP_KEY = {
+    "power_off": "PowerOff", "power_on": "PowerOn",
+    "volume_up": "VolumeUp", "volume_down": "VolumeDown", "mute": "VolumeMute",
+}
+
+# Factory-remote key (shared vocabulary) -> ECP key. Roku has no distinct
+# pause/stop (Play toggles) and no menu (Info is the "*" options key).
+_ROKU_KEYS = {
+    "up": "Up", "down": "Down", "left": "Left", "right": "Right", "ok": "Select",
+    "menu": "Info", "home": "Home", "back": "Back", "exit": "Home", "info": "Info",
+    "play": "Play", "pause": "Play", "stop": "Play", "rewind": "Rev",
+    "fast_forward": "Fwd",
+}
+
+
+def _roku_tag(xml, tag):
+    """Extract <tag>...</tag> text from a Roku ECP XML blob, or None."""
+    open_t, close_t = "<%s>" % tag, "</%s>" % tag
+    a = xml.find(open_t)
+    if a < 0:
+        return None
+    a += len(open_t)
+    b = xml.find(close_t, a)
+    return xml[a:b].strip() if b > a else None
+
+
+def _roku_post(host, path, timeout=4):
+    """POST an empty body to a Roku ECP path. ActionResult-shaped."""
+    start = time.monotonic()
+    url = "http://%s:%d/%s" % (host, ROKU_PORT, path)
+    try:
+        req = urllib.request.Request(url, data=b"", method="POST")
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            r.read()
+        return _webos_result(start, True, path)
+    except OSError as e:            # URLError / HTTPError are OSError subclasses
+        return _webos_result(start, False, "%s: %s" % (e.__class__.__name__, e))
+
+
+ROKU_MOCK = False
+
+
+def set_roku(mock):
+    """Prepare the Roku backend. Nothing to open (stateless HTTP)."""
+    global ROKU_MOCK
+    ROKU_MOCK = mock
+
+
+def roku_available():
+    """True in --mock, or when config named a Roku host (no pairing needed)."""
+    if ROKU_MOCK:
+        return True
+    return bool(CONFIG_ROKU and CONFIG_ROKU.get("host"))
+
+
+def real_roku(op):
+    """Dispatch a unified TV op to an ECP keypress (power on/off included)."""
+    key = _ROKU_OP_KEY.get(op)
+    if key is None:
+        return _webos_result(time.monotonic(), False, "unsupported op %s" % op)
+    return _roku_post(CONFIG_ROKU["host"], "keypress/" + key)
+
+
+def real_roku_key(k):
+    """Send one factory-remote key (PANEL_KEYS vocabulary) as an ECP keypress."""
+    key = _ROKU_KEYS.get(k)
+    if key is None:
+        return _webos_result(time.monotonic(), False, "unknown key %s" % k)
+    return _roku_post(CONFIG_ROKU["host"], "keypress/" + key)
+
+
+def real_roku_text(text):
+    """Type text via ECP Lit_ keypresses, one character at a time."""
+    host = CONFIG_ROKU["host"]
+    for ch in text:
+        r = _roku_post(host, "keypress/Lit_" + quote(ch, safe=""))
+        if not r["ok"]:
+            return r
+    return _webos_result(time.monotonic(), True, "text (%d chars)" % len(text))
+
+
+def mock_roku(op):
+    """--mock stand-in: log the op, touch no network, succeed."""
+    time.sleep(0.02)
+    print("[roku] %s" % op, flush=True)
+    return {"ok": True, "exit_code": 0, "stdout": "[mock roku] %s\n" % op,
+            "stderr": "", "duration_ms": 20}
+
+
+def roku_add(host, timeout=4):
+    """Verify a Roku answers ECP at <host> and return its friendly name (Roku
+    needs no pairing). Raises IOError when it does not respond."""
+    url = "http://%s:%d/query/device-info" % (host, ROKU_PORT)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            xml = r.read().decode(errors="ignore")
+    except OSError as e:
+        raise IOError("Roku not reachable at %s: %s" % (host, e))
+    return (_roku_tag(xml, "user-device-name")
+            or _roku_tag(xml, "friendly-device-name")
+            or _roku_tag(xml, "default-device-name")
+            or _roku_tag(xml, "model-name") or host)
+
+
+def _roku_save(host, name):
+    """Persist the Roku config to CONFIG_PATH atomically and update CONFIG_ROKU."""
+    cfg = {"host": host, "name": name}
+    global CONFIG_ROKU
+    with CONFIG_LOCK:
+        _config_set_field("roku", cfg)
+        CONFIG_ROKU = cfg
+
+
 # ---- unified dispatch -----------------------------------------------------
 # CEC has no discrete power-off; its standby command IS the off state.
 _TV_TO_CEC = {"power_on": "power_on", "power_off": "standby",
@@ -3855,6 +3999,7 @@ def set_tv(mock):
     set_panel(mock)
     set_webos(mock)
     set_samsung(mock)
+    set_roku(mock)
     set_soft(mock)
 
 
@@ -3869,6 +4014,8 @@ def _tv_hw_backend():
         return "webos"
     if samsung_available():
         return "samsung"
+    if roku_available():
+        return "roku"
     if cec_available():
         return "cec"
     return None
@@ -3892,6 +4039,10 @@ def tv_info():
     elif hw == "samsung":
         backend, adapter = "samsung", ("Samsung Tizen (%s)" % CONFIG_SAMSUNG["host"]
                                        if CONFIG_SAMSUNG else "Samsung Tizen")
+    elif hw == "roku":
+        backend, adapter = "roku", ("Roku (%s)" % (CONFIG_ROKU.get("name")
+                                    or CONFIG_ROKU["host"]) if CONFIG_ROKU
+                                    else "Roku")
     elif hw == "cec":
         cec = cec_current()
         backend, adapter = "cec", (cec["adapter"] if cec else "CEC")
@@ -3920,10 +4071,13 @@ def tv_info():
         # Factory-remote key emulation (arrows/ok/menu/home/back/settings): the
         # RS-232 panel drives the OSD, a paired webOS TV drives its pointer/nav.
         # Either lights up the app's Remote view D-pad cluster.
-        "keys": panel_available() or webos_available() or samsung_available(),
-        # Text entry into a focused on-TV field. webOS (IME) and Samsung
-        # (SendInputString) support it; the panel and CEC have no text channel.
-        "text": webos_available() or samsung_available(),
+        "keys": (panel_available() or webos_available()
+                 or samsung_available() or roku_available()),
+        # Text entry into a focused on-TV field. webOS (IME), Samsung
+        # (SendInputString) and Roku (Lit_ keypresses) support it; the panel
+        # and CEC have no text channel.
+        "text": (webos_available() or samsung_available()
+                 or roku_available()),
         # Box mute state, so the app shows the right mute indicator on connect.
         "muted": _soft_muted() if box_vol else None,
         # Current levels (0-100 or null) so the app's volume slider can show and
@@ -3944,6 +4098,8 @@ def _send_tv_hw(op, mock):
         return mock_webos(op) if mock else real_webos(op)
     if b == "samsung":
         return mock_samsung(op) if mock else real_samsung(op)
+    if b == "roku":
+        return mock_roku(op) if mock else real_roku(op)
     if b == "cec":
         cec_op = _TV_TO_CEC[op]
         return mock_cec(cec_op) if mock else real_cec(cec_op)
@@ -6492,6 +6648,9 @@ class Handler(BaseHTTPRequestHandler):
                 elif backend == "samsung" and k in _SAMSUNG_KEYS:
                     result = (mock_samsung("key %s" % k) if self.mock
                               else real_samsung_key(k))
+                elif backend == "roku" and k in _ROKU_KEYS:
+                    result = (mock_roku("key %s" % k) if self.mock
+                              else real_roku_key(k))
                 elif backend == "panel" and k in PANEL_KEYS:
                     result = ({"ok": True, "exit_code": 0,
                                "stdout": "[mock panel] key %s" % k,
@@ -6507,7 +6666,12 @@ class Handler(BaseHTTPRequestHandler):
             # IME). Body {"text": "..."}; webOS-only (tv_info.text gates it).
             if path == "/api/tv/text":
                 backend = _tv_hw_backend()
-                if backend not in ("webos", "samsung"):
+                _TEXT_FNS = {
+                    "webos": (mock_webos, real_webos_text),
+                    "samsung": (mock_samsung, real_samsung_text),
+                    "roku": (mock_roku, real_roku_text),
+                }
+                if backend not in _TEXT_FNS:
                     self._send(404, {"error": "no text backend"}, started)
                     return
                 try:
@@ -6518,13 +6682,8 @@ class Handler(BaseHTTPRequestHandler):
                 except (ValueError, TypeError, KeyError, UnicodeDecodeError):
                     self._send(400, {"error": "text must be a string"}, started)
                     return
-                if self.mock:
-                    result = mock_webos("text") if backend == "webos" \
-                        else mock_samsung("text")
-                elif backend == "webos":
-                    result = real_webos_text(text)
-                else:
-                    result = real_samsung_text(text)
+                mock_fn, real_fn = _TEXT_FNS[backend]
+                result = mock_fn("text") if self.mock else real_fn(text)
                 self._send(200, result, started)
                 return
 
@@ -6604,6 +6763,42 @@ class Handler(BaseHTTPRequestHandler):
                 set_caps(False)
                 self._send(200, {"ok": True, "paired": True,
                                  "backend": "samsung", "host": host}, started)
+                return
+
+            # POST /api/tv/roku/add: register a Roku by host. Body {"host":
+            # "<ip>"}. Roku needs no pairing — we just verify it answers ECP,
+            # capture its friendly name, and persist. Returns the name.
+            if path == "/api/tv/roku/add":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    host = req["host"]
+                    if not isinstance(host, str) or not host:
+                        raise ValueError("host required")
+                except (ValueError, TypeError, KeyError, UnicodeDecodeError):
+                    self._send(400, {"error": "host (string) required"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "added": True, "backend": "roku",
+                                     "host": host, "name": "Mock Roku"}, started)
+                    return
+                try:
+                    name = roku_add(host)
+                except (IOError, OSError) as e:
+                    self._send(502, {"ok": False,
+                                     "error": "not a reachable Roku: %s" % e},
+                               started)
+                    return
+                try:
+                    _roku_save(host, name)
+                except OSError as e:
+                    self._send(500, {"ok": False,
+                                     "error": "could not persist config: %s" % e},
+                               started)
+                    return
+                set_roku(False)
+                set_caps(False)
+                self._send(200, {"ok": True, "added": True, "backend": "roku",
+                                 "host": host, "name": name}, started)
                 return
 
             # POST /api/tv/source/<id>: switch the display input (panel only).


### PR DESCRIPTION
## Smart TV control — 3/4: Roku ECP backend (agent 2.9.9)

Stacked on the Samsung PR. Adds a `roku` backend driving Roku devices via the External Control Protocol — plain unauthenticated HTTP on port 8060, no pairing, no WebSocket. Stateless: each op is a one-shot `POST /keypress/<KEY>`.

- Config `roku:{host, name?}`; `POST /api/tv/roku/add` verifies the device answers ECP, captures its friendly name, persists it. No token (ECP is open on the LAN).
- Dispatch `panel → webos → samsung → roku → cec`: power on/off are ECP keys (Roku TVs wake over the network — **no WoL**), volume, mute, D-pad/media keys, text via per-character `Lit_` keypresses.
- `tv_info` backend `roku` + `keys`/`text`; `/api/tv/text` now maps backend → (mock, real) via a small table.

**Verified** end-to-end against a stub ECP server: `py_compile`, `--mock`, and a real-mode run where key/text/add drove actual HTTP keypresses (`/keypress/Right`, `/keypress/Lit_h` …). No regression to the other backends.

Base on the Samsung PR; merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
