### PR TITLE
feat(app): 'Check for updates' button (manual force re-check)

### DIFF
--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -39,6 +39,21 @@ export function AgentUpdateBanner() {
   const [applying, setApplying] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const applyingRef = useRef(false);
+  // Manual "Check for updates": undefined = not checked yet, else the forced
+  // result (which overrides the polled one so the row/banner reflect it).
+  const [checking, setChecking] = useState(false);
+  const [forced, setForced] = useState<UpdateCheck | null | undefined>(undefined);
+
+  const checkNow = useCallback(async () => {
+    setChecking(true);
+    try {
+      const r = await api.updateCheck(settings, { force: true });
+      setForced(r);
+      poll.refresh();
+    } finally {
+      setChecking(false);
+    }
+  }, [settings, poll]);
 
   const apply = useCallback(async () => {
     if (applyingRef.current || !check?.latest) return;
@@ -73,8 +88,37 @@ export function AgentUpdateBanner() {
     }
   }, [check?.latest, poll, settings]);
 
-  if (!check || !check.available) return null;
-  if (dismissed && dismissed === check.latest) return null;
+  // A forced manual check overrides the polled result.
+  const result = forced !== undefined ? forced : check;
+
+  // No update (or dismissed): a compact "Check for updates" row instead of the
+  // full banner, so the manual check is always available and can report "up to
+  // date" rather than the banner just vanishing.
+  if (!result?.available || (dismissed && dismissed === result.latest)) {
+    if (!configured) return null;
+    return (
+      <View style={styles.checkRow}>
+        <Text style={styles.checkStatus} numberOfLines={1}>
+          {checking
+            ? 'Checking…'
+            : result == null
+              ? 'Agent updates'
+              : `Up to date — agent ${result.installed}`}
+        </Text>
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            void checkNow();
+          }}
+          disabled={checking}
+          hitSlop={8}
+          style={styles.checkBtn}>
+          <Ionicons name="refresh" size={14} color={t.blue} />
+          <Text style={styles.checkBtnText}>Check for updates</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.card}>
@@ -151,6 +195,22 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     marginBottom: 14,
     gap: 8,
   },
+  checkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 14,
+    borderRadius: 12,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: 1,
+  },
+  checkStatus: { color: t.textDim, fontSize: 13, flex: 1 },
+  checkBtn: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  checkBtnText: { color: t.blue, fontSize: 13, fontWeight: '700' },
   header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   title: { color: t.text, fontSize: 14, fontWeight: '700', flex: 1 },
   sub: { color: t.textDim, fontSize: 12, fontFamily: mono },

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -88,22 +88,26 @@ export function AgentUpdateBanner() {
     }
   }, [check?.latest, poll, settings]);
 
-  // A forced manual check overrides the polled result.
-  const result = forced !== undefined ? forced : check;
+  // A forced manual check overrides the polled result — used for the row's
+  // status text. The banner below keys off `check` (kept current by the
+  // poll.refresh() in checkNow, since a forced check also warms the box cache).
+  const status = forced !== undefined ? forced : check;
 
   // No update (or dismissed): a compact "Check for updates" row instead of the
   // full banner, so the manual check is always available and can report "up to
   // date" rather than the banner just vanishing.
-  if (!result?.available || (dismissed && dismissed === result.latest)) {
+  if (!check?.available || (dismissed && dismissed === check.latest)) {
     if (!configured) return null;
     return (
       <View style={styles.checkRow}>
         <Text style={styles.checkStatus} numberOfLines={1}>
           {checking
             ? 'Checking…'
-            : result == null
+            : status == null
               ? 'Agent updates'
-              : `Up to date — agent ${result.installed}`}
+              : status.available
+                ? `Update available — agent ${status.latest}`
+                : `Up to date — agent ${status.installed}`}
         </Text>
         <Pressable
           onPress={() => {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -874,8 +874,13 @@ export const api = {
    * (cached); the app just reads the result over the LAN, so the app never
    * touches the internet. 404 -> null on older agents (no banner shown).
    */
-  updateCheck(settings: ConnSettings): Promise<UpdateCheck | null> {
-    return probeOrNull(request<UpdateCheck>(settings, '/api/update/check'));
+  updateCheck(
+    settings: ConnSettings,
+    opts: { force?: boolean } = {},
+  ): Promise<UpdateCheck | null> {
+    // force=1 bypasses the box's ~6h cache for a manual "Check for updates" tap.
+    const q = opts.force ? '?force=1' : '';
+    return probeOrNull(request<UpdateCheck>(settings, `/api/update/check${q}`));
   },
 
   /**


### PR DESCRIPTION
## What
A persistent **"Check for updates"** row in Setup → Account. Before, the agent update banner only appeared *when* an update existed (auto-checked ~2×/hour) — no way to check on demand or see "you're up to date".

## How (app-only)
Tapping it force-rechecks the box (`/api/update/check?force=1`, bypassing the box's ~6h cache — the agent already accepts `force`) and reports **"Up to date — agent X"** or reveals the existing update banner. `api.updateCheck` gains a `{ force }` option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)