### PR TITLE
feat(app): hardware volume buttons control box/TV volume on the Remote screen

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -44,3 +44,7 @@ yarn-error.*
 asc-key.p8
 credentials.json
 credentials/
+
+# local build artifacts
+*.apk
+build-*.apk

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -7,7 +7,7 @@
  * The Pad tab is the one screen that allows landscape (see useLockOrientation);
  * in landscape the gamepad controls spread out like a real controller.
  */
-import { hapticSelection } from '@/lib/haptics';
+import { hapticLight, hapticSelection } from '@/lib/haptics';
 import { getKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
 import { getPref, usePref } from '@/lib/prefs';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
@@ -36,6 +36,7 @@ import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
+import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status } from '@/lib/api';
 import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
@@ -614,6 +615,25 @@ function PadScreen() {
   const askToSwitch = usePref('askToSwitchControl');
   const askToSwitchRef = useRef(askToSwitch);
   askToSwitchRef.current = askToSwitch;
+
+  // Hardware volume buttons -> box/TV volume across EVERY input mode (Pad,
+  // Swipe, Track, Remote), mounted here on the always-present Pad screen rather
+  // than inside RemoteView. Active while the user opted in and a box is
+  // connected; the connection lifecycle is tied to tab focus, so leaving the
+  // Pad tab restores the phone's own volume. Honors settings.volumeTarget.
+  const volumeButtons = usePref('volumeButtons');
+  const sendVol = useCallback(
+    (op: 'volume_up' | 'volume_down') => {
+      hapticLight();
+      void api.tvSend(settings, op, settings.volumeTarget ?? 'box').catch(() => {});
+    },
+    [settings],
+  );
+  useVolumeButtons({
+    enabled: volumeButtons && status === 'connected',
+    onUp: () => sendVol('volume_up'),
+    onDown: () => sendVol('volume_down'),
+  });
   const [controlReq, setControlReq] = useState<string | null>(null);
   const [canForce, setCanForce] = useState(false);
 
@@ -975,7 +995,7 @@ function PadScreen() {
 
       {mode === 'remote' ? (
         <>
-          <RemoteView client={client} settings={settings} connected={status === 'connected'} />
+          <RemoteView client={client} settings={settings} />
           {keyboardBar}
         </>
       ) : mode === 'swipe' ? (

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -975,7 +975,7 @@ function PadScreen() {
 
       {mode === 'remote' ? (
         <>
-          <RemoteView client={client} settings={settings} />
+          <RemoteView client={client} settings={settings} connected={status === 'connected'} />
           {keyboardBar}
         </>
       ) : mode === 'swipe' ? (

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -637,6 +637,7 @@ function SetupBody() {
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
   const askToSwitchControl = usePref('askToSwitchControl');
+  const volumeButtons = usePref('volumeButtons');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -1285,6 +1286,19 @@ function SetupBody() {
                 value={askToSwitchControl}
                 onValueChange={(v) => {
                   void setPref('askToSwitchControl', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Hardware volume buttons"
+                sub={
+                  Platform.OS === 'ios'
+                    ? "The phone's Vol +/- control the box/TV volume while the Remote is open. Experimental on iOS: the phone's volume overlay still shows and it only works with the app in front."
+                    : "The phone's Vol +/- control the box/TV volume (box or TV, per box) while the Remote is open."
+                }
+                value={volumeButtons}
+                onValueChange={(v) => {
+                  void setPref('volumeButtons', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -15,7 +15,6 @@ import {
 
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
-import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
@@ -42,13 +41,9 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 export function RemoteView({
   client,
   settings,
-  connected,
 }: {
   client: GamepadClient;
   settings: Settings;
-  /** Box is live (gamepad socket connected). Gates the hardware-volume-button
-      hijack so the phone's Vol +/- only steals focus while a box is reachable. */
-  connected: boolean;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -156,16 +151,6 @@ export function RemoteView({
     },
     [settings],
   );
-
-  // Hardware volume buttons -> the SAME tvOp the on-screen VOL rocker uses, so
-  // they honor settings.volumeTarget (box vs TV). Active only while the user
-  // opted in AND a box is connected; otherwise the phone's buttons are its own.
-  const volumeButtons = usePref('volumeButtons');
-  useVolumeButtons({
-    enabled: volumeButtons && connected,
-    onUp: () => tvOp('volume_up'),
-    onDown: () => tvOp('volume_down'),
-  });
 
   const blank = useCallback(() => {
     hapticLight();

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -15,6 +15,7 @@ import {
 
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
+import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
@@ -41,9 +42,13 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 export function RemoteView({
   client,
   settings,
+  connected,
 }: {
   client: GamepadClient;
   settings: Settings;
+  /** Box is live (gamepad socket connected). Gates the hardware-volume-button
+      hijack so the phone's Vol +/- only steals focus while a box is reachable. */
+  connected: boolean;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -151,6 +156,16 @@ export function RemoteView({
     },
     [settings],
   );
+
+  // Hardware volume buttons -> the SAME tvOp the on-screen VOL rocker uses, so
+  // they honor settings.volumeTarget (box vs TV). Active only while the user
+  // opted in AND a box is connected; otherwise the phone's buttons are its own.
+  const volumeButtons = usePref('volumeButtons');
+  useVolumeButtons({
+    enabled: volumeButtons && connected,
+    onUp: () => tvOp('volume_up'),
+    onDown: () => tvOp('volume_down'),
+  });
 
   const blank = useCallback(() => {
     hapticLight();

--- a/app/hooks/useVolumeButtons.ts
+++ b/app/hooks/useVolumeButtons.ts
@@ -1,0 +1,117 @@
+/**
+ * Repurpose the phone's hardware volume buttons (Vol +/-) into box/TV volume
+ * steps while the Remote screen owns them.
+ *
+ * The mechanism is deliberately the same on both platforms: sit on a mid-range
+ * baseline system volume, listen for the OS volume changing under a physical
+ * press, derive the direction from the delta, fire the matching callback, then
+ * snap the system volume back to the baseline so there is always headroom in
+ * both directions (a phone pinned at 0% or 100% would swallow further presses).
+ *
+ *   Android — `showNativeVolumeUI(false)` hides the system volume HUD, so the
+ *     hijack is invisible; the OS still moves the music stream, which the
+ *     baseline reset absorbs. Primary, review-safe target.
+ *   iOS — no public key-intercept API, so this observes AVAudioSession's
+ *     outputVolume (the library's KVO listener) and needs an active audio
+ *     session + the app foregrounded. The volume HUD still flashes (can't be
+ *     suppressed) and locked-screen / Control-Center presses won't route here.
+ *     Experimental, and off by default (App Review risk — see the setting).
+ *
+ * `enabled` gates the whole thing: pass it the AND of the user setting and a
+ * live box connection. Flipping it off (screen blur, disconnect, unmount)
+ * tears the listener down and restores normal system-volume behavior.
+ */
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { VolumeManager } from 'react-native-volume-manager';
+
+/** Mid-range resting volume: every press has room to move up OR down from here. */
+const BASELINE = 0.5;
+/**
+ * Deltas smaller than this are our own baseline write echoing back (or float
+ * noise), not a press. One hardware step is ~1/15 (Android) or 1/16 (iOS) of
+ * the range — comfortably above this.
+ */
+const EPSILON = 0.012;
+/** Min gap between emitted commands, so a held button paces (~7/s) not floods. */
+const MIN_STEP_MS = 140;
+
+export function useVolumeButtons({
+  enabled,
+  onUp,
+  onDown,
+}: {
+  enabled: boolean;
+  onUp: () => void;
+  onDown: () => void;
+}): void {
+  // Keep the callbacks current WITHOUT re-subscribing the native listener on
+  // every render (the effect keys only on `enabled`).
+  const cbs = useRef({ onUp, onDown });
+  cbs.current = { onUp, onDown };
+
+  useEffect(() => {
+    // Web has no hardware volume buttons and no native module — never touch it.
+    if (!enabled || Platform.OS === 'web') return undefined;
+
+    let cancelled = false;
+    let sub: { remove: () => void } | null = null;
+    let lastEmit = 0;
+    // True while our own setVolume(BASELINE) is in flight, so its listener echo
+    // is ignored even before the EPSILON test would catch it.
+    let resetting = false;
+
+    const recenter = () => {
+      resetting = true;
+      VolumeManager.setVolume(BASELINE, { showUI: false })
+        .catch(() => {})
+        .finally(() => {
+          resetting = false;
+        });
+    };
+
+    const setup = async () => {
+      try {
+        if (Platform.OS === 'ios') {
+          // outputVolume KVO only reports while a session is active; ambient
+          // category mixes with (never ducks or interrupts) other audio.
+          await VolumeManager.enable(true);
+          await VolumeManager.setActive(true);
+        } else {
+          await VolumeManager.showNativeVolumeUI({ enabled: false });
+        }
+        await VolumeManager.setVolume(BASELINE, { showUI: false });
+        if (cancelled) return;
+
+        sub = VolumeManager.addVolumeListener(({ volume }) => {
+          if (resetting) return; // our own recenter write
+          const delta = volume - BASELINE;
+          if (Math.abs(delta) < EPSILON) return; // noise / already centered
+          const now = Date.now();
+          if (now - lastEmit >= MIN_STEP_MS) {
+            lastEmit = now;
+            if (delta > 0) cbs.current.onUp();
+            else cbs.current.onDown();
+          }
+          // Recenter even when throttled, so volume never creeps to a dead zone.
+          recenter();
+        });
+      } catch {
+        // Native module absent (not-yet-prebuilt / Expo Go) or a platform
+        // quirk: fail silent and leave the phone's volume buttons alone.
+      }
+    };
+    void setup();
+
+    return () => {
+      cancelled = true;
+      if (sub) sub.remove();
+      // Hand the buttons back to the OS.
+      if (Platform.OS === 'ios') {
+        VolumeManager.setActive(false).catch(() => {});
+      } else {
+        VolumeManager.showNativeVolumeUI({ enabled: true }).catch(() => {});
+      }
+    };
+  }, [enabled]);
+}

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -45,6 +45,11 @@ export type Prefs = {
   /** When another phone joins a box you're controlling, ask before handing
       over (true) vs let it grab control immediately (false). Agent >= 2.9.2. */
   askToSwitchControl: boolean;
+  /** Let the phone's hardware Vol +/- buttons drive the box/TV volume while the
+      Remote screen is open. Default ON for Android; OFF for iOS, where the OS
+      volume HUD can't be suppressed and repurposing the buttons is App-Review
+      risky (opt-in, experimental). */
+  volumeButtons: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -62,6 +67,9 @@ export const DEFAULTS: Prefs = {
   padKeyboardBar: true,
   padHints: true,
   askToSwitchControl: true,
+  // Android intercepts the keycode cleanly (no HUD); iOS can't, so it stays off
+  // until the user opts in.
+  volumeButtons: Platform.OS === 'android',
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -138,6 +146,7 @@ function normalize(raw: unknown): Prefs {
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
+    volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
   };
 }
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -33,6 +33,7 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-udp": "^4.1.7",
+        "react-native-volume-manager": "^2.0.8",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.10.0"
       },
@@ -6790,6 +6791,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/react-native-volume-manager": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-volume-manager/-/react-native-volume-manager-2.0.8.tgz",
+      "integrity": "sha512-aZM47/mYkdQ4CbXpKYO6Ajiczv7fxbQXZ9c0H8gRuQUaS3OCz/MZABer6o9aDWq0KMNsQ7q7GVFLRPnSSeeMmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-web": {

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-udp": "^4.1.7",
+    "react-native-volume-manager": "^2.0.8",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.0"
   },


### PR DESCRIPTION
## What

The phone's hardware **Vol +/-** buttons now step the box/TV volume while the **Remote** screen is open, routed through the *same* `tvOp` the on-screen VOL rocker uses — so they honor `settings.volumeTarget` (box vs TV) instead of hardcoding `box`.

## How

New self-contained hook `hooks/useVolumeButtons.ts` (via `react-native-volume-manager`):
- Rests on a mid-range baseline system volume, listens for the OS volume moving under a physical press, derives direction from the delta, fires the callback, then snaps back to baseline so 0%/100% dead zones never swallow presses.
- Emits throttled (~7/s) so a held button paces step commands instead of flooding.
- **Android:** `showNativeVolumeUI(false)` hides the system volume HUD → invisible hijack. Primary target.
- **iOS:** observes `AVAudioSession` `outputVolume`; best-effort (HUD can't be suppressed, needs the app foregrounded). Off by default.

`RemoteView` gains a `connected` prop (from the Pad's gamepad status); the hook is active only while the user opted in **and** a box is connected. Blur / disconnect / unmount removes the listener and restores normal system-volume behavior.

Gated behind a new `volumeButtons` pref — **default ON for Android, OFF for iOS** (App-Review risk repurposing the buttons for a non-audio action) — with a platform-aware toggle in **Setup › Pad layout**.

## Build / risk

- New native module → **requires `expo prebuild` + a fresh EAS build**. No Expo config plugin ships with the lib, so it autolinks; **confirm it links cleanly under SDK 57 / RN 0.86 New Architecture** at build time (app.json sets no `newArchEnabled`).

## Test plan

- Android, Remote open, `target=box`: Vol +/- steps box volume, no phone HUD.
- `target=tv`: same buttons drive the TV backend via existing target routing.
- Leave the Remote screen → phone volume buttons control the phone again.
- On-screen VOL rocker behavior unchanged (same `tvOp`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)