### PR TITLE
fix(wol): Wake-on-LAN silently disabled by react-native-udp .default

### DIFF
--- a/app/lib/wol.ts
+++ b/app/lib/wol.ts
@@ -13,9 +13,13 @@ import { Buffer } from 'buffer';
 // react-native-udp is a native module. Requiring it in a try/catch means a
 // build that predates the dependency disables wake instead of crashing at
 // startup; wolAvailable reports which case we are in.
+// The lib does `module.exports = UdpSockets` AND `export default`, so depending
+// on interop `.default` can be undefined and the module itself is the dgram
+// object — accept either. (A bare `.default` left wolAvailable always false.)
 let dgram: typeof import('react-native-udp').default | null = null;
 try {
-  dgram = require('react-native-udp').default;
+  const udp = require('react-native-udp');
+  dgram = (udp && (udp.default ?? udp)) || null;
 } catch {
   dgram = null;
 }


### PR DESCRIPTION
## Bug
`lib/wol.ts` reads `require('react-native-udp').default`, but the lib does `module.exports = UdpSockets` (a class), so **`.default` is `undefined`** — `wolAvailable` was **always false** and Wake-on-LAN **silently never fired**.

Found while building box discovery (same copy-pasted pattern blanked the scan card).

## Fix
Accept either shape: `const udp = require('react-native-udp'); dgram = udp.default ?? udp;`. One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)