### PR TITLE
chore(app): reconcile build numbers to shipped 2.9.2

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "42",
+      "buildNumber": "43",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 27
+      "versionCode": 28
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Local builds auto-incremented to iOS build 43 / Android vc 28 (shipped). Match app.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)