### PR TITLE
chore(app): reconcile build numbers to shipped 2.9.1 (build 41 / vc 26)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "40",
+      "buildNumber": "41",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 25
+      "versionCode": 26
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Local eas builds auto-incremented to iOS build 41 / Android versionCode 26 (shipped to TestFlight + Play). Bump app.json to match so the next build doesn't collide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)