### PR TITLE
feat(tv): SOURCE button opens the smart-TV input picker

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3755,6 +3755,7 @@ _SAMSUNG_KEYS = {
     "ok": "KEY_ENTER", "menu": "KEY_MENU", "home": "KEY_HOME", "back": "KEY_RETURN",
     "exit": "KEY_EXIT", "info": "KEY_INFO", "play": "KEY_PLAY", "pause": "KEY_PAUSE",
     "stop": "KEY_STOP", "rewind": "KEY_REWIND", "fast_forward": "KEY_FF",
+    "source": "KEY_SOURCE",   # opens the Tizen source/input menu
 }
 
 
@@ -4071,6 +4072,7 @@ _ATV_KEYS = {
     "up": 19, "down": 20, "left": 21, "right": 22, "ok": 23, "menu": 82,
     "home": 3, "back": 4, "exit": 4, "play": 126, "pause": 127, "stop": 86,
     "rewind": 89, "fast_forward": 90,
+    "source": 178,   # KEYCODE_TV_INPUT — opens the input picker on Google TV
 }
 
 
@@ -4728,6 +4730,11 @@ def tv_info():
         "keys": (panel_available() or webos_available()
                  or samsung_available() or roku_available()
                  or androidtv_available() or vidaa_available()),
+        # A "source" key opens the TV's input picker (agent >= 2.9.12). Android/
+        # Google TV (KEYCODE_TV_INPUT) and Samsung (KEY_SOURCE) have one; webOS/
+        # Roku don't (no single input-menu key), and the RS-232 panel uses its
+        # own explicit source list (source_box / sources) instead.
+        "source_key": androidtv_available() or samsung_available(),
         # Text entry into a focused on-TV field. webOS (IME), Samsung
         # (SendInputString) and Roku (Lit_ keypresses) support it; the panel
         # and CEC have no text channel.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -82,6 +82,14 @@ export function RemoteView({
   const [target, setTarget] = useState<'box' | 'tv'>('box');
   const nav = hasTvKeys ? target : 'box';
 
+  // MUTE button color reflects the reported mute state (tv.muted, refreshed by
+  // the poll), toggled optimistically on press for instant feedback. It used to
+  // be hardcoded red, so it always looked muted even when it wasn't.
+  const [muted, setMuted] = useState(false);
+  React.useEffect(() => {
+    if (typeof tv?.muted === 'boolean') setMuted(tv.muted);
+  }, [tv?.muted]);
+
   // Nav-circle input surface: the classic D-pad, or a relative-mouse trackpad
   // (desktop only). Force back to the D-pad if the box leaves desktop mode.
   const [surface, setSurface] = useState<'dpad' | 'track'>('dpad');
@@ -245,7 +253,7 @@ export function RemoteView({
           {hasSourceKey && target === 'tv' && (
             <Pressable
               onPress={() => tvKey('source')}
-              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}>
               <Ionicons name="swap-horizontal" size={20} color={t.blue} />
             </Pressable>
           )}
@@ -255,7 +263,7 @@ export function RemoteView({
                 hapticLight();
                 setTextOpen(true);
               }}
-              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}>
               <Ionicons name="keypad" size={20} color={t.blue} />
             </Pressable>
           )}
@@ -350,7 +358,15 @@ export function RemoteView({
           onMinus={() => tvOp('volume_down')}
         />
         <View style={styles.midStack}>
-          <MidBtn icon="volume-mute" label="MUTE" color={t.red} onPress={() => tvOp('mute')} />
+          <MidBtn
+            icon={muted ? 'volume-mute' : 'volume-high'}
+            label="MUTE"
+            color={muted ? t.red : t.text}
+            onPress={() => {
+              setMuted((m) => !m);
+              tvOp('mute');
+            }}
+          />
           <MidBtn icon="logo-steam" label="STEAM" color={t.green} onPress={steam} />
           <MidBtn icon="ellipsis-horizontal" label="QAM" color={t.amber} onPress={qam} />
         </View>
@@ -769,6 +785,19 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     backgroundColor: t.card,
     borderWidth: 1,
     borderColor: 'rgba(248,113,113,0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Neutral sibling of `pwr` for non-power icon buttons (SOURCE, keypad) — same
+  // footprint, plain card border instead of the power button's red one so they
+  // don't read as "danger".
+  iconBtn: {
+    width: 44,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -57,6 +57,7 @@ export function RemoteView({
   const tv = tvPoll.data?.available ? tvPoll.data : null;
   const hasTvKeys = tv?.keys === true;
   const hasTvText = tv?.text === true;
+  const hasSourceKey = tv?.source_key === true;
   const sources = tv?.sources ?? [];
   const canBlank = tv?.screen_toggle === true;
 
@@ -241,6 +242,13 @@ export function RemoteView({
               </Pressable>
             ))}
           </View>
+          {hasSourceKey && target === 'tv' && (
+            <Pressable
+              onPress={() => tvKey('source')}
+              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              <Ionicons name="swap-horizontal" size={20} color={t.blue} />
+            </Pressable>
+          )}
           {hasTvText && target === 'tv' && (
             <Pressable
               onPress={() => {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -392,6 +392,12 @@ export type Tv = {
    */
   keys?: boolean;
   /**
+   * A `source` key (POST /api/tv/key/source) opens the TV's input picker (agent
+   * >= 2.9.12). Set by Android/Google TV (KEYCODE_TV_INPUT) and Samsung
+   * (KEY_SOURCE); the RS-232 panel uses its explicit `sources` list instead.
+   */
+  source_key?: boolean;
+  /**
    * Text entry into a focused on-TV field via POST /api/tv/text (agent >=
    * 2.9.7). Set by the network smart-TV backends (webOS IME, Samsung
    * SendInputString, Roku Lit_ keys); never by panel/CEC.
@@ -418,6 +424,7 @@ export type TvKey =
   | 'home'
   | 'back'
   | 'settings'
+  | 'source'
   | 'bright_up'
   | 'bright_down';
 


### PR DESCRIPTION
## What
A **SOURCE** button on the Remote that opens the connected smart TV's **input picker** — previously input switching existed **only** for the RS-232 panel (its source pills); smart TVs (Google TV, Samsung, …) had nothing.

## How
New `source` factory-remote key mapped per backend:
- **Android/Google TV** → `KEYCODE_TV_INPUT` (opens the input picker)
- **Samsung** → `KEY_SOURCE` (opens the Tizen source menu)
- webOS / Roku have no single input-menu key → not advertised; the **RS-232 panel** keeps its explicit `sources` list.

Agent advertises a new `source_key` cap in `/api/tv`; `RemoteView` shows the SOURCE button in the TV target row when it's set. Reuses the existing `/api/tv/key/<k>` dispatch — no new endpoint.

## Verified (real Google TV)
`/api/tv` → `backend=androidtv, source_key=true`; `POST /api/tv/key/source` → `ok=true` (KEYCODE_TV_INPUT sent to the TV).

Agent → 2.9.12 (same `VERSION` line as the other open PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)