### PR TITLE
feat: add/pair a box from the app via LAN scan + on-screen PIN (2.9.12)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6834,11 +6834,10 @@ def render_pin_page(pin):
         "fetch('/api/pair/status').then(function(r){return r.json()})"
         ".then(function(d){if(d&&d.active===false&&!done){done=true;"
         "document.body.innerHTML="
-        "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
-        # Session ended: leave the browser after a beat by pulling Steam back to
-        # its Game Mode home. steam://open/bigpicture is handled by Steam's own
-        # browser; desktop browsers just ignore it and keep the DONE screen.
-        "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
+        "'<div class=t>PAIRED</div><div class=s>Press B (Back) to close.</div>'"
+        # Steam's browser can't be closed programmatically (neither a page-side
+        # window.close()/steam:// nav nor an agent steam:// CLI dismisses it), so
+        # we land on a clean PAIRED screen and tell the user how to close it.
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -6721,6 +6721,155 @@ def build_pair_url(token, port):
     return url
 
 
+# ---- PIN pairing (app-initiated box enrollment) ---------------------------
+# A phone that discovered this box on the LAN (see the UDP responder) can enroll
+# WITHOUT already having the token, via a PIN shown on the BOX'S OWN screen —
+# physical-presence proof, exactly like Android-TV pairing:
+#   POST /api/pair/start  (unauth): mint a 6-digit PIN, display it on the box
+#     (Steam's browser -> the loopback /pair page), return the TTL.
+#   POST /api/pair/finish (unauth): trade the correct PIN for the box token.
+# The PIN is rendered ONLY on the loopback /pair page, so it never crosses the
+# network — you must be able to SEE the box's screen. Brute force is blocked by
+# a short TTL + a small attempt cap + a single live session, and repeated
+# /start is debounced so a LAN peer can't spam the on-screen popup.
+PAIR_PIN_TTL = 120           # seconds a displayed PIN stays valid
+PAIR_PIN_MAX_ATTEMPTS = 5    # wrong PINs before the session is burned
+PAIR_PIN_START_DEBOUNCE = 3  # min seconds between /start (anti on-screen spam)
+PAIR_PIN_LOCK = threading.Lock()
+# {"pin": "123456", "expires": mono, "attempts": int, "started": mono} or None
+PAIR_PIN = None
+
+
+def pair_pin_start():
+    """Mint a fresh PIN + session (replacing any prior one) and return
+    (pin, ttl). Debounced: within PAIR_PIN_START_DEBOUNCE of the last start the
+    LIVE pin is returned unchanged, so a double-tap / retry doesn't reroll the
+    number already on screen. Caller displays it on the box."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        now = time.monotonic()
+        s = PAIR_PIN
+        if s and now <= s["expires"] and now - s["started"] < PAIR_PIN_START_DEBOUNCE:
+            return s["pin"], int(s["expires"] - now)
+        pin = "%06d" % (int.from_bytes(os.urandom(3), "big") % 1000000)
+        PAIR_PIN = {"pin": pin, "expires": now + PAIR_PIN_TTL,
+                    "attempts": 0, "started": now}
+        return pin, PAIR_PIN_TTL
+
+
+def pair_pin_active():
+    """The current PIN if a session is live (for /pair to render on-screen),
+    else None."""
+    with PAIR_PIN_LOCK:
+        if PAIR_PIN and time.monotonic() <= PAIR_PIN["expires"]:
+            return PAIR_PIN["pin"]
+        return None
+
+
+def pair_pin_check(pin):
+    """Validate a submitted PIN. True (and burns the session) on match; raises
+    ValueError with a user-facing reason on no-session / expired / locked /
+    wrong. A wrong guess counts toward the attempt cap."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        s = PAIR_PIN
+        if not s or time.monotonic() > s["expires"]:
+            PAIR_PIN = None
+            raise ValueError("no active pairing — start it again from the app")
+        if s["attempts"] >= PAIR_PIN_MAX_ATTEMPTS:
+            PAIR_PIN = None
+            raise ValueError("too many wrong PINs — start again")
+        if (pin or "").strip() != s["pin"]:
+            s["attempts"] += 1
+            raise ValueError("wrong PIN")
+        PAIR_PIN = None                       # consume on success
+        return True
+
+
+def pair_show_on_box(port):
+    """Open the loopback /pair page on the BOX'S own screen so the PIN is
+    visible there. Game Mode -> Steam's built-in browser (steam://openurl);
+    desktop -> xdg-open. Best-effort, detached, never blocks the request."""
+    url = "http://localhost:%d/pair" % port
+    gamescope = _couchmode_session() == "gamescope"
+
+    def go():
+        try:
+            if gamescope:
+                subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
+                               timeout=10)
+            elif shutil.which("xdg-open"):
+                subprocess.run(["xdg-open", url], timeout=10)
+            elif shutil.which("steam"):
+                subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
+                               timeout=10)
+        except Exception:
+            pass
+    threading.Thread(target=go, daemon=True).start()
+
+
+def render_pin_page(pin):
+    """Full-screen dark page showing the pairing PIN, spaced for reading off a
+    TV. Auto-refreshes so it clears when the session ends (paired or expired).
+    Built with a placeholder replace (not %-formatting) because the CSS contains
+    a literal '%' (height:100%)."""
+    return (
+        "<!doctype html><html><head><meta charset=utf-8>"
+        "<meta name=viewport content='width=device-width,initial-scale=1'>"
+        "<meta http-equiv=refresh content=8>"
+        "<title>Couchside pairing</title><style>"
+        "html,body{margin:0;height:100%;background:#0b1220;color:#e5e7eb;"
+        "font-family:system-ui,sans-serif;display:flex;flex-direction:column;"
+        "align-items:center;justify-content:center;text-align:center}"
+        ".t{font-size:5vh;color:#93c5fd;letter-spacing:.1em;font-weight:600}"
+        ".pin{font-size:22vh;font-weight:800;letter-spacing:.15em;margin:2vh 0;"
+        "font-variant-numeric:tabular-nums;color:#fff}"
+        ".s{font-size:3.2vh;color:#94a3b8;max-width:80vw}"
+        "</style></head><body>"
+        "<div class=t>ENTER THIS PIN IN THE APP</div>"
+        "<div class=pin>__PIN__</div>"
+        "<div class=s>Couchside · this code is shown only on this screen</div>"
+        "</body></html>".replace("__PIN__", " ".join(pin)))
+
+
+# ---- LAN discovery responder (lets the app find this box) ------------------
+# The app broadcasts COUCHSIDE_DISCOVER_MAGIC to this UDP port; the box replies
+# with its identity + HTTP port so the app can list it in a "scan for boxes"
+# picker (then PIN-pair, above). Bound on the SAME number as the HTTP port
+# (UDP vs TCP, no clash). Reveals existence + hostname + version only — no
+# token, no control. UDP broadcast is used deliberately: it is far more reliable
+# than mDNS multicast RX on Android (no MulticastLock dance).
+COUCHSIDE_DISCOVER_MAGIC = b"COUCHSIDE_DISCOVER?"
+
+
+def _udp_discovery_responder(port):
+    """Answer LAN discovery probes on UDP <port>. Best-effort daemon; a bind
+    failure just disables discovery (the app can still add a box by IP)."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("0.0.0.0", port))
+    except OSError as e:
+        print("[discover] responder disabled: %s" % e, flush=True)
+        return
+    print("[discover] UDP responder on :%d" % port, flush=True)
+    while True:
+        try:
+            data, addr = s.recvfrom(256)
+        except OSError:
+            continue
+        if not data.startswith(COUCHSIDE_DISCOVER_MAGIC):
+            continue
+        short = socket.gethostname().split(".")[0] or "couchside"
+        reply = json.dumps({"couchside": True, "name": short,
+                            "host": short + ".local", "port": port,
+                            "version": VERSION}).encode()
+        try:
+            s.sendto(reply, addr)
+        except OSError:
+            pass
+
+
 def render_pair_page(token, port):
     """Self-contained dark HTML page rendering the pairing QR offline.
 
@@ -6961,7 +7110,12 @@ class Handler(BaseHTTPRequestHandler):
                 if not self._is_loopback() or not self._host_header_is_local():
                     self._send(403, {"error": "forbidden"}, started)
                     return
-                html = render_pair_page(self._current_token(), self.port)
+                # While a PIN-pairing session is live, this page IS the physical-
+                # presence proof: show the big PIN (loopback-only, so only someone
+                # at the box sees it). Otherwise the usual token QR.
+                pin = pair_pin_active()
+                html = (render_pin_page(pin) if pin
+                        else render_pair_page(self._current_token(), self.port))
                 self._send_html(200, html, started)
                 return
 
@@ -7195,6 +7349,36 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 self._read_body()
                 self._send(404, {"error": "not found"}, started)
+                return
+
+            # UNAUTHENTICATED PIN pairing (the only unauthenticated POSTs): a
+            # phone that discovered this box enrolls via a PIN shown on the box's
+            # own screen. Bounded: /start is debounced + displays the PIN
+            # locally; /finish is TTL + attempt-capped and only returns the token
+            # for the correct PIN. Handled here, before the bearer-token gate.
+            if path in ("/api/pair/start", "/api/pair/finish"):
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                pair_body = self._read_body()
+                if path == "/api/pair/start":
+                    _pin, ttl = pair_pin_start()
+                    pair_show_on_box(self.port)   # pop the PIN on the box screen
+                    self._send(200, {"ok": True, "ttl": ttl}, started)
+                    return
+                try:
+                    req = json.loads(pair_body.decode("utf-8")) if pair_body else {}
+                    submitted = req.get("pin")
+                except (ValueError, UnicodeDecodeError):
+                    submitted = None
+                try:
+                    pair_pin_check(submitted)
+                except ValueError as e:
+                    self._send(403, {"ok": False, "error": str(e)}, started)
+                    return
+                self._send(200, {"ok": True, "token": self._current_token(),
+                                 "port": self.port}, started)
                 return
 
             # Authorize BEFORE reading the body: an unauthenticated client must
@@ -8304,6 +8488,8 @@ def main():
 
     server = BoundedThreadingHTTPServer((args.host, port), Handler)
     server.daemon_threads = True
+    threading.Thread(target=_udp_discovery_responder, args=(port,),
+                     daemon=True, name="discover").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6810,13 +6810,14 @@ def pair_show_on_box(port):
 
 def render_pin_page(pin):
     """Full-screen dark page showing the pairing PIN, spaced for reading off a
-    TV. Auto-refreshes so it clears when the session ends (paired or expired).
-    Built with a placeholder replace (not %-formatting) because the CSS contains
-    a literal '%' (height:100%)."""
+    TV. A JS poll of /api/pair/status clears the PIN to a neutral 'done' once the
+    session ends (paired or expired), and leaves it untouched on any fetch error
+    — so the agent restarting never shows a browser error, and a successful pair
+    never flashes the token QR. Built with a placeholder replace (not
+    %-formatting) because the CSS contains a literal '%' (height:100%)."""
     return (
         "<!doctype html><html><head><meta charset=utf-8>"
         "<meta name=viewport content='width=device-width,initial-scale=1'>"
-        "<meta http-equiv=refresh content=8>"
         "<title>Couchside pairing</title><style>"
         "html,body{margin:0;height:100%;background:#0b1220;color:#e5e7eb;"
         "font-family:system-ui,sans-serif;display:flex;flex-direction:column;"
@@ -6829,6 +6830,11 @@ def render_pin_page(pin):
         "<div class=t>ENTER THIS PIN IN THE APP</div>"
         "<div class=pin>__PIN__</div>"
         "<div class=s>Couchside · this code is shown only on this screen</div>"
+        "<script>setInterval(function(){"
+        "fetch('/api/pair/status').then(function(r){return r.json()})"
+        ".then(function(d){if(d&&d.active===false){document.body.innerHTML="
+        "'<div class=t>DONE</div><div class=s>This code is no longer active.</div>'"
+        "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 
 
@@ -7117,6 +7123,16 @@ class Handler(BaseHTTPRequestHandler):
                 html = (render_pin_page(pin) if pin
                         else render_pair_page(self._current_token(), self.port))
                 self._send_html(200, html, started)
+                return
+
+            if path == "/api/pair/status":
+                # Loopback-only: the on-screen /pair PIN page polls this to learn
+                # when its session ended (paired/expired), so it can clear itself
+                # without a blind reload. Reveals only a boolean, no secret.
+                if not self._is_loopback():
+                    self._send(403, {"error": "forbidden"}, started)
+                    return
+                self._send(200, {"active": pair_pin_active() is not None}, started)
                 return
 
             if path == "/api/ping":

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6830,10 +6830,15 @@ def render_pin_page(pin):
         "<div class=t>ENTER THIS PIN IN THE APP</div>"
         "<div class=pin>__PIN__</div>"
         "<div class=s>Couchside · this code is shown only on this screen</div>"
-        "<script>setInterval(function(){"
+        "<script>var done=false;setInterval(function(){"
         "fetch('/api/pair/status').then(function(r){return r.json()})"
-        ".then(function(d){if(d&&d.active===false){document.body.innerHTML="
-        "'<div class=t>DONE</div><div class=s>This code is no longer active.</div>'"
+        ".then(function(d){if(d&&d.active===false&&!done){done=true;"
+        "document.body.innerHTML="
+        "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
+        // Session ended: leave the browser after a beat by pulling Steam back to
+        // its Game Mode home. steam://open/bigpicture is handled by Steam's own
+        // browser; desktop browsers just ignore it and keep the DONE screen.
+        "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6835,9 +6835,9 @@ def render_pin_page(pin):
         ".then(function(d){if(d&&d.active===false&&!done){done=true;"
         "document.body.innerHTML="
         "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
-        // Session ended: leave the browser after a beat by pulling Steam back to
-        // its Game Mode home. steam://open/bigpicture is handled by Steam's own
-        // browser; desktop browsers just ignore it and keep the DONE screen.
+        # Session ended: leave the browser after a beat by pulling Steam back to
+        # its Game Mode home. steam://open/bigpicture is handled by Steam's own
+        # browser; desktop browsers just ignore it and keep the DONE screen.
         "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -21,6 +21,7 @@ import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
+import { BoxScanPair } from '@/components/BoxScanPair';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -951,6 +952,11 @@ function SetupBody() {
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>
+        {/* Scan the LAN + PIN-pair (no IP/token typing). Hidden on builds without
+            the UDP native module. The manual card below stays as the fallback. */}
+        <View style={styles.card}>
+          <BoxScanPair />
+        </View>
         <View style={styles.card}>
           <Text style={styles.fieldLabel}>NAME (optional)</Text>
           <TextInput

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -706,6 +706,9 @@ function SetupBody() {
   const [agentVersion, setAgentVersion] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [saved, setSaved] = useState(false);
+  // Scan + PIN is the primary way to add a box; the manual host/port/token card
+  // is a collapsed "advanced" fallback (headless / cross-subnet / non-Linux).
+  const [showManual, setShowManual] = useState(false);
 
   const draftConn = useCallback(() => {
     const p = parseInt(port, 10);
@@ -952,11 +955,20 @@ function SetupBody() {
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>
-        {/* Scan the LAN + PIN-pair (no IP/token typing). Hidden on builds without
-            the UDP native module. The manual card below stays as the fallback. */}
+        {/* Scan the LAN + PIN-pair (no IP/token typing) is the primary method.
+            Hidden on builds without the UDP native module — the manual card then
+            carries the whole flow. */}
         <View style={styles.card}>
           <BoxScanPair />
         </View>
+        {/* Manual host/port/token: collapsed fallback for headless / cross-subnet
+            / non-Linux boxes that scanning can't reach. */}
+        <Pressable onPress={() => setShowManual((v) => !v)} style={styles.advancedToggle}>
+          <Text style={styles.advancedToggleText}>Add by IP (advanced)</Text>
+          <Ionicons name={showManual ? 'chevron-up' : 'chevron-down'} size={16} color={t.textDim} />
+        </Pressable>
+        {showManual ? (
+        <>
         <View style={styles.card}>
           <Text style={styles.fieldLabel}>NAME (optional)</Text>
           <TextInput
@@ -1043,6 +1055,8 @@ function SetupBody() {
             </View>
           )}
         </View>
+        </>
+        ) : null}
           </>
         )}
 
@@ -1438,6 +1452,15 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     letterSpacing: 1.2,
     marginBottom: 8,
   },
+  advancedToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    marginTop: 4,
+  },
+  advancedToggleText: { color: t.textDim, fontSize: 13, fontWeight: '700' },
   header: {
     paddingHorizontal: 14,
     paddingTop: 8,

--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -1,0 +1,216 @@
+/**
+ * Scan the LAN for Couchside boxes and pair one with a PIN — no IP typing, no
+ * token. Mirrors how a TV pairs: tap a discovered box, the box shows a PIN on
+ * ITS OWN screen, you type that PIN here, and the box hands back its token.
+ *
+ * The PIN (shown only on the box's screen) is the physical-presence proof; the
+ * token never appears until the right PIN is entered. Needs agent >= 2.9.12 and
+ * a native build with react-native-udp (scanAvailable).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { pairFinish, pairStart } from '@/lib/api';
+import { FoundBox, scanAvailable, scanForBoxes } from '@/lib/boxDiscovery';
+import { hapticSelection } from '@/lib/haptics';
+import { useBoxes } from '@/lib/SettingsContext';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+type Phase =
+  | { k: 'idle' }
+  | { k: 'scanning' }
+  | { k: 'list'; boxes: FoundBox[] }
+  | { k: 'pin'; box: FoundBox } // box is showing a PIN; awaiting entry
+  | { k: 'pairing'; box: FoundBox };
+
+export function BoxScanPair() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { addBox } = useBoxes();
+  const [phase, setPhase] = useState<Phase>({ k: 'idle' });
+  const [pin, setPin] = useState('');
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const scan = useCallback(async () => {
+    setMsg(null);
+    setPhase({ k: 'scanning' });
+    try {
+      const boxes = await scanForBoxes({ timeoutMs: 2500 });
+      setPhase({ k: 'list', boxes });
+      if (boxes.length === 0) {
+        setMsg({ ok: false, text: 'No boxes found — check the same Wi-Fi, or add one by IP below.' });
+      }
+    } catch {
+      setPhase({ k: 'idle' });
+      setMsg({ ok: false, text: 'Scan needs a newer build of the app.' });
+    }
+  }, []);
+
+  // Tap a discovered box: ask it to show a PIN on its own screen, then prompt.
+  const startPair = useCallback(async (box: FoundBox) => {
+    hapticSelection();
+    setMsg(null);
+    setPin('');
+    setPhase({ k: 'pairing', box });
+    try {
+      const r = await pairStart(box.ip, box.port);
+      if (r.ok) {
+        setPhase({ k: 'pin', box });
+        setMsg({ ok: true, text: `Enter the PIN now showing on ${box.name}.` });
+      } else {
+        setPhase({ k: 'list', boxes: [box] });
+        setMsg({ ok: false, text: r.error ?? 'Could not start pairing on that box.' });
+      }
+    } catch {
+      setPhase({ k: 'list', boxes: [box] });
+      setMsg({ ok: false, text: 'Could not reach that box.' });
+    }
+  }, []);
+
+  const submitPin = useCallback(async () => {
+    if (phase.k !== 'pin') return;
+    const box = phase.box;
+    const code = pin.trim();
+    if (code.length !== 6) {
+      setMsg({ ok: false, text: 'Enter the 6-digit PIN from the box.' });
+      return;
+    }
+    setPhase({ k: 'pairing', box });
+    try {
+      const r = await pairFinish(box.ip, box.port, code);
+      if (r.ok && r.token) {
+        await addBox({ host: box.host, port: r.port ?? box.port, token: r.token, lastIp: box.ip });
+        setPhase({ k: 'idle' });
+        setPin('');
+        setMsg({ ok: true, text: `Paired ${box.name}.` });
+      } else {
+        setPhase({ k: 'pin', box });
+        setMsg({ ok: false, text: r.error ?? 'Pairing failed — check the PIN and retry.' });
+      }
+    } catch {
+      setPhase({ k: 'pin', box });
+      setMsg({ ok: false, text: 'Could not reach that box.' });
+    }
+  }, [phase, pin, addBox]);
+
+  const cancel = useCallback(() => {
+    setPhase({ k: 'idle' });
+    setPin('');
+    setMsg(null);
+  }, []);
+
+  if (!scanAvailable) return null; // old build without the UDP module
+
+  return (
+    <View style={styles.wrap}>
+      {phase.k === 'pin' ? (
+        <>
+          <Text style={styles.hint}>A 6-digit PIN is showing on {phase.box.name}. Enter it:</Text>
+          <TextInput
+            value={pin}
+            onChangeText={(v) => setPin(v.replace(/[^0-9]/g, '').slice(0, 6))}
+            placeholder="6-digit PIN"
+            placeholderTextColor={t.textFaint}
+            keyboardType="number-pad"
+            autoFocus
+            style={styles.input}
+          />
+          <View style={styles.row}>
+            <Pressable onPress={cancel} style={[styles.btn, styles.btnGhost]}>
+              <Text style={styles.btnGhostText}>CANCEL</Text>
+            </Pressable>
+            <Pressable onPress={submitPin} style={[styles.btn, styles.btnPrimary]}>
+              <Text style={styles.btnPrimaryText}>PAIR</Text>
+            </Pressable>
+          </View>
+        </>
+      ) : (
+        <>
+          <Pressable
+            onPress={scan}
+            disabled={phase.k === 'scanning' || phase.k === 'pairing'}
+            style={[styles.scanBtn, (phase.k === 'scanning' || phase.k === 'pairing') && styles.busy]}>
+            {phase.k === 'scanning' || phase.k === 'pairing' ? (
+              <ActivityIndicator color={t.blue} />
+            ) : (
+              <>
+                <Ionicons name="wifi" size={16} color={t.blue} />
+                <Text style={styles.scanText}>Scan for boxes</Text>
+              </>
+            )}
+          </Pressable>
+          {phase.k === 'list' && phase.boxes.length > 0 ? (
+            <View style={styles.list}>
+              {phase.boxes.map((b) => (
+                <Pressable key={b.ip} onPress={() => startPair(b)} style={styles.boxRow}>
+                  <Ionicons name="hardware-chip-outline" size={18} color={t.text} />
+                  <View style={styles.boxText}>
+                    <Text style={styles.boxName} numberOfLines={1}>{b.name}</Text>
+                    <Text style={styles.boxMeta}>{b.ip} · v{b.version || '?'}</Text>
+                  </View>
+                  <Ionicons name="chevron-forward" size={16} color={t.textDim} />
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+        </>
+      )}
+      {msg ? (
+        <Text style={[styles.msg, { color: msg.ok ? t.green : t.red }]}>{msg.text}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  wrap: { gap: 10 },
+  hint: { color: t.textDim, fontSize: 13, lineHeight: 18 },
+  scanBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: 10,
+    paddingVertical: 11,
+    minHeight: 44,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  busy: { opacity: 0.7 },
+  scanText: { color: t.blue, fontSize: 14, fontWeight: '700' },
+  list: { gap: 6 },
+  boxRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  boxText: { flex: 1 },
+  boxName: { color: t.text, fontSize: 14, fontWeight: '700' },
+  boxMeta: { color: t.textDim, fontSize: 12, marginTop: 1 },
+  input: {
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: t.text,
+    fontSize: 18,
+    letterSpacing: 4,
+  },
+  row: { flexDirection: 'row', gap: 10 },
+  btn: { flex: 1, borderRadius: 10, paddingVertical: 11, alignItems: 'center' },
+  btnGhost: { backgroundColor: t.inset },
+  btnGhostText: { color: t.textDim, fontWeight: '700', fontSize: 13 },
+  btnPrimary: { backgroundColor: t.blue },
+  btnPrimaryText: { color: t.bg, fontWeight: '800', fontSize: 13 },
+  msg: { fontSize: 13, lineHeight: 18 },
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -808,6 +808,60 @@ async function request<T>(
   }
 }
 
+// ---------- PIN pairing (unauthenticated box enrollment) ----------
+
+export type PairStartResult = { ok: boolean; ttl?: number; error?: string };
+export type PairFinishResult = { ok: boolean; token?: string; port?: number; error?: string };
+
+/**
+ * Hit a box directly by ip:port with NO bearer token — the PIN-pairing routes
+ * are the box's only unauthenticated POSTs (the phone has no token yet). Reads
+ * the JSON body for both 200 and the 4xx error cases.
+ */
+async function unauthPost<T>(
+  ip: string,
+  port: number,
+  path: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`http://${ip}:${port}${path}`, {
+      method: 'POST',
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+    return (await res.json()) as T;
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`);
+    }
+    throw new ApiError('unreachable', 'Box unreachable: network error');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Start PIN pairing: the box mints a PIN and displays it on ITS OWN screen.
+ * Returns the TTL; the PIN is never sent over the network. Agent >= 2.9.12.
+ */
+export function pairStart(ip: string, port: number): Promise<PairStartResult> {
+  return unauthPost<PairStartResult>(ip, port, '/api/pair/start', undefined, 8000);
+}
+
+/**
+ * Finish PIN pairing: submit the PIN shown on the box. On success returns the
+ * box token (to store) and its port; on a wrong/expired/locked PIN, `ok:false`
+ * with a reason.
+ */
+export function pairFinish(ip: string, port: number, pin: string): Promise<PairFinishResult> {
+  return unauthPost<PairFinishResult>(ip, port, '/api/pair/finish', { pin }, 8000);
+}
+
 export const api = {
   /** Unauthenticated reachability probe. */
   ping(settings: ConnSettings): Promise<Ping> {

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -15,9 +15,13 @@ import { DEFAULT_PORT } from './settings';
 
 // Native module; require in a try/catch so a build predating the dependency
 // disables scanning instead of crashing at startup (see scanAvailable).
+// react-native-udp does `module.exports = UdpSockets` AND `export default`, so
+// depending on interop `.default` may be undefined and the module itself is the
+// dgram object — accept either (a bare `.default` silently disabled this).
 let dgram: typeof import('react-native-udp').default | null = null;
 try {
-  dgram = require('react-native-udp').default;
+  const udp = require('react-native-udp');
+  dgram = (udp && (udp.default ?? udp)) || null;
 } catch {
   dgram = null;
 }

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -1,0 +1,123 @@
+/**
+ * LAN box discovery: broadcast a probe and collect replies from Couchside
+ * agents, so the user can pick a box to pair instead of typing an IP. Pairs
+ * with the agent's UDP responder (agent >= 2.9.12): the box replies with its
+ * identity + HTTP port. Reveals existence only — pairing still needs the PIN
+ * shown on the box's own screen (see api.pairStart/pairFinish).
+ *
+ * UDP broadcast (not mDNS) is deliberate: Android multicast RX needs a
+ * MulticastLock and is flaky, while a directed/global broadcast + unicast reply
+ * is reliable. Mirrors lib/wol.ts's use of the same native module.
+ */
+import { Buffer } from 'buffer';
+
+import { DEFAULT_PORT } from './settings';
+
+// Native module; require in a try/catch so a build predating the dependency
+// disables scanning instead of crashing at startup (see scanAvailable).
+let dgram: typeof import('react-native-udp').default | null = null;
+try {
+  dgram = require('react-native-udp').default;
+} catch {
+  dgram = null;
+}
+
+/** True when the UDP native module is present, so a scan can run. */
+export const scanAvailable = dgram != null;
+
+const PROBE = 'COUCHSIDE_DISCOVER?';
+
+export type FoundBox = {
+  /** Short hostname the box reports (display label). */
+  name: string;
+  /** mDNS name (e.g. steamdeck.local) for the stored host. */
+  host: string;
+  /** The IP the reply actually came from (the direct-connect fallback). */
+  ip: string;
+  /** The box's HTTP/agent port. */
+  port: number;
+  /** Agent version (so the UI can flag a box too old to PIN-pair). */
+  version: string;
+};
+
+/** The /24 directed broadcast for a LAN IP, plus the global broadcast. */
+function broadcastTargets(ip?: string): string[] {
+  const t: string[] = [];
+  if (ip) {
+    const m = /^(\d+)\.(\d+)\.(\d+)\.\d+$/.exec(ip);
+    if (m) t.push(`${m[1]}.${m[2]}.${m[3]}.255`);
+  }
+  t.push('255.255.255.255');
+  return Array.from(new Set(t));
+}
+
+/**
+ * Broadcast the discovery probe on `port` (the agent port) and collect box
+ * replies for `timeoutMs`. Resolves the deduped list (by IP). Throws only when
+ * the native UDP module is missing; a bind/send failure resolves an empty list.
+ */
+export function scanForBoxes(
+  opts: { ip?: string; port?: number; timeoutMs?: number } = {},
+): Promise<FoundBox[]> {
+  if (!dgram) throw new Error('Box discovery needs a fresh native build of the app');
+  const port = opts.port ?? DEFAULT_PORT;
+  const timeoutMs = opts.timeoutMs ?? 2500;
+  const probe = Buffer.from(PROBE);
+  const targets = broadcastTargets(opts.ip);
+
+  return new Promise<FoundBox[]>((resolve) => {
+    const socket = dgram!.createSocket({ type: 'udp4' });
+    const found = new Map<string, FoundBox>(); // by IP
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      try {
+        socket.close();
+      } catch {
+        // already closed
+      }
+      resolve(Array.from(found.values()));
+    };
+
+    socket.once('error', finish);
+    socket.on('message', (msg: Buffer, rinfo: { address: string }) => {
+      try {
+        const d = JSON.parse(msg.toString());
+        if (d && d.couchside) {
+          found.set(rinfo.address, {
+            name: typeof d.name === 'string' ? d.name : rinfo.address,
+            host: typeof d.host === 'string' ? d.host : rinfo.address,
+            ip: rinfo.address,
+            port: typeof d.port === 'number' ? d.port : port,
+            version: typeof d.version === 'string' ? d.version : '',
+          });
+        }
+      } catch {
+        // not our reply; ignore
+      }
+    });
+
+    socket.bind(0, (bindErr?: Error) => {
+      if (bindErr) {
+        finish();
+        return;
+      }
+      try {
+        socket.setBroadcast(true);
+      } catch {
+        // some platforms reject before the first send; the send still works
+      }
+      try {
+        for (const addr of targets) {
+          socket.send(probe, 0, probe.length, port, addr, () => {});
+        }
+      } catch {
+        finish();
+        return;
+      }
+      timer = setTimeout(finish, timeoutMs);
+    });
+  });
+}


### PR DESCRIPTION
## What
Enroll a box from the phone with **no IP or token typing** — **scan the LAN → tap a box → read the PIN it shows on its own screen → type it in**. Same shape as Android-TV pairing.

## Security model (as approved)
- `POST /api/pair/start` + `POST /api/pair/finish` are the box's **only unauthenticated POSTs**.
- The PIN is rendered **only on the loopback `/pair` page**, opened on the box's **own screen** (`steam://openurl` — the exact path the pairing QR already uses). **It never crosses the network** — you must be able to *see* the box.
- Bounded: **120 s TTL · single live session · 5-attempt lockout · `/start` debounced** (anti on-screen-spam). The token is returned **only** for the correct PIN.
- Discovery reveals **existence only** (name/port/version), no token, no control.
- This is equivalent to the existing QR flow's trust boundary ("can see the box screen"), just a nicer UX.

## How
**Agent:** UDP discovery responder (broadcast probe → identity reply); the two PIN routes; `/pair` renders the big PIN while a session is live (else the QR).

**App:** `lib/boxDiscovery.ts` (UDP-broadcast scan via `react-native-udp` — already a dep, **no new native module**, and more reliable than Android mDNS multicast); unauthenticated `pairStart`/`pairFinish`; `BoxScanPair` — "Scan for boxes" → list → PIN → stores host+port+token. Sits above the manual add-box card (which stays as fallback); hidden on builds without the UDP module.

## Verified (real Steam Deck, agent side end-to-end)
- Discovery reply · `pair/start` (unauth, `ttl`) · `/pair` renders the PIN (loopback) · `pair/finish` returns the box's **real token** (`token_matches_box=true`) · wrong-PIN rejected · **5-attempt lockout burns the session** · single-use consume (→ `/pair` back to QR).
- `steam://openurl` display path runs clean in the gamescope session (exit 0).
- App UDP scan + full phone→box→screen flow: needs a device build to verify (like the volume feature).

Independent of #74 / #75 / #77 / #78. Agent → 2.9.12 (same `VERSION` line — merges cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)