### PR TITLE
feat(app): smart-TV pairing UI + tv text/pair API (webOS/Samsung/Roku)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "38",
+      "buildNumber": "39",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 23
+      "versionCode": 24
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.8.6",
+    "version": "2.9.0",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "37",
+      "buildNumber": "38",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 22
+      "versionCode": 23
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -21,6 +21,7 @@ import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
+import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, ApiError } from '@/lib/api';
@@ -439,6 +440,10 @@ function BoxEditPanel({
           <StepRow label="2 · /api/status (Bearer token)" step={authStep} />
         </View>
       )}
+
+      <View style={styles.smartTvWrap}>
+        <SmartTvSetup settings={box} />
+      </View>
 
       <View style={styles.editFooter}>
         {box.lastIp != null && (
@@ -1459,6 +1464,7 @@ const styles = StyleSheet.create({
     paddingTop: 14,
   },
   editSteps: { marginTop: 14 },
+  smartTvWrap: { marginTop: 14 },
   editError: {
     color: theme.red,
     fontSize: 12,

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -1,0 +1,214 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
+import { normalizeMac } from '@/lib/settings';
+import { theme } from '@/lib/theme';
+
+type Brand = 'webos' | 'samsung' | 'roku';
+
+const BRANDS: { id: Brand; label: string; needsMac: boolean; verb: string }[] = [
+  { id: 'webos', label: 'LG webOS', needsMac: true, verb: 'Pair' },
+  { id: 'samsung', label: 'Samsung', needsMac: true, verb: 'Pair' },
+  { id: 'roku', label: 'Roku', needsMac: false, verb: 'Add' },
+];
+
+const NETWORK_BACKENDS = ['webos', 'samsung', 'roku'];
+
+/**
+ * Pair a networked smart TV (LG webOS / Samsung Tizen / Roku) to the box so the
+ * Pad tab's D-pad + text entry drive it. webOS/Samsung show an accept prompt on
+ * the TV and persist a key/token; Roku needs no pairing. The box's agent owns
+ * the connection — the phone only kicks off pairing over the LAN.
+ */
+export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
+  const [brand, setBrand] = useState<Brand>('webos');
+  const [host, setHost] = useState('');
+  const [mac, setMac] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
+  const active =
+    tvPoll.data?.available && NETWORK_BACKENDS.includes(tvPoll.data.backend)
+      ? tvPoll.data
+      : null;
+  const meta = BRANDS.find((b) => b.id === brand)!;
+
+  const submit = useCallback(async () => {
+    const h = host.trim();
+    if (!h) {
+      setMsg({ ok: false, text: 'Enter the TV’s IP address.' });
+      return;
+    }
+    setBusy(true);
+    setMsg({
+      ok: true,
+      text:
+        brand === 'roku'
+          ? 'Contacting the Roku…'
+          : 'Waiting for you to accept the prompt on the TV…',
+    });
+    try {
+      const m = meta.needsMac && mac.trim() ? normalizeMac(mac.trim()) ?? undefined : undefined;
+      let r: TvPairResult;
+      if (brand === 'webos') r = await api.tvPairWebos(settings, h, m);
+      else if (brand === 'samsung') r = await api.tvPairSamsung(settings, h, m);
+      else r = await api.tvAddRoku(settings, h);
+      if (r.ok) {
+        setMsg({
+          ok: true,
+          text: r.name ? `Connected: ${r.name}` : `Connected to ${meta.label}.`,
+        });
+        setHost('');
+        setMac('');
+      } else {
+        setMsg({ ok: false, text: r.error ?? 'Could not connect to the TV.' });
+      }
+    } catch {
+      setMsg({ ok: false, text: 'Could not reach the box or TV. Check the IP and try again.' });
+    } finally {
+      setBusy(false);
+    }
+  }, [brand, host, mac, meta, settings]);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>Smart TV remote</Text>
+      <Text style={styles.sub}>
+        Control a networked TV — LG webOS, Samsung, or Roku — from the Pad tab. The
+        D-pad and on-screen keyboard light up once it’s connected.
+      </Text>
+
+      {active ? (
+        <View style={styles.activeRow}>
+          <Ionicons name="tv" size={16} color={theme.green} />
+          <Text style={styles.activeText}>Connected: {active.adapter}</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.segment}>
+        {BRANDS.map((b) => (
+          <Pressable
+            key={b.id}
+            onPress={() => {
+              setBrand(b.id);
+              setMsg(null);
+            }}
+            style={[styles.seg, brand === b.id && styles.segOn]}>
+            <Text style={[styles.segText, brand === b.id && styles.segTextOn]}>{b.label}</Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <TextInput
+        value={host}
+        onChangeText={setHost}
+        placeholder="TV IP address (e.g. 192.168.1.50)"
+        placeholderTextColor={theme.textFaint}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="numbers-and-punctuation"
+        editable={!busy}
+        style={styles.input}
+      />
+      {meta.needsMac ? (
+        <TextInput
+          value={mac}
+          onChangeText={setMac}
+          placeholder="MAC for power-on (optional)"
+          placeholderTextColor={theme.textFaint}
+          autoCapitalize="none"
+          autoCorrect={false}
+          editable={!busy}
+          style={styles.input}
+        />
+      ) : null}
+
+      <Pressable onPress={submit} disabled={busy} style={[styles.button, busy && styles.buttonBusy]}>
+        {busy ? (
+          <ActivityIndicator color={theme.bg} />
+        ) : (
+          <Text style={styles.buttonText}>
+            {meta.verb} {meta.label}
+          </Text>
+        )}
+      </Pressable>
+
+      {msg ? (
+        <Text style={[styles.msg, { color: msg.ok ? theme.textDim : theme.red }]}>{msg.text}</Text>
+      ) : null}
+
+      <Text style={styles.hint}>
+        {brand === 'roku'
+          ? 'No pairing needed — just make sure the Roku is on and on this network.'
+          : `Your ${meta.label} TV must be on. An accept prompt appears on the TV — say yes. The MAC is optional and lets the box wake the TV over the network.`}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: theme.card,
+    borderColor: theme.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 16,
+    gap: 10,
+  },
+  title: { color: theme.text, fontSize: 16, fontWeight: '700' },
+  sub: { color: theme.textDim, fontSize: 13, lineHeight: 18 },
+  activeRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  activeText: { color: theme.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
+  segment: {
+    flexDirection: 'row',
+    backgroundColor: theme.inset,
+    borderRadius: 10,
+    padding: 3,
+    gap: 3,
+  },
+  seg: { flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center' },
+  segOn: { backgroundColor: theme.blue },
+  segText: { color: theme.textDim, fontSize: 13, fontWeight: '600' },
+  segTextOn: { color: theme.bg },
+  input: {
+    backgroundColor: theme.inset,
+    borderColor: theme.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: theme.text,
+    fontSize: 14,
+  },
+  button: {
+    backgroundColor: theme.green,
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+  },
+  buttonBusy: { opacity: 0.7 },
+  buttonText: { color: theme.bg, fontSize: 15, fontWeight: '700' },
+  msg: { fontSize: 13, lineHeight: 18 },
+  hint: { color: theme.textFaint, fontSize: 12, lineHeight: 16 },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -332,7 +332,13 @@ export type LaunchResult = {
  * and "cec" (HDMI-CEC) drive the TV; "soft" (agent >= 2.6) drives the box's own
  * audio sink and does volume/mute only, with no power.
  */
-export type TvBackend = 'panel' | 'cec' | 'soft';
+export type TvBackend =
+  | 'panel'
+  | 'cec'
+  | 'soft'
+  | 'webos'
+  | 'samsung'
+  | 'roku';
 
 /** TV-control probe result. The route 404s when no backend is available. */
 export type Tv = {
@@ -374,10 +380,17 @@ export type Tv = {
    */
   sources?: { id: string; label: string }[];
   /**
-   * Factory-remote key emulation over RS-232 (agent >= 2.7.0): arrows / ok /
-   * menu / home / back / settings via POST /api/tv/key/<k>. Panel only.
+   * Factory-remote / nav key emulation via POST /api/tv/key/<k> (agent >=
+   * 2.7.0 for the RS-232 panel; agent >= 2.9.7 also for the network smart-TV
+   * backends webOS/Samsung/Roku): arrows / ok / menu / home / back.
    */
   keys?: boolean;
+  /**
+   * Text entry into a focused on-TV field via POST /api/tv/text (agent >=
+   * 2.9.7). Set by the network smart-TV backends (webOS IME, Samsung
+   * SendInputString, Roku Lit_ keys); never by panel/CEC.
+   */
+  text?: boolean;
   /** Current box OS volume 0-100 (agent >= 2.7.0), or null when unreadable. */
   box_volume_level?: number | null;
   /**
@@ -407,6 +420,20 @@ export type VolumeTarget = 'box' | 'tv';
 
 /** The unified TV ops the agent accepts at POST /api/tv/<op>. */
 export type TvOp = 'power_on' | 'power_off' | 'volume_up' | 'volume_down' | 'mute';
+
+/**
+ * Result of a smart-TV pair/add call (webOS/Samsung pair, Roku add). `ok` is
+ * false with a human `error` when the TV rejected or was unreachable.
+ */
+export type TvPairResult = {
+  ok: boolean;
+  paired?: boolean;
+  added?: boolean;
+  backend?: TvBackend;
+  host?: string;
+  name?: string;
+  error?: string;
+};
 
 // ---------- Errors ----------
 
@@ -977,11 +1004,70 @@ export const api = {
     });
   },
 
-  /** Send one factory-remote key to the panel (RS-232 only; see Tv.keys). */
+  /** Send one factory-remote / nav key to the active backend (see Tv.keys). */
   tvKey(settings: ConnSettings, key: TvKey): Promise<ActionResult> {
     return request<ActionResult>(settings, `/api/tv/key/${key}`, {
       method: 'POST',
       timeoutMs: 12000,
+    });
+  },
+
+  /**
+   * Type text into a focused on-TV field (network smart-TV backends only; gated
+   * behind Tv.text). Routed to the active backend's text channel (webOS IME /
+   * Samsung SendInputString / Roku Lit_ keys).
+   */
+  tvText(settings: ConnSettings, text: string): Promise<ActionResult> {
+    return request<ActionResult>(settings, '/api/tv/text', {
+      method: 'POST',
+      timeoutMs: 12000,
+      body: { text },
+    });
+  },
+
+  /**
+   * Pair with an LG webOS TV. The TV shows an Accept prompt; the agent blocks
+   * until the user accepts (or ~60 s), then persists the granted key so later
+   * connects are silent. `mac` (optional) enables Wake-on-LAN power-on. The
+   * long timeout matches the on-TV accept wait.
+   */
+  tvPairWebos(
+    settings: ConnSettings,
+    host: string,
+    mac?: string,
+  ): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/webos/pair', {
+      method: 'POST',
+      timeoutMs: 70000,
+      body: mac ? { host, mac } : { host },
+    });
+  },
+
+  /**
+   * Pair with a Samsung Tizen TV. The TV shows an Allow prompt; on accept the
+   * agent persists the granted token. `mac` (optional) enables Wake-on-LAN.
+   */
+  tvPairSamsung(
+    settings: ConnSettings,
+    host: string,
+    mac?: string,
+  ): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/samsung/pair', {
+      method: 'POST',
+      timeoutMs: 70000,
+      body: mac ? { host, mac } : { host },
+    });
+  },
+
+  /**
+   * Register a Roku by host. Roku needs no pairing — the agent just verifies it
+   * answers ECP, captures its friendly name, and persists it.
+   */
+  tvAddRoku(settings: ConnSettings, host: string): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/roku/add', {
+      method: 'POST',
+      timeoutMs: 12000,
+      body: { host },
     });
   },
 


### PR DESCRIPTION
App pairing UI + api layer for the network smart-TV backends. Replaces closed #61 (stacked base deleted). Rebased onto main. Shipped to both stores as 2.9.0. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)