### PR TITLE
fix(tv-pairing): persist pairings when the agent user can't write the config dir

### DIFF
--- a/agent/couchside.service
+++ b/agent/couchside.service
@@ -1,6 +1,7 @@
 ; Couchside box agent: systemd unit TEMPLATE.
-; install.sh substitutes __USER__, __UID__ and __EXEC__ (the resolved daemon
-; path) with the invoking desktop user's real values and installs the result to
+; install.sh substitutes __USER__, __UID__, __EXEC__ (the resolved daemon path)
+; and __CONFIG__ (the user-owned state config path) with the invoking desktop
+; user's real values and installs the result to
 ; /etc/systemd/system/couchside.service. Do NOT hardcode /home here: the home
 ; can live at /var/home (Bazzite/ostree), be a systemd-homed image, or an LDAP
 ; path — install.sh injects the real install dir so the unit works anywhere.
@@ -16,7 +17,7 @@ User=__USER__
 ; with the udev rule the installer writes for /dev/uinput.
 SupplementaryGroups=input
 Environment=XDG_RUNTIME_DIR=/run/user/__UID__
-ExecStart=/usr/bin/python3 __EXEC__
+ExecStart=/usr/bin/python3 __EXEC__ --config __CONFIG__
 Restart=always
 RestartSec=3
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -186,6 +186,13 @@ CONFIG_VIDAA = None  # optional {"host","name","mac"} Hisense VIDAA (MQTT) confi
 ALLOW_APP_UPDATE = False
 LAUNCHERS = []  # list of {"id","label","cmd":[...]}, custom launchers only
 CONFIG_PATH = DEFAULT_CONFIG_PATH  # remembered by load_config() for rewrites
+# False when the config DIRECTORY isn't writable by the agent's user (a
+# root-owned dir under a non-root agent — a common ownership drift). Config
+# writes go via a temp file in that dir + os.replace, so an unwritable dir makes
+# every save (TV pairing, launcher edits) fail with a 500. Checked once at
+# startup (check_config_writable) and surfaced in /api/status so the failure is
+# never silent.
+CONFIG_WRITABLE = True
 CONFIG_LOCK = threading.Lock()  # serializes launcher config rewrites
 
 
@@ -486,6 +493,27 @@ def load_config(path):
     CONFIG_VIDAA = vidaa
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
+
+
+def check_config_writable():
+    """Verify the agent can persist config, and warn loudly if not.
+
+    Config writes go through a temp file in the config's DIRECTORY + os.replace
+    (see _config_set_field), so the DIR — not just the file — must be writable by
+    the agent's user. A root-owned config dir under a non-root agent (an install
+    ownership drift) makes every save — TV pairing, launcher edits — fail with a
+    500 the app used to render as a vague error. Surfaced in /api/status
+    (config_writable) so the condition is visible instead of silent. Call in
+    main() after load_config."""
+    global CONFIG_WRITABLE
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    # W_OK to create the temp file, X_OK to os.replace into the dir.
+    CONFIG_WRITABLE = os.access(directory, os.W_OK | os.X_OK)
+    if not CONFIG_WRITABLE:
+        print("WARNING: config dir %s is NOT writable by uid %d — TV pairing and "
+              "launcher changes will fail to save. chown the config dir to the "
+              "agent's user." % (directory, os.getuid()), file=sys.stderr,
+              flush=True)
 
 
 def _inject_session_actions():
@@ -1137,6 +1165,9 @@ def real_status():
         # request — a cheap pgrep — or the app's desktop cluster would freeze
         # at whatever session the agent booted in.
         "caps": dict(CAPS, desktop=desktop_available()),
+        # False when the config dir isn't writable by the agent user, so the app
+        # can warn that TV pairing / launcher edits won't persist (agent >= 2.9.12).
+        "config_writable": CONFIG_WRITABLE,
         "history": _history_snapshot(),
     }
 
@@ -1832,6 +1863,7 @@ def mock_status():
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
         "caps": CAPS,
+        "config_writable": True,
         "history": _history_snapshot(),
     }
 
@@ -8259,6 +8291,8 @@ def main():
     args = p.parse_args()
 
     load_config(args.config)
+    if not args.mock:
+        check_config_writable()  # warn loudly if pairings/launchers can't persist
     _inject_session_actions()
     _inject_suspend_action(args.mock)
     set_tv(args.mock)

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -11,9 +11,27 @@ import {
 } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
+import { api, ApiError, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
 import { normalizeMac } from '@/lib/settings';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/**
+ * A pairing error the user can act on. The box's own reason (e.g. a 500
+ * "could not persist config: Permission denied") is surfaced verbatim instead
+ * of a blanket "could not reach the box" — a server-side failure that masquer-
+ * ades as a network error is what turned a config-permission bug into a long
+ * hunt. Network/timeout kinds keep the friendly fallback (accurate for those).
+ */
+function pairErr(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    // http = the box answered with an error status; show what it said.
+    if (e.kind === 'http') return `${fallback} — box says: ${e.message}`;
+    // unreachable / timeout / unauthorized: the friendly fallback fits, but
+    // name the kind so it's still diagnosable.
+    return `${fallback} (${e.kind})`;
+  }
+  return fallback;
+}
 
 type Brand = 'webos' | 'samsung' | 'roku' | 'androidtv' | 'vidaa';
 
@@ -98,8 +116,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       else r = await api.tvAddRoku(settings, h);
       if (r.ok) connected(r);
       else setMsg({ ok: false, text: r.error ?? 'Could not connect to the TV.' });
-    } catch {
-      setMsg({ ok: false, text: 'Could not reach the box or TV. Check the IP and try again.' });
+    } catch (e: unknown) {
+      setMsg({ ok: false, text: pairErr(e, 'Could not reach the box or TV. Check the IP and try again.') });
     } finally {
       setBusy(false);
     }
@@ -118,8 +136,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       const r = await api.tvAndroidtvPairFinish(settings, c, m);
       if (r.ok) connected(r);
       else setMsg({ ok: false, text: r.error ?? 'Pairing failed — check the code and retry.' });
-    } catch {
-      setMsg({ ok: false, text: 'Could not reach the box. Try again.' });
+    } catch (e: unknown) {
+      setMsg({ ok: false, text: pairErr(e, 'Could not reach the box. Try again.') });
     } finally {
       setBusy(false);
     }

--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,14 @@ PORT_DEFAULT=8787
 INSTALL_DIR="${HOME}/.local/opt/couchside"
 ETC_DIR="/etc/couchside"
 TOKEN_FILE="${ETC_DIR}/token"
-CONFIG_FILE="${ETC_DIR}/config.json"
+# Agent-MUTATED state (TV pairings, launcher edits) lives in a user-owned state
+# dir, NOT the root-owned ETC_DIR. The agent runs as the desktop user and writes
+# config atomically (temp file in the dir + os.replace), so the dir must be
+# user-writable — but ETC_DIR must stay root-owned to protect the sudo-granted
+# couchside-journal wrapper (a user-writable ETC_DIR = replace the wrapper = root
+# code via the sudoers grant). Splitting them keeps both invariants.
+STATE_DIR="/var/lib/couchside"
+CONFIG_FILE="${STATE_DIR}/config.json"
 # Fixed-argument, root-owned wrapper for system-journal reads. The sudoers rule
 # grants ONLY this script (no wildcards); it validates its inputs and calls
 # journalctl with a locked-down option set, so --file/--directory can't be
@@ -358,6 +365,10 @@ if [ "$UNINSTALL" -eq 1 ]; then
         if ask_yn "Remove $ETC_DIR (pairing token + config; phones will need re-pairing)?"; then
             sudo rm -rf "$ETC_DIR"
             note "removed $ETC_DIR"
+            # The agent-mutated config (TV pairings) lives in STATE_DIR now —
+            # remove it alongside, so a purge doesn't leave stale pairings.
+            sudo rm -rf "$STATE_DIR" 2>/dev/null || true
+            note "removed $STATE_DIR"
         else
             note "kept $ETC_DIR"
         fi
@@ -509,6 +520,23 @@ sudo chmod 600 "$TOKEN_FILE"
 sudo chown "$USER_NAME" "$TOKEN_FILE"
 
 # ---------------------------------------------------------------------------
+# (e0) State dir for the agent-mutated config (user-owned; see STATE_DIR note).
+# Older installs kept config.json inside the root-owned $ETC_DIR, where the
+# non-root agent couldn't write it (every TV pairing / launcher edit 500'd).
+# Create the user-owned state dir and migrate any legacy config into it.
+# ---------------------------------------------------------------------------
+sudo mkdir -p "$STATE_DIR"
+sudo chown "$USER_NAME" "$STATE_DIR"
+sudo chmod 700 "$STATE_DIR"
+LEGACY_CONFIG="${ETC_DIR}/config.json"
+if sudo test -s "$LEGACY_CONFIG" && ! sudo test -s "$CONFIG_FILE"; then
+    note "migrating config $LEGACY_CONFIG -> $CONFIG_FILE (pairings preserved)"
+    sudo mv "$LEGACY_CONFIG" "$CONFIG_FILE"
+    sudo chown "$USER_NAME" "$CONFIG_FILE"
+    sudo chmod 600 "$CONFIG_FILE"
+fi
+
+# ---------------------------------------------------------------------------
 # (e) Initial config.json (only if absent)
 # ---------------------------------------------------------------------------
 if sudo test -s "$CONFIG_FILE"; then
@@ -569,7 +597,9 @@ order += ["reboot", "poweroff"]
 
 print(json.dumps({"units": units, "actions": actions, "action_order": order}, indent=2))
 PYEOF
-    sudo install -m 0644 -o root -g root "$WORK_DIR/config.json" "$CONFIG_FILE"
+    # User-owned so the agent (running as the desktop user) can rewrite it on
+    # every TV pairing / launcher edit. 0600 — it holds TV client certs/keys.
+    sudo install -m 0600 -o "$USER_NAME" "$WORK_DIR/config.json" "$CONFIG_FILE"
 fi
 
 # ---------------------------------------------------------------------------
@@ -726,8 +756,16 @@ say "Installing systemd unit $UNIT_DST"
 DAEMON_PATH="$INSTALL_DIR/couchsided.py"
 sed -e "s|/home/__USER__/.local/opt/couchside/couchsided.py|__EXEC__|g" \
     -e "s|__EXEC__|$DAEMON_PATH|g" \
+    -e "s|__CONFIG__|$CONFIG_FILE|g" \
     -e "s|__USER__|$USER_NAME|g" -e "s|__UID__|$USER_UID|g" \
     "$WORK_DIR/couchside.service" > "$WORK_DIR/couchside.service.rendered"
+# Heal an older template whose ExecStart predates the user-owned config path:
+# without --config the agent would read the default /etc path where config no
+# longer lives (it moved to STATE_DIR), so append it.
+if ! grep -q -- '--config' "$WORK_DIR/couchside.service.rendered"; then
+    sed -i "s|^\(ExecStart=.*couchsided\.py\)[[:space:]]*\$|\1 --config $CONFIG_FILE|" \
+        "$WORK_DIR/couchside.service.rendered"
+fi
 sudo install -m 0644 -o root -g root "$WORK_DIR/couchside.service.rendered" "$UNIT_DST"
 sudo systemctl daemon-reload
 sudo systemctl enable couchside.service
@@ -765,7 +803,7 @@ cat > "$PAIR_SCRIPT" <<'PAIREOF'
 # The /pair page is served LOCALHOST-ONLY by the agent, so it must be opened
 # here on the box (never over the network). Reads PORT from the agent config.
 set -u
-CONFIG_FILE="/etc/couchside/config.json"
+CONFIG_FILE="/var/lib/couchside/config.json"
 PORT_DEFAULT=8787
 PORT="$(python3 - "$CONFIG_FILE" "$PORT_DEFAULT" <<'PYEOF' 2>/dev/null || echo "$PORT_DEFAULT"
 import json, sys
@@ -923,13 +961,15 @@ PY
     # Opt-in: let the phone app trigger an update (POST /api/update/apply).
     # OFF by default. Must be set HERE on the box (not by the app), so the
     # capability only exists when you consciously enable it. Edits config.json
-    # (root-owned) + restarts the agent.
+    # (user-owned state dir) + restarts the agent — no sudo: the desktop user
+    # owns the state dir, and a sudo write would re-root the file the agent must
+    # itself be able to rewrite.
     case "${2:-}" in
       on|off)
         val="false"; [ "$2" = "on" ] && val="true"
-        sudo python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
+        python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
 import json, os, sys
-p = "/etc/couchside/config.json"
+p = "/var/lib/couchside/config.json"
 val = sys.argv[1] == "true"
 try:
     with open(p) as f: d = json.load(f)
@@ -947,7 +987,7 @@ PY
         echo "App-triggered updates: ${2}"
         ;;
       ""|status)
-        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /etc/couchside/config.json 2>/dev/null \
+        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /var/lib/couchside/config.json 2>/dev/null \
           && echo "App-triggered updates: on" || echo "App-triggered updates: off"
         ;;
       *) echo "usage: couchside allow-updates on|off" >&2; exit 2 ;;


### PR DESCRIPTION
## Root cause

TV pairing (Google TV, webOS, Samsung, Roku) silently failed with the app showing **"Could not reach the box."** The real cause was **permissions**, diagnosed on a real Steam Deck + Google TV:

- The agent runs as the **desktop user** (`systemd User=deck`), but config lived in **root-owned `/etc/couchside`**.
- Config writes use an atomic **temp file in that dir + `os.replace`** → a non-root agent gets **`PermissionError`** on every save.
- So the TV *accepted* the pairing (showed its "successful" toast), but `_androidtv_save` **500'd** and the cert was **never persisted** — an asymmetric pairing.
- The app's pairing catch was a **bare `catch {}`** that rendered any error (including that 500) as "Could not reach the box."

Journal proof: `pair/start 200`, `pair/finish 500` (~30 ms — a crash, not a timeout), config had no `androidtv` entry, and `deck` could not write `/etc/couchside`.

## Fixes

**1. App — surface the real error** (`SmartTvSetup.tsx`): the pair-start / androidtv-finish catches now show the box's actual reason (`box says: could not persist config: Permission denied`) instead of a blanket unreachable message.

**2. Agent — never fail silently** (`couchsided.py`, → 2.9.12): `check_config_writable()` logs a loud startup warning when the config **dir** isn't writable by the agent user, and `/api/status` gains **`config_writable`** so the app can surface it.

**3. Installer — fix the drift at the source** (`install.sh` + `couchside.service`): move the agent-mutated config to a **user-owned state dir `/var/lib/couchside`**, and keep `/etc/couchside` **root-owned**.

### Why not just `chown /etc/couchside` to the user
That dir holds **`couchside-journal`**, a root script the sudoers file grants **passwordless-root** (`install.sh`). A user-writable dir lets the user replace it → **local root escalation**. So config (mutable, user-owned) and the privileged wrapper (root-owned) are split into separate dirs. The unit gains `--config`, legacy `/etc` config is migrated, the `allow-updates` CLI drops its `sudo` (state dir is user-owned), and uninstall cleans the state dir.

## Verified (real Steam Deck + Google TV)
- `pair/finish` → **200**, cert saved, `/api/tv` → `backend=androidtv, keys=true`.
- `couchside-journal` stays **root-locked** (escalation hole closed).

Separate from the volume-buttons (#74) and webOS-keyboard (#75) PRs. Both this and #75 bump the agent to 2.9.12 (identical `VERSION` line change — merges cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)