### PR TITLE
docs+feat: smart-TV README section + Roku 403 runtime hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ The gamepad UI on the phone and the Steam sidebar responding on the TV, at the s
 - **QR pairing:** the installer prints a QR code; scan it with the phone camera and the app opens with host, port, and token prefilled.
 - **Volume, mute, and box power.** A control next to the device picker adjusts the box's own OS volume and mute (a real drag-to-set 0–100 slider on SteamOS/Bazzite). On an HDMI-CEC or RS-232 setup you can switch it to drive the TV/panel instead — and on an RS-232 panel, also switch the display's input source, blank the screen without cutting power to an OPS box, and pass factory-remote keys. The same control suspends the box and, once it is offline, wakes it back up with a Wake-on-LAN magic packet.
 
+## Control your TV
+
+Couchside can also drive a **networked smart TV directly** — no HDMI-CEC and no serial cable. Add one under **Setup → Boxes → Smart TV remote**; the D-pad and on-screen keyboard on the Pad tab light up once it's connected.
+
+- **LG webOS** — enter the TV's IP, then accept the pairing prompt that appears on the TV (once). An optional MAC address enables Wake-on-LAN power-on.
+- **Samsung (Tizen)** — enter the IP, then approve the "Allow" prompt on the TV. Optional MAC for Wake-on-LAN.
+- **Roku** — enter the IP; no pairing. **If the D-pad doesn't respond after adding, the Roku is blocking app control:** on the Roku, set _Settings → System → Advanced system settings → Control by mobile apps → Network access_ to **Permissive**.
+- **Android / Google TV** — enter the IP, then type the 6-digit code the TV shows. Optional MAC for Wake-on-LAN.
+
+These network backends run on the Linux agent. The Windows agent supports **Roku** (from `0.3.6-win`); LG/Samsung/Google TV are Linux-only for now. TV control also works **through the box** when it has an HDMI-CEC link or an RS-232 serial panel (power, volume, input source, on-screen remote) — see the volume/power control above.
+
 ## Requirements
 
 - A **SteamOS, Bazzite, or other systemd-based Linux** machine on your home network (HTPC, Steam Deck in desktop/docked use, mini PC…). The agent is pure Python 3 stdlib: no pip, and it works on immutable/ostree systems.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The gamepad UI on the phone and the Steam sidebar responding on the TV, at the s
 Couchside can also drive a **networked smart TV directly** — no HDMI-CEC and no serial cable. Add one under **Setup → Boxes → Smart TV remote**; the D-pad and on-screen keyboard on the Pad tab light up once it's connected.
 
 - **LG webOS** — enter the TV's IP, then accept the pairing prompt that appears on the TV (once). An optional MAC address enables Wake-on-LAN power-on.
-- **Samsung (Tizen)** — enter the IP, then approve the "Allow" prompt on the TV. Optional MAC for Wake-on-LAN.
+- **Samsung (Tizen)** _(beta — not yet validated on real hardware)_ — enter the IP, then approve the "Allow" prompt on the TV. Optional MAC for Wake-on-LAN.
 - **Roku** — enter the IP; no pairing. **If the D-pad doesn't respond after adding, the Roku is blocking app control:** on the Roku, set _Settings → System → Advanced system settings → Control by mobile apps → Network access_ to **Permissive**.
 - **Android / Google TV** — enter the IP, then type the 6-digit code the TV shows. Optional MAC for Wake-on-LAN.
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -31,6 +31,7 @@ import tempfile
 import termios
 import threading
 import time
+import urllib.error
 import urllib.request
 import zlib
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -3923,7 +3924,15 @@ def _roku_post(host, path, timeout=4):
         with urllib.request.urlopen(req, timeout=timeout) as r:
             r.read()
         return _webos_result(start, True, path)
-    except OSError as e:            # URLError / HTTPError are OSError subclasses
+    except urllib.error.HTTPError as e:
+        # A reachable Roku that refuses control (403) has its "Control by mobile
+        # apps" network access set below permissive. Flag it so the app can tell
+        # the user exactly what to change on the TV.
+        res = _webos_result(start, False, "HTTP %d: %s" % (e.code, e.reason))
+        if e.code == 403:
+            res["hint"] = "roku_control_disabled"
+        return res
+    except OSError as e:            # URLError etc. are OSError subclasses
         return _webos_result(start, False, "%s: %s" % (e.__class__.__name__, e))
 
 

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -48,6 +48,7 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.error
 import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlparse, parse_qs, unquote, quote
@@ -2439,7 +2440,15 @@ def _roku_post(host, path, timeout=4):
         with urllib.request.urlopen(req, timeout=timeout) as r:
             r.read()
         return _roku_result(start, True, path)
-    except OSError as e:            # URLError / HTTPError are OSError subclasses
+    except urllib.error.HTTPError as e:
+        # A reachable Roku that refuses control (403) has its "Control by mobile
+        # apps" network access set below permissive. Flag it so the app can tell
+        # the user exactly what to change on the TV.
+        res = _roku_result(start, False, "HTTP %d: %s" % (e.code, e.reason))
+        if e.code == 403:
+            res["hint"] = "roku_control_disabled"
+        return res
+    except OSError as e:            # URLError etc. are OSError subclasses
         return _roku_result(start, False, "%s: %s" % (e.__class__.__name__, e))
 
 

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -1,6 +1,6 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React, { useCallback, useState } from 'react';
-import { PanResponder, PanResponderInstance, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, PanResponder, PanResponderInstance, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
@@ -10,6 +10,10 @@ import { hapticLight } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { Settings } from '@/lib/settings';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+// Shown once per app session: a Roku that 403s control needs its "Control by
+// mobile apps" network access made permissive (surfaced from tvKey below).
+let rokuHintShown = false;
 
 type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -78,7 +82,21 @@ export function RemoteView({
   const tvKey = useCallback(
     (k: TvKey) => {
       hapticLight();
-      void api.tvKey(settings, k).catch(() => {});
+      api
+        .tvKey(settings, k)
+        .then((r) => {
+          // A reachable Roku that refuses control (403) means its "Control by
+          // mobile apps" network access isn't permissive. Tell the user how to
+          // fix it — once per session so a held D-pad doesn't spam alerts.
+          if (r && r.hint === 'roku_control_disabled' && !rokuHintShown) {
+            rokuHintShown = true;
+            Alert.alert(
+              'Roku is refusing control',
+              'This Roku is set to block control from apps. On the Roku, open Settings → System → Advanced system settings → Control by mobile apps → Network access and choose Permissive.',
+            );
+          }
+        })
+        .catch(() => {});
     },
     [settings],
   );

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -220,7 +220,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
 
       <Text style={styles.hint}>
         {brand === 'roku'
-          ? 'No pairing needed — just make sure the Roku is on and on this network.'
+          ? 'No pairing needed — just make sure the Roku is on and on this network. If the D-pad does not respond after adding, enable control on the Roku: Settings → System → Advanced system settings → Control by mobile apps → Network access → Permissive.'
           : brand === 'androidtv'
             ? 'Your Android/Google TV must be on. After “Pair”, a 6-digit code appears on the TV — enter it here. The MAC is optional (Wake-on-LAN power-on).'
             : `Your ${meta.label} TV must be on. An accept prompt appears on the TV — say yes. The MAC is optional and lets the box wake the TV over the network.`}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -198,6 +198,10 @@ export type ActionResult = {
   duration_ms: number;
   /** New mute state, returned by the mute op (agent >= 2.6.5). */
   muted?: boolean | null;
+  /** Machine-readable hint the app maps to a specific message. Currently
+      "roku_control_disabled" — a reachable Roku that 403s control because its
+      "Control by mobile apps" network access isn't permissive. */
+  hint?: string;
 };
 
 export type Journal = {


### PR DESCRIPTION
Follow-ups to the Windows Roku port — documenting the "Control by mobile apps → Permissive" requirement in the three places it matters.

## Changes
- **README** — new "Control your TV" section: LG webOS / Samsung / Roku / Google TV setup (via Setup → Boxes → Smart TV remote), the Roku Permissive note, and a line that the Windows agent supports Roku (`0.3.6-win`) while LG/Samsung/Google TV are Linux-only for now.
- **App setup hint** (`SmartTvSetup.tsx`) — the Roku add hint now tells users to set Control by mobile apps → Permissive if the D-pad doesn't respond.
- **Runtime 403 catch** — the real user-hit surface (a dead D-pad, not the setup screen):
  - Agents (Linux `couchsided.py` + Windows `couchsided-win.py`): `_roku_post` flags an ECP **403** with `hint:"roku_control_disabled"` (a reachable Roku whose "Control by mobile apps" access isn't permissive), instead of a generic failure.
  - App (`RemoteView.tsx` + `ActionResult.hint`): surfaces that hint as a **one-time alert** telling the user the exact Roku setting to change.

## Why
A recent Roku OS (15.2.4) 403s ECP `keypress` while `device-info`/`launch` stay open — so a Roku adds fine but the D-pad does nothing until the setting is flipped. The static hint is easy to miss (it's on the setup screen); the runtime alert fires where users actually hit it.

## Verification
`tsc --noEmit` clean; `py_compile` both agents; deterministic 403→hint check (401/500 don't set it).

Note: agent versions not bumped — the hint is additive (older agents omit it; the app handles its absence). Bump at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
