### PR TITLE
feat(theme): light/dark + accent theming (System/Light/Dark + accent picker)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -7,7 +7,7 @@
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
-    "userInterfaceStyle": "dark",
+    "userInterfaceStyle": "automatic",
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 
 import { hapticSelection } from '@/lib/haptics';
 import { useBoxes } from '@/lib/SettingsContext';
-import { theme } from '@/lib/theme';
+import { useTheme } from '@/lib/theme';
 
 // Default screen = the swipe Remote (Pad). First-run (empty fleet) is redirected
 // to Setup below so the user pairs a box before landing on the remote.
@@ -13,6 +13,7 @@ export const unstable_settings = {
 };
 
 export default function TabLayout() {
+  const t = useTheme();
   const { boxes, activeBox, ready } = useBoxes();
   const segments = useSegments();
 
@@ -50,13 +51,13 @@ export default function TabLayout() {
       screenListeners={{ tabPress: () => hapticSelection() }}
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: theme.blue,
-        tabBarInactiveTintColor: theme.textFaint,
+        tabBarActiveTintColor: t.blue,
+        tabBarInactiveTintColor: t.textFaint,
         tabBarStyle: {
-          backgroundColor: theme.tabBar,
-          borderTopColor: theme.tabBarBorder,
+          backgroundColor: t.tabBar,
+          borderTopColor: t.tabBarBorder,
         },
-        sceneStyle: { backgroundColor: theme.bg },
+        sceneStyle: { backgroundColor: t.bg },
       }}>
       <Tabs.Screen
         name="index"

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Alert,
   Platform,
@@ -16,15 +16,9 @@ import { usePoll } from '@/hooks/usePoll';
 import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
 import { hapticError, hapticHeavy, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, numeric, theme } from '@/lib/theme';
+import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const DANGER_ORDER: Danger[] = ['low', 'medium', 'high'];
-
-const DANGER_COLOR: Record<Danger, string> = {
-  low: theme.slate,
-  medium: theme.amber,
-  high: theme.red,
-};
 
 /** Confirm helper that also works on web (Alert buttons are no-ops on web). */
 function confirm(title: string, message: string, onConfirm: () => void) {
@@ -58,8 +52,15 @@ export default function ActionsTab() {
 }
 
 function ActionsScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const [run, setRun] = useState<RunRecord | null>(null);
+
+  const DANGER_COLOR = useMemo<Record<Danger, string>>(
+    () => ({ low: t.slate, medium: t.amber, high: t.red }),
+    [t],
+  );
 
   // No host yet (fresh install): don't poll, and show the pairing hint instead
   // of a red "Box unreachable" banner retrying every 2s against http://:8787.
@@ -188,7 +189,7 @@ function ActionsScreen() {
               <Text
                 style={[
                   styles.resultExit,
-                  { color: run.result.ok ? theme.green : theme.red },
+                  { color: run.result.ok ? t.green : t.red },
                 ]}>
                 exit {run.result.exit_code} · {run.result.duration_ms}ms ·{' '}
                 {run.result.ok ? 'OK' : 'FAILED'}
@@ -198,7 +199,7 @@ function ActionsScreen() {
                   <Text style={styles.resultOut}>{run.result.stdout}</Text>
                 ) : null}
                 {run.result.stderr ? (
-                  <Text style={[styles.resultOut, { color: theme.red }]}>
+                  <Text style={[styles.resultOut, { color: t.red }]}>
                     {run.result.stderr}
                   </Text>
                 ) : null}
@@ -214,43 +215,43 @@ function ActionsScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: theme.bg, paddingHorizontal: 14 },
-  title: { color: theme.text, fontSize: 26, fontWeight: '700', marginBottom: 12, fontFamily: mono },
+const makeStyles = (t: Palette) => StyleSheet.create({
+  screen: { flex: 1, backgroundColor: t.bg, paddingHorizontal: 14 },
+  title: { color: t.text, fontSize: 26, fontWeight: '700', marginBottom: 12, fontFamily: mono },
   list: { flex: 1 },
   group: { marginBottom: 16 },
   groupTitle: { fontSize: 11, fontWeight: '800', letterSpacing: 1.5, marginBottom: 8 },
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 8,
   },
   cardHead: { flexDirection: 'row', alignItems: 'center', marginBottom: 4 },
-  cardLabel: { color: theme.text, fontSize: 16, fontWeight: '700', flex: 1 },
+  cardLabel: { color: t.text, fontSize: 16, fontWeight: '700', flex: 1 },
   badge: {
     borderRadius: 6,
     paddingHorizontal: 8,
     paddingVertical: 3,
   },
   badgeText: { color: '#0b1220', fontSize: 11, fontWeight: '800' },
-  cardDesc: { color: theme.textDim, fontSize: 13, lineHeight: 18 },
+  cardDesc: { color: t.textDim, fontSize: 13, lineHeight: 18 },
   pressed: { opacity: 0.7 },
   emptyCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
   },
-  emptyTitle: { color: theme.text, fontSize: 16, fontWeight: '700', marginBottom: 6 },
-  emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+  emptyTitle: { color: t.text, fontSize: 16, fontWeight: '700', marginBottom: 6 },
+  emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19 },
   errBox: {
-    backgroundColor: theme.redDeep,
-    borderColor: theme.red,
+    backgroundColor: t.redDeep,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
@@ -259,17 +260,17 @@ const styles = StyleSheet.create({
   },
   errText: { color: '#fecaca', fontSize: 13, marginBottom: 8 },
   retryBtn: {
-    backgroundColor: theme.red,
+    backgroundColor: t.red,
     paddingVertical: 10,
     paddingHorizontal: 28,
     borderRadius: 8,
   },
   retryText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
-  dim: { color: theme.textDim, fontSize: 13 },
-  dimMono: { color: theme.textFaint, fontSize: 12, fontFamily: mono },
+  dim: { color: t.textDim, fontSize: 13 },
+  dimMono: { color: t.textFaint, fontSize: 12, fontFamily: mono },
   resultPanel: {
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 12,
@@ -277,10 +278,10 @@ const styles = StyleSheet.create({
     maxHeight: 240,
   },
   resultHead: { flexDirection: 'row', alignItems: 'center', marginBottom: 4 },
-  resultTitle: { color: theme.text, fontSize: 14, fontWeight: '700', flex: 1 },
-  resultClose: { color: theme.textDim, fontSize: 16, padding: 4 },
+  resultTitle: { color: t.text, fontSize: 14, fontWeight: '700', flex: 1 },
+  resultClose: { color: t.textDim, fontSize: 16, padding: 4 },
   resultExit: { fontSize: 12, marginBottom: 6, ...numeric },
-  resultErr: { color: theme.red, fontSize: 13, fontFamily: mono },
+  resultErr: { color: t.red, fontSize: 13, fontFamily: mono },
   resultScroll: { maxHeight: 150 },
-  resultOut: { color: theme.textDim, fontSize: 12, fontFamily: mono, lineHeight: 17 },
+  resultOut: { color: t.textDim, fontSize: 12, fontFamily: mono, lineHeight: 17 },
 });

--- a/app/app/(tabs)/fleet.tsx
+++ b/app/app/(tabs)/fleet.tsx
@@ -11,7 +11,8 @@ import { api, Status } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { Box } from '@/lib/settings';
 import { useBoxes } from '@/lib/SettingsContext';
-import { mono, numeric, pctColor, tempColor, theme } from '@/lib/theme';
+import { mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 /** One box's latest fleet snapshot. */
 type FleetEntry = {
@@ -144,6 +145,8 @@ function Tile({ box, entry, active, onPress }: {
   active: boolean;
   onPress: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const s = entry?.status ?? null;
   const up = entry != null && entry.error == null && s != null;
   const memPct = s ? Math.round((s.mem.used_mb / s.mem.total_mb) * 100) : 0;
@@ -158,7 +161,7 @@ function Tile({ box, entry, active, onPress }: {
         pressed && styles.pressed,
       ]}>
       <View style={styles.tileHeader}>
-        <View style={[styles.dot, { backgroundColor: up ? theme.green : theme.red }]} />
+        <View style={[styles.dot, { backgroundColor: up ? t.green : t.red }]} />
         <Text style={styles.tileName} numberOfLines={1}>
           {s?.hostname ?? box.name}
         </Text>
@@ -173,24 +176,24 @@ function Tile({ box, entry, active, onPress }: {
           <View style={styles.metricsRow}>
             <View style={styles.metric}>
               <Text style={styles.metricLabel}>TEMP</Text>
-              <Text style={[styles.metricValue, { color: tempColor(s.cpu_temp_c) }]}>
+              <Text style={[styles.metricValue, { color: tempColor(s.cpu_temp_c, t) }]}>
                 {s.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}°` : '—'}
               </Text>
             </View>
             <View style={styles.metric}>
               <Text style={styles.metricLabel}>LOAD</Text>
-              <Text style={[styles.metricValue, { color: theme.text }]}>
+              <Text style={[styles.metricValue, { color: t.text }]}>
                 {s.load[0].toFixed(2)}
               </Text>
             </View>
             <View style={styles.metric}>
               <Text style={styles.metricLabel}>MEM</Text>
-              <Text style={[styles.metricValue, { color: pctColor(memPct) }]}>{memPct}%</Text>
+              <Text style={[styles.metricValue, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
             </View>
           </View>
           {/* Load trend, indented to align with the metrics row. */}
           <View style={styles.sparkWrap}>
-            <Sparkline values={s.history?.load} color={theme.blue} height={16} />
+            <Sparkline values={s.history?.load} color={t.blue} height={16} />
           </View>
         </>
       ) : (
@@ -217,6 +220,7 @@ function FleetScreen() {
   const { boxes, activeBoxId, switchBox } = useBoxes();
   const statusInterval = usePref('statusIntervalMs');
   const fleet = useFleetStatus(boxes, statusInterval);
+  const styles = useThemedStyles(makeStyles);
 
   return (
     <ScrollView
@@ -241,43 +245,43 @@ function FleetScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   scroll: { flex: 1 },
   sectionTitle: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 11,
     letterSpacing: 1.5,
     marginBottom: 10,
   },
   tile: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 10,
   },
-  tileActive: { borderColor: theme.blue },
-  tileDown: { borderColor: theme.redDeep },
+  tileActive: { borderColor: t.blue },
+  tileDown: { borderColor: t.redDeep },
   pressed: { opacity: 0.7 },
   tileHeader: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   dot: { width: 9, height: 9, borderRadius: 5 },
   tileName: {
-    color: theme.text,
+    color: t.text,
     fontFamily: mono,
     fontSize: 16,
     fontWeight: '700',
     flexShrink: 1,
   },
   activeTag: {
-    color: theme.blue,
+    color: t.blue,
     fontFamily: mono,
     fontSize: 11,
     marginLeft: 'auto',
   },
   tileHost: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 11,
     marginTop: 2,
@@ -287,14 +291,14 @@ const styles = StyleSheet.create({
   sparkWrap: { marginLeft: 17 },
   metric: {},
   metricLabel: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 9,
     letterSpacing: 1,
   },
   metricValue: { ...numeric, fontSize: 18, fontWeight: '700', marginTop: 2 },
   downText: {
-    color: theme.red,
+    color: t.red,
     fontFamily: mono,
     fontSize: 11,
     marginTop: 10,

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -12,9 +12,11 @@ import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { noteBoxReachable } from '@/lib/review';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, numeric, pctColor, tempColor, theme } from '@/lib/theme';
+import { mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 function Bar({ pct, color }: { pct: number; color: string }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.barTrack}>
       <View
@@ -28,6 +30,7 @@ function Bar({ pct, color }: { pct: number; color: string }) {
 }
 
 function Card({ title, children }: { title: string; children: React.ReactNode }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.card}>
       <Text style={styles.cardTitle}>{title}</Text>
@@ -36,14 +39,16 @@ function Card({ title, children }: { title: string; children: React.ReactNode })
   );
 }
 
-function unitColor(active: string): string {
-  if (active === 'active') return theme.green;
-  if (active === 'failed') return theme.red;
-  return theme.amber;
+function unitColor(active: string, t: Palette): string {
+  if (active === 'active') return t.green;
+  if (active === 'failed') return t.red;
+  return t.amber;
 }
 
 function UnitChip({ unit }: { unit: Unit }) {
-  const color = unitColor(unit.active);
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const color = unitColor(unit.active, t);
   return (
     <View style={[styles.chip, { borderColor: color }]}>
       <View style={[styles.chipDot, { backgroundColor: color }]} />
@@ -79,6 +84,8 @@ export default function ConsoleTab() {
 }
 
 function ConsoleScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
 
   // No host yet (fresh install): don't poll, and show the pairing hint
@@ -116,7 +123,7 @@ function ConsoleScreen() {
           <View
             style={[
               styles.dot,
-              { backgroundColor: reachable ? theme.green : theme.red },
+              { backgroundColor: reachable ? t.green : t.red },
             ]}
           />
           <Text style={styles.hostname}>
@@ -166,15 +173,15 @@ function ConsoleScreen() {
             <View style={styles.row}>
               <View style={styles.half}>
                 <Card title="CPU TEMP">
-                  <Text style={[styles.bigMetric, { color: tempColor(s.cpu_temp_c) }]}>
+                  <Text style={[styles.bigMetric, { color: tempColor(s.cpu_temp_c, t) }]}>
                     {s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
                   </Text>
-                  <Sparkline values={s.history?.temp} color={tempColor(s.cpu_temp_c)} />
+                  <Sparkline values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
                 </Card>
               </View>
               <View style={styles.half}>
                 <Card title="UPTIME">
-                  <Text style={[styles.bigMetric, { color: theme.text }]}>
+                  <Text style={[styles.bigMetric, { color: t.text }]}>
                     {humanizeUptime(s.uptime_s)}
                   </Text>
                 </Card>
@@ -189,7 +196,7 @@ function ConsoleScreen() {
                   </Text>
                 ))}
               </View>
-              <Sparkline values={s.history?.load} color={theme.blue} />
+              <Sparkline values={s.history?.load} color={t.blue} />
             </Card>
 
             <Card title="MEMORY">
@@ -197,12 +204,12 @@ function ConsoleScreen() {
                 <Text style={styles.barLabel}>
                   {(s.mem.used_mb / 1024).toFixed(1)} / {(s.mem.total_mb / 1024).toFixed(1)} GB
                 </Text>
-                <Text style={[styles.barLabel, { color: pctColor(memPct) }]}>{memPct}%</Text>
+                <Text style={[styles.barLabel, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
               </View>
-              <Bar pct={memPct} color={pctColor(memPct)} />
+              <Bar pct={memPct} color={pctColor(memPct, t)} />
               {/* Fixed 0-100 scale: a memory sparkline that auto-scales would
                   make a 2% wiggle look like a cliff. */}
-              <Sparkline values={s.history?.mem_pct} color={pctColor(memPct)} min={0} max={100} />
+              <Sparkline values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
             </Card>
 
             <Card title="DISKS">
@@ -213,10 +220,10 @@ function ConsoleScreen() {
                     <Text style={styles.barLabel}>
                       {d.used_gb.toFixed(1)} / {d.total_gb.toFixed(1)} GB
                       {'   '}
-                      <Text style={{ color: pctColor(d.pct) }}>{d.pct}%</Text>
+                      <Text style={{ color: pctColor(d.pct, t) }}>{d.pct}%</Text>
                     </Text>
                   </View>
-                  <Bar pct={d.pct} color={pctColor(d.pct)} />
+                  <Bar pct={d.pct} color={pctColor(d.pct, t)} />
                 </View>
               ))}
             </Card>
@@ -253,8 +260,8 @@ function ConsoleScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: theme.bg },
+const makeStyles = (t: Palette) => StyleSheet.create({
+  screen: { flex: 1, backgroundColor: t.bg },
   scroll: { flex: 1 },
   header: {
     flexDirection: 'row',
@@ -263,21 +270,21 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   dot: { width: 14, height: 14, borderRadius: 7 },
-  hostname: { color: theme.text, fontSize: 26, fontWeight: '700', fontFamily: mono },
-  headerSub: { color: theme.textDim, fontSize: 13, marginLeft: 'auto' },
+  hostname: { color: t.text, fontSize: 26, fontWeight: '700', fontFamily: mono },
+  headerSub: { color: t.textDim, fontSize: 13, marginLeft: 'auto' },
   emptyCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
   },
-  emptyTitle: { color: theme.text, fontSize: 16, fontWeight: '700', marginBottom: 6 },
-  emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+  emptyTitle: { color: t.text, fontSize: 16, fontWeight: '700', marginBottom: 6 },
+  emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19 },
   banner: {
-    backgroundColor: theme.redDeep,
-    borderColor: theme.red,
+    backgroundColor: t.redDeep,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 12,
     padding: 16,
@@ -294,7 +301,7 @@ const styles = StyleSheet.create({
   bannerDetail: { color: '#fecaca', fontSize: 13, ...numeric },
   retryBtn: {
     marginTop: 12,
-    backgroundColor: theme.red,
+    backgroundColor: t.red,
     paddingVertical: 12,
     paddingHorizontal: 36,
     borderRadius: 8,
@@ -304,15 +311,15 @@ const styles = StyleSheet.create({
   row: { flexDirection: 'row', gap: 10 },
   half: { flex: 1 },
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 10,
   },
   cardTitle: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.2,
@@ -321,7 +328,7 @@ const styles = StyleSheet.create({
   bigMetric: { fontSize: 28, fontWeight: '700', ...numeric },
   loadRow: { flexDirection: 'row', justifyContent: 'space-between' },
   loadVal: {
-    color: theme.text,
+    color: t.text,
     fontSize: 22,
     fontWeight: '600',
     flex: 1,
@@ -329,16 +336,16 @@ const styles = StyleSheet.create({
     ...numeric,
   },
   barLabelRow: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 6 },
-  barLabel: { color: theme.textDim, fontSize: 12, ...numeric },
+  barLabel: { color: t.textDim, fontSize: 12, ...numeric },
   barTrack: {
     height: 10,
     borderRadius: 5,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     overflow: 'hidden',
   },
   barFill: { height: '100%', borderRadius: 5 },
   diskRow: { marginBottom: 12 },
-  diskMount: { color: theme.text, fontSize: 13, fontWeight: '600', fontFamily: mono },
+  diskMount: { color: t.text, fontSize: 13, fontWeight: '600', fontFamily: mono },
   chips: { gap: 8 },
   chip: {
     flexDirection: 'row',
@@ -348,11 +355,11 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingVertical: 10,
     paddingHorizontal: 12,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   chipDot: { width: 8, height: 8, borderRadius: 4 },
-  chipName: { color: theme.text, fontSize: 13, fontFamily: mono, flexShrink: 1 },
+  chipName: { color: t.text, fontSize: 13, fontFamily: mono, flexShrink: 1 },
   chipState: { fontSize: 12, marginLeft: 'auto', ...numeric },
-  unitErr: { color: theme.textDim, fontSize: 13 },
-  unitHint: { color: theme.textFaint, fontFamily: mono, fontSize: 10, marginTop: 10 },
+  unitErr: { color: t.textDim, fontSize: 13 },
+  unitHint: { color: t.textFaint, fontFamily: mono, fontSize: 10, marginTop: 10 },
 });

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -37,7 +37,7 @@ import {
 } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** Cross-platform confirm (Alert buttons are no-ops on web). */
 function confirmDelete(label: string, onConfirm: () => void) {
@@ -76,6 +76,8 @@ function LauncherTile({
   onDelete,
   download,
 }: TileProps) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [imgFailed, setImgFailed] = useState(false);
   // A failed cover latches to the text card so <Image> doesn't error-loop; clear
   // the latch when the URL changes (e.g. the app healed to the box's cached IP)
@@ -106,7 +108,7 @@ function LauncherTile({
           <Ionicons
             name={launcher.kind === 'steam' ? 'game-controller' : 'rocket'}
             size={32}
-            color={theme.textFaint}
+            color={t.textFaint}
           />
           <Text style={styles.tileFallbackLabel} numberOfLines={3}>
             {launcher.label}
@@ -128,15 +130,15 @@ function LauncherTile({
           <Ionicons
             name={download.state === 'paused' ? 'pause' : 'cloud-download'}
             size={11}
-            color={download.state === 'paused' ? theme.amber : theme.blue}
+            color={download.state === 'paused' ? t.amber : t.blue}
           />
           <Text style={styles.tilePillText}>{download.percent}%</Text>
         </View>
       )}
       {download && !isActiveDownload(download) && (
         <View style={[styles.tilePill, styles.tilePillQueued]}>
-          <Ionicons name="time-outline" size={11} color={theme.textDim} />
-          <Text style={[styles.tilePillText, { color: theme.textDim }]}>queued</Text>
+          <Ionicons name="time-outline" size={11} color={t.textDim} />
+          <Text style={[styles.tilePillText, { color: t.textDim }]}>queued</Text>
         </View>
       )}
 
@@ -145,7 +147,7 @@ function LauncherTile({
           onPress={onDelete}
           hitSlop={10}
           style={({ pressed }) => [styles.tileDelete, pressed && styles.pressed]}>
-          <Ionicons name="trash" size={16} color={theme.red} />
+          <Ionicons name="trash" size={16} color={t.red} />
         </Pressable>
       )}
     </Pressable>
@@ -158,8 +160,10 @@ function fmtGB(bytes: number): string {
 }
 
 function DownloadRow({ d }: { d: SteamDownload }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const paused = d.state === 'paused';
-  const fill = paused ? theme.amber : theme.blue;
+  const fill = paused ? t.amber : t.blue;
   const pct = Math.max(0, Math.min(100, d.percent));
   return (
     <View style={styles.dlRow}>
@@ -173,7 +177,7 @@ function DownloadRow({ d }: { d: SteamDownload }) {
         <View style={[styles.dlFill, { width: `${Math.max(2, pct)}%`, backgroundColor: fill }]} />
       </View>
       <View style={styles.dlMeta}>
-        <Text style={[styles.dlState, paused && { color: theme.amber }]}>
+        <Text style={[styles.dlState, paused && { color: t.amber }]}>
           {d.state.toUpperCase()}
         </Text>
         {d.bytes_total > 0 && (
@@ -188,6 +192,7 @@ function DownloadRow({ d }: { d: SteamDownload }) {
 
 /** A queued (pending, not-moving) update — compact, dimmed, no fake progress. */
 function QueuedRow({ d }: { d: SteamDownload }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.qRow}>
       <Text style={styles.qName} numberOfLines={1}>
@@ -205,6 +210,8 @@ function QueuedRow({ d }: { d: SteamDownload }) {
  * days. Hidden when nothing is downloading or queued.
  */
 function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [showQueue, setShowQueue] = useState(false);
   if (downloads.length === 0) return null;
   const active = downloads.filter(isActiveDownload);
@@ -214,7 +221,7 @@ function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
       {active.length > 0 && (
         <>
           <View style={styles.dlHeader}>
-            <Ionicons name="cloud-download" size={14} color={theme.blue} />
+            <Ionicons name="cloud-download" size={14} color={t.blue} />
             <Text style={styles.dlHeaderText}>DOWNLOADING</Text>
           </View>
           {active.map((d) => (
@@ -234,14 +241,14 @@ function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
               active.length > 0 && styles.dlHeaderGap,
               pressed && styles.pressed,
             ]}>
-            <Ionicons name="time-outline" size={13} color={theme.textDim} />
-            <Text style={[styles.dlHeaderText, { color: theme.textDim }]}>
+            <Ionicons name="time-outline" size={13} color={t.textDim} />
+            <Text style={[styles.dlHeaderText, { color: t.textDim }]}>
               QUEUED · {queued.length}
             </Text>
             <Ionicons
               name={showQueue ? 'chevron-up' : 'chevron-down'}
               size={14}
-              color={theme.textDim}
+              color={t.textDim}
             />
           </Pressable>
           {showQueue && queued.map((d) => <QueuedRow key={d.appid} d={d} />)}
@@ -260,6 +267,8 @@ type AddFormProps = {
 };
 
 function AddLauncherForm({ visible, onClose, onSubmit }: AddFormProps) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [label, setLabel] = useState('');
   const [cmd, setCmd] = useState('');
   const [busy, setBusy] = useState(false);
@@ -312,7 +321,7 @@ function AddLauncherForm({ visible, onClose, onSubmit }: AddFormProps) {
             value={label}
             onChangeText={setLabel}
             placeholder="e.g. RetroArch"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             style={styles.input}
             autoCapitalize="none"
             autoCorrect={false}
@@ -323,7 +332,7 @@ function AddLauncherForm({ visible, onClose, onSubmit }: AddFormProps) {
             value={cmd}
             onChangeText={setCmd}
             placeholder="e.g. flatpak run org.libretro.RetroArch"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             style={styles.input}
             autoCapitalize="none"
             autoCorrect={false}
@@ -347,7 +356,7 @@ function AddLauncherForm({ visible, onClose, onSubmit }: AddFormProps) {
                 (pressed || busy) && styles.pressed,
               ]}>
               {busy ? (
-                <ActivityIndicator color={theme.bg} size="small" />
+                <ActivityIndicator color={t.bg} size="small" />
               ) : (
                 <Text style={[styles.formBtnText, styles.formBtnTextPrimary]}>Add</Text>
               )}
@@ -376,6 +385,8 @@ export default function LaunchTab() {
 const TOAST_MS = 1500;
 
 function LaunchScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const { width } = useWindowDimensions();
   const [addOpen, setAddOpen] = useState(false);
@@ -522,7 +533,7 @@ function LaunchScreen() {
               setAddOpen(true);
             }}
             style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}>
-            <Ionicons name="add" size={18} color={theme.blue} />
+            <Ionicons name="add" size={18} color={t.blue} />
             <Text style={styles.addBtnText}>Add</Text>
           </Pressable>
         )}
@@ -535,7 +546,7 @@ function LaunchScreen() {
           <RefreshControl
             refreshing={refreshing}
             onRefresh={onRefresh}
-            tintColor={theme.textDim}
+            tintColor={t.textDim}
           />
         }>
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
@@ -544,7 +555,7 @@ function LaunchScreen() {
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
         {!configured && (
           <View style={styles.emptyCard}>
-            <Ionicons name="rocket" size={40} color={theme.textFaint} />
+            <Ionicons name="rocket" size={40} color={t.textFaint} />
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
               Open the Setup tab to pair with the Couchside agent on your media center or Steam
@@ -568,7 +579,7 @@ function LaunchScreen() {
         {/* Loading */}
         {configured && !list.data && list.error == null && (
           <View style={styles.center}>
-            <ActivityIndicator color={theme.textDim} />
+            <ActivityIndicator color={t.textDim} />
             <Text style={styles.dim}>loading launchers…</Text>
           </View>
         )}
@@ -576,7 +587,7 @@ function LaunchScreen() {
         {/* Empty state */}
         {list.data && launchers.length === 0 && (
           <View style={styles.emptyCard}>
-            <Ionicons name="rocket" size={40} color={theme.textFaint} />
+            <Ionicons name="rocket" size={40} color={t.textFaint} />
             <Text style={styles.emptyTitle}>No launchers yet</Text>
             <Text style={styles.emptyText}>
               Steam games are discovered automatically once you install them on the box. You can
@@ -585,7 +596,7 @@ function LaunchScreen() {
             <Pressable
               onPress={() => setAddOpen(true)}
               style={({ pressed }) => [styles.emptyAddBtn, pressed && styles.pressed]}>
-              <Ionicons name="add" size={18} color={theme.bg} />
+              <Ionicons name="add" size={18} color={t.bg} />
               <Text style={styles.emptyAddText}>Add a launcher</Text>
             </Pressable>
           </View>
@@ -628,8 +639,8 @@ function LaunchScreen() {
   );
 }
 
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: theme.bg },
+const makeStyles = (t: Palette) => StyleSheet.create({
+  screen: { flex: 1, backgroundColor: t.bg },
   header: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -637,27 +648,27 @@ const styles = StyleSheet.create({
     paddingTop: 12,
     paddingBottom: 10,
   },
-  title: { color: theme.text, fontSize: 26, fontWeight: '700', fontFamily: mono, flex: 1 },
+  title: { color: t.text, fontSize: 26, fontWeight: '700', fontFamily: mono, flex: 1 },
   addBtn: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 7,
     paddingHorizontal: 14,
   },
-  addBtnText: { color: theme.blue, fontSize: 14, fontWeight: '700', fontFamily: mono },
+  addBtnText: { color: t.blue, fontSize: 14, fontWeight: '700', fontFamily: mono },
 
   list: { flex: 1 },
   row: { flexDirection: 'row' },
 
   // Downloads section
   dlCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 14,
     padding: 14,
@@ -667,12 +678,12 @@ const styles = StyleSheet.create({
   dlHeader: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   dlHeaderGap: {
     marginTop: 4,
-    borderTopColor: theme.cardBorder,
+    borderTopColor: t.cardBorder,
     borderTopWidth: 1,
     paddingTop: 12,
   },
   dlHeaderText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 11,
     fontWeight: '700',
     fontFamily: mono,
@@ -680,22 +691,22 @@ const styles = StyleSheet.create({
   },
   // Queued (pending, not-moving) update rows: compact + dimmed.
   qRow: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingLeft: 19 },
-  qName: { color: theme.textDim, fontSize: 13, flex: 1, fontFamily: mono },
-  qSize: { color: theme.textFaint, fontSize: 11, fontFamily: mono },
+  qName: { color: t.textDim, fontSize: 13, flex: 1, fontFamily: mono },
+  qSize: { color: t.textFaint, fontSize: 11, fontFamily: mono },
   dlRow: { gap: 6 },
   dlTop: { flexDirection: 'row', alignItems: 'center' },
-  dlName: { color: theme.text, fontSize: 14, fontWeight: '600', flex: 1, fontFamily: mono },
-  dlPct: { color: theme.text, fontSize: 13, fontWeight: '700', fontFamily: mono, marginLeft: 8 },
+  dlName: { color: t.text, fontSize: 14, fontWeight: '600', flex: 1, fontFamily: mono },
+  dlPct: { color: t.text, fontSize: 13, fontWeight: '700', fontFamily: mono, marginLeft: 8 },
   dlTrack: {
     height: 6,
     borderRadius: 3,
-    backgroundColor: theme.cardBorder,
+    backgroundColor: t.cardBorder,
     overflow: 'hidden',
   },
   dlFill: { height: '100%', borderRadius: 3 },
   dlMeta: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
-  dlState: { color: theme.blue, fontSize: 10, fontWeight: '700', fontFamily: mono, letterSpacing: 0.8 },
-  dlBytes: { color: theme.textDim, fontSize: 11, fontFamily: mono },
+  dlState: { color: t.blue, fontSize: 10, fontWeight: '700', fontFamily: mono, letterSpacing: 0.8 },
+  dlBytes: { color: t.textDim, fontSize: 11, fontFamily: mono },
 
   // Per-tile download pill
   tilePill: {
@@ -710,17 +721,17 @@ const styles = StyleSheet.create({
     paddingVertical: 3,
     paddingHorizontal: 7,
   },
-  tilePillText: { color: theme.text, fontSize: 11, fontWeight: '700', fontFamily: mono },
+  tilePillText: { color: t.text, fontSize: 11, fontWeight: '700', fontFamily: mono },
   tilePillQueued: { backgroundColor: 'rgba(0,0,0,0.55)' },
 
   tile: {
     borderRadius: 14,
     overflow: 'hidden',
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  tilePressed: { opacity: 0.75, borderColor: theme.blue },
+  tilePressed: { opacity: 0.75, borderColor: t.blue },
   tileArt: { width: '100%', height: '100%' },
   tileFallback: {
     flex: 1,
@@ -730,7 +741,7 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   tileFallbackLabel: {
-    color: theme.text,
+    color: t.text,
     fontSize: 14,
     fontWeight: '700',
     textAlign: 'center',
@@ -745,7 +756,7 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     paddingHorizontal: 8,
   },
-  tileLabel: { color: theme.text, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  tileLabel: { color: t.text, fontSize: 12, fontWeight: '700', fontFamily: mono },
   tileDelete: {
     position: 'absolute',
     top: 6,
@@ -756,11 +767,11 @@ const styles = StyleSheet.create({
   },
 
   center: { alignItems: 'center', justifyContent: 'center', paddingVertical: 48, gap: 12 },
-  dim: { color: theme.textDim, fontSize: 13 },
+  dim: { color: t.textDim, fontSize: 13 },
 
   errBox: {
-    backgroundColor: theme.redDeep,
-    borderColor: theme.red,
+    backgroundColor: t.redDeep,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
@@ -769,7 +780,7 @@ const styles = StyleSheet.create({
   },
   errText: { color: '#fecaca', fontSize: 13, marginBottom: 8, textAlign: 'center' },
   retryBtn: {
-    backgroundColor: theme.red,
+    backgroundColor: t.red,
     paddingVertical: 10,
     paddingHorizontal: 28,
     borderRadius: 8,
@@ -777,8 +788,8 @@ const styles = StyleSheet.create({
   retryText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
 
   emptyCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 14,
     padding: 24,
@@ -786,19 +797,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     gap: 12,
   },
-  emptyTitle: { color: theme.text, fontSize: 18, fontWeight: '700' },
-  emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19, textAlign: 'center' },
+  emptyTitle: { color: t.text, fontSize: 18, fontWeight: '700' },
+  emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19, textAlign: 'center' },
   emptyAddBtn: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 999,
     paddingVertical: 10,
     paddingHorizontal: 20,
     marginTop: 4,
   },
-  emptyAddText: { color: theme.bg, fontSize: 14, fontWeight: '800' },
+  emptyAddText: { color: t.bg, fontSize: 14, fontWeight: '800' },
 
   pressed: { opacity: 0.7 },
 
@@ -807,8 +818,8 @@ const styles = StyleSheet.create({
     bottom: 20,
     left: 24,
     right: 24,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 12,
@@ -820,7 +831,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 8 },
     elevation: 8,
   },
-  toastText: { color: theme.text, fontSize: 14, fontWeight: '600', fontFamily: mono },
+  toastText: { color: t.text, fontSize: 14, fontWeight: '600', fontFamily: mono },
 
   backdrop: {
     flex: 1,
@@ -829,15 +840,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
   },
   formCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 16,
     padding: 20,
   },
-  formTitle: { color: theme.text, fontSize: 18, fontWeight: '700', marginBottom: 14 },
+  formTitle: { color: t.text, fontSize: 18, fontWeight: '700', marginBottom: 14 },
   formLabel: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1,
@@ -845,18 +856,18 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   input: {
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 10,
     paddingHorizontal: 12,
-    color: theme.text,
+    color: t.text,
     fontFamily: mono,
     fontSize: 14,
   },
-  formHint: { color: theme.textFaint, fontSize: 11, marginTop: 4 },
-  formError: { color: theme.red, fontSize: 13, marginTop: 10 },
+  formHint: { color: t.textFaint, fontSize: 11, marginTop: 4 },
+  formError: { color: t.red, fontSize: 13, marginTop: 10 },
   formButtons: { flexDirection: 'row', gap: 12, marginTop: 18 },
   formBtn: {
     flex: 1,
@@ -864,11 +875,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingVertical: 12,
     borderRadius: 10,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  formBtnPrimary: { backgroundColor: theme.blue, borderColor: theme.blue },
-  formBtnText: { color: theme.text, fontSize: 14, fontWeight: '700' },
-  formBtnTextPrimary: { color: theme.bg, fontWeight: '800' },
+  formBtnPrimary: { backgroundColor: t.blue, borderColor: t.blue },
+  formBtnText: { color: t.text, fontSize: 14, fontWeight: '700' },
+  formBtnTextPrimary: { color: t.bg, fontWeight: '800' },
 });

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -12,7 +12,7 @@ import { getKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
 import { getPref, usePref } from '@/lib/prefs';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNavigation } from 'expo-router';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
   AppState,
@@ -40,7 +40,8 @@ import { api, hostKey, Status } from '@/lib/api';
 import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 const KEEP_AWAKE_TAG = 'rescue-remote-pad';
 
@@ -65,6 +66,7 @@ type PadButtonProps = {
 };
 
 function PadButton({ label, onDown, onUp, style, color, fontSize }: PadButtonProps) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <Pressable
       onPressIn={() => {
@@ -139,6 +141,7 @@ function Stick({ onMove, onRelease }: StickProps) {
     }),
   ).current;
 
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.stickPad} {...responder.panHandlers}>
       <View style={styles.stickCross} pointerEvents="none" />
@@ -216,6 +219,7 @@ function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
   ).current;
 
   const hints = usePref('padHints');
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.swipeSurface} {...responder.panHandlers}>
       {hints && <Text style={styles.swipeHint}>swipe to move · tap to select</Text>}
@@ -263,6 +267,7 @@ function Trackpad({
     onDragEnd,
   });
   const hints = usePref('padHints');
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.trackpadSurface} {...responder.panHandlers}>
       {hints && (
@@ -430,6 +435,7 @@ function KeyboardBar({ onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarP
     [onBackspace, onEnter],
   );
 
+  const styles = useThemedStyles(makeStyles);
   return (
     <>
       <View
@@ -523,16 +529,6 @@ function KeyboardBar({ onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarP
 
 // ---------- Status pill ----------
 
-const STATUS_COLOR: Record<GamepadStatus, string> = {
-  connected: theme.green,
-  connecting: theme.amber,
-  error: theme.red,
-  closed: theme.red,
-  replaced: theme.amber,
-  waiting: theme.amber,
-  released: theme.amber,
-};
-
 /** This phone's label sent to the box so the holder's "wants control" prompt
  *  can name it. A platform label (no native device-name dependency). */
 const DEVICE_LABEL =
@@ -577,6 +573,20 @@ const MODES: { key: PadMode; label: string }[] = [
 ];
 
 function PadScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const STATUS_COLOR = useMemo<Record<GamepadStatus, string>>(
+    () => ({
+      connected: t.green,
+      connecting: t.amber,
+      error: t.red,
+      closed: t.red,
+      replaced: t.amber,
+      waiting: t.amber,
+      released: t.amber,
+    }),
+    [t],
+  );
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { width, height } = useWindowDimensions();
@@ -977,14 +987,14 @@ function PadScreen() {
               label="‹ BACK"
               {...btn('b')}
               style={styles.swipeBtn}
-              color={theme.red}
+              color={t.red}
               fontSize={12}
             />
             <PadButton
               label="STEAM"
               {...btn('guide')}
               style={[styles.swipeBtn, styles.guideBtn]}
-              color={theme.blue}
+              color={t.blue}
               fontSize={12}
             />
             <PadButton
@@ -992,7 +1002,7 @@ function PadScreen() {
               onDown={qam}
               onUp={NOOP}
               style={[styles.swipeBtn, styles.guideBtn]}
-              color={theme.blue}
+              color={t.blue}
               fontSize={26}
             />
             <PadButton label="MENU" {...btn('start')} style={styles.swipeBtn} fontSize={12} />
@@ -1043,7 +1053,7 @@ function PadScreen() {
                     label="STEAM"
                     {...btn('guide')}
                     style={[styles.tpBtn, styles.tpBtnWide, styles.guideBtn]}
-                    color={theme.blue}
+                    color={t.blue}
                     fontSize={11}
                   />
                   <PadButton
@@ -1051,7 +1061,7 @@ function PadScreen() {
                     onDown={qam}
                     onUp={NOOP}
                     style={[styles.tpBtn, styles.guideBtn]}
-                    color={theme.blue}
+                    color={t.blue}
                     fontSize={22}
                   />
                 </>
@@ -1112,7 +1122,7 @@ function PadScreen() {
                 <View style={styles.dpadRow}>
                   <PadButton label="◀" {...btn('dl')} style={styles.dpadBtn} />
                   {/* Center OK = A: opens/activates the highlighted item. */}
-                  <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={theme.green} fontSize={14} />
+                  <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={t.green} fontSize={14} />
                   <PadButton label="▶" {...btn('dr')} style={styles.dpadBtn} />
                 </View>
                 <View style={styles.dpadRow}>
@@ -1131,7 +1141,7 @@ function PadScreen() {
                   label="STEAM"
                   {...btn('guide')}
                   style={[styles.menuBtn, styles.guideBtn]}
-                  color={theme.blue}
+                  color={t.blue}
                   fontSize={11}
                 />
                 <PadButton
@@ -1139,7 +1149,7 @@ function PadScreen() {
                   onDown={qam}
                   onUp={NOOP}
                   style={[styles.menuBtn, styles.qamBtn, styles.guideBtn]}
-                  color={theme.blue}
+                  color={t.blue}
                   fontSize={20}
                 />
                 <PadButton label="START" {...btn('start')} style={styles.menuBtn} fontSize={11} />
@@ -1155,17 +1165,17 @@ function PadScreen() {
               <View style={styles.abxy}>
                 <View style={styles.abxyRow}>
                   <View style={styles.faceSpacer} />
-                  <PadButton label="Y" {...btn('y')} style={styles.faceBtn} color={theme.amber} />
+                  <PadButton label="Y" {...btn('y')} style={styles.faceBtn} color={t.amber} />
                   <View style={styles.faceSpacer} />
                 </View>
                 <View style={styles.abxyRow}>
-                  <PadButton label="X" {...btn('x')} style={styles.faceBtn} color={theme.blue} />
+                  <PadButton label="X" {...btn('x')} style={styles.faceBtn} color={t.blue} />
                   <View style={styles.faceSpacer} />
-                  <PadButton label="B" {...btn('b')} style={styles.faceBtn} color={theme.red} />
+                  <PadButton label="B" {...btn('b')} style={styles.faceBtn} color={t.red} />
                 </View>
                 <View style={styles.abxyRow}>
                   <View style={styles.faceSpacer} />
-                  <PadButton label="A" {...btn('a')} style={styles.faceBtn} color={theme.green} />
+                  <PadButton label="A" {...btn('a')} style={styles.faceBtn} color={t.green} />
                   <View style={styles.faceSpacer} />
                 </View>
               </View>
@@ -1192,7 +1202,7 @@ function PadScreen() {
               label="STEAM"
               {...btn('guide')}
               style={[styles.menuBtn, styles.guideBtn]}
-              color={theme.blue}
+              color={t.blue}
               fontSize={11}
             />
             <PadButton
@@ -1200,7 +1210,7 @@ function PadScreen() {
               onDown={qam}
               onUp={NOOP}
               style={[styles.menuBtn, styles.qamBtn, styles.guideBtn]}
-              color={theme.blue}
+              color={t.blue}
               fontSize={20}
             />
             <PadButton label="START" {...btn('start')} style={styles.menuBtn} fontSize={11} />
@@ -1217,7 +1227,7 @@ function PadScreen() {
               <View style={styles.dpadRow}>
                 <PadButton label="◀" {...btn('dl')} style={styles.dpadBtn} />
                 {/* Center OK = A: opens/activates the highlighted item. */}
-                <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={theme.green} fontSize={14} />
+                <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={t.green} fontSize={14} />
                 <PadButton label="▶" {...btn('dr')} style={styles.dpadBtn} />
               </View>
               <View style={styles.dpadRow}>
@@ -1230,17 +1240,17 @@ function PadScreen() {
             <View style={styles.abxy}>
               <View style={styles.abxyRow}>
                 <View style={styles.faceSpacer} />
-                <PadButton label="Y" {...btn('y')} style={styles.faceBtn} color={theme.amber} />
+                <PadButton label="Y" {...btn('y')} style={styles.faceBtn} color={t.amber} />
                 <View style={styles.faceSpacer} />
               </View>
               <View style={styles.abxyRow}>
-                <PadButton label="X" {...btn('x')} style={styles.faceBtn} color={theme.blue} />
+                <PadButton label="X" {...btn('x')} style={styles.faceBtn} color={t.blue} />
                 <View style={styles.faceSpacer} />
-                <PadButton label="B" {...btn('b')} style={styles.faceBtn} color={theme.red} />
+                <PadButton label="B" {...btn('b')} style={styles.faceBtn} color={t.red} />
               </View>
               <View style={styles.abxyRow}>
                 <View style={styles.faceSpacer} />
-                <PadButton label="A" {...btn('a')} style={styles.faceBtn} color={theme.green} />
+                <PadButton label="A" {...btn('a')} style={styles.faceBtn} color={t.green} />
                 <View style={styles.faceSpacer} />
               </View>
             </View>
@@ -1264,28 +1274,28 @@ function PadScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   screen: {
     flex: 1,
-    backgroundColor: theme.bg,
+    backgroundColor: t.bg,
     paddingHorizontal: 12,
     justifyContent: 'space-between',
   },
 
   btn: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     alignItems: 'center',
     justifyContent: 'center',
   },
   btnPressed: {
-    backgroundColor: theme.inset,
-    borderColor: theme.blue,
+    backgroundColor: t.inset,
+    borderColor: t.blue,
   },
   btnText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontFamily: mono,
     fontSize: 14,
     fontWeight: '700',
@@ -1300,8 +1310,8 @@ const styles = StyleSheet.create({
   },
   modeToggle: {
     flexDirection: 'row',
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     padding: 3,
@@ -1313,23 +1323,23 @@ const styles = StyleSheet.create({
     borderRadius: 999,
   },
   modeSegActive: {
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
   },
   modeSegText: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 10,
     fontWeight: '700',
     letterSpacing: 1,
   },
   modeSegTextActive: {
-    color: theme.blue,
+    color: t.blue,
   },
 
   swipeSurface: {
     flex: 1,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 24,
     alignItems: 'center',
@@ -1338,8 +1348,8 @@ const styles = StyleSheet.create({
   },
   trackpadSurface: {
     flex: 1,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 24,
     alignItems: 'center',
@@ -1347,7 +1357,7 @@ const styles = StyleSheet.create({
     padding: 18,
   },
   swipeHint: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 11,
     textAlign: 'center',
@@ -1381,8 +1391,8 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   kbBar: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 12,
@@ -1394,19 +1404,19 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   kbBarOpen: {
-    borderColor: theme.blue,
-    backgroundColor: theme.inset,
+    borderColor: t.blue,
+    backgroundColor: t.inset,
   },
   kbDragHandle: {
     width: 36,
     height: 4,
     borderRadius: 2,
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     opacity: 0.5,
     marginBottom: 6,
   },
   kbDone: {
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 999,
     paddingHorizontal: 20,
     alignItems: 'center',
@@ -1436,7 +1446,7 @@ const styles = StyleSheet.create({
     elevation: 6,
   },
   kbFloatDone: {
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 999,
     paddingVertical: 12,
     paddingHorizontal: 18,
@@ -1447,14 +1457,14 @@ const styles = StyleSheet.create({
   },
   // Edge chevrons on the closed bar: the horizontal mode-switch swipe cue.
   kbSwipeCue: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontFamily: mono,
     fontSize: 16,
     fontWeight: '700',
     paddingHorizontal: 14,
   },
   kbBarText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontFamily: mono,
     fontSize: 12,
     fontWeight: '700',
@@ -1466,12 +1476,12 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     paddingHorizontal: 12,
     paddingVertical: 8,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderTopWidth: 1,
-    borderTopColor: theme.cardBorder,
+    borderTopColor: t.cardBorder,
   },
   kbAccessoryHint: {
-    color: theme.textDim,
+    color: t.textDim,
     fontFamily: mono,
     fontSize: 12,
     fontWeight: '700',
@@ -1483,7 +1493,7 @@ const styles = StyleSheet.create({
   inputBlockedBar: {
     marginTop: 8,
     backgroundColor: 'rgba(251, 191, 36, 0.12)',
-    borderColor: theme.amber,
+    borderColor: t.amber,
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 8,
@@ -1496,25 +1506,25 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     gap: 10,
     backgroundColor: 'rgba(96,165,250,0.12)',
-    borderColor: theme.blue,
+    borderColor: t.blue,
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 8,
     paddingHorizontal: 12,
   },
-  handoffText: { flex: 1, color: theme.text, fontSize: 13, fontWeight: '600' },
+  handoffText: { flex: 1, color: t.text, fontSize: 13, fontWeight: '600' },
   handoffBtns: { flexDirection: 'row', gap: 8 },
   handoffBtn: {
     paddingVertical: 8,
     paddingHorizontal: 16,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
-    backgroundColor: theme.card,
+    borderColor: t.cardBorder,
+    backgroundColor: t.card,
   },
-  handoffBtnPass: { backgroundColor: theme.blue, borderColor: theme.blue },
+  handoffBtnPass: { backgroundColor: t.blue, borderColor: t.blue },
   handoffBtnText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontFamily: mono,
     fontSize: 12,
     fontWeight: '800',
@@ -1522,14 +1532,14 @@ const styles = StyleSheet.create({
   },
   handoffBtnPassText: { color: '#0b1220' },
   inputBlockedText: {
-    color: theme.amber,
+    color: t.amber,
     fontFamily: mono,
     fontSize: 12,
     fontWeight: '700',
     lineHeight: 16,
   },
   kbBarTextOpen: {
-    color: theme.blue,
+    color: t.blue,
   },
   hiddenInput: {
     // Invisible but FOCUSABLE. iOS won't let a fully transparent (alpha 0) or
@@ -1563,8 +1573,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: 6,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 6,
@@ -1577,7 +1587,7 @@ const styles = StyleSheet.create({
     borderRadius: 4,
   },
   pillText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontFamily: mono,
     fontSize: 10,
     flexShrink: 1,
@@ -1599,7 +1609,7 @@ const styles = StyleSheet.create({
     width: 48,
   },
   guideBtn: {
-    borderColor: theme.blue,
+    borderColor: t.blue,
   },
 
   clusterRow: {
@@ -1662,8 +1672,8 @@ const styles = StyleSheet.create({
     width: STICK_SIZE,
     height: STICK_SIZE,
     borderRadius: STICK_SIZE / 2,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     alignItems: 'center',
     justifyContent: 'center',
@@ -1673,14 +1683,14 @@ const styles = StyleSheet.create({
     width: 10,
     height: 10,
     borderRadius: 5,
-    backgroundColor: theme.cardBorder,
+    backgroundColor: t.cardBorder,
   },
   stickNub: {
     width: NUB_SIZE,
     height: NUB_SIZE,
     borderRadius: NUB_SIZE / 2,
-    backgroundColor: theme.card,
-    borderColor: theme.blue,
+    backgroundColor: t.card,
+    borderColor: t.blue,
     borderWidth: 1,
   },
 

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -41,7 +41,19 @@ import { buy, getProduct, restore } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
 import { VolumeTarget } from '@/lib/api';
 import { useBoxes, useBoxOnlineStatus, BoxReachability } from '@/lib/SettingsContext';
-import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import {
+  ACCENTS,
+  ACCENT_KEYS,
+  mono,
+  setAccent,
+  setThemeMode,
+  useAccent,
+  useResolvedScheme,
+  useTheme,
+  useThemedStyles,
+  useThemeMode,
+  type Palette,
+} from '@/lib/theme';
 
 /**
  * Build the pairing link for a box.
@@ -608,6 +620,9 @@ function SetupBody() {
   const status = useBoxOnlineStatus(boxes, { active: true, intervalMs: 10000 });
   const hapticsOn = useHapticsEnabled();
   const keepAwakeOn = useKeepAwakeEnabled();
+  const themeMode = useThemeMode();
+  const accent = useAccent();
+  const scheme = useResolvedScheme();
   const confirmSuspend = usePref('confirmSuspend');
   const defaultPadMode = usePref('defaultPadMode');
   const statusIntervalMs = usePref('statusIntervalMs');
@@ -1088,6 +1103,48 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+            </View>
+
+            <View style={[styles.card, styles.cardGroup]}>
+              <CardHeader icon="color-palette-outline" label="APPEARANCE" />
+              <SegPref
+                label="Theme"
+                sub="Follow the system, or force light or dark."
+                options={[
+                  { value: 'system', label: 'System' },
+                  { value: 'light', label: 'Light' },
+                  { value: 'dark', label: 'Dark' },
+                ]}
+                value={themeMode}
+                onSelect={(v) => {
+                  void setThemeMode(v);
+                  hapticSelection();
+                }}
+              />
+              <View style={styles.prefCol}>
+                <View style={styles.prefBody}>
+                  <Text style={styles.prefLabel}>Accent</Text>
+                  <Text style={styles.prefSub}>The app&apos;s highlight color.</Text>
+                </View>
+                <View style={styles.accentRow}>
+                  {ACCENT_KEYS.map((k) => (
+                    <Pressable
+                      key={k}
+                      onPress={() => {
+                        void setAccent(k);
+                        hapticSelection();
+                      }}
+                      accessibilityRole="button"
+                      accessibilityLabel={ACCENTS[k].label}
+                      style={[
+                        styles.accentSwatch,
+                        { backgroundColor: ACCENTS[k][scheme] },
+                        accent === k && styles.accentSwatchActive,
+                      ]}
+                    />
+                  ))}
+                </View>
+              </View>
             </View>
 
             <View style={[styles.card, styles.cardGroup]}>
@@ -1656,6 +1713,15 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   segActive: { backgroundColor: t.card },
   segText: { color: t.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
   segTextActive: { color: t.text },
+  accentRow: { flexDirection: 'row', gap: 12, flexWrap: 'wrap' },
+  accentSwatch: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  accentSwatchActive: { borderColor: t.text },
   versionLabel: { color: t.textDim, fontSize: 13 },
   versionValue: { color: t.green, fontSize: 13, fontFamily: mono, fontWeight: '700' },
   hint: { color: t.textFaint, fontSize: 12, lineHeight: 17, fontFamily: mono },

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -41,7 +41,7 @@ import { buy, getProduct, restore } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
 import { VolumeTarget } from '@/lib/api';
 import { useBoxes, useBoxOnlineStatus, BoxReachability } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 /**
  * Build the pairing link for a box.
@@ -87,6 +87,7 @@ const APP_BUILD =
 const SETUP_GUIDE_URL = 'https://couchside.tv/#how';
 
 function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <Modal
       visible={box != null}
@@ -134,14 +135,16 @@ function errDetail(e: unknown): string {
 }
 
 function StepRow({ label, step }: { label: string; step: StepState }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const mark =
     step.state === 'ok' ? '✓' : step.state === 'fail' ? '✗' : step.state === 'running' ? '…' : '·';
   const color =
     step.state === 'ok'
-      ? theme.green
+      ? t.green
       : step.state === 'fail'
-        ? theme.red
-        : theme.textFaint;
+        ? t.red
+        : t.textFaint;
   return (
     <View style={styles.stepRow}>
       <Text style={[styles.stepMark, { color }]}>{mark}</Text>
@@ -157,6 +160,8 @@ function StepRow({ label, step }: { label: string; step: StepState }) {
 
 /** Subtle entitlement pill: trial countdown (amber) / unlocked (green). */
 function EntitlementPill() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { entitlement, ready } = useEntitlement();
   if (!ready) return null;
   // A store-unreachable fail-open must not claim "Unlocked": report the real
@@ -168,10 +173,10 @@ function EntitlementPill() {
       ? `Trial: ${entitlement.trialDaysLeft} day${entitlement.trialDaysLeft === 1 ? '' : 's'} left`
       : 'Trial ended';
   const color = purchased
-    ? theme.green
+    ? t.green
     : entitlement.trialDaysLeft > 0
-      ? theme.amber
-      : theme.red;
+      ? t.amber
+      : t.red;
   return (
     <View style={[styles.pill, { borderColor: color }]}>
       <Text style={[styles.pillText, { color }]}>{label}</Text>
@@ -181,6 +186,7 @@ function EntitlementPill() {
 
 /** Subtle gold Early Adopter badge: purchased before the cutoff, local-only. */
 function EarlyAdopterBadge() {
+  const styles = useThemedStyles(makeStyles);
   const { entitlement, ready } = useEntitlement();
   if (!ready || !entitlement.isEarlyAdopter) return null;
   return (
@@ -190,10 +196,10 @@ function EarlyAdopterBadge() {
   );
 }
 
-function dotColor(status: BoxReachability | undefined): string {
-  if (status === 'reachable') return theme.green;
-  if (status === 'offline') return theme.slate;
-  return theme.amber;
+function dotColor(status: BoxReachability | undefined, t: Palette): string {
+  if (status === 'reachable') return t.green;
+  if (status === 'offline') return t.slate;
+  return t.amber;
 }
 
 /** Cross-platform confirm (Alert buttons are no-ops on web). */
@@ -239,6 +245,8 @@ function BoxEditPanel({
   /** True if the given host+port already belongs to a *different* box. */
   conflict: (host: string, port: number) => boolean;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [name, setName] = useState(box.name);
   const [host, setHost] = useState(box.host);
   const [port, setPort] = useState(String(box.port));
@@ -336,7 +344,7 @@ function BoxEditPanel({
         value={name}
         onChangeText={setName}
         placeholder="box name"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         autoCapitalize="none"
         autoCorrect={false}
       />
@@ -350,7 +358,7 @@ function BoxEditPanel({
           setError(null);
         }}
         placeholder="steamdeck.local · bazzite.local"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         autoCapitalize="none"
         autoCorrect={false}
       />
@@ -364,7 +372,7 @@ function BoxEditPanel({
           setError(null);
         }}
         placeholder="8787"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         keyboardType="number-pad"
       />
 
@@ -379,7 +387,7 @@ function BoxEditPanel({
         value={token}
         onChangeText={setToken}
         placeholder="bearer token"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         secureTextEntry={!showToken}
         autoCapitalize="none"
         autoCorrect={false}
@@ -394,7 +402,7 @@ function BoxEditPanel({
           setError(null);
         }}
         placeholder="aa:bb:cc:dd:ee:ff · auto-learned when reachable"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         autoCapitalize="none"
         autoCorrect={false}
       />
@@ -478,6 +486,8 @@ function TogglePref({
   value: boolean;
   onValueChange: (v: boolean) => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.prefRow}>
       <View style={styles.prefBody}>
@@ -487,9 +497,9 @@ function TogglePref({
       <Switch
         value={value}
         onValueChange={onValueChange}
-        trackColor={{ false: theme.inset, true: theme.blue }}
+        trackColor={{ false: t.inset, true: t.blue }}
         thumbColor="#f8fafc"
-        ios_backgroundColor={theme.inset}
+        ios_backgroundColor={t.inset}
       />
     </View>
   );
@@ -509,6 +519,7 @@ function SegPref<T extends string | number>({
   value: T;
   onSelect: (v: T) => void;
 }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.prefCol}>
       <View style={styles.prefBody}>
@@ -543,6 +554,8 @@ const SETUP_TABS: { key: SetupTab; label: string; icon: IoniconName }[] = [
 ];
 
 function CategoryTabs({ tab, onTab }: { tab: SetupTab; onTab: (t: SetupTab) => void }) {
+  const pal = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.tabBar}>
       {SETUP_TABS.map((t) => {
@@ -555,7 +568,7 @@ function CategoryTabs({ tab, onTab }: { tab: SetupTab; onTab: (t: SetupTab) => v
               onTab(t.key);
             }}
             style={[styles.tabItem, active && styles.tabItemActive]}>
-            <Ionicons name={t.icon} size={15} color={active ? theme.text : theme.textFaint} />
+            <Ionicons name={t.icon} size={15} color={active ? pal.text : pal.textFaint} />
             <Text style={[styles.tabLabel, active && styles.tabLabelActive]} numberOfLines={1}>
               {t.label}
             </Text>
@@ -568,15 +581,19 @@ function CategoryTabs({ tab, onTab }: { tab: SetupTab; onTab: (t: SetupTab) => v
 
 /** A small section header inside a card: icon + uppercase label. */
 function CardHeader({ icon, label }: { icon: IoniconName; label: string }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.cardHeader}>
-      <Ionicons name={icon} size={14} color={theme.textDim} />
+      <Ionicons name={icon} size={14} color={t.textDim} />
       <Text style={styles.cardHeaderText}>{label}</Text>
     </View>
   );
 }
 
 function SetupBody() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { entitlement, recordPurchase } = useEntitlement();
   const {
     boxes,
@@ -783,7 +800,7 @@ function SetupBody() {
             setTab('account');
           }}
           style={({ pressed }) => [styles.unlockRow, pressed && styles.pressed]}>
-          <Ionicons name="lock-open-outline" size={18} color={theme.blue} />
+          <Ionicons name="lock-open-outline" size={18} color={t.blue} />
           <View style={styles.unlockRowBody}>
             <Text style={styles.unlockRowTitle}>Unlock Couchside — {price ?? '$4.99'}</Text>
             <Text style={styles.unlockRowSub}>
@@ -794,7 +811,7 @@ function SetupBody() {
                 : 'Trial ended · one-time purchase, no subscription'}
             </Text>
           </View>
-          <Ionicons name="chevron-forward" size={18} color={theme.textDim} />
+          <Ionicons name="chevron-forward" size={18} color={t.textDim} />
         </Pressable>
       )}
       {/* Logs hosts its own FlatList and must not live inside a ScrollView.
@@ -831,11 +848,11 @@ function SetupBody() {
                 void Linking.openURL(SETUP_GUIDE_URL);
               }}
               style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
-              <Ionicons name="hardware-chip-outline" size={15} color={theme.blue} />
+              <Ionicons name="hardware-chip-outline" size={15} color={t.blue} />
               <Text style={styles.emptyLinkText}>
                 Haven&apos;t installed the agent? Setup guide
               </Text>
-              <Ionicons name="open-outline" size={13} color={theme.blue} />
+              <Ionicons name="open-outline" size={13} color={t.blue} />
             </Pressable>
           </View>
         ) : (
@@ -847,7 +864,7 @@ function SetupBody() {
                 <Pressable
                   onPress={() => setEditingId(isEditing ? null : box.id)}
                   style={styles.boxMain}>
-                  <View style={[styles.boxDot, { backgroundColor: dotColor(status[box.id]) }]} />
+                  <View style={[styles.boxDot, { backgroundColor: dotColor(status[box.id], t) }]} />
                   <View style={styles.boxBody}>
                     <Text style={styles.boxName} numberOfLines={1}>
                       {box.name}
@@ -889,14 +906,14 @@ function SetupBody() {
                         }}
                         hitSlop={8}
                         style={styles.iconBtn}>
-                        <Text style={[styles.iconBtnText, { color: theme.blue }]}>SET ACTIVE</Text>
+                        <Text style={[styles.iconBtnText, { color: t.blue }]}>SET ACTIVE</Text>
                       </Pressable>
                     )}
                     <Pressable
                       onPress={() => setQrBox(box)}
                       hitSlop={8}
                       style={styles.iconBtn}>
-                      <Text style={[styles.iconBtnText, { color: theme.textDim }]}>SHOW QR</Text>
+                      <Text style={[styles.iconBtnText, { color: t.textDim }]}>SHOW QR</Text>
                     </Pressable>
                     <Pressable
                       onPress={() => setEditingId(box.id)}
@@ -908,7 +925,7 @@ function SetupBody() {
                       onPress={() => confirmRemove(box.name, () => void removeBox(box.id))}
                       hitSlop={8}
                       style={styles.iconBtn}>
-                      <Text style={[styles.iconBtnText, { color: theme.red }]}>REMOVE</Text>
+                      <Text style={[styles.iconBtnText, { color: t.red }]}>REMOVE</Text>
                     </Pressable>
                   </View>
                 )}
@@ -926,7 +943,7 @@ function SetupBody() {
             value={name}
             onChangeText={setName}
             placeholder="Media center · Steam Deck"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             autoCapitalize="none"
             autoCorrect={false}
             editable={ready}
@@ -938,7 +955,7 @@ function SetupBody() {
             value={host}
             onChangeText={setHost}
             placeholder="steamdeck.local · bazzite.local"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             autoCapitalize="none"
             autoCorrect={false}
             editable={ready}
@@ -950,7 +967,7 @@ function SetupBody() {
             value={port}
             onChangeText={setPort}
             placeholder="8787"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             keyboardType="number-pad"
             editable={ready}
           />
@@ -961,7 +978,7 @@ function SetupBody() {
             value={token}
             onChangeText={setToken}
             placeholder="bearer token"
-            placeholderTextColor={theme.textFaint}
+            placeholderTextColor={t.textFaint}
             secureTextEntry
             autoCapitalize="none"
             autoCorrect={false}
@@ -1027,9 +1044,9 @@ function SetupBody() {
                     void setHapticsEnabled(v);
                     if (v) hapticSelection();
                   }}
-                  trackColor={{ false: theme.inset, true: theme.blue }}
+                  trackColor={{ false: t.inset, true: t.blue }}
                   thumbColor="#f8fafc"
-                  ios_backgroundColor={theme.inset}
+                  ios_backgroundColor={t.inset}
                 />
               </View>
               <TogglePref
@@ -1089,9 +1106,9 @@ function SetupBody() {
                     void setKeepAwakeEnabled(v);
                     hapticSelection();
                   }}
-                  trackColor={{ false: theme.inset, true: theme.blue }}
+                  trackColor={{ false: t.inset, true: t.blue }}
                   thumbColor="#f8fafc"
-                  ios_backgroundColor={theme.inset}
+                  ios_backgroundColor={t.inset}
                 />
               </View>
               <SegPref
@@ -1246,7 +1263,7 @@ function SetupBody() {
                 </Text>
               </Pressable>
               {restoreMsg != null && (
-                <Text style={[styles.restoreMsg, { color: restoreMsg.ok ? theme.green : theme.red }]}>
+                <Text style={[styles.restoreMsg, { color: restoreMsg.ok ? t.green : t.red }]}>
                   {restoreMsg.text}
                 </Text>
               )}
@@ -1267,14 +1284,14 @@ function SetupBody() {
                 void openWriteReview();
               }}
               style={({ pressed }) => [styles.rateRow, pressed && styles.pressed]}>
-              <Ionicons name="star-outline" size={18} color={theme.amber} />
+              <Ionicons name="star-outline" size={18} color={t.amber} />
               <View style={styles.rateBody}>
                 <Text style={styles.rateTitle}>Rate Couchside</Text>
                 <Text style={styles.rateSub}>
                   A quick review helps other people find it.
                 </Text>
               </View>
-              <Ionicons name="open-outline" size={16} color={theme.textDim} />
+              <Ionicons name="open-outline" size={16} color={t.textDim} />
             </Pressable>
 
             {/* First-run lifeline: the app is useless without the box-side agent,
@@ -1286,18 +1303,18 @@ function SetupBody() {
                 void Linking.openURL(SETUP_GUIDE_URL);
               }}
               style={({ pressed }) => [styles.rateRow, pressed && styles.pressed]}>
-              <Ionicons name="hardware-chip-outline" size={18} color={theme.blue} />
+              <Ionicons name="hardware-chip-outline" size={18} color={t.blue} />
               <View style={styles.rateBody}>
                 <Text style={styles.rateTitle}>Set up a box</Text>
                 <Text style={styles.rateSub}>
                   Install the agent — instructions at couchside.tv.
                 </Text>
               </View>
-              <Ionicons name="open-outline" size={16} color={theme.textDim} />
+              <Ionicons name="open-outline" size={16} color={t.textDim} />
             </Pressable>
 
             <View style={styles.aboutRow}>
-              <Ionicons name="information-circle-outline" size={16} color={theme.textDim} />
+              <Ionicons name="information-circle-outline" size={16} color={t.textDim} />
               <Text style={styles.aboutText}>
                 Couchside v{APP_VERSION}
                 {APP_BUILD ? ` (${Platform.OS === 'ios' ? 'build' : 'vc'} ${APP_BUILD})` : ''}
@@ -1316,11 +1333,11 @@ function SetupBody() {
   );
 }
 
-const styles = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: theme.bg },
+const makeStyles = (t: Palette) => StyleSheet.create({
+  screen: { flex: 1, backgroundColor: t.bg },
   // Collapse the ScrollView while the Logs tab (its own FlatList) is showing.
   hidden: { display: 'none' },
-  title: { color: theme.text, fontSize: 26, fontWeight: '700', fontFamily: mono },
+  title: { color: t.text, fontSize: 26, fontWeight: '700', fontFamily: mono },
   titleRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1333,26 +1350,26 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     paddingVertical: 4,
     paddingHorizontal: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   pillText: { fontSize: 11, fontWeight: '700', letterSpacing: 0.5, fontFamily: mono },
   earlyBadge: {
     borderWidth: 1,
-    borderColor: theme.amber,
+    borderColor: t.amber,
     borderRadius: 999,
     paddingVertical: 4,
     paddingHorizontal: 10,
     backgroundColor: 'rgba(251,191,36,0.12)',
   },
   earlyBadgeText: {
-    color: theme.amber,
+    color: t.amber,
     fontSize: 10,
     fontWeight: '800',
     letterSpacing: 0.6,
     fontFamily: mono,
   },
   sectionLabel: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.2,
@@ -1362,18 +1379,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     paddingTop: 8,
     paddingBottom: 10,
-    borderBottomColor: theme.cardBorder,
+    borderBottomColor: t.cardBorder,
     borderBottomWidth: 1,
-    backgroundColor: theme.bg,
+    backgroundColor: t.bg,
   },
   tabBar: {
     flexDirection: 'row',
     gap: 4,
     padding: 4,
     borderRadius: 12,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   tabItem: {
     flex: 1,
@@ -1385,18 +1402,18 @@ const styles = StyleSheet.create({
     borderRadius: 9,
   },
   tabItemActive: {
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   tabLabel: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 12,
     fontWeight: '700',
     letterSpacing: 0.3,
     fontFamily: mono,
   },
-  tabLabelActive: { color: theme.text },
+  tabLabelActive: { color: t.text },
   cardHeader: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1404,7 +1421,7 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
   cardHeaderText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 11,
     fontWeight: '800',
     letterSpacing: 1.2,
@@ -1420,24 +1437,24 @@ const styles = StyleSheet.create({
     minHeight: 26,
   },
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 12,
   },
-  emptyText: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+  emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19 },
   emptyLink: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 6,
     marginTop: 12,
   },
-  emptyLinkText: { color: theme.blue, fontSize: 13, fontWeight: '600' },
+  emptyLinkText: { color: t.blue, fontSize: 13, fontWeight: '600' },
   boxCard: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 12,
@@ -1447,11 +1464,11 @@ const styles = StyleSheet.create({
   boxMain: { flexDirection: 'row', alignItems: 'center', gap: 12 },
   boxDot: { width: 10, height: 10, borderRadius: 5 },
   boxBody: { flex: 1, minWidth: 0 },
-  boxName: { color: theme.text, fontSize: 15, fontWeight: '700', fontFamily: mono },
-  activeTag: { color: theme.blue, fontSize: 12, fontWeight: '700' },
-  boxHost: { color: theme.textFaint, fontSize: 12, fontFamily: mono, marginTop: 2 },
+  boxName: { color: t.text, fontSize: 15, fontWeight: '700', fontFamily: mono },
+  activeTag: { color: t.blue, fontSize: 12, fontWeight: '700' },
+  boxHost: { color: t.textFaint, fontSize: 12, fontFamily: mono, marginTop: 2 },
   chevron: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 12,
     fontWeight: '800',
     letterSpacing: 1,
@@ -1459,14 +1476,14 @@ const styles = StyleSheet.create({
   },
   editPanel: {
     marginTop: 12,
-    borderTopColor: theme.cardBorder,
+    borderTopColor: t.cardBorder,
     borderTopWidth: 1,
     paddingTop: 14,
   },
   editSteps: { marginTop: 14 },
   smartTvWrap: { marginTop: 14 },
   editError: {
-    color: theme.red,
+    color: t.red,
     fontSize: 12,
     fontFamily: mono,
     marginTop: 10,
@@ -1479,7 +1496,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
   },
   editLastIp: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontFamily: mono,
     marginRight: 'auto',
@@ -1491,7 +1508,7 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
   tokenToggle: {
-    color: theme.blue,
+    color: t.blue,
     fontSize: 11,
     fontWeight: '800',
     letterSpacing: 1,
@@ -1507,25 +1524,25 @@ const styles = StyleSheet.create({
   },
   iconBtn: { paddingVertical: 2 },
   iconBtnText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 11,
     fontWeight: '800',
     letterSpacing: 1,
     fontFamily: mono,
   },
   fieldLabel: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.2,
     marginBottom: 6,
   },
   input: {
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 8,
-    color: theme.text,
+    color: t.text,
     fontSize: 15,
     fontFamily: mono,
     paddingVertical: 12,
@@ -1539,9 +1556,9 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     alignItems: 'center',
   },
-  btnTest: { backgroundColor: theme.inset, borderColor: theme.blue, borderWidth: 1 },
-  btnTestText: { color: theme.blue, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
-  btnSave: { backgroundColor: theme.blue },
+  btnTest: { backgroundColor: t.inset, borderColor: t.blue, borderWidth: 1 },
+  btnTestText: { color: t.blue, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  btnSave: { backgroundColor: t.blue },
   btnSaveText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   rateRow: {
     flexDirection: 'row',
@@ -1553,14 +1570,14 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     paddingVertical: 12,
     paddingHorizontal: 14,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
   },
   rateBody: { flex: 1 },
-  rateTitle: { color: theme.text, fontSize: 14, fontWeight: '700' },
-  rateSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
+  rateTitle: { color: t.text, fontSize: 14, fontWeight: '700' },
+  rateSub: { color: t.textDim, fontSize: 11, marginTop: 2 },
   aboutRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1568,7 +1585,7 @@ const styles = StyleSheet.create({
     marginBottom: 4,
     paddingHorizontal: 2,
   },
-  aboutText: { color: theme.textDim, fontSize: 12 },
+  aboutText: { color: t.textDim, fontSize: 12 },
   unlockRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1577,16 +1594,16 @@ const styles = StyleSheet.create({
     marginTop: 10,
     paddingVertical: 12,
     paddingHorizontal: 14,
-    backgroundColor: theme.card,
-    borderColor: theme.blue,
+    backgroundColor: t.card,
+    borderColor: t.blue,
     borderWidth: 1,
     borderRadius: 12,
   },
   unlockRowBody: { flex: 1 },
-  unlockRowTitle: { color: theme.text, fontSize: 14, fontWeight: '800' },
-  unlockRowSub: { color: theme.textDim, fontSize: 11, marginTop: 2 },
+  unlockRowTitle: { color: t.text, fontSize: 14, fontWeight: '800' },
+  unlockRowSub: { color: t.textDim, fontSize: 11, marginTop: 2 },
   btnBuy: {
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 8,
     paddingVertical: 14,
     alignItems: 'center',
@@ -1594,26 +1611,26 @@ const styles = StyleSheet.create({
   },
   btnBuyText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   btnRestore: {
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 8,
     paddingVertical: 14,
     alignItems: 'center',
   },
-  btnRestoreText: { color: theme.textDim, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  btnRestoreText: { color: t.textDim, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   restoreMsg: { fontSize: 12, fontFamily: mono, marginTop: 10 },
-  purchaseHint: { color: theme.textFaint, fontSize: 11, marginTop: 10 },
+  purchaseHint: { color: t.textFaint, fontSize: 11, marginTop: 10 },
   pressed: { opacity: 0.7 },
   stepRow: { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 10, gap: 10 },
   stepMark: { fontSize: 18, fontWeight: '800', width: 22, textAlign: 'center' },
   stepBody: { flex: 1 },
-  stepLabel: { color: theme.text, fontSize: 13, fontFamily: mono },
+  stepLabel: { color: t.text, fontSize: 13, fontFamily: mono },
   stepDetail: { fontSize: 12, fontFamily: mono, marginTop: 3 },
   versionRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    borderTopColor: theme.cardBorder,
+    borderTopColor: t.cardBorder,
     borderTopWidth: 1,
     paddingTop: 10,
     marginTop: 2,
@@ -1626,22 +1643,22 @@ const styles = StyleSheet.create({
   },
   prefBody: { flex: 1, minWidth: 0 },
   prefCol: { gap: 10 },
-  prefLabel: { color: theme.text, fontSize: 15, fontWeight: '600', fontFamily: mono },
-  prefSub: { color: theme.textFaint, fontSize: 12, marginTop: 3 },
+  prefLabel: { color: t.text, fontSize: 15, fontWeight: '600', fontFamily: mono },
+  prefSub: { color: t.textFaint, fontSize: 12, marginTop: 3 },
   segRow: {
     flexDirection: 'row',
     gap: 2,
     padding: 2,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   seg: { flex: 1, paddingVertical: 10, borderRadius: 8, alignItems: 'center' },
-  segActive: { backgroundColor: theme.card },
-  segText: { color: theme.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
-  segTextActive: { color: theme.text },
-  versionLabel: { color: theme.textDim, fontSize: 13 },
-  versionValue: { color: theme.green, fontSize: 13, fontFamily: mono, fontWeight: '700' },
-  hint: { color: theme.textFaint, fontSize: 12, lineHeight: 17, fontFamily: mono },
+  segActive: { backgroundColor: t.card },
+  segText: { color: t.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
+  segTextActive: { color: t.text },
+  versionLabel: { color: t.textDim, fontSize: 13 },
+  versionValue: { color: t.green, fontSize: 13, fontFamily: mono, fontWeight: '700' },
+  hint: { color: t.textFaint, fontSize: 12, lineHeight: 17, fontFamily: mono },
 
   // ---- Pairing QR modal ----
   qrBackdrop: {
@@ -1654,15 +1671,15 @@ const styles = StyleSheet.create({
   qrSheet: {
     width: '100%',
     maxWidth: 360,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 16,
     padding: 20,
     alignItems: 'center',
   },
   qrTitle: {
-    color: theme.text,
+    color: t.text,
     fontSize: 16,
     fontWeight: '700',
     fontFamily: mono,
@@ -1677,7 +1694,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   qrCaption: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 13,
     fontFamily: mono,
     marginTop: 14,
@@ -1689,12 +1706,12 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
   },
   qrFallbackText: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontFamily: mono,
   },
   qrFallbackToken: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontFamily: mono,
     marginTop: 2,
@@ -1702,8 +1719,8 @@ const styles = StyleSheet.create({
   },
   qrClose: {
     marginTop: 18,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 8,
     paddingVertical: 12,
@@ -1711,7 +1728,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   qrCloseText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontWeight: '800',
     fontSize: 13,
     letterSpacing: 1,

--- a/app/app/+not-found.tsx
+++ b/app/app/+not-found.tsx
@@ -1,9 +1,11 @@
 import { Link, Stack } from 'expo-router';
 import { StyleSheet, Text, View } from 'react-native';
 
-import { theme } from '@/lib/theme';
+import { useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 export default function NotFoundScreen() {
+  const styles = useThemedStyles(makeStyles);
   return (
     <>
       <Stack.Screen options={{ title: 'Not found' }} />
@@ -17,15 +19,15 @@ export default function NotFoundScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: theme.bg,
+    backgroundColor: t.bg,
     alignItems: 'center',
     justifyContent: 'center',
     padding: 20,
   },
-  title: { fontSize: 18, fontWeight: '600', color: theme.text },
+  title: { fontSize: 18, fontWeight: '600', color: t.text },
   link: { marginTop: 16, paddingVertical: 16 },
-  linkText: { fontSize: 15, color: theme.blue },
+  linkText: { fontSize: 15, color: t.blue },
 });

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,5 +1,6 @@
-import { DarkTheme, Stack, ThemeProvider } from 'expo-router';
+import { DarkTheme, DefaultTheme, Stack, ThemeProvider } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useMemo } from 'react';
 import 'react-native-reanimated';
 
 import { ReviewPrompt } from '@/components/ReviewPrompt';
@@ -9,7 +10,7 @@ import { UnlockToast } from '@/components/UnlockToast';
 import { DeepLinkHandler } from '@/lib/DeepLink';
 import { EntitlementProvider } from '@/lib/EntitlementContext';
 import { SettingsProvider } from '@/lib/SettingsContext';
-import { theme } from '@/lib/theme';
+import { useResolvedScheme, useTheme } from '@/lib/theme';
 
 export { ErrorBoundary } from 'expo-router';
 
@@ -17,24 +18,29 @@ export const unstable_settings = {
   initialRouteName: '(tabs)',
 };
 
-const opsTheme = {
-  ...DarkTheme,
-  colors: {
-    ...DarkTheme.colors,
-    background: theme.bg,
-    card: theme.tabBar,
-    border: theme.tabBarBorder,
-    text: theme.text,
-    primary: theme.blue,
-  },
-};
-
 export default function RootLayout() {
+  const t = useTheme();
+  const scheme = useResolvedScheme();
+  const navTheme = useMemo(() => {
+    const base = scheme === 'light' ? DefaultTheme : DarkTheme;
+    return {
+      ...base,
+      colors: {
+        ...base.colors,
+        background: t.bg,
+        card: t.tabBar,
+        border: t.tabBarBorder,
+        text: t.text,
+        primary: t.blue,
+      },
+    };
+  }, [t, scheme]);
+
   return (
     <SettingsProvider>
       <EntitlementProvider>
-        <ThemeProvider value={opsTheme}>
-          <StatusBar style="light" />
+        <ThemeProvider value={navTheme}>
+          <StatusBar style={scheme === 'light' ? 'dark' : 'light'} />
           <DeepLinkHandler />
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -16,11 +16,14 @@ import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, UpdateCheck } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 const POLL_MS = 30 * 60 * 1000; // twice an hour; the box caches for ~6h anyway
 
 export function AgentUpdateBanner() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
   const configured = settings.host.trim().length > 0;
   const poll = usePoll<UpdateCheck | null>(
@@ -76,7 +79,7 @@ export function AgentUpdateBanner() {
   return (
     <View style={styles.card}>
       <View style={styles.header}>
-        <Ionicons name="arrow-up-circle" size={18} color={theme.blue} />
+        <Ionicons name="arrow-up-circle" size={18} color={t.blue} />
         <Text style={styles.title} numberOfLines={1}>
           Agent update available{check.latest ? ` — ${check.latest}` : ''}
         </Text>
@@ -87,7 +90,7 @@ export function AgentUpdateBanner() {
               hapticLight();
               setDismissed(check.latest);
             }}>
-            <Ionicons name="close" size={16} color={theme.textDim} />
+            <Ionicons name="close" size={16} color={t.textDim} />
           </Pressable>
         )}
       </View>
@@ -108,7 +111,7 @@ export function AgentUpdateBanner() {
             <Ionicons
               name={expanded ? 'chevron-up' : 'chevron-down'}
               size={14}
-              color={theme.blue}
+              color={t.blue}
             />
             <Text style={styles.notesToggleText}>What's new</Text>
           </Pressable>
@@ -138,10 +141,10 @@ export function AgentUpdateBanner() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.blue,
+    backgroundColor: t.card,
+    borderColor: t.blue,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
@@ -149,13 +152,13 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  title: { color: theme.text, fontSize: 14, fontWeight: '700', flex: 1 },
-  sub: { color: theme.textDim, fontSize: 12, fontFamily: mono },
+  title: { color: t.text, fontSize: 14, fontWeight: '700', flex: 1 },
+  sub: { color: t.textDim, fontSize: 12, fontFamily: mono },
   notesToggle: { flexDirection: 'row', alignItems: 'center', gap: 5 },
-  notesToggleText: { color: theme.blue, fontSize: 13, fontWeight: '600' },
-  notes: { color: theme.textDim, fontSize: 12, lineHeight: 18, fontFamily: mono },
+  notesToggleText: { color: t.blue, fontSize: 13, fontWeight: '600' },
+  notes: { color: t.textDim, fontSize: 12, lineHeight: 18, fontFamily: mono },
   btn: {
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 10,
     paddingVertical: 11,
     alignItems: 'center',
@@ -163,7 +166,7 @@ const styles = StyleSheet.create({
   },
   btnPressed: { opacity: 0.85 },
   btnText: { color: '#0b1220', fontSize: 14, fontWeight: '700' },
-  msg: { color: theme.text, fontSize: 13, lineHeight: 19 },
-  hint: { color: theme.textDim, fontSize: 12, lineHeight: 18 },
-  code: { fontFamily: mono, color: theme.text },
+  msg: { color: t.text, fontSize: 13, lineHeight: 19 },
+  hint: { color: t.textDim, fontSize: 12, lineHeight: 18 },
+  code: { fontFamily: mono, color: t.text },
 });

--- a/app/components/BoxSwitcher.tsx
+++ b/app/components/BoxSwitcher.tsx
@@ -23,20 +23,25 @@ import {
   useBoxes,
   useBoxOnlineStatus,
 } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 /** Reachability -> dot color. Unknown (not yet probed) is amber. */
-function dotColor(status: BoxReachability | undefined): string {
-  if (status === 'reachable') return theme.green;
-  if (status === 'offline') return theme.slate;
-  return theme.amber; // 'unknown' / not yet probed
+function dotColor(status: BoxReachability | undefined, t: Palette): string {
+  if (status === 'reachable') return t.green;
+  if (status === 'offline') return t.slate;
+  return t.amber; // 'unknown' / not yet probed
 }
 
 function Dot({ status }: { status: BoxReachability | undefined }) {
-  return <View style={[styles.dot, { backgroundColor: dotColor(status) }]} />;
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  return <View style={[styles.dot, { backgroundColor: dotColor(status, t) }]} />;
 }
 
 export function BoxSwitcher() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const insets = useSafeAreaInsets();
   const { boxes, activeBox, activeBoxId, switchBox } = useBoxes();
   const [open, setOpen] = useState(false);
@@ -83,7 +88,7 @@ export function BoxSwitcher() {
             <Ionicons
               name={open ? 'chevron-up' : 'chevron-down'}
               size={16}
-              color={theme.textDim}
+              color={t.textDim}
             />
           )}
         </Pressable>
@@ -124,7 +129,7 @@ export function BoxSwitcher() {
                       </Text>
                     </View>
                     {isActive && (
-                      <Ionicons name="checkmark" size={18} color={theme.blue} />
+                      <Ionicons name="checkmark" size={18} color={t.blue} />
                     )}
                   </Pressable>
                 );
@@ -136,7 +141,7 @@ export function BoxSwitcher() {
                   styles.addRow,
                   pressed && styles.rowPressed,
                 ]}>
-                <Ionicons name="add" size={18} color={theme.blue} />
+                <Ionicons name="add" size={18} color={t.blue} />
                 <Text style={styles.addText}>Add a box</Text>
               </Pressable>
             </Pressable>
@@ -147,13 +152,13 @@ export function BoxSwitcher() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   headerWrap: {
     paddingHorizontal: 14,
     paddingBottom: 8,
-    backgroundColor: theme.bg,
+    backgroundColor: t.bg,
     borderBottomWidth: 1,
-    borderBottomColor: theme.cardBorder,
+    borderBottomColor: t.cardBorder,
   },
   headerRow: {
     flexDirection: 'row',
@@ -166,8 +171,8 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     flexShrink: 1,
     gap: 8,
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 8,
@@ -175,7 +180,7 @@ const styles = StyleSheet.create({
   },
   pressed: { opacity: 0.7 },
   pillLabel: {
-    color: theme.text,
+    color: t.text,
     fontFamily: mono,
     fontSize: 14,
     fontWeight: '700',
@@ -191,8 +196,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
   },
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 14,
     paddingVertical: 6,
@@ -210,10 +215,10 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 14,
   },
-  rowPressed: { backgroundColor: theme.inset },
+  rowPressed: { backgroundColor: t.inset },
   rowBody: { flex: 1, minWidth: 0 },
-  rowName: { color: theme.text, fontSize: 15, fontWeight: '700', fontFamily: mono },
-  rowHost: { color: theme.textFaint, fontSize: 12, fontFamily: mono, marginTop: 2 },
+  rowName: { color: t.text, fontSize: 15, fontWeight: '700', fontFamily: mono },
+  rowHost: { color: t.textFaint, fontSize: 12, fontFamily: mono, marginTop: 2 },
   addRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -221,8 +226,8 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 14,
     borderTopWidth: 1,
-    borderTopColor: theme.cardBorder,
+    borderTopColor: t.cardBorder,
     marginTop: 4,
   },
-  addText: { color: theme.blue, fontSize: 14, fontWeight: '700', fontFamily: mono },
+  addText: { color: t.blue, fontSize: 14, fontWeight: '700', fontFamily: mono },
 });

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -14,7 +14,7 @@ import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api, ConnSettings, Displays } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
-import { mono, theme } from '@/lib/theme';
+import { mono, Palette, useTheme, useThemedStyles } from '@/lib/theme';
 
 export function CouchModeSheet({
   visible,
@@ -32,6 +32,8 @@ export function CouchModeSheet({
   onChanged: (session: 'gamescope' | 'desktop') => void;
   onClose: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const inGameMode = displays?.session === 'gamescope';
   const outputs = displays?.game_outputs ?? [];
   // Show the picker only where the choice is actually honored (the agent
@@ -92,7 +94,7 @@ export function CouchModeSheet({
           {inGameMode ? (
             <>
               <View style={styles.armedRow}>
-                <Ionicons name="game-controller" size={18} color={theme.green} />
+                <Ionicons name="game-controller" size={18} color={t.green} />
                 <Text style={styles.armedText}>Gaming on the TV</Text>
               </View>
               <Pressable
@@ -150,21 +152,21 @@ export function CouchModeSheet({
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
   sheet: {
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     padding: 20,
     paddingBottom: 32,
     gap: 10,
   },
-  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
-  sub: { color: theme.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
-  blurb: { color: theme.textDim, fontSize: 13, lineHeight: 19 },
+  title: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  sub: { color: t.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
+  blurb: { color: t.textDim, fontSize: 13, lineHeight: 19 },
 
   pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
   pill: {
@@ -172,13 +174,13 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 14,
     borderRadius: 999,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  pillOn: { borderColor: theme.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
-  pillText: { color: theme.textDim, fontSize: 14, fontWeight: '600', fontFamily: mono },
-  pillTextOn: { color: theme.blue },
+  pillOn: { borderColor: t.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
+  pillText: { color: t.textDim, fontSize: 14, fontWeight: '600', fontFamily: mono },
+  pillTextOn: { color: t.blue },
   pressed: { opacity: 0.7 },
 
   startBtn: {
@@ -189,18 +191,18 @@ const styles = StyleSheet.create({
     gap: 8,
     paddingVertical: 13,
     borderRadius: 12,
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
   },
-  exitBtn: { backgroundColor: theme.green },
+  exitBtn: { backgroundColor: t.green },
   startText: { color: '#fff', fontSize: 15, fontWeight: '700' },
 
   armedRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     padding: 12,
   },
-  armedText: { color: theme.text, fontSize: 15 },
+  armedText: { color: t.text, fontSize: 15 },
 });

--- a/app/components/LogsPanel.tsx
+++ b/app/components/LogsPanel.tsx
@@ -5,7 +5,7 @@ import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, Journal, Unit, UnitScope } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type PickerUnit = { unit: string; scope: UnitScope; short: string };
 
@@ -29,6 +29,8 @@ function toPicker(units: Unit[]): PickerUnit[] {
  * flex room, not wrap it in a ScrollView.
  */
 export function LogsPanel() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
 
   const [selected, setSelected] = useState(0);
@@ -91,8 +93,8 @@ export function LogsPanel() {
           <Switch
             value={auto}
             onValueChange={setAuto}
-            trackColor={{ false: theme.inset, true: theme.green }}
-            thumbColor={theme.text}
+            trackColor={{ false: t.inset, true: t.green }}
+            thumbColor={t.text}
           />
           <Pressable
             onPress={journal.refresh}
@@ -128,14 +130,14 @@ export function LogsPanel() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   root: { flex: 1, paddingHorizontal: 14, paddingTop: 14 },
   segments: {
     flexDirection: 'row',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     padding: 3,
     marginBottom: 10,
   },
@@ -145,33 +147,33 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
   },
-  segmentActive: { backgroundColor: theme.card, borderWidth: 1, borderColor: theme.blue },
-  segmentText: { color: theme.textDim, fontSize: 12, fontFamily: mono },
-  segmentTextActive: { color: theme.blue, fontWeight: '700' },
+  segmentActive: { backgroundColor: t.card, borderWidth: 1, borderColor: t.blue },
+  segmentText: { color: t.textDim, fontSize: 12, fontFamily: mono },
+  segmentTextActive: { color: t.blue, fontWeight: '700' },
   toolbar: {
     flexDirection: 'row',
     alignItems: 'center',
     marginBottom: 8,
     gap: 8,
   },
-  unitLabel: { color: theme.text, fontSize: 12, fontFamily: mono, flex: 1 },
-  scopeLabel: { color: theme.textFaint },
+  unitLabel: { color: t.text, fontSize: 12, fontFamily: mono, flex: 1 },
+  scopeLabel: { color: t.textFaint },
   toolbarRight: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  autoLabel: { color: theme.textDim, fontSize: 12 },
+  autoLabel: { color: t.textDim, fontSize: 12 },
   refreshBtn: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 8,
     paddingVertical: 10,
     paddingHorizontal: 14,
   },
-  refreshText: { color: theme.blue, fontSize: 12, fontWeight: '700', letterSpacing: 1 },
+  refreshText: { color: t.blue, fontSize: 12, fontWeight: '700', letterSpacing: 1 },
   pressed: { opacity: 0.7 },
   logBox: {
     flex: 1,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     paddingHorizontal: 10,
@@ -180,19 +182,19 @@ const styles = StyleSheet.create({
   },
   logList: { flex: 1 },
   line: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 11,
     fontFamily: mono,
     lineHeight: 16,
   },
   errStrip: {
-    backgroundColor: theme.redDeep,
-    borderColor: theme.red,
+    backgroundColor: t.redDeep,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 8,
     padding: 8,
     marginTop: 8,
   },
   errText: { color: '#fecaca', fontSize: 12, fontFamily: mono },
-  dim: { color: theme.textFaint, fontSize: 12, fontFamily: mono, paddingVertical: 12 },
+  dim: { color: t.textFaint, fontSize: 12, fontFamily: mono, paddingVertical: 12 },
 });

--- a/app/components/NowPlayingCard.tsx
+++ b/app/components/NowPlayingCard.tsx
@@ -13,7 +13,7 @@ import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
 import { hapticLight, hapticMedium } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, numeric, theme } from '@/lib/theme';
+import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 function fmtTime(ms: number): string {
   const t = Math.max(0, Math.round(ms / 1000));
@@ -23,6 +23,8 @@ function fmtTime(ms: number): string {
 }
 
 export function NowPlayingCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
@@ -143,7 +145,7 @@ export function NowPlayingCard() {
             <ArtImage uri={artUri} />
           ) : (
             <View style={styles.artPlaceholder}>
-              <Ionicons name="musical-notes" size={22} color={theme.textFaint} />
+              <Ionicons name="musical-notes" size={22} color={t.textFaint} />
             </View>
           )}
         </View>
@@ -192,11 +194,13 @@ export function NowPlayingCard() {
 
 /** Split out so the art <Image> can fail-soft to a placeholder via onError. */
 function ArtImage({ uri }: { uri: string }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [failed, setFailed] = useState(false);
   if (failed) {
     return (
       <View style={styles.artPlaceholder}>
-        <Ionicons name="musical-notes" size={22} color={theme.textFaint} />
+        <Ionicons name="musical-notes" size={22} color={t.textFaint} />
       </View>
     );
   }
@@ -216,6 +220,8 @@ function TransportButton({
   disabled?: boolean;
   primary?: boolean;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <Pressable
       onPress={onPress}
@@ -229,23 +235,23 @@ function TransportButton({
       <Ionicons
         name={icon}
         size={primary ? 26 : 22}
-        color={disabled ? theme.textFaint : primary ? theme.bg : theme.text}
+        color={disabled ? t.textFaint : primary ? t.bg : t.text}
       />
     </Pressable>
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 10,
   },
   cardTitle: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.2,
@@ -254,16 +260,16 @@ const styles = StyleSheet.create({
   },
   pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 10 },
   pill: {
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 4,
     paddingHorizontal: 10,
     maxWidth: 160,
   },
-  pillOn: { backgroundColor: theme.green, borderColor: theme.green },
-  pillText: { color: theme.textDim, fontSize: 11, fontFamily: mono },
-  pillTextOn: { color: theme.bg, fontWeight: '700' },
+  pillOn: { backgroundColor: t.green, borderColor: t.green },
+  pillText: { color: t.textDim, fontSize: 11, fontFamily: mono },
+  pillTextOn: { color: t.bg, fontWeight: '700' },
 
   row: { flexDirection: 'row', alignItems: 'center', gap: 12 },
   art: { width: 56, height: 56, borderRadius: 8, overflow: 'hidden' },
@@ -272,24 +278,24 @@ const styles = StyleSheet.create({
     width: 56,
     height: 56,
     borderRadius: 8,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     alignItems: 'center',
     justifyContent: 'center',
   },
   meta: { flex: 1 },
-  trackTitle: { color: theme.text, fontSize: 15, fontWeight: '700' },
-  trackArtist: { color: theme.textDim, fontSize: 13, marginTop: 2 },
+  trackTitle: { color: t.text, fontSize: 15, fontWeight: '700' },
+  trackArtist: { color: t.textDim, fontSize: 13, marginTop: 2 },
 
   barTrack: {
     height: 6,
     borderRadius: 3,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     overflow: 'hidden',
     marginTop: 14,
   },
-  barFill: { height: '100%', borderRadius: 3, backgroundColor: theme.green },
+  barFill: { height: '100%', borderRadius: 3, backgroundColor: t.green },
   times: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 6 },
-  time: { color: theme.textDim, fontSize: 11, ...numeric },
+  time: { color: t.textDim, fontSize: 11, ...numeric },
 
   transport: {
     flexDirection: 'row',
@@ -304,9 +310,9 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
-  tBtnPrimary: { backgroundColor: theme.green, width: 54, height: 54 },
+  tBtnPrimary: { backgroundColor: t.green, width: 54, height: 54 },
   tBtnPressed: { opacity: 0.7 },
   tBtnDisabled: { opacity: 0.4 },
 });

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -5,7 +5,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { recordPurchaseDate } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
 import { buy, getProduct, restore } from '@/lib/purchase';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 const FALLBACK_PRICE = '$4.99';
 
@@ -17,6 +18,7 @@ const FALLBACK_PRICE = '$4.99';
 export default function Paywall() {
   const insets = useSafeAreaInsets();
   const { recordPurchase } = useEntitlement();
+  const styles = useThemedStyles(makeStyles);
 
   const [price, setPrice] = useState<string | null>(null);
   const [busy, setBusy] = useState<'buy' | 'restore' | null>(null);
@@ -113,10 +115,10 @@ export default function Paywall() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   screen: {
     flex: 1,
-    backgroundColor: theme.bg,
+    backgroundColor: t.bg,
     paddingHorizontal: 28,
     justifyContent: 'space-between',
   },
@@ -125,20 +127,20 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     overflow: 'hidden',
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     marginBottom: 18,
   },
   mark: { width: 88, height: 88 },
   appName: {
-    color: theme.text,
+    color: t.text,
     fontSize: 24,
     fontWeight: '800',
     fontFamily: mono,
     marginBottom: 6,
   },
-  title: { color: theme.amber, fontSize: 15, fontWeight: '700', marginBottom: 12 },
+  title: { color: t.amber, fontSize: 15, fontWeight: '700', marginBottom: 12 },
   blurb: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 13,
     lineHeight: 19,
     textAlign: 'center',
@@ -146,7 +148,7 @@ const styles = StyleSheet.create({
   },
   buyBtn: {
     alignSelf: 'stretch',
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
     borderRadius: 10,
     paddingVertical: 15,
     alignItems: 'center',
@@ -155,16 +157,16 @@ const styles = StyleSheet.create({
   buyBtnText: { color: '#0b1220', fontSize: 14, fontWeight: '800', letterSpacing: 1 },
   restoreBtn: {
     alignSelf: 'stretch',
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 10,
     paddingVertical: 13,
     alignItems: 'center',
   },
-  restoreBtnText: { color: theme.textDim, fontSize: 13, fontWeight: '700', letterSpacing: 1 },
+  restoreBtnText: { color: t.textDim, fontSize: 13, fontWeight: '700', letterSpacing: 1 },
   error: {
-    color: theme.red,
+    color: t.red,
     fontSize: 12,
     fontFamily: mono,
     textAlign: 'center',

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -12,7 +12,8 @@ import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 import { sendWol, wolAvailable } from '@/lib/wol';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
@@ -56,6 +57,8 @@ function VolumeSlider({
   onStep: (dir: 1 | -1) => void;
   onDone: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const absolute = level != null;
   const [w, setW] = React.useState(0);
   const [frac, setFrac] = React.useState(absolute ? level / 100 : 0.5);
@@ -145,7 +148,7 @@ function VolumeSlider({
 
   return (
     <View style={styles.sliderRow}>
-      <Ionicons name="volume-low" size={18} color={theme.textDim} />
+      <Ionicons name="volume-low" size={18} color={t.textDim} />
       <View
         style={styles.sliderTrack}
         onLayout={(e) => setW(e.nativeEvent.layout.width)}
@@ -158,7 +161,7 @@ function VolumeSlider({
       {absolute ? (
         <Text style={styles.sliderPct}>{Math.round(frac * 100)}</Text>
       ) : (
-        <Ionicons name="volume-high" size={18} color={theme.textDim} />
+        <Ionicons name="volume-high" size={18} color={t.textDim} />
       )}
     </View>
   );
@@ -173,6 +176,8 @@ function VolumeSlider({
  * nothing to control.
  */
 export function RemotePowerBar() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const insets = useSafeAreaInsets();
   const { settings, ready, update } = useSettings();
   const configured = settings.host.trim().length > 0;
@@ -539,9 +544,9 @@ export function RemotePowerBar() {
           <Ionicons
             name={inGameMode ? 'game-controller' : 'tv-outline'}
             size={16}
-            color={inGameMode ? theme.green : theme.text}
+            color={inGameMode ? t.green : t.text}
           />
-          <Text style={[styles.couchLabel, inGameMode && { color: theme.green }]}>
+          <Text style={[styles.couchLabel, inGameMode && { color: t.green }]}>
             {inGameMode ? 'On TV' : 'Couch'}
           </Text>
         </Pressable>
@@ -554,8 +559,8 @@ export function RemotePowerBar() {
         }}
         hitSlop={8}
         style={({ pressed }) => [styles.trigger, pressed && styles.pressed]}>
-        <Ionicons name={triggerIcon} size={20} color={theme.text} />
-        <Ionicons name="chevron-down" size={14} color={theme.textDim} />
+        <Ionicons name={triggerIcon} size={20} color={t.text} />
+        <Ionicons name="chevron-down" size={14} color={t.textDim} />
       </Pressable>
 
       <Modal
@@ -574,8 +579,8 @@ export function RemotePowerBar() {
                     onWake();
                   }}
                   style={({ pressed }) => [styles.bigBtn, pressed && styles.pressed]}>
-                  <Ionicons name="power" size={22} color={theme.green} />
-                  <Text style={[styles.bigLabel, { color: theme.green }]}>
+                  <Ionicons name="power" size={22} color={t.green} />
+                  <Text style={[styles.bigLabel, { color: t.green }]}>
                     {waking ? 'Waking…' : 'Wake box'}
                   </Text>
                 </Pressable>
@@ -594,8 +599,8 @@ export function RemotePowerBar() {
                       wired === false && styles.disabled,
                       pressed && styles.pressed,
                     ]}>
-                    <Ionicons name="moon" size={22} color={theme.amber} />
-                    <Text style={[styles.bigLabel, { color: theme.amber }]}>
+                    <Ionicons name="moon" size={22} color={t.amber} />
+                    <Text style={[styles.bigLabel, { color: t.amber }]}>
                       {wired === false ? 'Suspend (needs Ethernet)' : 'Suspend'}
                     </Text>
                   </Pressable>
@@ -616,7 +621,7 @@ export function RemotePowerBar() {
                     setSaverOpen(true);
                   }}
                   style={({ pressed }) => [styles.bigBtn, pressed && styles.pressed]}>
-                  <Ionicons name="film-outline" size={22} color={theme.text} />
+                  <Ionicons name="film-outline" size={22} color={t.text} />
                   <Text style={styles.bigLabel}>
                     {saver?.running ? 'Screensaver · playing' : 'Screensaver'}
                   </Text>
@@ -631,7 +636,7 @@ export function RemotePowerBar() {
                     setSleepOpen(true);
                   }}
                   style={({ pressed }) => [styles.bigBtn, pressed && styles.pressed]}>
-                  <Ionicons name="timer-outline" size={22} color={theme.text} />
+                  <Ionicons name="timer-outline" size={22} color={t.text} />
                   <Text style={styles.bigLabel}>
                     {schedule.sleep
                       ? `${schedule.sleep.action === 'poweroff' ? 'Power off' : 'Suspend'} in ${Math.max(
@@ -649,15 +654,15 @@ export function RemotePowerBar() {
                     disabled={busy}
                     onPress={() => sendPower('power_on')}
                     style={({ pressed }) => [styles.tvBtn, pressed && styles.pressed]}>
-                    <Ionicons name="power" size={18} color={theme.green} />
-                    <Text style={[styles.tvBtnText, { color: theme.green }]}>TV On</Text>
+                    <Ionicons name="power" size={18} color={t.green} />
+                    <Text style={[styles.tvBtnText, { color: t.green }]}>TV On</Text>
                   </Pressable>
                   <Pressable
                     disabled={busy}
                     onPress={() => sendPower('power_off')}
                     style={({ pressed }) => [styles.tvBtn, pressed && styles.pressed]}>
-                    <Ionicons name="power-outline" size={18} color={theme.textDim} />
-                    <Text style={[styles.tvBtnText, { color: theme.textDim }]}>TV Off</Text>
+                    <Ionicons name="power-outline" size={18} color={t.textDim} />
+                    <Text style={[styles.tvBtnText, { color: t.textDim }]}>TV Off</Text>
                   </Pressable>
                 </View>
               )}
@@ -683,8 +688,8 @@ export function RemotePowerBar() {
                     disabled={busy}
                     onPress={onSwitchToBox}
                     style={({ pressed }) => [styles.sourceBtn, pressed && styles.pressed]}>
-                    <Ionicons name="tv" size={18} color={theme.green} />
-                    <Text style={[styles.sourceBtnText, { color: theme.green }]}>Switch to Box</Text>
+                    <Ionicons name="tv" size={18} color={t.green} />
+                    <Text style={[styles.sourceBtnText, { color: t.green }]}>Switch to Box</Text>
                   </Pressable>
                 )
               )}
@@ -694,8 +699,8 @@ export function RemotePowerBar() {
                   disabled={busy}
                   onPress={onBlankScreen}
                   style={({ pressed }) => [styles.sourceBtn, pressed && styles.pressed]}>
-                  <Ionicons name="eye-off-outline" size={18} color={theme.amber} />
-                  <Text style={[styles.sourceBtnText, { color: theme.amber }]}>Blank Screen</Text>
+                  <Ionicons name="eye-off-outline" size={18} color={t.amber} />
+                  <Text style={[styles.sourceBtnText, { color: t.amber }]}>Blank Screen</Text>
                 </Pressable>
               )}
 
@@ -734,7 +739,7 @@ export function RemotePowerBar() {
                       disabled={busy}
                       onPress={() => sendTv('volume_down')}
                       style={({ pressed }) => [styles.volBtn, pressed && styles.pressed]}>
-                      <Ionicons name="volume-low" size={24} color={theme.text} />
+                      <Ionicons name="volume-low" size={24} color={t.text} />
                     </Pressable>
                     <Pressable
                       disabled={busy}
@@ -753,14 +758,14 @@ export function RemotePowerBar() {
                       <Ionicons
                         name={muted ? 'volume-mute' : 'volume-medium'}
                         size={24}
-                        color={muted ? theme.red : theme.text}
+                        color={muted ? t.red : t.text}
                       />
                     </Pressable>
                     <Pressable
                       disabled={busy}
                       onPress={() => sendTv('volume_up')}
                       style={({ pressed }) => [styles.volBtn, pressed && styles.pressed]}>
-                      <Ionicons name="volume-high" size={24} color={theme.text} />
+                      <Ionicons name="volume-high" size={24} color={t.text} />
                     </Pressable>
                   </View>
                 </>
@@ -798,7 +803,7 @@ export function RemotePowerBar() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   couchBtn: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -807,12 +812,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
-    backgroundColor: theme.card,
+    borderColor: t.cardBorder,
+    backgroundColor: t.card,
     marginRight: 8,
   },
-  couchBtnActive: { borderColor: theme.green, backgroundColor: 'rgba(52,211,153,0.10)' },
-  couchLabel: { color: theme.text, fontSize: 13, fontWeight: '700', fontFamily: mono },
+  couchBtnActive: { borderColor: t.green, backgroundColor: 'rgba(52,211,153,0.10)' },
+  couchLabel: { color: t.text, fontSize: 13, fontWeight: '700', fontFamily: mono },
   trigger: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -821,8 +826,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     borderRadius: 999,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
-    backgroundColor: theme.card,
+    borderColor: t.cardBorder,
+    backgroundColor: t.card,
   },
   pressed: { opacity: 0.6 },
   disabled: { opacity: 0.45 },
@@ -831,8 +836,8 @@ const styles = StyleSheet.create({
   card: {
     width: 260,
     maxWidth: '100%',
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 14,
     padding: 8,
@@ -850,12 +855,12 @@ const styles = StyleSheet.create({
     height: 52,
     paddingHorizontal: 14,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   bigLabel: { fontSize: 15, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
   suspendGroup: { gap: 6 },
   warnText: {
-    color: theme.amber,
+    color: t.amber,
     fontSize: 11,
     fontFamily: mono,
     lineHeight: 15,
@@ -870,7 +875,7 @@ const styles = StyleSheet.create({
     gap: 8,
     height: 48,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   tvBtnText: { fontSize: 14, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
   volRow: { flexDirection: 'row', gap: 8 },
@@ -878,12 +883,12 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 56,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  volBtnMuted: { backgroundColor: theme.redDeep, borderWidth: 1, borderColor: theme.red },
-  volBtnActive: { borderWidth: 1, borderColor: theme.green },
+  volBtnMuted: { backgroundColor: t.redDeep, borderWidth: 1, borderColor: t.red },
+  volBtnActive: { borderWidth: 1, borderColor: t.green },
   sourceBtn: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -891,12 +896,12 @@ const styles = StyleSheet.create({
     gap: 8,
     height: 48,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   sourceBtnText: { fontSize: 14, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
   sourceSection: { gap: 6 },
   sourceHdr: {
-    color: theme.textFaint,
+    color: t.textFaint,
     fontSize: 11,
     fontWeight: '700',
     letterSpacing: 1.2,
@@ -908,17 +913,17 @@ const styles = StyleSheet.create({
     paddingVertical: 9,
     paddingHorizontal: 12,
     borderRadius: 8,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
-  sourcePillText: { color: theme.text, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  sourcePillText: { color: t.text, fontSize: 12, fontWeight: '700', fontFamily: mono },
   sliderRow: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingHorizontal: 2 },
   sliderTrack: {
     flex: 1,
     height: 40,
     borderRadius: 20,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     justifyContent: 'center',
   },
   sliderThumb: {
@@ -928,7 +933,7 @@ const styles = StyleSheet.create({
     marginLeft: -13,
     top: 7,
     borderRadius: 13,
-    backgroundColor: theme.text,
+    backgroundColor: t.text,
   },
   sliderFill: {
     position: 'absolute',
@@ -939,7 +944,7 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(96,165,250,0.25)',
   },
   sliderPct: {
-    color: theme.text,
+    color: t.text,
     fontSize: 13,
     fontWeight: '700',
     fontFamily: mono,
@@ -951,10 +956,10 @@ const styles = StyleSheet.create({
     gap: 2,
     padding: 2,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
   },
   seg: { flex: 1, paddingVertical: 8, borderRadius: 8, alignItems: 'center' },
-  segActive: { backgroundColor: theme.card },
-  segText: { color: theme.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
-  segTextActive: { color: theme.text },
+  segActive: { backgroundColor: t.card },
+  segText: { color: t.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
+  segTextActive: { color: t.text },
 });

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -9,7 +9,7 @@ import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { Settings } from '@/lib/settings';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -30,6 +30,8 @@ export function RemoteView({
   client: GamepadClient;
   settings: Settings;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   // TV caps, self-polled: cheap, and the strip adapts if the backend changes.
   // Deliberately does NOT gate on tvPoll.error: usePoll keeps last-good data
   // through a transient failure, and dropping the caps there would silently
@@ -200,7 +202,7 @@ export function RemoteView({
           </View>
           {canBlank && (
             <Pressable onPress={blank} style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
-              <Ionicons name="power" size={20} color={theme.red} />
+              <Ionicons name="power" size={20} color={t.red} />
             </Pressable>
           )}
         </View>
@@ -220,7 +222,7 @@ export function RemoteView({
               <Ionicons
                 name={s === 'dpad' ? 'apps' : 'move'}
                 size={14}
-                color={surface === s ? theme.blue : theme.textDim}
+                color={surface === s ? t.blue : t.textDim}
               />
               <Text style={[styles.segText, surface === s && styles.segTextActive]}>
                 {s === 'dpad' ? 'D-PAD' : 'TRACKPAD'}
@@ -289,9 +291,9 @@ export function RemoteView({
           onMinus={() => tvOp('volume_down')}
         />
         <View style={styles.midStack}>
-          <MidBtn icon="volume-mute" label="MUTE" color={theme.red} onPress={() => tvOp('mute')} />
-          <MidBtn icon="logo-steam" label="STEAM" color={theme.green} onPress={steam} />
-          <MidBtn icon="ellipsis-horizontal" label="QAM" color={theme.amber} onPress={qam} />
+          <MidBtn icon="volume-mute" label="MUTE" color={t.red} onPress={() => tvOp('mute')} />
+          <MidBtn icon="logo-steam" label="STEAM" color={t.green} onPress={steam} />
+          <MidBtn icon="ellipsis-horizontal" label="QAM" color={t.amber} onPress={qam} />
         </View>
         {hasTvKeys ? (
           <Rocker
@@ -318,7 +320,7 @@ export function RemoteView({
                   isBox && styles.sourcePillBox,
                   pressed && styles.pressed,
                 ]}>
-                <Text style={[styles.sourceText, isBox && { color: theme.green }]}>
+                <Text style={[styles.sourceText, isBox && { color: t.green }]}>
                   {isBox ? 'BOX' : s.label.toUpperCase()}
                 </Text>
               </Pressable>
@@ -341,9 +343,11 @@ function CornerBtn({
   label: string;
   onPress: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <Pressable onPress={onPress} style={({ pressed }) => [styles.corner, pressed && styles.pressed]}>
-      <Ionicons name={icon} size={17} color={theme.text} />
+      <Ionicons name={icon} size={17} color={t.text} />
       <Text style={styles.cornerText}>{label}</Text>
     </Pressable>
   );
@@ -400,6 +404,7 @@ function Dpad({
   /** Joystick armed/released — the parent locks page scrolling while armed. */
   onJoyActive: (active: boolean) => void;
 }) {
+  const styles = useThemedStyles(makeStyles);
   const sens = usePref('trackpadSensitivity');
   const [joy, setJoy] = useState(false);
   const geo = dpadGeometry(size);
@@ -548,6 +553,7 @@ function dpadGeometry(size: number) {
  * right-click, two-finger drag=scroll).
  */
 function NavTrackpad({ size, responder }: { size: number; responder: PanResponderInstance }) {
+  const styles = useThemedStyles(makeStyles);
   const hints = usePref('padHints');
   return (
     <View
@@ -570,9 +576,11 @@ function DeskBtn({
   label: string;
   onPress: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <Pressable onPress={onPress} style={({ pressed }) => [styles.desk, pressed && styles.pressed]}>
-      <Ionicons name={icon} size={17} color={theme.text} />
+      <Ionicons name={icon} size={17} color={t.text} />
       <Text style={styles.deskText}>{label}</Text>
     </Pressable>
   );
@@ -587,14 +595,16 @@ function Rocker({
   onPlus: () => void;
   onMinus: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.rocker}>
       <Pressable onPress={onPlus} style={({ pressed }) => [styles.rockerBtn, pressed && styles.pressed]}>
-        <Ionicons name="add" size={26} color={theme.text} />
+        <Ionicons name="add" size={26} color={t.text} />
       </Pressable>
       <Text style={styles.rockerLabel}>{label}</Text>
       <Pressable onPress={onMinus} style={({ pressed }) => [styles.rockerBtn, pressed && styles.pressed]}>
-        <Ionicons name="remove" size={26} color={theme.text} />
+        <Ionicons name="remove" size={26} color={t.text} />
       </Pressable>
     </View>
   );
@@ -611,6 +621,7 @@ function MidBtn({
   color: string;
   onPress: () => void;
 }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <Pressable onPress={onPress} style={({ pressed }) => [styles.mid, pressed && styles.pressed]}>
       <Ionicons name={icon} size={18} color={color} />
@@ -621,7 +632,7 @@ function MidBtn({
 
 // ---- styles ----------------------------------------------------------------
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   // Fixed, non-scrolling column. gap spaces the rows; navBlock (flex:1) eats
   // the leftover so the elastic circle fits without any scroll.
   root: { flex: 1, gap: 10, paddingBottom: 6 },
@@ -634,18 +645,18 @@ const styles = StyleSheet.create({
     gap: 2,
     padding: 2,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   surfaceSeg: {
     flexDirection: 'row',
     gap: 2,
     padding: 2,
     borderRadius: 10,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   seg: {
     flex: 1,
@@ -656,14 +667,14 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     alignItems: 'center',
   },
-  segActive: { backgroundColor: theme.card, borderWidth: 1, borderColor: theme.blue },
-  segText: { color: theme.textDim, fontSize: 12, fontWeight: '700', fontFamily: mono },
-  segTextActive: { color: theme.blue },
+  segActive: { backgroundColor: t.card, borderWidth: 1, borderColor: t.blue },
+  segText: { color: t.textDim, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  segTextActive: { color: t.blue },
   pwr: {
     width: 44,
     height: 40,
     borderRadius: 10,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
     borderColor: 'rgba(248,113,113,0.5)',
     alignItems: 'center',
@@ -680,12 +691,12 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 12,
     borderRadius: 12,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   cornerText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 10,
     fontWeight: '800',
     letterSpacing: 1,
@@ -714,7 +725,7 @@ const styles = StyleSheet.create({
   okPressed: { backgroundColor: '#cbd5e1' },
   okText: { color: '#0b1220', fontWeight: '800', fontFamily: mono },
   // OK disc while the hold-to-point joystick is armed.
-  okJoy: { backgroundColor: theme.blue, borderColor: theme.blue },
+  okJoy: { backgroundColor: t.blue, borderColor: t.blue },
 
   // Trackpad face of the nav circle (same disc, different surface).
   navTrack: {
@@ -739,12 +750,12 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 10,
     borderRadius: 12,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   deskText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 9,
     fontWeight: '800',
     letterSpacing: 0.8,
@@ -755,9 +766,9 @@ const styles = StyleSheet.create({
   rocker: {
     width: 84,
     borderRadius: 42,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     alignItems: 'center',
     paddingVertical: 6,
   },
@@ -770,7 +781,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   rockerLabel: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 13,
     fontWeight: '800',
     letterSpacing: 1,
@@ -786,9 +797,9 @@ const styles = StyleSheet.create({
     gap: 7,
     paddingVertical: 13,
     borderRadius: 12,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   midText: { fontSize: 11, fontWeight: '800', letterSpacing: 0.5, fontFamily: mono },
 
@@ -797,13 +808,13 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 14,
     borderRadius: 10,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
   sourcePillBox: { borderColor: 'rgba(52,211,153,0.5)' },
   sourceText: {
-    color: theme.textDim,
+    color: t.textDim,
     fontSize: 11,
     fontWeight: '800',
     letterSpacing: 0.5,

--- a/app/components/ReviewToast.tsx
+++ b/app/components/ReviewToast.tsx
@@ -4,7 +4,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { hapticLight } from '@/lib/haptics';
 import { openWriteReview, subscribeReviewInvite } from '@/lib/review';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 const TOAST_MS = 8000;
 
@@ -52,6 +53,8 @@ export function ReviewToast() {
     setShown(false);
   }, []);
 
+  const styles = useThemedStyles(makeStyles);
+
   if (!shown) return null;
 
   return (
@@ -76,37 +79,37 @@ export function ReviewToast() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   wrap: { position: 'absolute', left: 0, right: 0, alignItems: 'center' },
   toast: {
     maxWidth: '92%',
-    backgroundColor: theme.card,
-    borderColor: theme.blue,
+    backgroundColor: t.card,
+    borderColor: t.blue,
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 12,
     paddingHorizontal: 16,
   },
   title: {
-    color: theme.text,
+    color: t.text,
     fontFamily: mono,
     fontSize: 13,
     fontWeight: '800',
     textAlign: 'center',
   },
-  sub: { color: theme.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
+  sub: { color: t.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
   actions: { flexDirection: 'row', gap: 10, marginTop: 12 },
   btn: {
     flex: 1,
     paddingVertical: 9,
     borderRadius: 8,
     alignItems: 'center',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderWidth: 1,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
   },
-  btnText: { color: theme.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
-  btnPrimary: { backgroundColor: theme.blue, borderColor: theme.blue },
+  btnText: { color: t.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  btnPrimary: { backgroundColor: t.blue, borderColor: t.blue },
   btnPrimaryText: { color: '#0b1220', fontSize: 12, fontWeight: '800', letterSpacing: 1 },
   pressed: { opacity: 0.7 },
 });

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -15,12 +15,14 @@ import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, screenFrameSource, ScreenInfo } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const FRAME_INTERVAL_MS = 1000;
 const FULLSCREEN_INTERVAL_MS = 700;
 
 export function ScreenPreview() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
@@ -159,7 +161,7 @@ export function ScreenPreview() {
             <Ionicons
               name={active ? 'stop' : 'play'}
               size={12}
-              color={active ? theme.bg : theme.green}
+              color={active ? t.bg : t.green}
             />
             <Text style={[styles.pillText, active && styles.pillTextOn]}>
               {active ? 'STOP' : 'START PREVIEW'}
@@ -170,12 +172,12 @@ export function ScreenPreview() {
 
       {noSession ? (
         <View style={styles.stateBox}>
-          <Ionicons name="tv-outline" size={26} color={theme.textFaint} />
+          <Ionicons name="tv-outline" size={26} color={t.textFaint} />
           <Text style={styles.stateText}>no capturable session (greeter?)</Text>
         </View>
       ) : !active ? (
         <View style={styles.stateBox}>
-          <Ionicons name="eye-outline" size={26} color={theme.textFaint} />
+          <Ionicons name="eye-outline" size={26} color={t.textFaint} />
           <Text style={styles.stateText}>Preview is off. Tap START to see the screen.</Text>
         </View>
       ) : (
@@ -211,34 +213,34 @@ export function ScreenPreview() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     padding: 14,
     marginBottom: 10,
   },
   header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
-  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  title: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
   pill: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 5,
-    borderColor: theme.green,
+    borderColor: t.green,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 4,
     paddingHorizontal: 10,
   },
-  pillOn: { backgroundColor: theme.green },
-  pillText: { color: theme.green, fontSize: 11, fontWeight: '700', fontFamily: mono },
-  pillTextOn: { color: theme.bg },
+  pillOn: { backgroundColor: t.green },
+  pillText: { color: t.green, fontSize: 11, fontWeight: '700', fontFamily: mono },
+  pillTextOn: { color: t.bg },
   pressed: { opacity: 0.7 },
 
   stateBox: { alignItems: 'center', justifyContent: 'center', paddingVertical: 22, gap: 8 },
-  stateText: { color: theme.textDim, fontSize: 13, textAlign: 'center' },
+  stateText: { color: t.textDim, fontSize: 13, textAlign: 'center' },
 
   frameWrap: {
     borderRadius: 8,
@@ -257,10 +259,10 @@ const styles = StyleSheet.create({
     paddingVertical: 3,
     paddingHorizontal: 8,
   },
-  failText: { color: theme.amber, fontSize: 10, fontWeight: '700', fontFamily: mono },
+  failText: { color: t.amber, fontSize: 10, fontWeight: '700', fontFamily: mono },
 
   fsRoot: { flex: 1, backgroundColor: 'rgba(0,0,0,0.95)', alignItems: 'center', justifyContent: 'center' },
   fsImage: { width: '100%', height: '100%' },
   fsHint: { position: 'absolute', bottom: 30 },
-  fsHintText: { color: theme.textDim, fontSize: 12, fontFamily: mono },
+  fsHintText: { color: t.textDim, fontSize: 12, fontFamily: mono },
 });

--- a/app/components/ScreensaverSheet.tsx
+++ b/app/components/ScreensaverSheet.tsx
@@ -9,7 +9,7 @@ import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api, ConnSettings, Screensaver } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** Display labels for the agent's theme ids (order = display order). */
 const THEME_LABELS: Record<string, string> = {
@@ -103,6 +103,8 @@ export function ScreensaverSheet({
     }
   }, [busy, settings, onChanged]);
 
+  const styles = useThemedStyles(makeStyles);
+
   const themes = saver?.themes?.length ? saver.themes : Object.keys(THEME_LABELS);
 
   return (
@@ -166,20 +168,20 @@ export function ScreensaverSheet({
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
   sheet: {
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     padding: 20,
     paddingBottom: 32,
     gap: 10,
   },
-  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
-  sub: { color: theme.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
+  title: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  sub: { color: t.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1, fontFamily: mono, marginTop: 6 },
 
   pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
   pill: {
@@ -187,13 +189,13 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     paddingHorizontal: 14,
     borderRadius: 999,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  pillOn: { borderColor: theme.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
-  pillText: { color: theme.textDim, fontSize: 14, fontWeight: '600' },
-  pillTextOn: { color: theme.blue },
+  pillOn: { borderColor: t.blue, backgroundColor: 'rgba(80,150,255,0.12)' },
+  pillText: { color: t.textDim, fontSize: 14, fontWeight: '600' },
+  pillTextOn: { color: t.blue },
   pressed: { opacity: 0.7 },
 
   seg: { flexDirection: 'row', gap: 6, marginTop: 4 },
@@ -202,19 +204,19 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 8,
     borderRadius: 10,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  segOn: { backgroundColor: theme.inset, borderColor: theme.textDim },
-  segText: { color: theme.textDim, fontSize: 14, fontWeight: '600' },
-  segTextOn: { color: theme.text },
+  segOn: { backgroundColor: t.inset, borderColor: t.textDim },
+  segText: { color: t.textDim, fontSize: 14, fontWeight: '600' },
+  segTextOn: { color: t.text },
 
   startBtn: {
     marginTop: 12,
     alignItems: 'center',
     paddingVertical: 12,
     borderRadius: 12,
-    backgroundColor: theme.blue,
+    backgroundColor: t.blue,
   },
   startText: { color: '#fff', fontSize: 15, fontWeight: '700' },
 
@@ -222,17 +224,17 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     padding: 12,
   },
-  armedText: { color: theme.text, fontSize: 15 },
+  armedText: { color: t.text, fontSize: 15 },
   cancelBtn: {
-    borderColor: theme.red,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 5,
     paddingHorizontal: 12,
   },
-  cancelText: { color: theme.red, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  cancelText: { color: t.red, fontSize: 12, fontWeight: '700', fontFamily: mono },
 });

--- a/app/components/SleepTimerSheet.tsx
+++ b/app/components/SleepTimerSheet.tsx
@@ -10,7 +10,8 @@ import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api, ConnSettings, PowerSchedule } from '@/lib/api';
 import { hapticError, hapticLight, hapticWarning } from '@/lib/haptics';
-import { mono, numeric, theme } from '@/lib/theme';
+import { mono, numeric, useTheme, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 const PRESETS_MIN = [15, 30, 45, 60, 90, 120];
 
@@ -39,6 +40,8 @@ export function SleepTimerSheet({
   onChanged: () => void;
   onClose: () => void;
 }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [action, setAction] = useState<'suspend' | 'poweroff'>('suspend');
   const [busy, setBusy] = useState(false);
 
@@ -145,7 +148,7 @@ export function SleepTimerSheet({
                       style={[
                         styles.segText,
                         action === a && styles.segTextOn,
-                        a === 'poweroff' && action === a && { color: theme.red },
+                        a === 'poweroff' && action === a && { color: t.red },
                       ]}>
                       {a === 'suspend' ? 'Suspend' : 'Power off'}
                     </Text>
@@ -198,19 +201,19 @@ export function SleepTimerSheet({
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
   sheet: {
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     padding: 20,
     paddingBottom: 32,
     gap: 10,
   },
-  title: { color: theme.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
+  title: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
 
   seg: { flexDirection: 'row', gap: 6, marginTop: 4 },
   segBtn: {
@@ -218,12 +221,12 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 8,
     borderRadius: 10,
-    borderColor: theme.cardBorder,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  segOn: { backgroundColor: theme.inset, borderColor: theme.textDim },
-  segText: { color: theme.textDim, fontSize: 14, fontWeight: '600' },
-  segTextOn: { color: theme.text },
+  segOn: { backgroundColor: t.inset, borderColor: t.textDim },
+  segText: { color: t.textDim, fontSize: 14, fontWeight: '600' },
+  segTextOn: { color: t.text },
 
   pills: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 4 },
   pill: {
@@ -232,29 +235,29 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
     paddingHorizontal: 14,
     borderRadius: 999,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
   },
-  pillText: { color: theme.text, fontSize: 15, fontWeight: '700', ...numeric },
+  pillText: { color: t.text, fontSize: 15, fontWeight: '700', ...numeric },
   pressed: { opacity: 0.7 },
 
   armedRow: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     padding: 12,
   },
-  armedText: { color: theme.text, fontSize: 15 },
-  armedCount: { color: theme.amber, fontWeight: '700', ...numeric },
+  armedText: { color: t.text, fontSize: 15 },
+  armedCount: { color: t.amber, fontWeight: '700', ...numeric },
   cancelBtn: {
-    borderColor: theme.red,
+    borderColor: t.red,
     borderWidth: 1,
     borderRadius: 999,
     paddingVertical: 5,
     paddingHorizontal: 12,
   },
-  cancelText: { color: theme.red, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  cancelText: { color: t.red, fontSize: 12, fontWeight: '700', fontFamily: mono },
 });

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -12,7 +12,7 @@ import {
 import { usePoll } from '@/hooks/usePoll';
 import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
 import { normalizeMac } from '@/lib/settings';
-import { theme } from '@/lib/theme';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type Brand = 'webos' | 'samsung' | 'roku';
 
@@ -31,6 +31,8 @@ const NETWORK_BACKENDS = ['webos', 'samsung', 'roku'];
  * the connection — the phone only kicks off pairing over the LAN.
  */
 export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
   const [brand, setBrand] = useState<Brand>('webos');
   const [host, setHost] = useState('');
   const [mac, setMac] = useState('');
@@ -91,7 +93,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
 
       {active ? (
         <View style={styles.activeRow}>
-          <Ionicons name="tv" size={16} color={theme.green} />
+          <Ionicons name="tv" size={16} color={t.green} />
           <Text style={styles.activeText}>Connected: {active.adapter}</Text>
         </View>
       ) : null}
@@ -114,7 +116,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
         value={host}
         onChangeText={setHost}
         placeholder="TV IP address (e.g. 192.168.1.50)"
-        placeholderTextColor={theme.textFaint}
+        placeholderTextColor={t.textFaint}
         autoCapitalize="none"
         autoCorrect={false}
         keyboardType="numbers-and-punctuation"
@@ -126,7 +128,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
           value={mac}
           onChangeText={setMac}
           placeholder="MAC for power-on (optional)"
-          placeholderTextColor={theme.textFaint}
+          placeholderTextColor={t.textFaint}
           autoCapitalize="none"
           autoCorrect={false}
           editable={!busy}
@@ -136,7 +138,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
 
       <Pressable onPress={submit} disabled={busy} style={[styles.button, busy && styles.buttonBusy]}>
         {busy ? (
-          <ActivityIndicator color={theme.bg} />
+          <ActivityIndicator color={t.bg} />
         ) : (
           <Text style={styles.buttonText}>
             {meta.verb} {meta.label}
@@ -145,7 +147,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       </Pressable>
 
       {msg ? (
-        <Text style={[styles.msg, { color: msg.ok ? theme.textDim : theme.red }]}>{msg.text}</Text>
+        <Text style={[styles.msg, { color: msg.ok ? t.textDim : t.red }]}>{msg.text}</Text>
       ) : null}
 
       <Text style={styles.hint}>
@@ -157,50 +159,50 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   card: {
-    backgroundColor: theme.card,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 14,
     padding: 16,
     gap: 10,
   },
-  title: { color: theme.text, fontSize: 16, fontWeight: '700' },
-  sub: { color: theme.textDim, fontSize: 13, lineHeight: 18 },
+  title: { color: t.text, fontSize: 16, fontWeight: '700' },
+  sub: { color: t.textDim, fontSize: 13, lineHeight: 18 },
   activeRow: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 8,
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     paddingVertical: 8,
     paddingHorizontal: 12,
   },
-  activeText: { color: theme.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
+  activeText: { color: t.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
   segment: {
     flexDirection: 'row',
-    backgroundColor: theme.inset,
+    backgroundColor: t.inset,
     borderRadius: 10,
     padding: 3,
     gap: 3,
   },
   seg: { flex: 1, paddingVertical: 9, borderRadius: 8, alignItems: 'center' },
-  segOn: { backgroundColor: theme.blue },
-  segText: { color: theme.textDim, fontSize: 13, fontWeight: '600' },
-  segTextOn: { color: theme.bg },
+  segOn: { backgroundColor: t.blue },
+  segText: { color: t.textDim, fontSize: 13, fontWeight: '600' },
+  segTextOn: { color: t.bg },
   input: {
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: StyleSheet.hairlineWidth,
     borderRadius: 10,
     paddingHorizontal: 12,
     paddingVertical: 11,
-    color: theme.text,
+    color: t.text,
     fontSize: 14,
   },
   button: {
-    backgroundColor: theme.green,
+    backgroundColor: t.green,
     borderRadius: 10,
     paddingVertical: 12,
     alignItems: 'center',
@@ -208,7 +210,7 @@ const styles = StyleSheet.create({
     minHeight: 44,
   },
   buttonBusy: { opacity: 0.7 },
-  buttonText: { color: theme.bg, fontSize: 15, fontWeight: '700' },
+  buttonText: { color: t.bg, fontSize: 15, fontWeight: '700' },
   msg: { fontSize: 13, lineHeight: 18 },
-  hint: { color: theme.textFaint, fontSize: 12, lineHeight: 16 },
+  hint: { color: t.textFaint, fontSize: 12, lineHeight: 16 },
 });

--- a/app/components/Sparkline.tsx
+++ b/app/components/Sparkline.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
-import { theme } from '@/lib/theme';
-
 /**
  * Tiny bar sparkline for the Console/Fleet vitals cards. Plain Views — no SVG
  * dependency — one slim bar per sample, height scaled into [min,max]. Null

--- a/app/components/TabScreen.tsx
+++ b/app/components/TabScreen.tsx
@@ -10,9 +10,11 @@ import { StyleSheet, Text, View } from 'react-native';
 import { BoxSwitcher } from '@/components/BoxSwitcher';
 import { TrialNudge } from '@/components/TrialNudge';
 import { IS_BETA_BUILD } from '@/lib/entitlement';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 
 export function TabScreen({ children }: { children: React.ReactNode }) {
+  const styles = useThemedStyles(makeStyles);
   return (
     <View style={styles.root}>
       <BoxSwitcher />
@@ -29,8 +31,8 @@ export function TabScreen({ children }: { children: React.ReactNode }) {
   );
 }
 
-const styles = StyleSheet.create({
-  root: { flex: 1, backgroundColor: theme.bg },
+const makeStyles = (t: Palette) => StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg },
   body: { flex: 1 },
   // Pinned above the tab bar, non-interactive so it never eats a touch.
   betaBadge: {
@@ -42,11 +44,11 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     backgroundColor: 'rgba(0,0,0,0.55)',
     borderWidth: 1,
-    borderColor: theme.amber,
+    borderColor: t.amber,
     opacity: 0.9,
   },
   betaText: {
-    color: theme.amber,
+    color: t.amber,
     fontSize: 10,
     fontWeight: '800',
     fontFamily: mono,

--- a/app/components/TrialEndsToast.tsx
+++ b/app/components/TrialEndsToast.tsx
@@ -4,7 +4,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { isGenuinelyPurchased } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
 import { lastDayToastShown, markLastDayToastShown } from '@/lib/trialNudge';
 
 const TOAST_MS = 3200;
@@ -23,6 +24,7 @@ export function TrialEndsToast() {
   const insets = useSafeAreaInsets();
   const { entitlement, ready } = useEntitlement();
   const [shown, setShown] = useState(false);
+  const styles = useThemedStyles(makeStyles);
 
   // Exactly one day left. Not `state === 'trial'` (the store-unreachable
   // fail-open reports 'purchased' over a still-running clock), and not `<= 1`
@@ -60,23 +62,23 @@ export function TrialEndsToast() {
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   wrap: { position: 'absolute', left: 0, right: 0, alignItems: 'center' },
   toast: {
     maxWidth: '90%',
-    backgroundColor: theme.card,
-    borderColor: theme.amber,
+    backgroundColor: t.card,
+    borderColor: t.amber,
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 10,
     paddingHorizontal: 16,
   },
   title: {
-    color: theme.amber,
+    color: t.amber,
     fontFamily: mono,
     fontSize: 13,
     fontWeight: '800',
     textAlign: 'center',
   },
-  sub: { color: theme.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
+  sub: { color: t.textDim, fontSize: 11, marginTop: 3, textAlign: 'center' },
 });

--- a/app/components/TrialNudge.tsx
+++ b/app/components/TrialNudge.tsx
@@ -6,7 +6,7 @@ import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { isGenuinelyPurchased } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
 import { hapticLight } from '@/lib/haptics';
-import { theme } from '@/lib/theme';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 import {
   dismissNudge,
   isNudgeDismissed,
@@ -29,6 +29,8 @@ export function TrialNudge() {
   const { entitlement, ready } = useEntitlement();
   const pathname = usePathname();
   const router = useRouter();
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
 
   const [threshold, setThreshold] = useState<NudgeThreshold | null>(null);
 
@@ -77,7 +79,7 @@ export function TrialNudge() {
 
   const { title, sub } = nudgeCopy(entitlement.trialDaysLeft);
   const urgent = entitlement.trialDaysLeft <= 1;
-  const accent = urgent ? theme.amber : theme.blue;
+  const accent = urgent ? t.amber : t.blue;
 
   return (
     <Pressable
@@ -92,13 +94,13 @@ export function TrialNudge() {
         onPress={onDismiss}
         hitSlop={10}
         style={({ pressed }) => [styles.close, pressed && styles.pressed]}>
-        <Ionicons name="close" size={16} color={theme.textDim} />
+        <Ionicons name="close" size={16} color={t.textDim} />
       </Pressable>
     </Pressable>
   );
 }
 
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   row: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -107,13 +109,13 @@ const styles = StyleSheet.create({
     marginTop: 8,
     paddingVertical: 9,
     paddingHorizontal: 12,
-    backgroundColor: theme.card,
+    backgroundColor: t.card,
     borderWidth: 1,
     borderRadius: 10,
   },
   body: { flex: 1 },
   title: { fontSize: 13, fontWeight: '800' },
-  sub: { color: theme.textDim, fontSize: 11, marginTop: 1 },
+  sub: { color: t.textDim, fontSize: 11, marginTop: 1 },
   close: { padding: 2 },
   pressed: { opacity: 0.7 },
 });

--- a/app/components/UnlockToast.tsx
+++ b/app/components/UnlockToast.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { subscribeUnlocked } from '@/lib/EntitlementContext';
-import { mono, theme } from '@/lib/theme';
+import { mono, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** Matches the launch-tab toast lifetime. */
 const UNLOCK_TOAST_MS = 1500;
@@ -22,6 +22,7 @@ const UNLOCK_TOAST_MS = 1500;
  */
 export function UnlockToast() {
   const insets = useSafeAreaInsets();
+  const styles = useThemedStyles(makeStyles);
   const [shown, setShown] = useState(false);
   const [early, setEarly] = useState(false);
 
@@ -51,13 +52,13 @@ export function UnlockToast() {
 
 // Box matches the launch-tab toast (lib theme, dark ops-console look); anchored
 // at the top since, unlike the in-tab toast, this floats above the tab bar too.
-const styles = StyleSheet.create({
+const makeStyles = (t: Palette) => StyleSheet.create({
   toast: {
     position: 'absolute',
     left: 24,
     right: 24,
-    backgroundColor: theme.inset,
-    borderColor: theme.cardBorder,
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 12,
@@ -71,6 +72,6 @@ const styles = StyleSheet.create({
     elevation: 12,
     zIndex: 1000,
   },
-  toastText: { color: theme.text, fontSize: 14, fontWeight: '600', fontFamily: mono },
-  earlyText: { color: theme.amber, fontSize: 12, fontWeight: '700', fontFamily: mono },
+  toastText: { color: t.text, fontSize: 14, fontWeight: '600', fontFamily: mono },
+  earlyText: { color: t.amber, fontSize: 12, fontWeight: '700', fontFamily: mono },
 });

--- a/app/lib/theme.ts
+++ b/app/lib/theme.ts
@@ -1,7 +1,44 @@
-import { Platform, TextStyle } from 'react-native';
+import { useMemo, useSyncExternalStore } from 'react';
+import { Platform, TextStyle, useColorScheme } from 'react-native';
+import * as SecureStore from 'expo-secure-store';
 
-/** Dark ops-console palette. Legible at 2am. */
-export const theme = {
+/**
+ * Theming: light + dark palettes, a user-selectable accent, and the hooks that
+ * resolve them live. Components read colors through `useTheme()` (or
+ * `useThemedStyles()` for StyleSheet-based styles) so they react to the system
+ * scheme, the user's Light/Dark/System override, and the chosen accent.
+ *
+ * BACKWARD COMPAT: `export const theme` (the dark palette) is kept so the many
+ * components not yet converted to `useTheme()` still compile and render exactly
+ * as before (dark). Convert files incrementally; nothing breaks mid-sweep.
+ */
+
+// ---------------------------------------------------------------------------
+// Palettes
+// ---------------------------------------------------------------------------
+
+export type Palette = {
+  bg: string;
+  card: string;
+  cardBorder: string;
+  inset: string;
+  text: string;
+  textDim: string;
+  textFaint: string;
+  green: string;
+  amber: string;
+  red: string;
+  redDeep: string;
+  blue: string;
+  slate: string;
+  tabBar: string;
+  tabBarBorder: string;
+  /** The resolved accent hue (drives the active/link color; mirrors `blue`). */
+  accent: string;
+};
+
+/** Dark ops-console palette. Legible at 2am. The historical default. */
+const dark: Palette = {
   bg: '#0b1220',
   card: '#141c2e',
   cardBorder: '#1e2942',
@@ -17,7 +54,58 @@ export const theme = {
   slate: '#64748b',
   tabBar: '#0e1526',
   tabBarBorder: '#1e2942',
-} as const;
+  accent: '#60a5fa',
+};
+
+/** Light palette. Same navy/green identity, tuned for contrast on a light bg. */
+const light: Palette = {
+  bg: '#f6f8fc',
+  card: '#ffffff',
+  cardBorder: '#dbe3f0',
+  inset: '#eef2f9',
+  text: '#0b1220',
+  textDim: '#4a5670',
+  textFaint: '#8b97ad',
+  green: '#059669',
+  amber: '#b45309',
+  red: '#dc2626',
+  redDeep: '#fecaca',
+  blue: '#2563eb',
+  slate: '#64748b',
+  tabBar: '#ffffff',
+  tabBarBorder: '#dbe3f0',
+  accent: '#2563eb',
+};
+
+export const palettes: Record<'dark' | 'light', Palette> = { dark, light };
+
+/**
+ * BACKWARD COMPAT: static dark palette. Deprecated — use `useTheme()`. Kept so
+ * unconverted components stay pixel-identical to today until they're converted.
+ */
+export const theme = dark;
+
+// ---------------------------------------------------------------------------
+// Accents
+// ---------------------------------------------------------------------------
+
+export type AccentKey = 'blue' | 'green' | 'violet' | 'amber' | 'rose' | 'teal';
+
+/** The selectable accent hues, one value per scheme (tuned for contrast). */
+export const ACCENTS: Record<AccentKey, { label: string; dark: string; light: string }> = {
+  blue: { label: 'Blue', dark: '#60a5fa', light: '#2563eb' },
+  green: { label: 'Green', dark: '#34d399', light: '#059669' },
+  violet: { label: 'Violet', dark: '#a78bfa', light: '#7c3aed' },
+  amber: { label: 'Amber', dark: '#fbbf24', light: '#d97706' },
+  rose: { label: 'Rose', dark: '#fb7185', light: '#e11d48' },
+  teal: { label: 'Teal', dark: '#2dd4bf', light: '#0d9488' },
+};
+
+export const ACCENT_KEYS = Object.keys(ACCENTS) as AccentKey[];
+
+// ---------------------------------------------------------------------------
+// Type + numeric fragments (unchanged)
+// ---------------------------------------------------------------------------
 
 export const mono = Platform.select({
   ios: 'Menlo',
@@ -31,15 +119,181 @@ export const numeric: TextStyle = {
   fontVariant: ['tabular-nums'],
 };
 
-export function tempColor(c: number | null): string {
-  if (c == null) return theme.textFaint;
-  if (c < 70) return theme.green;
-  if (c < 85) return theme.amber;
-  return theme.red;
+// Semantic status colors. Take a palette so converted callers get theme-correct
+// green/amber/red; default to dark for the not-yet-converted callers (BC).
+export function tempColor(c: number | null, t: Palette = dark): string {
+  if (c == null) return t.textFaint;
+  if (c < 70) return t.green;
+  if (c < 85) return t.amber;
+  return t.red;
 }
 
-export function pctColor(pct: number): string {
-  if (pct < 70) return theme.green;
-  if (pct < 90) return theme.amber;
-  return theme.red;
+export function pctColor(pct: number, t: Palette = dark): string {
+  if (pct < 70) return t.green;
+  if (pct < 90) return t.amber;
+  return t.red;
+}
+
+// ---------------------------------------------------------------------------
+// Persisted theme preferences (self-contained external store; mirrors the
+// prefs.ts / haptics.ts pattern so a segmented control reads/writes live).
+// ---------------------------------------------------------------------------
+
+export type ThemeMode = 'system' | 'light' | 'dark';
+
+type ThemePrefs = { mode: ThemeMode; accent: AccentKey };
+
+// Default preserves today's look exactly: forced dark, blue accent. Change
+// `mode` to 'system' here once the light palette is verified across every
+// screen and you want new installs to follow the OS by default.
+const THEME_DEFAULTS: ThemePrefs = { mode: 'dark', accent: 'blue' };
+
+const THEME_KEY = 'couchside.theme.v1';
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(key, value);
+      }
+    } catch {
+      // storage unavailable (private mode): lives in memory this session
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+let prefs: ThemePrefs = { ...THEME_DEFAULTS };
+const listeners = new Set<() => void>();
+
+function emitChange(): void {
+  for (const l of listeners) l();
+}
+
+function normalize(raw: unknown): ThemePrefs {
+  const o = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>;
+  const mode: ThemeMode =
+    o.mode === 'system' || o.mode === 'light' || o.mode === 'dark'
+      ? o.mode
+      : THEME_DEFAULTS.mode;
+  const accent: AccentKey =
+    typeof o.accent === 'string' && (ACCENT_KEYS as string[]).includes(o.accent)
+      ? (o.accent as AccentKey)
+      : THEME_DEFAULTS.accent;
+  return { mode, accent };
+}
+
+let loadStarted = false;
+/** Load persisted theme prefs once. Safe to call repeatedly. */
+export async function loadThemePrefs(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  const raw = await storageGet(THEME_KEY);
+  if (raw == null) return;
+  try {
+    prefs = normalize(JSON.parse(raw));
+    emitChange();
+  } catch {
+    // malformed blob: keep defaults
+  }
+}
+// Kick the load off at import so values are ready by first paint.
+void loadThemePrefs();
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+export function getThemeMode(): ThemeMode {
+  return prefs.mode;
+}
+
+export async function setThemeMode(mode: ThemeMode): Promise<void> {
+  if (prefs.mode === mode) return;
+  prefs = { ...prefs, mode };
+  emitChange();
+  // Native chrome (status bar) is synced in the root _layout via expo-status-bar
+  // driven by useResolvedScheme() — see the sweep. Palette override is JS-side.
+  await storageSet(THEME_KEY, JSON.stringify(prefs));
+}
+
+export function useThemeMode(): ThemeMode {
+  return useSyncExternalStore(
+    subscribe,
+    () => prefs.mode,
+    () => prefs.mode,
+  );
+}
+
+export function getAccent(): AccentKey {
+  return prefs.accent;
+}
+
+export async function setAccent(accent: AccentKey): Promise<void> {
+  if (prefs.accent === accent) return;
+  prefs = { ...prefs, accent };
+  emitChange();
+  await storageSet(THEME_KEY, JSON.stringify(prefs));
+}
+
+export function useAccent(): AccentKey {
+  return useSyncExternalStore(
+    subscribe,
+    () => prefs.accent,
+    () => prefs.accent,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The hooks components use
+// ---------------------------------------------------------------------------
+
+/** The active scheme after applying the user's override to the system scheme. */
+export function useResolvedScheme(): 'light' | 'dark' {
+  const system = useColorScheme();
+  const mode = useThemeMode();
+  if (mode === 'system') return system === 'light' ? 'light' : 'dark';
+  return mode;
+}
+
+/** The live palette: scheme-correct base with the chosen accent applied. */
+export function useTheme(): Palette {
+  const scheme = useResolvedScheme();
+  const accent = useAccent();
+  return useMemo(() => {
+    const base = palettes[scheme];
+    const acc = ACCENTS[accent][scheme];
+    // The accent drives the primary active/link color (historically `blue`).
+    return { ...base, accent: acc, blue: acc };
+  }, [scheme, accent]);
+}
+
+/**
+ * Memoized themed StyleSheet. Convert a module-scope
+ *   `const styles = StyleSheet.create({ card: { backgroundColor: theme.card } })`
+ * into
+ *   `const makeStyles = (t: Palette) => StyleSheet.create({ card: { backgroundColor: t.card } });`
+ *   `const styles = useThemedStyles(makeStyles);` (inside the component)
+ * so the styles rebuild when the theme changes.
+ */
+export function useThemedStyles<T>(factory: (t: Palette) => T): T {
+  const t = useTheme();
+  return useMemo(() => factory(t), [t]);
 }

--- a/app/node_modules
+++ b/app/node_modules
@@ -1,0 +1,1 @@
+/Users/temery/Developer/rescue-remote/app/node_modules

--- a/app/node_modules
+++ b/app/node_modules
@@ -1,1 +1,0 @@
-/Users/temery/Developer/rescue-remote/app/node_modules


### PR DESCRIPTION
Adds full light/dark theming with a user-selectable accent, driven by the system scheme + a Light/Dark/System override.

## What's here
- **`lib/theme.ts` foundation** — `dark` + `light` palettes, 6 accents (`ACCENTS`), a persisted mode/accent store (`useThemeMode`/`setThemeMode`, `useAccent`/`setAccent`), and the hooks: `useResolvedScheme()`, `useTheme(): Palette`, `useThemedStyles(factory)`.
- **All 28 components + both layouts converted** off the static `theme` import onto the hooks — module-scope `StyleSheet.create` → `makeStyles(t)` consumed via `useThemedStyles`; inline reads → `useTheme()`; `tempColor`/`pctColor` threaded the live palette; non-component helpers take a `Palette` param (no hooks outside component top level).
- **Root `_layout.tsx`** builds the React Navigation theme + `StatusBar` style from the resolved scheme.
- **Settings UI** — an APPEARANCE card in the Preferences tab: a Theme segmented control (System/Light/Dark) + accent swatches.
- **`app.json`** `userInterfaceStyle` → `automatic`.

## Design / safety
- Ships at **`mode:'dark'` by default → zero visual change** for existing users; Light/System is opt-in. Change `THEME_DEFAULTS.mode` to `'system'` once Light is verified on-device.
- The static `theme` export (dark) is intentionally **kept** so the conversion was incremental and never broke the build; it can be removed once nothing imports it.
- Accent overrides the primary blue/active color app-wide.

## Verification
- `tsc --noEmit` clean at every step (foundation, full sweep, settings, final).
- No residual static `theme.X` reads (bar a doc comment); no hooks inside `.map`/callbacks.
- No eslint is configured in the repo, so react-hooks lint couldn't run — helpers were param-threaded instead of calling hooks, confirmed by grep.

## Before merge / release
- [ ] **Android:** `npx expo install expo-system-ui` — required for `automatic` to honor appearance on Android (not currently a dep; iOS works without it).
- [ ] **On-device:** eyeball Light mode across every screen and tune the `light` palette hex values in `lib/theme.ts` as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
