### PR TITLE
feat(app): smart-TV pairing UI + tv text/pair API (webOS/Samsung/Roku)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -34,7 +34,7 @@ import time
 import urllib.request
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from urllib.parse import urlparse, parse_qs, unquote
+from urllib.parse import urlparse, parse_qs, quote, unquote
 
 try:
     import fcntl  # POSIX only; uinput needs it (Linux), absent on Windows
@@ -42,7 +42,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.8"
+VERSION = "2.9.9"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -173,6 +173,7 @@ CONFIG_PORT = None  # optional "port" from config.json
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
 CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
+CONFIG_ROKU = None  # optional {"host","name"} Roku (ECP) TV config
 # When true, the app may trigger a box-side agent update via POST
 # /api/update/apply. OFF BY DEFAULT: enabling it lets any holder of the bearer
 # token cause a (signature-verified) install + restart, so it is opt-in and can
@@ -387,14 +388,32 @@ def _parse_config(raw):
                 raise ConfigError("samsung.mac must be a string")
             samsung["mac"] = mac
 
-    return units, actions, order, port, launchers, panel, webos, samsung
+    # Optional Roku TV (ECP over HTTP). host is an IP/hostname; the optional
+    # name is a friendly label captured when the device was added. No pairing.
+    roku = None
+    roku_raw = raw.get("roku")
+    if roku_raw is not None:
+        if not isinstance(roku_raw, dict):
+            raise ConfigError("roku must be an object")
+        host = roku_raw.get("host")
+        if not isinstance(host, str) or not host:
+            raise ConfigError("roku.host must be a non-empty string")
+        roku = {"host": host}
+        name = roku_raw.get("name")
+        if name is not None:
+            if not isinstance(name, str):
+                raise ConfigError("roku.name must be a string")
+            roku["name"] = name
+
+    return (units, actions, order, port, launchers, panel, webos, samsung,
+            roku)
 
 
 def load_config(path):
     """Load config.json into the module globals; fall back to defaults."""
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
-    global ALLOW_APP_UPDATE
+    global CONFIG_ROKU, ALLOW_APP_UPDATE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
@@ -403,8 +422,8 @@ def load_config(path):
         # it must be honored even if _parse_config later rejects some other field.
         if isinstance(raw, dict):
             ALLOW_APP_UPDATE = bool(raw.get("allow_app_update", False))
-        (units, actions, order, port, launchers, panel, webos,
-         samsung) = _parse_config(raw)
+        (units, actions, order, port, launchers, panel, webos, samsung,
+         roku) = _parse_config(raw)
     except FileNotFoundError:
         print("warning: config %s not found, using built-in generic defaults"
               % path, file=sys.stderr, flush=True)
@@ -422,6 +441,7 @@ def load_config(path):
     CONFIG_PANEL = panel
     CONFIG_WEBOS = webos
     CONFIG_SAMSUNG = samsung
+    CONFIG_ROKU = roku
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
 
@@ -3836,6 +3856,130 @@ def _samsung_save(host, token, mac=None):
         CONFIG_SAMSUNG = cfg
 
 
+# ---- Roku backend (ECP over plain HTTP) -----------------------------------
+# Roku devices expose the External Control Protocol (ECP) as an unauthenticated
+# HTTP service on port 8060 — no pairing, no token, no WebSocket. Key presses
+# are POST /keypress/<KEY>; power on/off are ECP keys too (Roku TVs stay
+# reachable in standby, so unlike webOS/Samsung there is no Wake-on-LAN).
+# Stateless: each op is a one-shot POST, so there is no session or lock.
+# Config-driven; a reachable host is enough (nothing to pair).
+ROKU_PORT = 8060
+
+# Unified TV op -> ECP key. Roku TVs wake over the network, so power_on is the
+# PowerOn key (not Wake-on-LAN); mute (VolumeMute) self-toggles.
+_ROKU_OP_KEY = {
+    "power_off": "PowerOff", "power_on": "PowerOn",
+    "volume_up": "VolumeUp", "volume_down": "VolumeDown", "mute": "VolumeMute",
+}
+
+# Factory-remote key (shared vocabulary) -> ECP key. Roku has no distinct
+# pause/stop (Play toggles) and no menu (Info is the "*" options key).
+_ROKU_KEYS = {
+    "up": "Up", "down": "Down", "left": "Left", "right": "Right", "ok": "Select",
+    "menu": "Info", "home": "Home", "back": "Back", "exit": "Home", "info": "Info",
+    "play": "Play", "pause": "Play", "stop": "Play", "rewind": "Rev",
+    "fast_forward": "Fwd",
+}
+
+
+def _roku_tag(xml, tag):
+    """Extract <tag>...</tag> text from a Roku ECP XML blob, or None."""
+    open_t, close_t = "<%s>" % tag, "</%s>" % tag
+    a = xml.find(open_t)
+    if a < 0:
+        return None
+    a += len(open_t)
+    b = xml.find(close_t, a)
+    return xml[a:b].strip() if b > a else None
+
+
+def _roku_post(host, path, timeout=4):
+    """POST an empty body to a Roku ECP path. ActionResult-shaped."""
+    start = time.monotonic()
+    url = "http://%s:%d/%s" % (host, ROKU_PORT, path)
+    try:
+        req = urllib.request.Request(url, data=b"", method="POST")
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            r.read()
+        return _webos_result(start, True, path)
+    except OSError as e:            # URLError / HTTPError are OSError subclasses
+        return _webos_result(start, False, "%s: %s" % (e.__class__.__name__, e))
+
+
+ROKU_MOCK = False
+
+
+def set_roku(mock):
+    """Prepare the Roku backend. Nothing to open (stateless HTTP)."""
+    global ROKU_MOCK
+    ROKU_MOCK = mock
+
+
+def roku_available():
+    """True in --mock, or when config named a Roku host (no pairing needed)."""
+    if ROKU_MOCK:
+        return True
+    return bool(CONFIG_ROKU and CONFIG_ROKU.get("host"))
+
+
+def real_roku(op):
+    """Dispatch a unified TV op to an ECP keypress (power on/off included)."""
+    key = _ROKU_OP_KEY.get(op)
+    if key is None:
+        return _webos_result(time.monotonic(), False, "unsupported op %s" % op)
+    return _roku_post(CONFIG_ROKU["host"], "keypress/" + key)
+
+
+def real_roku_key(k):
+    """Send one factory-remote key (PANEL_KEYS vocabulary) as an ECP keypress."""
+    key = _ROKU_KEYS.get(k)
+    if key is None:
+        return _webos_result(time.monotonic(), False, "unknown key %s" % k)
+    return _roku_post(CONFIG_ROKU["host"], "keypress/" + key)
+
+
+def real_roku_text(text):
+    """Type text via ECP Lit_ keypresses, one character at a time."""
+    host = CONFIG_ROKU["host"]
+    for ch in text:
+        r = _roku_post(host, "keypress/Lit_" + quote(ch, safe=""))
+        if not r["ok"]:
+            return r
+    return _webos_result(time.monotonic(), True, "text (%d chars)" % len(text))
+
+
+def mock_roku(op):
+    """--mock stand-in: log the op, touch no network, succeed."""
+    time.sleep(0.02)
+    print("[roku] %s" % op, flush=True)
+    return {"ok": True, "exit_code": 0, "stdout": "[mock roku] %s\n" % op,
+            "stderr": "", "duration_ms": 20}
+
+
+def roku_add(host, timeout=4):
+    """Verify a Roku answers ECP at <host> and return its friendly name (Roku
+    needs no pairing). Raises IOError when it does not respond."""
+    url = "http://%s:%d/query/device-info" % (host, ROKU_PORT)
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            xml = r.read().decode(errors="ignore")
+    except OSError as e:
+        raise IOError("Roku not reachable at %s: %s" % (host, e))
+    return (_roku_tag(xml, "user-device-name")
+            or _roku_tag(xml, "friendly-device-name")
+            or _roku_tag(xml, "default-device-name")
+            or _roku_tag(xml, "model-name") or host)
+
+
+def _roku_save(host, name):
+    """Persist the Roku config to CONFIG_PATH atomically and update CONFIG_ROKU."""
+    cfg = {"host": host, "name": name}
+    global CONFIG_ROKU
+    with CONFIG_LOCK:
+        _config_set_field("roku", cfg)
+        CONFIG_ROKU = cfg
+
+
 # ---- unified dispatch -----------------------------------------------------
 # CEC has no discrete power-off; its standby command IS the off state.
 _TV_TO_CEC = {"power_on": "power_on", "power_off": "standby",
@@ -3855,6 +3999,7 @@ def set_tv(mock):
     set_panel(mock)
     set_webos(mock)
     set_samsung(mock)
+    set_roku(mock)
     set_soft(mock)
 
 
@@ -3869,6 +4014,8 @@ def _tv_hw_backend():
         return "webos"
     if samsung_available():
         return "samsung"
+    if roku_available():
+        return "roku"
     if cec_available():
         return "cec"
     return None
@@ -3892,6 +4039,10 @@ def tv_info():
     elif hw == "samsung":
         backend, adapter = "samsung", ("Samsung Tizen (%s)" % CONFIG_SAMSUNG["host"]
                                        if CONFIG_SAMSUNG else "Samsung Tizen")
+    elif hw == "roku":
+        backend, adapter = "roku", ("Roku (%s)" % (CONFIG_ROKU.get("name")
+                                    or CONFIG_ROKU["host"]) if CONFIG_ROKU
+                                    else "Roku")
     elif hw == "cec":
         cec = cec_current()
         backend, adapter = "cec", (cec["adapter"] if cec else "CEC")
@@ -3920,10 +4071,13 @@ def tv_info():
         # Factory-remote key emulation (arrows/ok/menu/home/back/settings): the
         # RS-232 panel drives the OSD, a paired webOS TV drives its pointer/nav.
         # Either lights up the app's Remote view D-pad cluster.
-        "keys": panel_available() or webos_available() or samsung_available(),
-        # Text entry into a focused on-TV field. webOS (IME) and Samsung
-        # (SendInputString) support it; the panel and CEC have no text channel.
-        "text": webos_available() or samsung_available(),
+        "keys": (panel_available() or webos_available()
+                 or samsung_available() or roku_available()),
+        # Text entry into a focused on-TV field. webOS (IME), Samsung
+        # (SendInputString) and Roku (Lit_ keypresses) support it; the panel
+        # and CEC have no text channel.
+        "text": (webos_available() or samsung_available()
+                 or roku_available()),
         # Box mute state, so the app shows the right mute indicator on connect.
         "muted": _soft_muted() if box_vol else None,
         # Current levels (0-100 or null) so the app's volume slider can show and
@@ -3944,6 +4098,8 @@ def _send_tv_hw(op, mock):
         return mock_webos(op) if mock else real_webos(op)
     if b == "samsung":
         return mock_samsung(op) if mock else real_samsung(op)
+    if b == "roku":
+        return mock_roku(op) if mock else real_roku(op)
     if b == "cec":
         cec_op = _TV_TO_CEC[op]
         return mock_cec(cec_op) if mock else real_cec(cec_op)
@@ -6492,6 +6648,9 @@ class Handler(BaseHTTPRequestHandler):
                 elif backend == "samsung" and k in _SAMSUNG_KEYS:
                     result = (mock_samsung("key %s" % k) if self.mock
                               else real_samsung_key(k))
+                elif backend == "roku" and k in _ROKU_KEYS:
+                    result = (mock_roku("key %s" % k) if self.mock
+                              else real_roku_key(k))
                 elif backend == "panel" and k in PANEL_KEYS:
                     result = ({"ok": True, "exit_code": 0,
                                "stdout": "[mock panel] key %s" % k,
@@ -6507,7 +6666,12 @@ class Handler(BaseHTTPRequestHandler):
             # IME). Body {"text": "..."}; webOS-only (tv_info.text gates it).
             if path == "/api/tv/text":
                 backend = _tv_hw_backend()
-                if backend not in ("webos", "samsung"):
+                _TEXT_FNS = {
+                    "webos": (mock_webos, real_webos_text),
+                    "samsung": (mock_samsung, real_samsung_text),
+                    "roku": (mock_roku, real_roku_text),
+                }
+                if backend not in _TEXT_FNS:
                     self._send(404, {"error": "no text backend"}, started)
                     return
                 try:
@@ -6518,13 +6682,8 @@ class Handler(BaseHTTPRequestHandler):
                 except (ValueError, TypeError, KeyError, UnicodeDecodeError):
                     self._send(400, {"error": "text must be a string"}, started)
                     return
-                if self.mock:
-                    result = mock_webos("text") if backend == "webos" \
-                        else mock_samsung("text")
-                elif backend == "webos":
-                    result = real_webos_text(text)
-                else:
-                    result = real_samsung_text(text)
+                mock_fn, real_fn = _TEXT_FNS[backend]
+                result = mock_fn("text") if self.mock else real_fn(text)
                 self._send(200, result, started)
                 return
 
@@ -6604,6 +6763,42 @@ class Handler(BaseHTTPRequestHandler):
                 set_caps(False)
                 self._send(200, {"ok": True, "paired": True,
                                  "backend": "samsung", "host": host}, started)
+                return
+
+            # POST /api/tv/roku/add: register a Roku by host. Body {"host":
+            # "<ip>"}. Roku needs no pairing — we just verify it answers ECP,
+            # capture its friendly name, and persist. Returns the name.
+            if path == "/api/tv/roku/add":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    host = req["host"]
+                    if not isinstance(host, str) or not host:
+                        raise ValueError("host required")
+                except (ValueError, TypeError, KeyError, UnicodeDecodeError):
+                    self._send(400, {"error": "host (string) required"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "added": True, "backend": "roku",
+                                     "host": host, "name": "Mock Roku"}, started)
+                    return
+                try:
+                    name = roku_add(host)
+                except (IOError, OSError) as e:
+                    self._send(502, {"ok": False,
+                                     "error": "not a reachable Roku: %s" % e},
+                               started)
+                    return
+                try:
+                    _roku_save(host, name)
+                except OSError as e:
+                    self._send(500, {"ok": False,
+                                     "error": "could not persist config: %s" % e},
+                               started)
+                    return
+                set_roku(False)
+                set_caps(False)
+                self._send(200, {"ok": True, "added": True, "backend": "roku",
+                                 "host": host, "name": name}, started)
                 return
 
             # POST /api/tv/source/<id>: switch the display input (panel only).

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "38",
+      "buildNumber": "39",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 23
+      "versionCode": 24
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.6",
+    "version": "2.9.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "37",
+      "buildNumber": "38",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 22
+      "versionCode": 23
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -21,6 +21,7 @@ import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
+import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, ApiError } from '@/lib/api';
@@ -439,6 +440,10 @@ function BoxEditPanel({
           <StepRow label="2 · /api/status (Bearer token)" step={authStep} />
         </View>
       )}
+
+      <View style={styles.smartTvWrap}>
+        <SmartTvSetup settings={box} />
+      </View>
 
       <View style={styles.editFooter}>
         {box.lastIp != null && (
@@ -1459,6 +1464,7 @@ const styles = StyleSheet.create({
     paddingTop: 14,
   },
   editSteps: { marginTop: 14 },
+  smartTvWrap: { marginTop: 14 },
   editError: {
     color: theme.red,
     fontSize: 12,

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -1,0 +1,214 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
+import { normalizeMac } from '@/lib/settings';
+import { theme } from '@/lib/theme';
+
+type Brand = 'webos' | 'samsung' | 'roku';
+
+const BRANDS: { id: Brand; label: string; needsMac: boolean; verb: string }[] = [
+  { id: 'webos', label: 'LG webOS', needsMac: true, verb: 'Pair' },
+  { id: 'samsung', label: 'Samsung', needsMac: true, verb: 'Pair' },
+  { id: 'roku', label: 'Roku', needsMac: false, verb: 'Add' },
+];
+
+const NETWORK_BACKENDS = ['webos', 'samsung', 'roku'];
+
+/**
+ * Pair a networked smart TV (LG webOS / Samsung Tizen / Roku) to the box so the
+ * Pad tab's D-pad + text entry drive it. webOS/Samsung show an accept prompt on
+ * the TV and persist a key/token; Roku needs no pairing. The box's agent owns
+ * the connection — the phone only kicks off pairing over the LAN.
+ */
+export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
+  const [brand, setBrand] = useState<Brand>('webos');
+  const [host, setHost] = useState('');
+  const [mac, setMac] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
+  const active =
+    tvPoll.data?.available && NETWORK_BACKENDS.includes(tvPoll.data.backend)
+      ? tvPoll.data
+      : null;
+  const meta = BRANDS.find((b) => b.id === brand)!;
+
+  const submit = useCallback(async () => {
+    const h = host.trim();
+    if (!h) {
+      setMsg({ ok: false, text: 'Enter the TV’s IP address.' });
+      return;
+    }
+    setBusy(true);
+    setMsg({
+      ok: true,
+      text:
+        brand === 'roku'
+          ? 'Contacting the Roku…'
+          : 'Waiting for you to accept the prompt on the TV…',
+    });
+    try {
+      const m = meta.needsMac && mac.trim() ? normalizeMac(mac.trim()) ?? undefined : undefined;
+      let r: TvPairResult;
+      if (brand === 'webos') r = await api.tvPairWebos(settings, h, m);
+      else if (brand === 'samsung') r = await api.tvPairSamsung(settings, h, m);
+      else r = await api.tvAddRoku(settings, h);
+      if (r.ok) {
+        setMsg({
+          ok: true,
+          text: r.name ? `Connected: ${r.name}` : `Connected to ${meta.label}.`,
+        });
+        setHost('');
+        setMac('');
+      } else {
+        setMsg({ ok: false, text: r.error ?? 'Could not connect to the TV.' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Could not reach the box or TV. Check the IP and try again.' });
+    } finally {
+      setBusy(false);
+    }
+  }, [brand, host, mac, meta, settings]);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Smart TV remote</Text>
+      <Text style={styles.sub}>
+        Control a networked TV — LG webOS, Samsung, or Roku — from the Pad tab. The
+        D-pad and on-screen keyboard light up once it’s connected.
+      </Text>
+
+      {active ? (
+        <View style={styles.activeRow}>
+          <Ionicons name="tv" size={16} color={theme.green} />
+          <Text style={styles.activeText}>Connected: {active.adapter}</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.segment}>
+        {BRANDS.map((b) => (
+          <Pressable
+            key={b.id}
+            onPress={() => {
+              setBrand(b.id);
+              setMsg(null);
+            }}
+            style={[styles.seg, brand === b.id && styles.segOn]}>
+            <Text style={[styles.segText, brand === b.id && styles.segTextOn]}>{b.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <TextInput
+        value={host}
+        onChangeText={setHost}
+        placeholder="TV IP address (e.g. 192.168.1.50)"
+        placeholderTextColor={theme.textFaint}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="numbers-and-punctuation"
+        editable={!busy}
+        style={styles.input}
+      />
+      {meta.needsMac ? (
+        <TextInput
+          value={mac}
+          onChangeText={setMac}
+          placeholder="MAC for power-on (optional)"
+          placeholderTextColor={theme.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!busy}
+          style={styles.input}
+        />
+      ) : null}
+
+      <Pressable onPress={submit} disabled={busy} style={[styles.button, busy && styles.buttonBusy]}>
+        {busy ? (
+          <ActivityIndicator color={theme.bg} />
+        ) : (
+          <Text style={styles.buttonText}>
+            {meta.verb} {meta.label}
+          </Text>
+        )}
+      </Pressable>
+
+      {msg ? (
+        <Text style={[styles.msg, { color: msg.ok ? theme.textDim : theme.red }]}>{msg.text}</Text>
+      ) : null}
+
+      <Text style={styles.hint}>
+        {brand === 'roku'
+          ? 'No pairing needed — just make sure the Roku is on and on this network.'
+          : `Your ${meta.label} TV must be on. An accept prompt appears on the TV — say yes. The MAC is optional and lets the box wake the TV over the network.`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 16,
+    gap: 10,
+  },
+  title: { color: theme.text, fontSize: 16, fontWeight: '700' },
+  sub: { color: theme.textDim, fontSize: 13, lineHeight: 18 },
+  activeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  activeText: { color: theme.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
+  segment: {
+    flexDirection: 'row',
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    padding: 3,
+    gap: 3,
+  },
+  seg: { flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center' },
+  segOn: { backgroundColor: theme.blue },
+  segText: { color: theme.textDim, fontSize: 13, fontWeight: '600' },
+  segTextOn: { color: theme.bg },
+  input: {
+    backgroundColor: theme.inset,
+    borderColor: theme.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: theme.text,
+    fontSize: 14,
+  },
+  button: {
+    backgroundColor: theme.green,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+  },
+  buttonBusy: { opacity: 0.7 },
+  buttonText: { color: theme.bg, fontSize: 15, fontWeight: '700' },
+  msg: { fontSize: 13, lineHeight: 18 },
+  hint: { color: theme.textFaint, fontSize: 12, lineHeight: 16 },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -332,7 +332,13 @@ export type LaunchResult = {
  * and "cec" (HDMI-CEC) drive the TV; "soft" (agent >= 2.6) drives the box's own
  * audio sink and does volume/mute only, with no power.
  */
-export type TvBackend = 'panel' | 'cec' | 'soft';
+export type TvBackend =
+  | 'panel'
+  | 'cec'
+  | 'soft'
+  | 'webos'
+  | 'samsung'
+  | 'roku';
 
 /** TV-control probe result. The route 404s when no backend is available. */
 export type Tv = {
@@ -374,10 +380,17 @@ export type Tv = {
    */
   sources?: { id: string; label: string }[];
   /**
-   * Factory-remote key emulation over RS-232 (agent >= 2.7.0): arrows / ok /
-   * menu / home / back / settings via POST /api/tv/key/<k>. Panel only.
+   * Factory-remote / nav key emulation via POST /api/tv/key/<k> (agent >=
+   * 2.7.0 for the RS-232 panel; agent >= 2.9.7 also for the network smart-TV
+   * backends webOS/Samsung/Roku): arrows / ok / menu / home / back.
    */
   keys?: boolean;
+  /**
+   * Text entry into a focused on-TV field via POST /api/tv/text (agent >=
+   * 2.9.7). Set by the network smart-TV backends (webOS IME, Samsung
+   * SendInputString, Roku Lit_ keys); never by panel/CEC.
+   */
+  text?: boolean;
   /** Current box OS volume 0-100 (agent >= 2.7.0), or null when unreadable. */
   box_volume_level?: number | null;
   /**
@@ -407,6 +420,20 @@ export type VolumeTarget = 'box' | 'tv';
 
 /** The unified TV ops the agent accepts at POST /api/tv/<op>. */
 export type TvOp = 'power_on' | 'power_off' | 'volume_up' | 'volume_down' | 'mute';
+
+/**
+ * Result of a smart-TV pair/add call (webOS/Samsung pair, Roku add). `ok` is
+ * false with a human `error` when the TV rejected or was unreachable.
+ */
+export type TvPairResult = {
+  ok: boolean;
+  paired?: boolean;
+  added?: boolean;
+  backend?: TvBackend;
+  host?: string;
+  name?: string;
+  error?: string;
+};
 
 // ---------- Errors ----------
 
@@ -977,11 +1004,70 @@ export const api = {
     });
   },
 
-  /** Send one factory-remote key to the panel (RS-232 only; see Tv.keys). */
+  /** Send one factory-remote / nav key to the active backend (see Tv.keys). */
   tvKey(settings: ConnSettings, key: TvKey): Promise<ActionResult> {
     return request<ActionResult>(settings, `/api/tv/key/${key}`, {
       method: 'POST',
       timeoutMs: 12000,
+    });
+  },
+
+  /**
+   * Type text into a focused on-TV field (network smart-TV backends only; gated
+   * behind Tv.text). Routed to the active backend's text channel (webOS IME /
+   * Samsung SendInputString / Roku Lit_ keys).
+   */
+  tvText(settings: ConnSettings, text: string): Promise<ActionResult> {
+    return request<ActionResult>(settings, '/api/tv/text', {
+      method: 'POST',
+      timeoutMs: 12000,
+      body: { text },
+    });
+  },
+
+  /**
+   * Pair with an LG webOS TV. The TV shows an Accept prompt; the agent blocks
+   * until the user accepts (or ~60 s), then persists the granted key so later
+   * connects are silent. `mac` (optional) enables Wake-on-LAN power-on. The
+   * long timeout matches the on-TV accept wait.
+   */
+  tvPairWebos(
+    settings: ConnSettings,
+    host: string,
+    mac?: string,
+  ): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/webos/pair', {
+      method: 'POST',
+      timeoutMs: 70000,
+      body: mac ? { host, mac } : { host },
+    });
+  },
+
+  /**
+   * Pair with a Samsung Tizen TV. The TV shows an Allow prompt; on accept the
+   * agent persists the granted token. `mac` (optional) enables Wake-on-LAN.
+   */
+  tvPairSamsung(
+    settings: ConnSettings,
+    host: string,
+    mac?: string,
+  ): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/samsung/pair', {
+      method: 'POST',
+      timeoutMs: 70000,
+      body: mac ? { host, mac } : { host },
+    });
+  },
+
+  /**
+   * Register a Roku by host. Roku needs no pairing — the agent just verifies it
+   * answers ECP, captures its friendly name, and persists it.
+   */
+  tvAddRoku(settings: ConnSettings, host: string): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/roku/add', {
+      method: 'POST',
+      timeoutMs: 12000,
+      body: { host },
     });
   },
 


### PR DESCRIPTION
## Smart TV control — 4/4: app pairing UI + TV API (mobile)

Stacked on the Roku PR. Wires the phone app to the three new network smart-TV backends. **Requires a new mobile app build to ship** (agent-side backends ship via the agent update path independently).

- `api.ts`: `TvBackend` +webos/samsung/roku; `Tv.text` capability flag; `TvPairResult` + `api.tvText` / `tvPairWebos` / `tvPairSamsung` / `tvAddRoku` (pair calls use a long timeout for the on-TV accept wait).
- `components/SmartTvSetup.tsx`: a self-contained pairing card — brand picker + IP + optional MAC — that kicks off pairing over the LAN and reports status; surfaces the currently-connected TV via `/api/tv`.
- `setup.tsx`: mounts `SmartTvSetup` inside each box's editor (the box's agent owns the TV connection).

The Pad tab's D-pad already lights up for these backends via the existing `Tv.keys` gate — no RemoteView change needed. **Typecheck clean** (`tsc --noEmit`). Not yet rendered in a simulator; text-entry UI in the Pad remains a follow-up.

Base on the Roku PR; merge last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
