### PR TITLE
feat(agent+app): auto-pop the phone keyboard on webOS on-TV text focus (2.9.12)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -3497,6 +3497,9 @@ def set_webos(mock):
     if WEBOS is not None:
         WEBOS.close()
     WEBOS = None
+    # (Re)arm the on-TV text-focus watcher for the new config (no-op in --mock
+    # or when unpaired). Retires any prior watcher via the generation bump.
+    start_webos_ime_watch()
 
 
 def webos_available():
@@ -3608,6 +3611,103 @@ def mock_webos(op):
     print("[webos] %s" % op, flush=True)
     return {"ok": True, "exit_code": 0, "stdout": "[mock webos] %s\n" % op,
             "stderr": "", "duration_ms": 50}
+
+
+# ---- webOS on-TV text-focus push (feeds the app's auto-keyboard) -----------
+# LG's mobile remote learns when a TV text field is focused by SUBSCRIBING to
+# ssap://com.webos.service.ime/registerRemoteKeyboard: the TV pushes a frame
+# whenever input focus opens or closes (payload.currentWidget.focus). We mirror
+# that here on a DEDICATED SSAP socket (the request/response session is
+# serialised + dropped when idle, so it can't host a long-lived subscription)
+# and relay each transition to the connected phones over the gamepad socket as
+# {"t":"input_focus","open":bool,"value":str}. The app then pops its text sheet
+# so the user types on the phone. Best-effort: any socket error just reconnects
+# with backoff, and it advertises via the tv_info `text_focus_push` cap so the
+# app only auto-pops where this actually fires (webOS today).
+_WEBOS_IME_URI = "ssap://com.webos.service.ime/registerRemoteKeyboard"
+# Longer than the request/response default: a focused-field subscription idles
+# for minutes between transitions (webOS WS pings keep the socket warm).
+_WEBOS_IME_TIMEOUT = 30
+# Monotonic generation: bumped by every set_webos() so a re-pair (or teardown)
+# retires any running watcher without needing to reach into its blocked recv.
+_WEBOS_IME_GEN = 0
+
+
+def _webos_ime_text(cw):
+    """Best-effort current field text from a registerRemoteKeyboard widget.
+    webOS rarely echoes existing content on this channel, so this is usually
+    "" — the app treats the sheet as empty then, which is correct."""
+    for k in ("focusText", "text", "value", "inputText"):
+        v = cw.get(k)
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+def start_webos_ime_watch():
+    """(Re)start the IME focus watcher. Bumping the generation stops any prior
+    watcher; a new daemon thread starts only for a real, paired webOS TV (never
+    in --mock, which has no socket). Call after any set_webos()."""
+    global _WEBOS_IME_GEN
+    _WEBOS_IME_GEN += 1
+    if _WEBOS_MOCK or not webos_available():
+        return
+    gen = _WEBOS_IME_GEN
+    threading.Thread(target=_webos_ime_watch, args=(gen,), daemon=True,
+                     name="webos-ime").start()
+
+
+def _webos_ime_watch(gen):
+    """Hold one registerRemoteKeyboard subscription open and broadcast focus
+    transitions to the phones. Runs until its generation is superseded; any
+    error reconnects with capped backoff. Never raises out of the thread."""
+    backoff = 2
+    logged = False                            # log an outage once, not per retry
+    while gen == _WEBOS_IME_GEN:
+        sess = None
+        try:
+            sess = _WebOSSession(CONFIG_WEBOS["host"])
+            sess.ws.sock.settimeout(_WEBOS_IME_TIMEOUT)
+            sess.register(CONFIG_WEBOS.get("client_key"))
+            sub_id = sess._send({"type": "subscribe", "uri": _WEBOS_IME_URI})
+            backoff = 2                       # a clean connect resets backoff
+            logged = False
+            last_open = None
+            while gen == _WEBOS_IME_GEN:
+                try:
+                    msg = json.loads(sess.ws.recv_text())
+                except socket.timeout:
+                    continue                  # idle field; keep the socket open
+                if msg.get("id") != sub_id:
+                    continue                  # register echo / unrelated frame
+                if msg.get("type") == "error":
+                    raise IOError(msg.get("error", "ime subscription error"))
+                cw = (msg.get("payload") or {}).get("currentWidget")
+                if not isinstance(cw, dict) or "focus" not in cw:
+                    continue
+                open_ = bool(cw.get("focus"))
+                if open_ == last_open:
+                    continue                  # de-dupe repeated same-state pushes
+                last_open = open_
+                if gen != _WEBOS_IME_GEN:
+                    break
+                if open_:
+                    _gamepad_broadcast({"t": "input_focus", "open": True,
+                                        "value": _webos_ime_text(cw)})
+                else:
+                    _gamepad_broadcast({"t": "input_focus", "open": False})
+        except (IOError, OSError, ValueError, KeyError) as e:
+            if not logged:
+                print("[webos-ime] subscription paused (%s: %s); retrying"
+                      % (e.__class__.__name__, e), flush=True)
+                logged = True
+        finally:
+            if sess is not None:
+                sess.close()
+        if gen != _WEBOS_IME_GEN:
+            break
+        time.sleep(backoff)                   # TV asleep / network blip
+        backoff = min(backoff * 2, 30)
 
 
 def webos_pair(host, timeout=60):
@@ -4721,6 +4821,11 @@ def tv_info():
         # and CEC have no text channel.
         "text": (webos_available() or samsung_available()
                  or roku_available()),
+        # Backend PUSHES a focus signal when an on-TV text field opens/closes,
+        # so the app can auto-raise its keyboard (see the t:input_focus frame on
+        # /ws/gamepad). webOS-only today (registerRemoteKeyboard subscription);
+        # every other backend keeps the manual text button, so this stays false.
+        "text_focus_push": webos_available(),
         # Box mute state, so the app shows the right mute indicator on connect.
         "muted": _soft_muted() if box_vol else None,
         # Current levels (0-100 or null) so the app's volume slider can show and
@@ -6409,6 +6514,18 @@ def _wsend_op(entry, opcode, payload=b""):
             ws_send(entry["conn"], opcode, payload)
         except OSError:
             pass
+
+
+def _gamepad_broadcast(obj):
+    """Send one JSON frame to every live gamepad session (holder + waiters).
+    Snapshots the list under the lock, then sends outside it (each _wsend_json
+    takes only that socket's slock), so socket I/O never blocks GAMEPAD_LOCK.
+    Best-effort: a dead socket is skipped. Used for out-of-band pushes such as
+    the webOS on-TV text-focus signal (t:input_focus)."""
+    with GAMEPAD_LOCK:
+        entries = list(GAMEPAD_SESSIONS)
+    for entry in entries:
+        _wsend_json(entry, obj)
 
 
 def _release_devices(entry):

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -1,5 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Modal,
@@ -59,17 +59,58 @@ export function RemoteView({
   const hasTvText = tv?.text === true;
   const sources = tv?.sources ?? [];
   const canBlank = tv?.screen_toggle === true;
+  // Backend pushes an on-TV focus signal (webOS): we auto-raise the text sheet
+  // on focus and dismiss it on blur. Held in a ref too so the (once-registered)
+  // focus listener always sees the current cap without re-subscribing.
+  const canFocusPush = tv?.text_focus_push === true;
+  const focusPushRef = useRef(canFocusPush);
+  focusPushRef.current = canFocusPush;
 
   // On-TV text entry (webOS IME / Samsung / Roku Lit_ keys). Opens a small
   // modal; sends the whole string to /api/tv/text.
   const [textOpen, setTextOpen] = useState(false);
   const [textVal, setTextVal] = useState('');
+  // Who opened the sheet: a manual keypad tap vs an auto focus-push. Only a
+  // focus-push-opened sheet is auto-dismissed on focus-close, so we never yank
+  // a sheet the user opened themselves.
+  const textSrc = useRef<'manual' | 'focus' | null>(null);
+  const closeText = useCallback(() => {
+    setTextOpen(false);
+    setTextVal('');
+    textSrc.current = null;
+  }, []);
+  const openTextManual = useCallback(() => {
+    textSrc.current = 'manual';
+    setTextOpen(true);
+  }, []);
   const sendText = useCallback(() => {
     const s = textVal;
     setTextOpen(false);
     setTextVal('');
+    textSrc.current = null;
     if (s) void api.tvText(settings, s).catch(() => {});
   }, [textVal, settings]);
+
+  // Auto-keyboard: when the box advertises text_focus_push (webOS) and pushes a
+  // focus-open, raise the sheet with any current field text (the sheet's
+  // autoFocus TextInput pops the phone keyboard); on focus-close, dismiss it —
+  // but only if focus-push opened it, so a manually opened sheet stays put.
+  useEffect(() => {
+    client.onInputFocus((open, value) => {
+      if (open) {
+        if (!focusPushRef.current) return;
+        if (textSrc.current === 'manual') return; // don't clobber a manual sheet
+        textSrc.current = 'focus';
+        setTextVal(value);
+        setTextOpen(true);
+      } else if (textSrc.current === 'focus') {
+        setTextOpen(false);
+        setTextVal('');
+        textSrc.current = null;
+      }
+    });
+    return () => client.onInputFocus(null);
+  }, [client]);
 
   // Desktop nav, self-polled and session-aware: the SteamOS/Bazzite desktop
   // cluster (Start menu, trackpad, overview) appears only while the box is in
@@ -245,7 +286,7 @@ export function RemoteView({
             <Pressable
               onPress={() => {
                 hapticLight();
-                setTextOpen(true);
+                openTextManual();
               }}
               style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
               <Ionicons name="keypad" size={20} color={t.blue} />
@@ -385,8 +426,8 @@ export function RemoteView({
         visible={textOpen}
         transparent
         animationType="fade"
-        onRequestClose={() => setTextOpen(false)}>
-        <Pressable style={styles.textBackdrop} onPress={() => setTextOpen(false)}>
+        onRequestClose={closeText}>
+        <Pressable style={styles.textBackdrop} onPress={closeText}>
           <Pressable style={styles.textSheet} onPress={() => {}}>
             <Text style={styles.textTitle}>Send text to the TV</Text>
             <TextInput
@@ -402,7 +443,7 @@ export function RemoteView({
               style={styles.textInput}
             />
             <View style={styles.textBtnRow}>
-              <Pressable onPress={() => setTextOpen(false)} style={styles.textBtn}>
+              <Pressable onPress={closeText} style={styles.textBtn}>
                 <Text style={styles.textBtnCancel}>CANCEL</Text>
               </Pressable>
               <Pressable onPress={sendText} style={[styles.textBtn, styles.textBtnSendBg]}>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -397,6 +397,14 @@ export type Tv = {
    * SendInputString, Roku Lit_ keys); never by panel/CEC.
    */
   text?: boolean;
+  /**
+   * Backend PUSHES a focus signal (agent >= 2.9.12) when an on-TV text field
+   * opens/closes, delivered as a {t:'input_focus'} frame on /ws/gamepad. Only
+   * webOS reports it today (registerRemoteKeyboard); when set, the app auto-
+   * raises its text sheet on focus and dismisses it on blur. Absent on every
+   * other backend, which keep the manual text button unchanged.
+   */
+  text_focus_push?: boolean;
   /** Current box OS volume 0-100 (agent >= 2.7.0), or null when unreadable. */
   box_volume_level?: number | null;
   /**

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -183,6 +183,15 @@ export class GamepadClient {
     | ((blocked: boolean, msg: string | null) => void)
     | null = null;
 
+  // On-TV text-focus push (agent >= 2.9.12, webOS). The backend sends
+  // input_focus{open,value} when a text field on the TV gains/loses focus, so
+  // the app can auto-raise its keyboard. This is a transient EVENT, not a
+  // persisted state — the listener fires only on receipt (no replay on
+  // subscribe), so a freshly mounted view never re-pops a stale keyboard.
+  private inputFocusListener:
+    | ((open: boolean, value: string) => void)
+    | null = null;
+
   // Controller handoff (agent >= 2.9.2). When this phone HOLDS control and
   // another asks for it, the agent sends control_request{name}; the UI prompts
   // Pass/Keep. controlRequest holds the pending requester name (or null).
@@ -281,6 +290,20 @@ export class GamepadClient {
   ): void {
     this.blockedListener = fn;
     if (fn) fn(this.inputBlocked, this.blockedMsg);
+  }
+
+  /**
+   * Register the (single) on-TV text-focus listener. Unlike the state
+   * listeners above it does NOT fire immediately: input_focus is an event, so
+   * replaying a stale value on subscribe could pop the keyboard for a field the
+   * user already left. Fires with (open, value) on each pushed transition.
+   */
+  onInputFocus(fn: ((open: boolean, value: string) => void) | null): void {
+    this.inputFocusListener = fn;
+  }
+
+  private emitInputFocus(open: boolean, value: string): void {
+    if (this.inputFocusListener) this.inputFocusListener(open, value);
   }
 
   getStatus(): GamepadStatus {
@@ -582,6 +605,7 @@ export class GamepadClient {
       let msg: {
         t?: string; dev?: string; msg?: string; text?: string;
         code?: string; name?: string; holder?: string; by?: string;
+        open?: boolean; value?: string;
       };
       try {
         msg = JSON.parse(String(ev.data));
@@ -636,6 +660,13 @@ export class GamepadClient {
         this.setInputBlocked(true, typeof msg.msg === 'string' ? msg.msg : null);
       } else if (msg.t === 'resumed') {
         this.setInputBlocked(false, null);
+      } else if (msg.t === 'input_focus') {
+        // A text field on the TV opened/closed (webOS). Relay to the view so it
+        // can raise/dismiss the phone keyboard; value carries any current text.
+        this.emitInputFocus(
+          msg.open === true,
+          typeof msg.value === 'string' ? msg.value : '',
+        );
       }
       // {"t":"pong"} needs no handling.
     };


### PR DESCRIPTION
## What

When a text field gains focus **on a webOS (LG) TV**, the app auto-opens its text sheet and raises the phone keyboard so the user types on the phone; when focus leaves, it auto-dismisses. **Capability-gated** — everywhere else (Roku / Samsung / VIDAA / Android TV / the box itself) behavior is unchanged and the manual text button stays.

## Feasibility (why webOS only)

The box/TV side must *emit* a focus signal. webOS does, via the SSAP `com.webos.service.ime/registerRemoteKeyboard` subscription. No other current backend has a reliable focus-push, so this ships webOS-only and advertises a capability the app checks before auto-popping.

## Agent (Linux; the Windows agent has no webOS backend, untouched)

- `tv_info()` gains **`text_focus_push`** (true only for webOS).
- A dedicated SSAP watcher subscribes to `registerRemoteKeyboard` on **its own socket** (the request/response session is serialized + dropped when idle, so it can't host a subscription) and relays each transition to the phones over the **existing** `/ws/gamepad` socket as `{"t":"input_focus","open":bool,"value":str}`.
- Best-effort: any socket error reconnects with capped backoff and logs the outage **once**; a dropped subscription never touches gamepad control. Lifecycle owned by `set_webos()` via a generation counter, so pairing re-arms it and `--mock`/unpaired starts nothing.
- New `_gamepad_broadcast()` snapshots sessions under the lock and sends outside it (per-socket lock), so the push never blocks `GAMEPAD_LOCK`.
- Agent version → **2.9.12**.

## App

- `Tv.text_focus_push` added to the type.
- `GamepadClient` parses `input_focus` and exposes `onInputFocus(open, value)` — **event-only** (no replay on subscribe, so a remount never re-pops a stale field).
- `RemoteView` subscribes and, when the cap is present, opens its **existing** text sheet on focus (autoFocus raises the keyboard) and dismisses on blur. It tracks whether the sheet was opened by focus-push vs a manual tap, so an auto-dismiss never yanks a sheet the user opened, and a focus-push never clobbers one. Text still sends via the existing `api.tvText` path — only *when* the sheet opens changes.

## Test plan

- webOS TV: focus a search/text field on the TV → phone sheet auto-opens with keyboard up; typing sends to the TV; leaving the field auto-dismisses.
- Backend without the cap: no auto-pop; manual text button unchanged.
- Socket resilience: dropping/restoring the IME subscription never breaks gamepad control or reconnects.

Verified so far: `py_compile` + app `tsc` clean; `--mock` agent boots and `/api/tv` advertises `text_focus_push: true`. On-TV acceptance needs a real webOS TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)