### PR TITLE
feat: Couchside 2.9.3 — remote-input, discovery, PIN pairing, agent 2.9.12

### DIFF
--- a/agent/couchside.service
+++ b/agent/couchside.service
@@ -1,6 +1,7 @@
 ; Couchside box agent: systemd unit TEMPLATE.
-; install.sh substitutes __USER__, __UID__ and __EXEC__ (the resolved daemon
-; path) with the invoking desktop user's real values and installs the result to
+; install.sh substitutes __USER__, __UID__, __EXEC__ (the resolved daemon path)
+; and __CONFIG__ (the user-owned state config path) with the invoking desktop
+; user's real values and installs the result to
 ; /etc/systemd/system/couchside.service. Do NOT hardcode /home here: the home
 ; can live at /var/home (Bazzite/ostree), be a systemd-homed image, or an LDAP
 ; path — install.sh injects the real install dir so the unit works anywhere.
@@ -16,7 +17,7 @@ User=__USER__
 ; with the udev rule the installer writes for /dev/uinput.
 SupplementaryGroups=input
 Environment=XDG_RUNTIME_DIR=/run/user/__UID__
-ExecStart=/usr/bin/python3 __EXEC__
+ExecStart=/usr/bin/python3 __EXEC__ --config __CONFIG__
 Restart=always
 RestartSec=3
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -3497,6 +3497,9 @@ def set_webos(mock):
     if WEBOS is not None:
         WEBOS.close()
     WEBOS = None
+    # (Re)arm the on-TV text-focus watcher for the new config (no-op in --mock
+    # or when unpaired). Retires any prior watcher via the generation bump.
+    start_webos_ime_watch()
 
 
 def webos_available():
@@ -3608,6 +3611,103 @@ def mock_webos(op):
     print("[webos] %s" % op, flush=True)
     return {"ok": True, "exit_code": 0, "stdout": "[mock webos] %s\n" % op,
             "stderr": "", "duration_ms": 50}
+
+
+# ---- webOS on-TV text-focus push (feeds the app's auto-keyboard) -----------
+# LG's mobile remote learns when a TV text field is focused by SUBSCRIBING to
+# ssap://com.webos.service.ime/registerRemoteKeyboard: the TV pushes a frame
+# whenever input focus opens or closes (payload.currentWidget.focus). We mirror
+# that here on a DEDICATED SSAP socket (the request/response session is
+# serialised + dropped when idle, so it can't host a long-lived subscription)
+# and relay each transition to the connected phones over the gamepad socket as
+# {"t":"input_focus","open":bool,"value":str}. The app then pops its text sheet
+# so the user types on the phone. Best-effort: any socket error just reconnects
+# with backoff, and it advertises via the tv_info `text_focus_push` cap so the
+# app only auto-pops where this actually fires (webOS today).
+_WEBOS_IME_URI = "ssap://com.webos.service.ime/registerRemoteKeyboard"
+# Longer than the request/response default: a focused-field subscription idles
+# for minutes between transitions (webOS WS pings keep the socket warm).
+_WEBOS_IME_TIMEOUT = 30
+# Monotonic generation: bumped by every set_webos() so a re-pair (or teardown)
+# retires any running watcher without needing to reach into its blocked recv.
+_WEBOS_IME_GEN = 0
+
+
+def _webos_ime_text(cw):
+    """Best-effort current field text from a registerRemoteKeyboard widget.
+    webOS rarely echoes existing content on this channel, so this is usually
+    "" — the app treats the sheet as empty then, which is correct."""
+    for k in ("focusText", "text", "value", "inputText"):
+        v = cw.get(k)
+        if isinstance(v, str):
+            return v
+    return ""
+
+
+def start_webos_ime_watch():
+    """(Re)start the IME focus watcher. Bumping the generation stops any prior
+    watcher; a new daemon thread starts only for a real, paired webOS TV (never
+    in --mock, which has no socket). Call after any set_webos()."""
+    global _WEBOS_IME_GEN
+    _WEBOS_IME_GEN += 1
+    if _WEBOS_MOCK or not webos_available():
+        return
+    gen = _WEBOS_IME_GEN
+    threading.Thread(target=_webos_ime_watch, args=(gen,), daemon=True,
+                     name="webos-ime").start()
+
+
+def _webos_ime_watch(gen):
+    """Hold one registerRemoteKeyboard subscription open and broadcast focus
+    transitions to the phones. Runs until its generation is superseded; any
+    error reconnects with capped backoff. Never raises out of the thread."""
+    backoff = 2
+    logged = False                            # log an outage once, not per retry
+    while gen == _WEBOS_IME_GEN:
+        sess = None
+        try:
+            sess = _WebOSSession(CONFIG_WEBOS["host"])
+            sess.ws.sock.settimeout(_WEBOS_IME_TIMEOUT)
+            sess.register(CONFIG_WEBOS.get("client_key"))
+            sub_id = sess._send({"type": "subscribe", "uri": _WEBOS_IME_URI})
+            backoff = 2                       # a clean connect resets backoff
+            logged = False
+            last_open = None
+            while gen == _WEBOS_IME_GEN:
+                try:
+                    msg = json.loads(sess.ws.recv_text())
+                except socket.timeout:
+                    continue                  # idle field; keep the socket open
+                if msg.get("id") != sub_id:
+                    continue                  # register echo / unrelated frame
+                if msg.get("type") == "error":
+                    raise IOError(msg.get("error", "ime subscription error"))
+                cw = (msg.get("payload") or {}).get("currentWidget")
+                if not isinstance(cw, dict) or "focus" not in cw:
+                    continue
+                open_ = bool(cw.get("focus"))
+                if open_ == last_open:
+                    continue                  # de-dupe repeated same-state pushes
+                last_open = open_
+                if gen != _WEBOS_IME_GEN:
+                    break
+                if open_:
+                    _gamepad_broadcast({"t": "input_focus", "open": True,
+                                        "value": _webos_ime_text(cw)})
+                else:
+                    _gamepad_broadcast({"t": "input_focus", "open": False})
+        except (IOError, OSError, ValueError, KeyError) as e:
+            if not logged:
+                print("[webos-ime] subscription paused (%s: %s); retrying"
+                      % (e.__class__.__name__, e), flush=True)
+                logged = True
+        finally:
+            if sess is not None:
+                sess.close()
+        if gen != _WEBOS_IME_GEN:
+            break
+        time.sleep(backoff)                   # TV asleep / network blip
+        backoff = min(backoff * 2, 30)
 
 
 def webos_pair(host, timeout=60):
@@ -4721,6 +4821,11 @@ def tv_info():
         # and CEC have no text channel.
         "text": (webos_available() or samsung_available()
                  or roku_available()),
+        # Backend PUSHES a focus signal when an on-TV text field opens/closes,
+        # so the app can auto-raise its keyboard (see the t:input_focus frame on
+        # /ws/gamepad). webOS-only today (registerRemoteKeyboard subscription);
+        # every other backend keeps the manual text button, so this stays false.
+        "text_focus_push": webos_available(),
         # Box mute state, so the app shows the right mute indicator on connect.
         "muted": _soft_muted() if box_vol else None,
         # Current levels (0-100 or null) so the app's volume slider can show and
@@ -6409,6 +6514,18 @@ def _wsend_op(entry, opcode, payload=b""):
             ws_send(entry["conn"], opcode, payload)
         except OSError:
             pass
+
+
+def _gamepad_broadcast(obj):
+    """Send one JSON frame to every live gamepad session (holder + waiters).
+    Snapshots the list under the lock, then sends outside it (each _wsend_json
+    takes only that socket's slock), so socket I/O never blocks GAMEPAD_LOCK.
+    Best-effort: a dead socket is skipped. Used for out-of-band pushes such as
+    the webOS on-TV text-focus signal (t:input_focus)."""
+    with GAMEPAD_LOCK:
+        entries = list(GAMEPAD_SESSIONS)
+    for entry in entries:
+        _wsend_json(entry, obj)
 
 
 def _release_devices(entry):

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3755,6 +3755,7 @@ _SAMSUNG_KEYS = {
     "ok": "KEY_ENTER", "menu": "KEY_MENU", "home": "KEY_HOME", "back": "KEY_RETURN",
     "exit": "KEY_EXIT", "info": "KEY_INFO", "play": "KEY_PLAY", "pause": "KEY_PAUSE",
     "stop": "KEY_STOP", "rewind": "KEY_REWIND", "fast_forward": "KEY_FF",
+    "source": "KEY_SOURCE",   # opens the Tizen source/input menu
 }
 
 
@@ -4071,6 +4072,7 @@ _ATV_KEYS = {
     "up": 19, "down": 20, "left": 21, "right": 22, "ok": 23, "menu": 82,
     "home": 3, "back": 4, "exit": 4, "play": 126, "pause": 127, "stop": 86,
     "rewind": 89, "fast_forward": 90,
+    "source": 178,   # KEYCODE_TV_INPUT — opens the input picker on Google TV
 }
 
 
@@ -4728,6 +4730,11 @@ def tv_info():
         "keys": (panel_available() or webos_available()
                  or samsung_available() or roku_available()
                  or androidtv_available() or vidaa_available()),
+        # A "source" key opens the TV's input picker (agent >= 2.9.12). Android/
+        # Google TV (KEYCODE_TV_INPUT) and Samsung (KEY_SOURCE) have one; webOS/
+        # Roku don't (no single input-menu key), and the RS-232 panel uses its
+        # own explicit source list (source_box / sources) instead.
+        "source_key": androidtv_available() or samsung_available(),
         # Text entry into a focused on-TV field. webOS (IME), Samsung
         # (SendInputString) and Roku (Lit_ keypresses) support it; the panel
         # and CEC have no text channel.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -186,6 +186,13 @@ CONFIG_VIDAA = None  # optional {"host","name","mac"} Hisense VIDAA (MQTT) confi
 ALLOW_APP_UPDATE = False
 LAUNCHERS = []  # list of {"id","label","cmd":[...]}, custom launchers only
 CONFIG_PATH = DEFAULT_CONFIG_PATH  # remembered by load_config() for rewrites
+# False when the config DIRECTORY isn't writable by the agent's user (a
+# root-owned dir under a non-root agent — a common ownership drift). Config
+# writes go via a temp file in that dir + os.replace, so an unwritable dir makes
+# every save (TV pairing, launcher edits) fail with a 500. Checked once at
+# startup (check_config_writable) and surfaced in /api/status so the failure is
+# never silent.
+CONFIG_WRITABLE = True
 CONFIG_LOCK = threading.Lock()  # serializes launcher config rewrites
 
 
@@ -486,6 +493,27 @@ def load_config(path):
     CONFIG_VIDAA = vidaa
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
+
+
+def check_config_writable():
+    """Verify the agent can persist config, and warn loudly if not.
+
+    Config writes go through a temp file in the config's DIRECTORY + os.replace
+    (see _config_set_field), so the DIR — not just the file — must be writable by
+    the agent's user. A root-owned config dir under a non-root agent (an install
+    ownership drift) makes every save — TV pairing, launcher edits — fail with a
+    500 the app used to render as a vague error. Surfaced in /api/status
+    (config_writable) so the condition is visible instead of silent. Call in
+    main() after load_config."""
+    global CONFIG_WRITABLE
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    # W_OK to create the temp file, X_OK to os.replace into the dir.
+    CONFIG_WRITABLE = os.access(directory, os.W_OK | os.X_OK)
+    if not CONFIG_WRITABLE:
+        print("WARNING: config dir %s is NOT writable by uid %d — TV pairing and "
+              "launcher changes will fail to save. chown the config dir to the "
+              "agent's user." % (directory, os.getuid()), file=sys.stderr,
+              flush=True)
 
 
 def _inject_session_actions():
@@ -1137,6 +1165,9 @@ def real_status():
         # request — a cheap pgrep — or the app's desktop cluster would freeze
         # at whatever session the agent booted in.
         "caps": dict(CAPS, desktop=desktop_available()),
+        # False when the config dir isn't writable by the agent user, so the app
+        # can warn that TV pairing / launcher edits won't persist (agent >= 2.9.12).
+        "config_writable": CONFIG_WRITABLE,
         "history": _history_snapshot(),
     }
 
@@ -1832,6 +1863,7 @@ def mock_status():
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
         "caps": CAPS,
+        "config_writable": True,
         "history": _history_snapshot(),
     }
 
@@ -8259,6 +8291,8 @@ def main():
     args = p.parse_args()
 
     load_config(args.config)
+    if not args.mock:
+        check_config_writable()  # warn loudly if pairings/launchers can't persist
     _inject_session_actions()
     _inject_suspend_action(args.mock)
     set_tv(args.mock)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6834,11 +6834,10 @@ def render_pin_page(pin):
         "fetch('/api/pair/status').then(function(r){return r.json()})"
         ".then(function(d){if(d&&d.active===false&&!done){done=true;"
         "document.body.innerHTML="
-        "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
-        # Session ended: leave the browser after a beat by pulling Steam back to
-        # its Game Mode home. steam://open/bigpicture is handled by Steam's own
-        # browser; desktop browsers just ignore it and keep the DONE screen.
-        "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
+        "'<div class=t>PAIRED</div><div class=s>Press B (Back) to close.</div>'"
+        # Steam's browser can't be closed programmatically (neither a page-side
+        # window.close()/steam:// nav nor an agent steam:// CLI dismisses it), so
+        # we land on a clean PAIRED screen and tell the user how to close it.
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -6721,6 +6721,155 @@ def build_pair_url(token, port):
     return url
 
 
+# ---- PIN pairing (app-initiated box enrollment) ---------------------------
+# A phone that discovered this box on the LAN (see the UDP responder) can enroll
+# WITHOUT already having the token, via a PIN shown on the BOX'S OWN screen —
+# physical-presence proof, exactly like Android-TV pairing:
+#   POST /api/pair/start  (unauth): mint a 6-digit PIN, display it on the box
+#     (Steam's browser -> the loopback /pair page), return the TTL.
+#   POST /api/pair/finish (unauth): trade the correct PIN for the box token.
+# The PIN is rendered ONLY on the loopback /pair page, so it never crosses the
+# network — you must be able to SEE the box's screen. Brute force is blocked by
+# a short TTL + a small attempt cap + a single live session, and repeated
+# /start is debounced so a LAN peer can't spam the on-screen popup.
+PAIR_PIN_TTL = 120           # seconds a displayed PIN stays valid
+PAIR_PIN_MAX_ATTEMPTS = 5    # wrong PINs before the session is burned
+PAIR_PIN_START_DEBOUNCE = 3  # min seconds between /start (anti on-screen spam)
+PAIR_PIN_LOCK = threading.Lock()
+# {"pin": "123456", "expires": mono, "attempts": int, "started": mono} or None
+PAIR_PIN = None
+
+
+def pair_pin_start():
+    """Mint a fresh PIN + session (replacing any prior one) and return
+    (pin, ttl). Debounced: within PAIR_PIN_START_DEBOUNCE of the last start the
+    LIVE pin is returned unchanged, so a double-tap / retry doesn't reroll the
+    number already on screen. Caller displays it on the box."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        now = time.monotonic()
+        s = PAIR_PIN
+        if s and now <= s["expires"] and now - s["started"] < PAIR_PIN_START_DEBOUNCE:
+            return s["pin"], int(s["expires"] - now)
+        pin = "%06d" % (int.from_bytes(os.urandom(3), "big") % 1000000)
+        PAIR_PIN = {"pin": pin, "expires": now + PAIR_PIN_TTL,
+                    "attempts": 0, "started": now}
+        return pin, PAIR_PIN_TTL
+
+
+def pair_pin_active():
+    """The current PIN if a session is live (for /pair to render on-screen),
+    else None."""
+    with PAIR_PIN_LOCK:
+        if PAIR_PIN and time.monotonic() <= PAIR_PIN["expires"]:
+            return PAIR_PIN["pin"]
+        return None
+
+
+def pair_pin_check(pin):
+    """Validate a submitted PIN. True (and burns the session) on match; raises
+    ValueError with a user-facing reason on no-session / expired / locked /
+    wrong. A wrong guess counts toward the attempt cap."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        s = PAIR_PIN
+        if not s or time.monotonic() > s["expires"]:
+            PAIR_PIN = None
+            raise ValueError("no active pairing — start it again from the app")
+        if s["attempts"] >= PAIR_PIN_MAX_ATTEMPTS:
+            PAIR_PIN = None
+            raise ValueError("too many wrong PINs — start again")
+        if (pin or "").strip() != s["pin"]:
+            s["attempts"] += 1
+            raise ValueError("wrong PIN")
+        PAIR_PIN = None                       # consume on success
+        return True
+
+
+def pair_show_on_box(port):
+    """Open the loopback /pair page on the BOX'S own screen so the PIN is
+    visible there. Game Mode -> Steam's built-in browser (steam://openurl);
+    desktop -> xdg-open. Best-effort, detached, never blocks the request."""
+    url = "http://localhost:%d/pair" % port
+    gamescope = _couchmode_session() == "gamescope"
+
+    def go():
+        try:
+            if gamescope:
+                subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
+                               timeout=10)
+            elif shutil.which("xdg-open"):
+                subprocess.run(["xdg-open", url], timeout=10)
+            elif shutil.which("steam"):
+                subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
+                               timeout=10)
+        except Exception:
+            pass
+    threading.Thread(target=go, daemon=True).start()
+
+
+def render_pin_page(pin):
+    """Full-screen dark page showing the pairing PIN, spaced for reading off a
+    TV. Auto-refreshes so it clears when the session ends (paired or expired).
+    Built with a placeholder replace (not %-formatting) because the CSS contains
+    a literal '%' (height:100%)."""
+    return (
+        "<!doctype html><html><head><meta charset=utf-8>"
+        "<meta name=viewport content='width=device-width,initial-scale=1'>"
+        "<meta http-equiv=refresh content=8>"
+        "<title>Couchside pairing</title><style>"
+        "html,body{margin:0;height:100%;background:#0b1220;color:#e5e7eb;"
+        "font-family:system-ui,sans-serif;display:flex;flex-direction:column;"
+        "align-items:center;justify-content:center;text-align:center}"
+        ".t{font-size:5vh;color:#93c5fd;letter-spacing:.1em;font-weight:600}"
+        ".pin{font-size:22vh;font-weight:800;letter-spacing:.15em;margin:2vh 0;"
+        "font-variant-numeric:tabular-nums;color:#fff}"
+        ".s{font-size:3.2vh;color:#94a3b8;max-width:80vw}"
+        "</style></head><body>"
+        "<div class=t>ENTER THIS PIN IN THE APP</div>"
+        "<div class=pin>__PIN__</div>"
+        "<div class=s>Couchside · this code is shown only on this screen</div>"
+        "</body></html>".replace("__PIN__", " ".join(pin)))
+
+
+# ---- LAN discovery responder (lets the app find this box) ------------------
+# The app broadcasts COUCHSIDE_DISCOVER_MAGIC to this UDP port; the box replies
+# with its identity + HTTP port so the app can list it in a "scan for boxes"
+# picker (then PIN-pair, above). Bound on the SAME number as the HTTP port
+# (UDP vs TCP, no clash). Reveals existence + hostname + version only — no
+# token, no control. UDP broadcast is used deliberately: it is far more reliable
+# than mDNS multicast RX on Android (no MulticastLock dance).
+COUCHSIDE_DISCOVER_MAGIC = b"COUCHSIDE_DISCOVER?"
+
+
+def _udp_discovery_responder(port):
+    """Answer LAN discovery probes on UDP <port>. Best-effort daemon; a bind
+    failure just disables discovery (the app can still add a box by IP)."""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        s.bind(("0.0.0.0", port))
+    except OSError as e:
+        print("[discover] responder disabled: %s" % e, flush=True)
+        return
+    print("[discover] UDP responder on :%d" % port, flush=True)
+    while True:
+        try:
+            data, addr = s.recvfrom(256)
+        except OSError:
+            continue
+        if not data.startswith(COUCHSIDE_DISCOVER_MAGIC):
+            continue
+        short = socket.gethostname().split(".")[0] or "couchside"
+        reply = json.dumps({"couchside": True, "name": short,
+                            "host": short + ".local", "port": port,
+                            "version": VERSION}).encode()
+        try:
+            s.sendto(reply, addr)
+        except OSError:
+            pass
+
+
 def render_pair_page(token, port):
     """Self-contained dark HTML page rendering the pairing QR offline.
 
@@ -6961,7 +7110,12 @@ class Handler(BaseHTTPRequestHandler):
                 if not self._is_loopback() or not self._host_header_is_local():
                     self._send(403, {"error": "forbidden"}, started)
                     return
-                html = render_pair_page(self._current_token(), self.port)
+                # While a PIN-pairing session is live, this page IS the physical-
+                # presence proof: show the big PIN (loopback-only, so only someone
+                # at the box sees it). Otherwise the usual token QR.
+                pin = pair_pin_active()
+                html = (render_pin_page(pin) if pin
+                        else render_pair_page(self._current_token(), self.port))
                 self._send_html(200, html, started)
                 return
 
@@ -7195,6 +7349,36 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 self._read_body()
                 self._send(404, {"error": "not found"}, started)
+                return
+
+            # UNAUTHENTICATED PIN pairing (the only unauthenticated POSTs): a
+            # phone that discovered this box enrolls via a PIN shown on the box's
+            # own screen. Bounded: /start is debounced + displays the PIN
+            # locally; /finish is TTL + attempt-capped and only returns the token
+            # for the correct PIN. Handled here, before the bearer-token gate.
+            if path in ("/api/pair/start", "/api/pair/finish"):
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                pair_body = self._read_body()
+                if path == "/api/pair/start":
+                    _pin, ttl = pair_pin_start()
+                    pair_show_on_box(self.port)   # pop the PIN on the box screen
+                    self._send(200, {"ok": True, "ttl": ttl}, started)
+                    return
+                try:
+                    req = json.loads(pair_body.decode("utf-8")) if pair_body else {}
+                    submitted = req.get("pin")
+                except (ValueError, UnicodeDecodeError):
+                    submitted = None
+                try:
+                    pair_pin_check(submitted)
+                except ValueError as e:
+                    self._send(403, {"ok": False, "error": str(e)}, started)
+                    return
+                self._send(200, {"ok": True, "token": self._current_token(),
+                                 "port": self.port}, started)
                 return
 
             # Authorize BEFORE reading the body: an unauthenticated client must
@@ -8304,6 +8488,8 @@ def main():
 
     server = BoundedThreadingHTTPServer((args.host, port), Handler)
     server.daemon_threads = True
+    threading.Thread(target=_udp_discovery_responder, args=(port,),
+                     daemon=True, name="discover").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6810,13 +6810,14 @@ def pair_show_on_box(port):
 
 def render_pin_page(pin):
     """Full-screen dark page showing the pairing PIN, spaced for reading off a
-    TV. Auto-refreshes so it clears when the session ends (paired or expired).
-    Built with a placeholder replace (not %-formatting) because the CSS contains
-    a literal '%' (height:100%)."""
+    TV. A JS poll of /api/pair/status clears the PIN to a neutral 'done' once the
+    session ends (paired or expired), and leaves it untouched on any fetch error
+    — so the agent restarting never shows a browser error, and a successful pair
+    never flashes the token QR. Built with a placeholder replace (not
+    %-formatting) because the CSS contains a literal '%' (height:100%)."""
     return (
         "<!doctype html><html><head><meta charset=utf-8>"
         "<meta name=viewport content='width=device-width,initial-scale=1'>"
-        "<meta http-equiv=refresh content=8>"
         "<title>Couchside pairing</title><style>"
         "html,body{margin:0;height:100%;background:#0b1220;color:#e5e7eb;"
         "font-family:system-ui,sans-serif;display:flex;flex-direction:column;"
@@ -6829,6 +6830,11 @@ def render_pin_page(pin):
         "<div class=t>ENTER THIS PIN IN THE APP</div>"
         "<div class=pin>__PIN__</div>"
         "<div class=s>Couchside · this code is shown only on this screen</div>"
+        "<script>setInterval(function(){"
+        "fetch('/api/pair/status').then(function(r){return r.json()})"
+        ".then(function(d){if(d&&d.active===false){document.body.innerHTML="
+        "'<div class=t>DONE</div><div class=s>This code is no longer active.</div>'"
+        "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 
 
@@ -7117,6 +7123,16 @@ class Handler(BaseHTTPRequestHandler):
                 html = (render_pin_page(pin) if pin
                         else render_pair_page(self._current_token(), self.port))
                 self._send_html(200, html, started)
+                return
+
+            if path == "/api/pair/status":
+                # Loopback-only: the on-screen /pair PIN page polls this to learn
+                # when its session ended (paired/expired), so it can clear itself
+                # without a blind reload. Reveals only a boolean, no secret.
+                if not self._is_loopback():
+                    self._send(403, {"error": "forbidden"}, started)
+                    return
+                self._send(200, {"active": pair_pin_active() is not None}, started)
                 return
 
             if path == "/api/ping":

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6830,10 +6830,15 @@ def render_pin_page(pin):
         "<div class=t>ENTER THIS PIN IN THE APP</div>"
         "<div class=pin>__PIN__</div>"
         "<div class=s>Couchside · this code is shown only on this screen</div>"
-        "<script>setInterval(function(){"
+        "<script>var done=false;setInterval(function(){"
         "fetch('/api/pair/status').then(function(r){return r.json()})"
-        ".then(function(d){if(d&&d.active===false){document.body.innerHTML="
-        "'<div class=t>DONE</div><div class=s>This code is no longer active.</div>'"
+        ".then(function(d){if(d&&d.active===false&&!done){done=true;"
+        "document.body.innerHTML="
+        "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
+        // Session ended: leave the browser after a beat by pulling Steam back to
+        // its Game Mode home. steam://open/bigpicture is handled by Steam's own
+        // browser; desktop browsers just ignore it and keep the DONE screen.
+        "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6835,9 +6835,9 @@ def render_pin_page(pin):
         ".then(function(d){if(d&&d.active===false&&!done){done=true;"
         "document.body.innerHTML="
         "'<div class=t>DONE</div><div class=s>Returning to Steam\\u2026</div>';"
-        // Session ended: leave the browser after a beat by pulling Steam back to
-        // its Game Mode home. steam://open/bigpicture is handled by Steam's own
-        // browser; desktop browsers just ignore it and keep the DONE screen.
+        # Session ended: leave the browser after a beat by pulling Steam back to
+        # its Game Mode home. steam://open/bigpicture is handled by Steam's own
+        # browser; desktop browsers just ignore it and keep the DONE screen.
         "setTimeout(function(){location.href='steam://open/bigpicture'},8000)"
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -20,6 +20,7 @@ import hmac
 import json
 import os
 import random
+import re
 import select
 import shutil
 import socket
@@ -43,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4618,6 +4619,264 @@ def _vidaa_save(host, name=None, mac=None):
         CONFIG_VIDAA = cfg
 
 
+# ---- LAN TV discovery (mDNS + SSDP sweep) ---------------------------------
+# GET /api/tv/discover runs a short multicast sweep FROM THE BOX and returns the
+# TVs it can reach, so the app can offer a "scan" picker instead of making the
+# user type an IP. The box is the right scanner: it is the machine that will
+# actually control the TV (so anything found is guaranteed box-reachable), and
+# it runs real multicast where phone mDNS is flaky. Pure stdlib, in character
+# with the other hand-rolled protocols here.
+#   Android/Google TV: mDNS PTR _androidtvremote2._tcp  (THE pairing service)
+#   Samsung Tizen:     mDNS PTR _samsungmsf._tcp
+#   Roku:              SSDP ST roku:ecp   (name via /query/device-info)
+#   LG webOS:          SSDP, LG-identified responses  (friendlyName from UPnP)
+# VIDAA has no standard discovery, so it is never listed (manual add stays).
+_MDNS_ADDR = ("224.0.0.251", 5353)
+_SSDP_ADDR = ("239.255.255.250", 1900)
+
+
+def _mdns_query_pkt(service):
+    pkt = struct.pack("!HHHHHH", 0, 0, 1, 0, 0, 0)  # 1 question, PTR/IN below
+    for label in service.split("."):
+        pkt += bytes([len(label)]) + label.encode()
+    return pkt + b"\x00" + struct.pack("!HH", 12, 1)
+
+
+def _dns_name(buf, pos):
+    """Parse a (possibly compression-pointer) DNS name; return (name, next_pos)."""
+    labels, jumped, nxt = [], False, pos
+    for _ in range(128):
+        ln = buf[pos]
+        if ln == 0:
+            pos += 1
+            if not jumped:
+                nxt = pos
+            break
+        if ln & 0xC0 == 0xC0:
+            ptr = ((ln & 0x3F) << 8) | buf[pos + 1]
+            if not jumped:
+                nxt = pos + 2
+            pos, jumped = ptr, True
+            continue
+        pos += 1
+        labels.append(buf[pos:pos + ln].decode("utf-8", "replace"))
+        pos += ln
+    return ".".join(labels), nxt
+
+
+def _parse_mdns(buf):
+    """One mDNS packet -> (ptr_targets[], srv{name:(host,port)}, a{name:ip})."""
+    ptr, srv, a = [], {}, {}
+    try:
+        qd, an, ns, ar = struct.unpack("!HHHH", buf[4:12])
+        pos = 12
+        for _ in range(qd):
+            _, pos = _dns_name(buf, pos)
+            pos += 4
+        for _ in range(an + ns + ar):
+            name, pos = _dns_name(buf, pos)
+            rtype, _cls, _ttl, rdlen = struct.unpack("!HHIH", buf[pos:pos + 10])
+            pos += 10
+            if rtype == 12:                        # PTR
+                tgt, _ = _dns_name(buf, pos)
+                ptr.append(tgt)
+            elif rtype == 33:                      # SRV -> host + port
+                port = struct.unpack("!H", buf[pos + 4:pos + 6])[0]
+                host, _ = _dns_name(buf, pos + 6)
+                srv[name] = (host, port)
+            elif rtype == 1 and rdlen == 4:        # A -> IPv4
+                a[name] = ".".join(str(x) for x in buf[pos:pos + 4])
+            pos += rdlen
+    except Exception:
+        pass                                       # a malformed packet is skipped
+    return ptr, srv, a
+
+
+def _mdns_discover(service, timeout=2.5):
+    """Return [{name, host}] for a mDNS service PTR (e.g. _androidtvremote2._tcp
+    .local). Best-effort; empty on any failure."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+    except OSError:
+        pass
+    s.settimeout(0.5)
+    inst, srv_all, a_all = set(), {}, {}
+    try:
+        s.sendto(_mdns_query_pkt(service), _MDNS_ADDR)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                data, _ = s.recvfrom(4096)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            ptr, srv, a = _parse_mdns(data)
+            srv_all.update(srv)
+            a_all.update(a)
+            for n in ptr:
+                if n.endswith(service):
+                    inst.add(n)
+            for n in srv:
+                if n.endswith(service):
+                    inst.add(n)
+    finally:
+        s.close()
+    out = []
+    for name in inst:
+        host, _port = srv_all.get(name, (None, None))
+        ip = a_all.get(host) if host else None
+        if not ip and len(a_all) == 1:             # single host seen: use it
+            ip = next(iter(a_all.values()))
+        if not ip:
+            continue
+        label = name[: -len(service) - 1].rstrip(".") or name
+        out.append({"name": label, "host": ip})
+    return out
+
+
+def _ssdp_search(st, timeout=2.5):
+    """M-SEARCH for <st>; return response header dicts (with _ip). Best-effort."""
+    msg = ("M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\n"
+           'MAN: "ssdp:discover"\r\nMX: 1\r\nST: %s\r\n\r\n' % st).encode()
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.settimeout(0.5)
+    res = []
+    try:
+        s.sendto(msg, _SSDP_ADDR)
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                data, addr = s.recvfrom(2048)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            h = {"_ip": addr[0]}
+            for line in data.decode("utf-8", "replace").split("\r\n")[1:]:
+                if ":" in line:
+                    k, v = line.split(":", 1)
+                    h[k.strip().lower()] = v.strip()
+            res.append(h)
+    finally:
+        s.close()
+    return res
+
+
+def _discover_http(url, timeout=2.0):
+    try:
+        import urllib.request
+        with urllib.request.urlopen(url, timeout=timeout) as r:
+            return r.read().decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+def _roku_name(ip):
+    xml = _discover_http("http://%s:8060/query/device-info" % ip)
+    for tag in ("user-device-name", "friendly-device-name", "default-device-name"):
+        m = re.search(r"<%s>(.*?)</%s>" % (tag, tag), xml)
+        if m and m.group(1).strip():
+            return m.group(1).strip()
+    return "Roku"
+
+
+def _discover_androidtv():
+    # _androidtvremote2._tcp is the pairing service (what we control); its
+    # instance name is usually the friendly TV name. _googlecast._tcp is queried
+    # only to fill in a blank/generic name (some firmwares report one there).
+    tvs = _mdns_discover("_androidtvremote2._tcp.local")
+    cast = {c["host"]: c["name"]
+            for c in _mdns_discover("_googlecast._tcp.local", timeout=1.5)
+            if c.get("name")}
+    out = []
+    for t in tvs:
+        name = t["name"]
+        if (not name or name == t["host"]) and cast.get(t["host"]):
+            name = cast[t["host"]]
+        out.append({"brand": "androidtv", "name": name or "Android TV",
+                    "host": t["host"]})
+    return out
+
+
+def _discover_samsung():
+    return [{"brand": "samsung", "name": t["name"], "host": t["host"]}
+            for t in _mdns_discover("_samsungmsf._tcp.local")]
+
+
+def _discover_roku():
+    out, seen = [], set()
+    for r in _ssdp_search("roku:ecp"):
+        ip = r.get("_ip")
+        if ip and ip not in seen:
+            seen.add(ip)
+            out.append({"brand": "roku", "name": _roku_name(ip), "host": ip})
+    return out
+
+
+def _discover_webos():
+    """LG webOS via SSDP: filter ssdp:all to LG-identified responses and pull the
+    friendlyName from the UPnP device description."""
+    out, seen = [], set()
+    for r in _ssdp_search("ssdp:all", timeout=2.5):
+        ip = r.get("_ip")
+        blob = (r.get("server", "") + r.get("usn", "") + r.get("location", "")).lower()
+        if not ip or ip in seen or not re.search(r"\blg\b|webos|lge", blob):
+            continue
+        seen.add(ip)
+        name = ""
+        loc = r.get("location", "")
+        if loc:
+            m = re.search(r"<friendlyName>(.*?)</friendlyName>", _discover_http(loc))
+            if m:
+                name = m.group(1).strip()
+        out.append({"brand": "webos", "name": name or "LG webOS", "host": ip})
+    return out
+
+
+def tv_discover(mock, timeout=2.6):
+    """Sweep the LAN for controllable TVs (see the module note). Returns a list
+    of {brand, name, host}, deduped by host (a pairing backend wins over a bare
+    UPnP echo of the same set). Each method runs in its own thread so the whole
+    sweep is ~one timeout, not the sum."""
+    if mock:
+        return [
+            {"brand": "androidtv", "name": "Living Room TV (mock)", "host": "10.0.0.51"},
+            {"brand": "webos", "name": "Bedroom LG (mock)", "host": "10.0.0.52"},
+            {"brand": "roku", "name": "Office Roku (mock)", "host": "10.0.0.53"},
+        ]
+    results, lock = [], threading.Lock()
+
+    def run(fn):
+        try:
+            found = fn()
+        except Exception:
+            found = []
+        with lock:
+            results.extend(found)
+
+    threads = [threading.Thread(target=run, args=(fn,), daemon=True) for fn in
+               (_discover_androidtv, _discover_samsung, _discover_roku, _discover_webos)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout + 2.5)
+    # Dedup by host; brand priority = pairing backends over passive echoes.
+    order = {"androidtv": 0, "webos": 1, "samsung": 2, "roku": 3}
+    best = {}
+    for tv in results:
+        host = tv.get("host")
+        if not host:
+            continue
+        cur = best.get(host)
+        if cur is None or order.get(tv["brand"], 9) < order.get(cur["brand"], 9):
+            best[host] = tv
+    return sorted(best.values(), key=lambda t: (order.get(t["brand"], 9), t["name"]))
+
+
 # ---- unified dispatch -----------------------------------------------------
 # CEC has no discrete power-off; its standby command IS the off state.
 _TV_TO_CEC = {"power_on": "power_on", "power_off": "standby",
@@ -7043,6 +7302,11 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "not found"}, started)
                 else:
                     self._send(200, info, started)
+            elif path == "/api/tv/discover":
+                # LAN scan (mDNS + SSDP, ~3s) so the app can offer a "scan for
+                # TVs" picker instead of a manual IP. Always 200 (possibly an
+                # empty list) — it is an action, not a probe-and-appear cap.
+                self._send(200, {"tvs": tv_discover(self.mock)}, started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -43,7 +43,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.11"
+VERSION = "2.9.12"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -44,3 +44,7 @@ yarn-error.*
 asc-key.p8
 credentials.json
 credentials/
+
+# local build artifacts
+*.apk
+build-*.apk

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.2",
+    "version": "2.9.3",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "43",
+      "buildNumber": "44",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 28
+      "versionCode": 29
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -7,7 +7,7 @@
  * The Pad tab is the one screen that allows landscape (see useLockOrientation);
  * in landscape the gamepad controls spread out like a real controller.
  */
-import { hapticSelection } from '@/lib/haptics';
+import { hapticLight, hapticSelection } from '@/lib/haptics';
 import { getKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
 import { getPref, usePref } from '@/lib/prefs';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
@@ -36,6 +36,7 @@ import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
+import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status } from '@/lib/api';
 import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
@@ -614,6 +615,25 @@ function PadScreen() {
   const askToSwitch = usePref('askToSwitchControl');
   const askToSwitchRef = useRef(askToSwitch);
   askToSwitchRef.current = askToSwitch;
+
+  // Hardware volume buttons -> box/TV volume across EVERY input mode (Pad,
+  // Swipe, Track, Remote), mounted here on the always-present Pad screen rather
+  // than inside RemoteView. Active while the user opted in and a box is
+  // connected; the connection lifecycle is tied to tab focus, so leaving the
+  // Pad tab restores the phone's own volume. Honors settings.volumeTarget.
+  const volumeButtons = usePref('volumeButtons');
+  const sendVol = useCallback(
+    (op: 'volume_up' | 'volume_down') => {
+      hapticLight();
+      void api.tvSend(settings, op, settings.volumeTarget ?? 'box').catch(() => {});
+    },
+    [settings],
+  );
+  useVolumeButtons({
+    enabled: volumeButtons && status === 'connected',
+    onUp: () => sendVol('volume_up'),
+    onDown: () => sendVol('volume_down'),
+  });
   const [controlReq, setControlReq] = useState<string | null>(null);
   const [canForce, setCanForce] = useState(false);
 
@@ -975,7 +995,7 @@ function PadScreen() {
 
       {mode === 'remote' ? (
         <>
-          <RemoteView client={client} settings={settings} connected={status === 'connected'} />
+          <RemoteView client={client} settings={settings} />
           {keyboardBar}
         </>
       ) : mode === 'swipe' ? (

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -975,7 +975,7 @@ function PadScreen() {
 
       {mode === 'remote' ? (
         <>
-          <RemoteView client={client} settings={settings} />
+          <RemoteView client={client} settings={settings} connected={status === 'connected'} />
           {keyboardBar}
         </>
       ) : mode === 'swipe' ? (

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -21,6 +21,7 @@ import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
+import { BoxScanPair } from '@/components/BoxScanPair';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -951,6 +952,11 @@ function SetupBody() {
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>
+        {/* Scan the LAN + PIN-pair (no IP/token typing). Hidden on builds without
+            the UDP native module. The manual card below stays as the fallback. */}
+        <View style={styles.card}>
+          <BoxScanPair />
+        </View>
         <View style={styles.card}>
           <Text style={styles.fieldLabel}>NAME (optional)</Text>
           <TextInput

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1191,7 +1191,7 @@ function SetupBody() {
               </View>
               <SegPref
                 label="Default input mode"
-                sub="What a newly paired box starts on."
+                sub="The view the Pad tab opens on. Applies to the active box now, and seeds newly paired boxes."
                 options={[
                   { value: 'gamepad', label: 'Pad' },
                   { value: 'swipe', label: 'Swipe' },
@@ -1201,6 +1201,10 @@ function SetupBody() {
                 value={defaultPadMode}
                 onSelect={(v) => {
                   void setPref('defaultPadMode', v);
+                  // The Pad tab reads the ACTIVE box's per-box padMode once a box
+                  // is paired, so the pref alone changes nothing for existing
+                  // boxes. Write it through so the setting takes effect live.
+                  if (activeBoxId) void updateBox(activeBoxId, { padMode: v });
                   hapticSelection();
                 }}
               />
@@ -1313,8 +1317,8 @@ function SetupBody() {
                 label="Hardware volume buttons"
                 sub={
                   Platform.OS === 'ios'
-                    ? "The phone's Vol +/- control the box/TV volume while the Remote is open. Experimental on iOS: the phone's volume overlay still shows and it only works with the app in front."
-                    : "The phone's Vol +/- control the box/TV volume (box or TV, per box) while the Remote is open."
+                    ? "The phone's Vol +/- control the box/TV volume on any Pad tab surface. Experimental on iOS: the phone's volume overlay still shows and it only works with the app in front."
+                    : "The phone's Vol +/- control the box/TV volume (box or TV, per box) on any Pad tab surface."
                 }
                 value={volumeButtons}
                 onValueChange={(v) => {

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -706,6 +706,9 @@ function SetupBody() {
   const [agentVersion, setAgentVersion] = useState<string | null>(null);
   const [testing, setTesting] = useState(false);
   const [saved, setSaved] = useState(false);
+  // Scan + PIN is the primary way to add a box; the manual host/port/token card
+  // is a collapsed "advanced" fallback (headless / cross-subnet / non-Linux).
+  const [showManual, setShowManual] = useState(false);
 
   const draftConn = useCallback(() => {
     const p = parseInt(port, 10);
@@ -952,11 +955,20 @@ function SetupBody() {
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>
-        {/* Scan the LAN + PIN-pair (no IP/token typing). Hidden on builds without
-            the UDP native module. The manual card below stays as the fallback. */}
+        {/* Scan the LAN + PIN-pair (no IP/token typing) is the primary method.
+            Hidden on builds without the UDP native module — the manual card then
+            carries the whole flow. */}
         <View style={styles.card}>
           <BoxScanPair />
         </View>
+        {/* Manual host/port/token: collapsed fallback for headless / cross-subnet
+            / non-Linux boxes that scanning can't reach. */}
+        <Pressable onPress={() => setShowManual((v) => !v)} style={styles.advancedToggle}>
+          <Text style={styles.advancedToggleText}>Add by IP (advanced)</Text>
+          <Ionicons name={showManual ? 'chevron-up' : 'chevron-down'} size={16} color={t.textDim} />
+        </Pressable>
+        {showManual ? (
+        <>
         <View style={styles.card}>
           <Text style={styles.fieldLabel}>NAME (optional)</Text>
           <TextInput
@@ -1043,6 +1055,8 @@ function SetupBody() {
             </View>
           )}
         </View>
+        </>
+        ) : null}
           </>
         )}
 
@@ -1438,6 +1452,15 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     letterSpacing: 1.2,
     marginBottom: 8,
   },
+  advancedToggle: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 4,
+    marginTop: 4,
+  },
+  advancedToggleText: { color: t.textDim, fontSize: 13, fontWeight: '700' },
   header: {
     paddingHorizontal: 14,
     paddingTop: 8,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -637,6 +637,7 @@ function SetupBody() {
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
   const askToSwitchControl = usePref('askToSwitchControl');
+  const volumeButtons = usePref('volumeButtons');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -1285,6 +1286,19 @@ function SetupBody() {
                 value={askToSwitchControl}
                 onValueChange={(v) => {
                   void setPref('askToSwitchControl', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Hardware volume buttons"
+                sub={
+                  Platform.OS === 'ios'
+                    ? "The phone's Vol +/- control the box/TV volume while the Remote is open. Experimental on iOS: the phone's volume overlay still shows and it only works with the app in front."
+                    : "The phone's Vol +/- control the box/TV volume (box or TV, per box) while the Remote is open."
+                }
+                value={volumeButtons}
+                onValueChange={(v) => {
+                  void setPref('volumeButtons', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -39,6 +39,21 @@ export function AgentUpdateBanner() {
   const [applying, setApplying] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
   const applyingRef = useRef(false);
+  // Manual "Check for updates": undefined = not checked yet, else the forced
+  // result (which overrides the polled one so the row/banner reflect it).
+  const [checking, setChecking] = useState(false);
+  const [forced, setForced] = useState<UpdateCheck | null | undefined>(undefined);
+
+  const checkNow = useCallback(async () => {
+    setChecking(true);
+    try {
+      const r = await api.updateCheck(settings, { force: true });
+      setForced(r);
+      poll.refresh();
+    } finally {
+      setChecking(false);
+    }
+  }, [settings, poll]);
 
   const apply = useCallback(async () => {
     if (applyingRef.current || !check?.latest) return;
@@ -73,8 +88,37 @@ export function AgentUpdateBanner() {
     }
   }, [check?.latest, poll, settings]);
 
-  if (!check || !check.available) return null;
-  if (dismissed && dismissed === check.latest) return null;
+  // A forced manual check overrides the polled result.
+  const result = forced !== undefined ? forced : check;
+
+  // No update (or dismissed): a compact "Check for updates" row instead of the
+  // full banner, so the manual check is always available and can report "up to
+  // date" rather than the banner just vanishing.
+  if (!result?.available || (dismissed && dismissed === result.latest)) {
+    if (!configured) return null;
+    return (
+      <View style={styles.checkRow}>
+        <Text style={styles.checkStatus} numberOfLines={1}>
+          {checking
+            ? 'Checking…'
+            : result == null
+              ? 'Agent updates'
+              : `Up to date — agent ${result.installed}`}
+        </Text>
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            void checkNow();
+          }}
+          disabled={checking}
+          hitSlop={8}
+          style={styles.checkBtn}>
+          <Ionicons name="refresh" size={14} color={t.blue} />
+          <Text style={styles.checkBtnText}>Check for updates</Text>
+        </Pressable>
+      </View>
+    );
+  }
 
   return (
     <View style={styles.card}>
@@ -151,6 +195,22 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     marginBottom: 14,
     gap: 8,
   },
+  checkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 14,
+    borderRadius: 12,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: 1,
+  },
+  checkStatus: { color: t.textDim, fontSize: 13, flex: 1 },
+  checkBtn: { flexDirection: 'row', alignItems: 'center', gap: 5 },
+  checkBtnText: { color: t.blue, fontSize: 13, fontWeight: '700' },
   header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   title: { color: t.text, fontSize: 14, fontWeight: '700', flex: 1 },
   sub: { color: t.textDim, fontSize: 12, fontFamily: mono },

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -88,22 +88,26 @@ export function AgentUpdateBanner() {
     }
   }, [check?.latest, poll, settings]);
 
-  // A forced manual check overrides the polled result.
-  const result = forced !== undefined ? forced : check;
+  // A forced manual check overrides the polled result — used for the row's
+  // status text. The banner below keys off `check` (kept current by the
+  // poll.refresh() in checkNow, since a forced check also warms the box cache).
+  const status = forced !== undefined ? forced : check;
 
   // No update (or dismissed): a compact "Check for updates" row instead of the
   // full banner, so the manual check is always available and can report "up to
   // date" rather than the banner just vanishing.
-  if (!result?.available || (dismissed && dismissed === result.latest)) {
+  if (!check?.available || (dismissed && dismissed === check.latest)) {
     if (!configured) return null;
     return (
       <View style={styles.checkRow}>
         <Text style={styles.checkStatus} numberOfLines={1}>
           {checking
             ? 'Checking…'
-            : result == null
+            : status == null
               ? 'Agent updates'
-              : `Up to date — agent ${result.installed}`}
+              : status.available
+                ? `Update available — agent ${status.latest}`
+                : `Up to date — agent ${status.installed}`}
         </Text>
         <Pressable
           onPress={() => {

--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -1,0 +1,216 @@
+/**
+ * Scan the LAN for Couchside boxes and pair one with a PIN — no IP typing, no
+ * token. Mirrors how a TV pairs: tap a discovered box, the box shows a PIN on
+ * ITS OWN screen, you type that PIN here, and the box hands back its token.
+ *
+ * The PIN (shown only on the box's screen) is the physical-presence proof; the
+ * token never appears until the right PIN is entered. Needs agent >= 2.9.12 and
+ * a native build with react-native-udp (scanAvailable).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { pairFinish, pairStart } from '@/lib/api';
+import { FoundBox, scanAvailable, scanForBoxes } from '@/lib/boxDiscovery';
+import { hapticSelection } from '@/lib/haptics';
+import { useBoxes } from '@/lib/SettingsContext';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+type Phase =
+  | { k: 'idle' }
+  | { k: 'scanning' }
+  | { k: 'list'; boxes: FoundBox[] }
+  | { k: 'pin'; box: FoundBox } // box is showing a PIN; awaiting entry
+  | { k: 'pairing'; box: FoundBox };
+
+export function BoxScanPair() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { addBox } = useBoxes();
+  const [phase, setPhase] = useState<Phase>({ k: 'idle' });
+  const [pin, setPin] = useState('');
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+
+  const scan = useCallback(async () => {
+    setMsg(null);
+    setPhase({ k: 'scanning' });
+    try {
+      const boxes = await scanForBoxes({ timeoutMs: 2500 });
+      setPhase({ k: 'list', boxes });
+      if (boxes.length === 0) {
+        setMsg({ ok: false, text: 'No boxes found — check the same Wi-Fi, or add one by IP below.' });
+      }
+    } catch {
+      setPhase({ k: 'idle' });
+      setMsg({ ok: false, text: 'Scan needs a newer build of the app.' });
+    }
+  }, []);
+
+  // Tap a discovered box: ask it to show a PIN on its own screen, then prompt.
+  const startPair = useCallback(async (box: FoundBox) => {
+    hapticSelection();
+    setMsg(null);
+    setPin('');
+    setPhase({ k: 'pairing', box });
+    try {
+      const r = await pairStart(box.ip, box.port);
+      if (r.ok) {
+        setPhase({ k: 'pin', box });
+        setMsg({ ok: true, text: `Enter the PIN now showing on ${box.name}.` });
+      } else {
+        setPhase({ k: 'list', boxes: [box] });
+        setMsg({ ok: false, text: r.error ?? 'Could not start pairing on that box.' });
+      }
+    } catch {
+      setPhase({ k: 'list', boxes: [box] });
+      setMsg({ ok: false, text: 'Could not reach that box.' });
+    }
+  }, []);
+
+  const submitPin = useCallback(async () => {
+    if (phase.k !== 'pin') return;
+    const box = phase.box;
+    const code = pin.trim();
+    if (code.length !== 6) {
+      setMsg({ ok: false, text: 'Enter the 6-digit PIN from the box.' });
+      return;
+    }
+    setPhase({ k: 'pairing', box });
+    try {
+      const r = await pairFinish(box.ip, box.port, code);
+      if (r.ok && r.token) {
+        await addBox({ host: box.host, port: r.port ?? box.port, token: r.token, lastIp: box.ip });
+        setPhase({ k: 'idle' });
+        setPin('');
+        setMsg({ ok: true, text: `Paired ${box.name}.` });
+      } else {
+        setPhase({ k: 'pin', box });
+        setMsg({ ok: false, text: r.error ?? 'Pairing failed — check the PIN and retry.' });
+      }
+    } catch {
+      setPhase({ k: 'pin', box });
+      setMsg({ ok: false, text: 'Could not reach that box.' });
+    }
+  }, [phase, pin, addBox]);
+
+  const cancel = useCallback(() => {
+    setPhase({ k: 'idle' });
+    setPin('');
+    setMsg(null);
+  }, []);
+
+  if (!scanAvailable) return null; // old build without the UDP module
+
+  return (
+    <View style={styles.wrap}>
+      {phase.k === 'pin' ? (
+        <>
+          <Text style={styles.hint}>A 6-digit PIN is showing on {phase.box.name}. Enter it:</Text>
+          <TextInput
+            value={pin}
+            onChangeText={(v) => setPin(v.replace(/[^0-9]/g, '').slice(0, 6))}
+            placeholder="6-digit PIN"
+            placeholderTextColor={t.textFaint}
+            keyboardType="number-pad"
+            autoFocus
+            style={styles.input}
+          />
+          <View style={styles.row}>
+            <Pressable onPress={cancel} style={[styles.btn, styles.btnGhost]}>
+              <Text style={styles.btnGhostText}>CANCEL</Text>
+            </Pressable>
+            <Pressable onPress={submitPin} style={[styles.btn, styles.btnPrimary]}>
+              <Text style={styles.btnPrimaryText}>PAIR</Text>
+            </Pressable>
+          </View>
+        </>
+      ) : (
+        <>
+          <Pressable
+            onPress={scan}
+            disabled={phase.k === 'scanning' || phase.k === 'pairing'}
+            style={[styles.scanBtn, (phase.k === 'scanning' || phase.k === 'pairing') && styles.busy]}>
+            {phase.k === 'scanning' || phase.k === 'pairing' ? (
+              <ActivityIndicator color={t.blue} />
+            ) : (
+              <>
+                <Ionicons name="wifi" size={16} color={t.blue} />
+                <Text style={styles.scanText}>Scan for boxes</Text>
+              </>
+            )}
+          </Pressable>
+          {phase.k === 'list' && phase.boxes.length > 0 ? (
+            <View style={styles.list}>
+              {phase.boxes.map((b) => (
+                <Pressable key={b.ip} onPress={() => startPair(b)} style={styles.boxRow}>
+                  <Ionicons name="hardware-chip-outline" size={18} color={t.text} />
+                  <View style={styles.boxText}>
+                    <Text style={styles.boxName} numberOfLines={1}>{b.name}</Text>
+                    <Text style={styles.boxMeta}>{b.ip} · v{b.version || '?'}</Text>
+                  </View>
+                  <Ionicons name="chevron-forward" size={16} color={t.textDim} />
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
+        </>
+      )}
+      {msg ? (
+        <Text style={[styles.msg, { color: msg.ok ? t.green : t.red }]}>{msg.text}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  wrap: { gap: 10 },
+  hint: { color: t.textDim, fontSize: 13, lineHeight: 18 },
+  scanBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: 10,
+    paddingVertical: 11,
+    minHeight: 44,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  busy: { opacity: 0.7 },
+  scanText: { color: t.blue, fontSize: 14, fontWeight: '700' },
+  list: { gap: 6 },
+  boxRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  boxText: { flex: 1 },
+  boxName: { color: t.text, fontSize: 14, fontWeight: '700' },
+  boxMeta: { color: t.textDim, fontSize: 12, marginTop: 1 },
+  input: {
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: t.text,
+    fontSize: 18,
+    letterSpacing: 4,
+  },
+  row: { flexDirection: 'row', gap: 10 },
+  btn: { flex: 1, borderRadius: 10, paddingVertical: 11, alignItems: 'center' },
+  btnGhost: { backgroundColor: t.inset },
+  btnGhostText: { color: t.textDim, fontWeight: '700', fontSize: 13 },
+  btnPrimary: { backgroundColor: t.blue },
+  btnPrimaryText: { color: t.bg, fontWeight: '800', fontSize: 13 },
+  msg: { fontSize: 13, lineHeight: 18 },
+});

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -123,6 +123,14 @@ export function RemoteView({
   const [target, setTarget] = useState<'box' | 'tv'>('box');
   const nav = hasTvKeys ? target : 'box';
 
+  // MUTE button color reflects the reported mute state (tv.muted, refreshed by
+  // the poll), toggled optimistically on press for instant feedback. It used to
+  // be hardcoded red, so it always looked muted even when it wasn't.
+  const [muted, setMuted] = useState(false);
+  useEffect(() => {
+    if (typeof tv?.muted === 'boolean') setMuted(tv.muted);
+  }, [tv?.muted]);
+
   // Nav-circle input surface: the classic D-pad, or a relative-mouse trackpad
   // (desktop only). Force back to the D-pad if the box leaves desktop mode.
   const [surface, setSurface] = useState<'dpad' | 'track'>('dpad');
@@ -286,7 +294,7 @@ export function RemoteView({
           {hasSourceKey && target === 'tv' && (
             <Pressable
               onPress={() => tvKey('source')}
-              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}>
               <Ionicons name="swap-horizontal" size={20} color={t.blue} />
             </Pressable>
           )}
@@ -296,7 +304,7 @@ export function RemoteView({
                 hapticLight();
                 openTextManual();
               }}
-              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}>
               <Ionicons name="keypad" size={20} color={t.blue} />
             </Pressable>
           )}
@@ -391,7 +399,15 @@ export function RemoteView({
           onMinus={() => tvOp('volume_down')}
         />
         <View style={styles.midStack}>
-          <MidBtn icon="volume-mute" label="MUTE" color={t.red} onPress={() => tvOp('mute')} />
+          <MidBtn
+            icon={muted ? 'volume-mute' : 'volume-high'}
+            label="MUTE"
+            color={muted ? t.red : t.text}
+            onPress={() => {
+              setMuted((m) => !m);
+              tvOp('mute');
+            }}
+          />
           <MidBtn icon="logo-steam" label="STEAM" color={t.green} onPress={steam} />
           <MidBtn icon="ellipsis-horizontal" label="QAM" color={t.amber} onPress={qam} />
         </View>
@@ -810,6 +826,19 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     backgroundColor: t.card,
     borderWidth: 1,
     borderColor: 'rgba(248,113,113,0.5)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  // Neutral sibling of `pwr` for non-power icon buttons (SOURCE, keypad) — same
+  // footprint, plain card border instead of the power button's red one so they
+  // don't read as "danger".
+  iconBtn: {
+    width: 44,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -15,7 +15,6 @@ import {
 
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
-import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
@@ -42,13 +41,9 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 export function RemoteView({
   client,
   settings,
-  connected,
 }: {
   client: GamepadClient;
   settings: Settings;
-  /** Box is live (gamepad socket connected). Gates the hardware-volume-button
-      hijack so the phone's Vol +/- only steals focus while a box is reachable. */
-  connected: boolean;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -156,16 +151,6 @@ export function RemoteView({
     },
     [settings],
   );
-
-  // Hardware volume buttons -> the SAME tvOp the on-screen VOL rocker uses, so
-  // they honor settings.volumeTarget (box vs TV). Active only while the user
-  // opted in AND a box is connected; otherwise the phone's buttons are its own.
-  const volumeButtons = usePref('volumeButtons');
-  useVolumeButtons({
-    enabled: volumeButtons && connected,
-    onUp: () => tvOp('volume_up'),
-    onDown: () => tvOp('volume_down'),
-  });
 
   const blank = useCallback(() => {
     hapticLight();

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -57,6 +57,7 @@ export function RemoteView({
   const tv = tvPoll.data?.available ? tvPoll.data : null;
   const hasTvKeys = tv?.keys === true;
   const hasTvText = tv?.text === true;
+  const hasSourceKey = tv?.source_key === true;
   const sources = tv?.sources ?? [];
   const canBlank = tv?.screen_toggle === true;
 
@@ -241,6 +242,13 @@ export function RemoteView({
               </Pressable>
             ))}
           </View>
+          {hasSourceKey && target === 'tv' && (
+            <Pressable
+              onPress={() => tvKey('source')}
+              style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+              <Ionicons name="swap-horizontal" size={20} color={t.blue} />
+            </Pressable>
+          )}
           {hasTvText && target === 'tv' && (
             <Pressable
               onPress={() => {

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -15,6 +15,7 @@ import {
 
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
+import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
@@ -41,9 +42,13 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
 export function RemoteView({
   client,
   settings,
+  connected,
 }: {
   client: GamepadClient;
   settings: Settings;
+  /** Box is live (gamepad socket connected). Gates the hardware-volume-button
+      hijack so the phone's Vol +/- only steals focus while a box is reachable. */
+  connected: boolean;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -151,6 +156,16 @@ export function RemoteView({
     },
     [settings],
   );
+
+  // Hardware volume buttons -> the SAME tvOp the on-screen VOL rocker uses, so
+  // they honor settings.volumeTarget (box vs TV). Active only while the user
+  // opted in AND a box is connected; otherwise the phone's buttons are its own.
+  const volumeButtons = usePref('volumeButtons');
+  useVolumeButtons({
+    enabled: volumeButtons && connected,
+    onUp: () => tvOp('volume_up'),
+    onDown: () => tvOp('volume_down'),
+  });
 
   const blank = useCallback(() => {
     hapticLight();

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -1,5 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Modal,
@@ -59,17 +59,58 @@ export function RemoteView({
   const hasTvText = tv?.text === true;
   const sources = tv?.sources ?? [];
   const canBlank = tv?.screen_toggle === true;
+  // Backend pushes an on-TV focus signal (webOS): we auto-raise the text sheet
+  // on focus and dismiss it on blur. Held in a ref too so the (once-registered)
+  // focus listener always sees the current cap without re-subscribing.
+  const canFocusPush = tv?.text_focus_push === true;
+  const focusPushRef = useRef(canFocusPush);
+  focusPushRef.current = canFocusPush;
 
   // On-TV text entry (webOS IME / Samsung / Roku Lit_ keys). Opens a small
   // modal; sends the whole string to /api/tv/text.
   const [textOpen, setTextOpen] = useState(false);
   const [textVal, setTextVal] = useState('');
+  // Who opened the sheet: a manual keypad tap vs an auto focus-push. Only a
+  // focus-push-opened sheet is auto-dismissed on focus-close, so we never yank
+  // a sheet the user opened themselves.
+  const textSrc = useRef<'manual' | 'focus' | null>(null);
+  const closeText = useCallback(() => {
+    setTextOpen(false);
+    setTextVal('');
+    textSrc.current = null;
+  }, []);
+  const openTextManual = useCallback(() => {
+    textSrc.current = 'manual';
+    setTextOpen(true);
+  }, []);
   const sendText = useCallback(() => {
     const s = textVal;
     setTextOpen(false);
     setTextVal('');
+    textSrc.current = null;
     if (s) void api.tvText(settings, s).catch(() => {});
   }, [textVal, settings]);
+
+  // Auto-keyboard: when the box advertises text_focus_push (webOS) and pushes a
+  // focus-open, raise the sheet with any current field text (the sheet's
+  // autoFocus TextInput pops the phone keyboard); on focus-close, dismiss it —
+  // but only if focus-push opened it, so a manually opened sheet stays put.
+  useEffect(() => {
+    client.onInputFocus((open, value) => {
+      if (open) {
+        if (!focusPushRef.current) return;
+        if (textSrc.current === 'manual') return; // don't clobber a manual sheet
+        textSrc.current = 'focus';
+        setTextVal(value);
+        setTextOpen(true);
+      } else if (textSrc.current === 'focus') {
+        setTextOpen(false);
+        setTextVal('');
+        textSrc.current = null;
+      }
+    });
+    return () => client.onInputFocus(null);
+  }, [client]);
 
   // Desktop nav, self-polled and session-aware: the SteamOS/Bazzite desktop
   // cluster (Start menu, trackpad, overview) appears only while the box is in
@@ -245,7 +286,7 @@ export function RemoteView({
             <Pressable
               onPress={() => {
                 hapticLight();
-                setTextOpen(true);
+                openTextManual();
               }}
               style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
               <Ionicons name="keypad" size={20} color={t.blue} />
@@ -385,8 +426,8 @@ export function RemoteView({
         visible={textOpen}
         transparent
         animationType="fade"
-        onRequestClose={() => setTextOpen(false)}>
-        <Pressable style={styles.textBackdrop} onPress={() => setTextOpen(false)}>
+        onRequestClose={closeText}>
+        <Pressable style={styles.textBackdrop} onPress={closeText}>
           <Pressable style={styles.textSheet} onPress={() => {}}>
             <Text style={styles.textTitle}>Send text to the TV</Text>
             <TextInput
@@ -402,7 +443,7 @@ export function RemoteView({
               style={styles.textInput}
             />
             <View style={styles.textBtnRow}>
-              <Pressable onPress={() => setTextOpen(false)} style={styles.textBtn}>
+              <Pressable onPress={closeText} style={styles.textBtn}>
                 <Text style={styles.textBtnCancel}>CANCEL</Text>
               </Pressable>
               <Pressable onPress={sendText} style={[styles.textBtn, styles.textBtnSendBg]}>

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -11,9 +11,27 @@ import {
 } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
+import { api, ApiError, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
 import { normalizeMac } from '@/lib/settings';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/**
+ * A pairing error the user can act on. The box's own reason (e.g. a 500
+ * "could not persist config: Permission denied") is surfaced verbatim instead
+ * of a blanket "could not reach the box" — a server-side failure that masquer-
+ * ades as a network error is what turned a config-permission bug into a long
+ * hunt. Network/timeout kinds keep the friendly fallback (accurate for those).
+ */
+function pairErr(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    // http = the box answered with an error status; show what it said.
+    if (e.kind === 'http') return `${fallback} — box says: ${e.message}`;
+    // unreachable / timeout / unauthorized: the friendly fallback fits, but
+    // name the kind so it's still diagnosable.
+    return `${fallback} (${e.kind})`;
+  }
+  return fallback;
+}
 
 type Brand = 'webos' | 'samsung' | 'roku' | 'androidtv' | 'vidaa';
 
@@ -98,8 +116,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       else r = await api.tvAddRoku(settings, h);
       if (r.ok) connected(r);
       else setMsg({ ok: false, text: r.error ?? 'Could not connect to the TV.' });
-    } catch {
-      setMsg({ ok: false, text: 'Could not reach the box or TV. Check the IP and try again.' });
+    } catch (e: unknown) {
+      setMsg({ ok: false, text: pairErr(e, 'Could not reach the box or TV. Check the IP and try again.') });
     } finally {
       setBusy(false);
     }
@@ -118,8 +136,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       const r = await api.tvAndroidtvPairFinish(settings, c, m);
       if (r.ok) connected(r);
       else setMsg({ ok: false, text: r.error ?? 'Pairing failed — check the code and retry.' });
-    } catch {
-      setMsg({ ok: false, text: 'Could not reach the box. Try again.' });
+    } catch (e: unknown) {
+      setMsg({ ok: false, text: pairErr(e, 'Could not reach the box. Try again.') });
     } finally {
       setBusy(false);
     }

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, ConnSettings, hostKey, Tv, TvPairResult } from '@/lib/api';
+import { api, ApiError, ConnSettings, DiscoveredTv, hostKey, Tv, TvPairResult } from '@/lib/api';
 import { normalizeMac } from '@/lib/settings';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -44,6 +44,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
   const [awaitingCode, setAwaitingCode] = useState(false); // androidtv step 2
   const [busy, setBusy] = useState(false);
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null);
+  const [scanning, setScanning] = useState(false);
+  const [found, setFound] = useState<DiscoveredTv[] | null>(null);
 
   const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
   const active =
@@ -59,9 +61,44 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       setMac('');
       setCode('');
       setAwaitingCode(false);
+      setFound(null);
     },
     [meta],
   );
+
+  // "Scan for TVs": the box sweeps the LAN (mDNS + SSDP) and returns pairable
+  // TVs, so the user taps one instead of typing an IP. A 404 = agent too old.
+  const scan = useCallback(async () => {
+    setScanning(true);
+    setMsg(null);
+    try {
+      const r = await api.tvDiscover(settings);
+      setFound(r.tvs);
+      if (r.tvs.length === 0) {
+        setMsg({ ok: false, text: 'No TVs found on the network — enter the IP below.' });
+      }
+    } catch (e: unknown) {
+      setFound([]);
+      setMsg({
+        ok: false,
+        text:
+          e instanceof ApiError && e.kind === 'http' && e.status === 404
+            ? 'This box’s agent is too old to scan — update it, or enter the IP below.'
+            : 'Scan failed — enter the IP below.',
+      });
+    } finally {
+      setScanning(false);
+    }
+  }, [settings]);
+
+  // Tap a discovered TV: prefill its brand + IP, then the normal pair flow runs.
+  const pick = useCallback((tv: DiscoveredTv) => {
+    setBrand(tv.brand);
+    setHost(tv.host);
+    setAwaitingCode(false);
+    setCode('');
+    setMsg({ ok: true, text: `${tv.name} — tap ${BRANDS.find((b) => b.id === tv.brand)?.verb ?? 'Pair'} below.` });
+  }, []);
 
   const submit = useCallback(async () => {
     const h = host.trim();
@@ -185,6 +222,35 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
         </>
       ) : (
         <>
+          <Pressable
+            onPress={scan}
+            disabled={scanning || busy}
+            style={[styles.scanBtn, (scanning || busy) && styles.buttonBusy]}>
+            {scanning ? (
+              <ActivityIndicator color={t.blue} />
+            ) : (
+              <>
+                <Ionicons name="wifi" size={16} color={t.blue} />
+                <Text style={styles.scanBtnText}>Scan for TVs</Text>
+              </>
+            )}
+          </Pressable>
+          {found && found.length > 0 ? (
+            <View style={styles.foundList}>
+              {found.map((tv) => (
+                <Pressable key={tv.host} onPress={() => pick(tv)} style={styles.foundRow}>
+                  <Ionicons name="tv-outline" size={18} color={t.text} />
+                  <View style={styles.foundText}>
+                    <Text style={styles.foundName} numberOfLines={1}>{tv.name}</Text>
+                    <Text style={styles.foundMeta}>
+                      {(BRANDS.find((b) => b.id === tv.brand)?.label ?? tv.brand)} · {tv.host}
+                    </Text>
+                  </View>
+                  <Ionicons name="chevron-forward" size={16} color={t.textDim} />
+                </Pressable>
+              ))}
+            </View>
+          ) : null}
           <TextInput
             value={host}
             onChangeText={setHost}
@@ -292,6 +358,34 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   buttonBusy: { opacity: 0.7 },
   buttonText: { color: t.bg, fontSize: 15, fontWeight: '700' },
+  scanBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: 10,
+    paddingVertical: 11,
+    minHeight: 44,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  scanBtnText: { color: t.blue, fontSize: 14, fontWeight: '700' },
+  foundList: { gap: 6 },
+  foundRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  foundText: { flex: 1 },
+  foundName: { color: t.text, fontSize: 14, fontWeight: '700' },
+  foundMeta: { color: t.textDim, fontSize: 12, marginTop: 1 },
   msg: { fontSize: 13, lineHeight: 18 },
   hint: { color: t.textFaint, fontSize: 12, lineHeight: 16 },
 });

--- a/app/hooks/useVolumeButtons.ts
+++ b/app/hooks/useVolumeButtons.ts
@@ -1,0 +1,117 @@
+/**
+ * Repurpose the phone's hardware volume buttons (Vol +/-) into box/TV volume
+ * steps while the Remote screen owns them.
+ *
+ * The mechanism is deliberately the same on both platforms: sit on a mid-range
+ * baseline system volume, listen for the OS volume changing under a physical
+ * press, derive the direction from the delta, fire the matching callback, then
+ * snap the system volume back to the baseline so there is always headroom in
+ * both directions (a phone pinned at 0% or 100% would swallow further presses).
+ *
+ *   Android — `showNativeVolumeUI(false)` hides the system volume HUD, so the
+ *     hijack is invisible; the OS still moves the music stream, which the
+ *     baseline reset absorbs. Primary, review-safe target.
+ *   iOS — no public key-intercept API, so this observes AVAudioSession's
+ *     outputVolume (the library's KVO listener) and needs an active audio
+ *     session + the app foregrounded. The volume HUD still flashes (can't be
+ *     suppressed) and locked-screen / Control-Center presses won't route here.
+ *     Experimental, and off by default (App Review risk — see the setting).
+ *
+ * `enabled` gates the whole thing: pass it the AND of the user setting and a
+ * live box connection. Flipping it off (screen blur, disconnect, unmount)
+ * tears the listener down and restores normal system-volume behavior.
+ */
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { VolumeManager } from 'react-native-volume-manager';
+
+/** Mid-range resting volume: every press has room to move up OR down from here. */
+const BASELINE = 0.5;
+/**
+ * Deltas smaller than this are our own baseline write echoing back (or float
+ * noise), not a press. One hardware step is ~1/15 (Android) or 1/16 (iOS) of
+ * the range — comfortably above this.
+ */
+const EPSILON = 0.012;
+/** Min gap between emitted commands, so a held button paces (~7/s) not floods. */
+const MIN_STEP_MS = 140;
+
+export function useVolumeButtons({
+  enabled,
+  onUp,
+  onDown,
+}: {
+  enabled: boolean;
+  onUp: () => void;
+  onDown: () => void;
+}): void {
+  // Keep the callbacks current WITHOUT re-subscribing the native listener on
+  // every render (the effect keys only on `enabled`).
+  const cbs = useRef({ onUp, onDown });
+  cbs.current = { onUp, onDown };
+
+  useEffect(() => {
+    // Web has no hardware volume buttons and no native module — never touch it.
+    if (!enabled || Platform.OS === 'web') return undefined;
+
+    let cancelled = false;
+    let sub: { remove: () => void } | null = null;
+    let lastEmit = 0;
+    // True while our own setVolume(BASELINE) is in flight, so its listener echo
+    // is ignored even before the EPSILON test would catch it.
+    let resetting = false;
+
+    const recenter = () => {
+      resetting = true;
+      VolumeManager.setVolume(BASELINE, { showUI: false })
+        .catch(() => {})
+        .finally(() => {
+          resetting = false;
+        });
+    };
+
+    const setup = async () => {
+      try {
+        if (Platform.OS === 'ios') {
+          // outputVolume KVO only reports while a session is active; ambient
+          // category mixes with (never ducks or interrupts) other audio.
+          await VolumeManager.enable(true);
+          await VolumeManager.setActive(true);
+        } else {
+          await VolumeManager.showNativeVolumeUI({ enabled: false });
+        }
+        await VolumeManager.setVolume(BASELINE, { showUI: false });
+        if (cancelled) return;
+
+        sub = VolumeManager.addVolumeListener(({ volume }) => {
+          if (resetting) return; // our own recenter write
+          const delta = volume - BASELINE;
+          if (Math.abs(delta) < EPSILON) return; // noise / already centered
+          const now = Date.now();
+          if (now - lastEmit >= MIN_STEP_MS) {
+            lastEmit = now;
+            if (delta > 0) cbs.current.onUp();
+            else cbs.current.onDown();
+          }
+          // Recenter even when throttled, so volume never creeps to a dead zone.
+          recenter();
+        });
+      } catch {
+        // Native module absent (not-yet-prebuilt / Expo Go) or a platform
+        // quirk: fail silent and leave the phone's volume buttons alone.
+      }
+    };
+    void setup();
+
+    return () => {
+      cancelled = true;
+      if (sub) sub.remove();
+      // Hand the buttons back to the OS.
+      if (Platform.OS === 'ios') {
+        VolumeManager.setActive(false).catch(() => {});
+      } else {
+        VolumeManager.showNativeVolumeUI({ enabled: true }).catch(() => {});
+      }
+    };
+  }, [enabled]);
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -392,6 +392,12 @@ export type Tv = {
    */
   keys?: boolean;
   /**
+   * A `source` key (POST /api/tv/key/source) opens the TV's input picker (agent
+   * >= 2.9.12). Set by Android/Google TV (KEYCODE_TV_INPUT) and Samsung
+   * (KEY_SOURCE); the RS-232 panel uses its explicit `sources` list instead.
+   */
+  source_key?: boolean;
+  /**
    * Text entry into a focused on-TV field via POST /api/tv/text (agent >=
    * 2.9.7). Set by the network smart-TV backends (webOS IME, Samsung
    * SendInputString, Roku Lit_ keys); never by panel/CEC.
@@ -418,6 +424,7 @@ export type TvKey =
   | 'home'
   | 'back'
   | 'settings'
+  | 'source'
   | 'bright_up'
   | 'bright_down';
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -874,8 +874,13 @@ export const api = {
    * (cached); the app just reads the result over the LAN, so the app never
    * touches the internet. 404 -> null on older agents (no banner shown).
    */
-  updateCheck(settings: ConnSettings): Promise<UpdateCheck | null> {
-    return probeOrNull(request<UpdateCheck>(settings, '/api/update/check'));
+  updateCheck(
+    settings: ConnSettings,
+    opts: { force?: boolean } = {},
+  ): Promise<UpdateCheck | null> {
+    // force=1 bypasses the box's ~6h cache for a manual "Check for updates" tap.
+    const q = opts.force ? '?force=1' : '';
+    return probeOrNull(request<UpdateCheck>(settings, `/api/update/check${q}`));
   },
 
   /**

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -397,6 +397,14 @@ export type Tv = {
    * SendInputString, Roku Lit_ keys); never by panel/CEC.
    */
   text?: boolean;
+  /**
+   * Backend PUSHES a focus signal (agent >= 2.9.12) when an on-TV text field
+   * opens/closes, delivered as a {t:'input_focus'} frame on /ws/gamepad. Only
+   * webOS reports it today (registerRemoteKeyboard); when set, the app auto-
+   * raises its text sheet on focus and dismisses it on blur. Absent on every
+   * other backend, which keep the manual text button unchanged.
+   */
+  text_focus_push?: boolean;
   /** Current box OS volume 0-100 (agent >= 2.7.0), or null when unreadable. */
   box_volume_level?: number | null;
   /**

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -346,6 +346,16 @@ export type TvBackend =
   | 'androidtv'
   | 'vidaa';
 
+/**
+ * A TV the box found on the LAN (GET /api/tv/discover, agent >= 2.9.12). `brand`
+ * is one of the pairable network backends; `host` feeds the existing pair flow.
+ */
+export type DiscoveredTv = {
+  brand: 'webos' | 'samsung' | 'roku' | 'androidtv';
+  name: string;
+  host: string;
+};
+
 /** TV-control probe result. The route 404s when no backend is available. */
 export type Tv = {
   available: boolean;
@@ -1104,6 +1114,17 @@ export const api = {
         timeoutMs: 20000,
         body: { host },
       });
+  },
+
+  /**
+   * Scan the LAN (from the box) for pairable TVs (agent >= 2.9.12). The box runs
+   * a ~3s mDNS + SSDP sweep, so give it a generous budget. Always resolves (an
+   * empty list means none found); a 404 means the agent predates discovery.
+   */
+  tvDiscover(settings: ConnSettings): Promise<{ tvs: DiscoveredTv[] }> {
+    return request<{ tvs: DiscoveredTv[] }>(settings, '/api/tv/discover', {
+      timeoutMs: 8000,
+    });
   },
 
   /**

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -808,6 +808,60 @@ async function request<T>(
   }
 }
 
+// ---------- PIN pairing (unauthenticated box enrollment) ----------
+
+export type PairStartResult = { ok: boolean; ttl?: number; error?: string };
+export type PairFinishResult = { ok: boolean; token?: string; port?: number; error?: string };
+
+/**
+ * Hit a box directly by ip:port with NO bearer token — the PIN-pairing routes
+ * are the box's only unauthenticated POSTs (the phone has no token yet). Reads
+ * the JSON body for both 200 and the 4xx error cases.
+ */
+async function unauthPost<T>(
+  ip: string,
+  port: number,
+  path: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(`http://${ip}:${port}${path}`, {
+      method: 'POST',
+      headers: body !== undefined ? { 'Content-Type': 'application/json' } : {},
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+    return (await res.json()) as T;
+  } catch (e: unknown) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`);
+    }
+    throw new ApiError('unreachable', 'Box unreachable: network error');
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Start PIN pairing: the box mints a PIN and displays it on ITS OWN screen.
+ * Returns the TTL; the PIN is never sent over the network. Agent >= 2.9.12.
+ */
+export function pairStart(ip: string, port: number): Promise<PairStartResult> {
+  return unauthPost<PairStartResult>(ip, port, '/api/pair/start', undefined, 8000);
+}
+
+/**
+ * Finish PIN pairing: submit the PIN shown on the box. On success returns the
+ * box token (to store) and its port; on a wrong/expired/locked PIN, `ok:false`
+ * with a reason.
+ */
+export function pairFinish(ip: string, port: number, pin: string): Promise<PairFinishResult> {
+  return unauthPost<PairFinishResult>(ip, port, '/api/pair/finish', { pin }, 8000);
+}
+
 export const api = {
   /** Unauthenticated reachability probe. */
   ping(settings: ConnSettings): Promise<Ping> {

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -15,9 +15,13 @@ import { DEFAULT_PORT } from './settings';
 
 // Native module; require in a try/catch so a build predating the dependency
 // disables scanning instead of crashing at startup (see scanAvailable).
+// react-native-udp does `module.exports = UdpSockets` AND `export default`, so
+// depending on interop `.default` may be undefined and the module itself is the
+// dgram object — accept either (a bare `.default` silently disabled this).
 let dgram: typeof import('react-native-udp').default | null = null;
 try {
-  dgram = require('react-native-udp').default;
+  const udp = require('react-native-udp');
+  dgram = (udp && (udp.default ?? udp)) || null;
 } catch {
   dgram = null;
 }

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -1,0 +1,123 @@
+/**
+ * LAN box discovery: broadcast a probe and collect replies from Couchside
+ * agents, so the user can pick a box to pair instead of typing an IP. Pairs
+ * with the agent's UDP responder (agent >= 2.9.12): the box replies with its
+ * identity + HTTP port. Reveals existence only — pairing still needs the PIN
+ * shown on the box's own screen (see api.pairStart/pairFinish).
+ *
+ * UDP broadcast (not mDNS) is deliberate: Android multicast RX needs a
+ * MulticastLock and is flaky, while a directed/global broadcast + unicast reply
+ * is reliable. Mirrors lib/wol.ts's use of the same native module.
+ */
+import { Buffer } from 'buffer';
+
+import { DEFAULT_PORT } from './settings';
+
+// Native module; require in a try/catch so a build predating the dependency
+// disables scanning instead of crashing at startup (see scanAvailable).
+let dgram: typeof import('react-native-udp').default | null = null;
+try {
+  dgram = require('react-native-udp').default;
+} catch {
+  dgram = null;
+}
+
+/** True when the UDP native module is present, so a scan can run. */
+export const scanAvailable = dgram != null;
+
+const PROBE = 'COUCHSIDE_DISCOVER?';
+
+export type FoundBox = {
+  /** Short hostname the box reports (display label). */
+  name: string;
+  /** mDNS name (e.g. steamdeck.local) for the stored host. */
+  host: string;
+  /** The IP the reply actually came from (the direct-connect fallback). */
+  ip: string;
+  /** The box's HTTP/agent port. */
+  port: number;
+  /** Agent version (so the UI can flag a box too old to PIN-pair). */
+  version: string;
+};
+
+/** The /24 directed broadcast for a LAN IP, plus the global broadcast. */
+function broadcastTargets(ip?: string): string[] {
+  const t: string[] = [];
+  if (ip) {
+    const m = /^(\d+)\.(\d+)\.(\d+)\.\d+$/.exec(ip);
+    if (m) t.push(`${m[1]}.${m[2]}.${m[3]}.255`);
+  }
+  t.push('255.255.255.255');
+  return Array.from(new Set(t));
+}
+
+/**
+ * Broadcast the discovery probe on `port` (the agent port) and collect box
+ * replies for `timeoutMs`. Resolves the deduped list (by IP). Throws only when
+ * the native UDP module is missing; a bind/send failure resolves an empty list.
+ */
+export function scanForBoxes(
+  opts: { ip?: string; port?: number; timeoutMs?: number } = {},
+): Promise<FoundBox[]> {
+  if (!dgram) throw new Error('Box discovery needs a fresh native build of the app');
+  const port = opts.port ?? DEFAULT_PORT;
+  const timeoutMs = opts.timeoutMs ?? 2500;
+  const probe = Buffer.from(PROBE);
+  const targets = broadcastTargets(opts.ip);
+
+  return new Promise<FoundBox[]>((resolve) => {
+    const socket = dgram!.createSocket({ type: 'udp4' });
+    const found = new Map<string, FoundBox>(); // by IP
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = () => {
+      if (timer) clearTimeout(timer);
+      timer = null;
+      try {
+        socket.close();
+      } catch {
+        // already closed
+      }
+      resolve(Array.from(found.values()));
+    };
+
+    socket.once('error', finish);
+    socket.on('message', (msg: Buffer, rinfo: { address: string }) => {
+      try {
+        const d = JSON.parse(msg.toString());
+        if (d && d.couchside) {
+          found.set(rinfo.address, {
+            name: typeof d.name === 'string' ? d.name : rinfo.address,
+            host: typeof d.host === 'string' ? d.host : rinfo.address,
+            ip: rinfo.address,
+            port: typeof d.port === 'number' ? d.port : port,
+            version: typeof d.version === 'string' ? d.version : '',
+          });
+        }
+      } catch {
+        // not our reply; ignore
+      }
+    });
+
+    socket.bind(0, (bindErr?: Error) => {
+      if (bindErr) {
+        finish();
+        return;
+      }
+      try {
+        socket.setBroadcast(true);
+      } catch {
+        // some platforms reject before the first send; the send still works
+      }
+      try {
+        for (const addr of targets) {
+          socket.send(probe, 0, probe.length, port, addr, () => {});
+        }
+      } catch {
+        finish();
+        return;
+      }
+      timer = setTimeout(finish, timeoutMs);
+    });
+  });
+}

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -183,6 +183,15 @@ export class GamepadClient {
     | ((blocked: boolean, msg: string | null) => void)
     | null = null;
 
+  // On-TV text-focus push (agent >= 2.9.12, webOS). The backend sends
+  // input_focus{open,value} when a text field on the TV gains/loses focus, so
+  // the app can auto-raise its keyboard. This is a transient EVENT, not a
+  // persisted state — the listener fires only on receipt (no replay on
+  // subscribe), so a freshly mounted view never re-pops a stale keyboard.
+  private inputFocusListener:
+    | ((open: boolean, value: string) => void)
+    | null = null;
+
   // Controller handoff (agent >= 2.9.2). When this phone HOLDS control and
   // another asks for it, the agent sends control_request{name}; the UI prompts
   // Pass/Keep. controlRequest holds the pending requester name (or null).
@@ -281,6 +290,20 @@ export class GamepadClient {
   ): void {
     this.blockedListener = fn;
     if (fn) fn(this.inputBlocked, this.blockedMsg);
+  }
+
+  /**
+   * Register the (single) on-TV text-focus listener. Unlike the state
+   * listeners above it does NOT fire immediately: input_focus is an event, so
+   * replaying a stale value on subscribe could pop the keyboard for a field the
+   * user already left. Fires with (open, value) on each pushed transition.
+   */
+  onInputFocus(fn: ((open: boolean, value: string) => void) | null): void {
+    this.inputFocusListener = fn;
+  }
+
+  private emitInputFocus(open: boolean, value: string): void {
+    if (this.inputFocusListener) this.inputFocusListener(open, value);
   }
 
   getStatus(): GamepadStatus {
@@ -582,6 +605,7 @@ export class GamepadClient {
       let msg: {
         t?: string; dev?: string; msg?: string; text?: string;
         code?: string; name?: string; holder?: string; by?: string;
+        open?: boolean; value?: string;
       };
       try {
         msg = JSON.parse(String(ev.data));
@@ -636,6 +660,13 @@ export class GamepadClient {
         this.setInputBlocked(true, typeof msg.msg === 'string' ? msg.msg : null);
       } else if (msg.t === 'resumed') {
         this.setInputBlocked(false, null);
+      } else if (msg.t === 'input_focus') {
+        // A text field on the TV opened/closed (webOS). Relay to the view so it
+        // can raise/dismiss the phone keyboard; value carries any current text.
+        this.emitInputFocus(
+          msg.open === true,
+          typeof msg.value === 'string' ? msg.value : '',
+        );
       }
       // {"t":"pong"} needs no handling.
     };

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -45,6 +45,11 @@ export type Prefs = {
   /** When another phone joins a box you're controlling, ask before handing
       over (true) vs let it grab control immediately (false). Agent >= 2.9.2. */
   askToSwitchControl: boolean;
+  /** Let the phone's hardware Vol +/- buttons drive the box/TV volume while the
+      Remote screen is open. Default ON for Android; OFF for iOS, where the OS
+      volume HUD can't be suppressed and repurposing the buttons is App-Review
+      risky (opt-in, experimental). */
+  volumeButtons: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -62,6 +67,9 @@ export const DEFAULTS: Prefs = {
   padKeyboardBar: true,
   padHints: true,
   askToSwitchControl: true,
+  // Android intercepts the keycode cleanly (no HUD); iOS can't, so it stays off
+  // until the user opts in.
+  volumeButtons: Platform.OS === 'android',
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -138,6 +146,7 @@ function normalize(raw: unknown): Prefs {
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
+    volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
   };
 }
 

--- a/app/lib/wol.ts
+++ b/app/lib/wol.ts
@@ -13,9 +13,13 @@ import { Buffer } from 'buffer';
 // react-native-udp is a native module. Requiring it in a try/catch means a
 // build that predates the dependency disables wake instead of crashing at
 // startup; wolAvailable reports which case we are in.
+// The lib does `module.exports = UdpSockets` AND `export default`, so depending
+// on interop `.default` can be undefined and the module itself is the dgram
+// object — accept either. (A bare `.default` left wolAvailable always false.)
 let dgram: typeof import('react-native-udp').default | null = null;
 try {
-  dgram = require('react-native-udp').default;
+  const udp = require('react-native-udp');
+  dgram = (udp && (udp.default ?? udp)) || null;
 } catch {
   dgram = null;
 }

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -33,6 +33,7 @@
         "react-native-safe-area-context": "~5.7.0",
         "react-native-screens": "4.25.2",
         "react-native-udp": "^4.1.7",
+        "react-native-volume-manager": "^2.0.8",
         "react-native-web": "~0.21.0",
         "react-native-worklets": "0.10.0"
       },
@@ -6790,6 +6791,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/react-native-volume-manager": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-volume-manager/-/react-native-volume-manager-2.0.8.tgz",
+      "integrity": "sha512-aZM47/mYkdQ4CbXpKYO6Ajiczv7fxbQXZ9c0H8gRuQUaS3OCz/MZABer6o9aDWq0KMNsQ7q7GVFLRPnSSeeMmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/react-native-web": {

--- a/app/package.json
+++ b/app/package.json
@@ -28,6 +28,7 @@
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",
     "react-native-udp": "^4.1.7",
+    "react-native-volume-manager": "^2.0.8",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.10.0"
   },

--- a/install.sh
+++ b/install.sh
@@ -95,7 +95,14 @@ PORT_DEFAULT=8787
 INSTALL_DIR="${HOME}/.local/opt/couchside"
 ETC_DIR="/etc/couchside"
 TOKEN_FILE="${ETC_DIR}/token"
-CONFIG_FILE="${ETC_DIR}/config.json"
+# Agent-MUTATED state (TV pairings, launcher edits) lives in a user-owned state
+# dir, NOT the root-owned ETC_DIR. The agent runs as the desktop user and writes
+# config atomically (temp file in the dir + os.replace), so the dir must be
+# user-writable — but ETC_DIR must stay root-owned to protect the sudo-granted
+# couchside-journal wrapper (a user-writable ETC_DIR = replace the wrapper = root
+# code via the sudoers grant). Splitting them keeps both invariants.
+STATE_DIR="/var/lib/couchside"
+CONFIG_FILE="${STATE_DIR}/config.json"
 # Fixed-argument, root-owned wrapper for system-journal reads. The sudoers rule
 # grants ONLY this script (no wildcards); it validates its inputs and calls
 # journalctl with a locked-down option set, so --file/--directory can't be
@@ -358,6 +365,10 @@ if [ "$UNINSTALL" -eq 1 ]; then
         if ask_yn "Remove $ETC_DIR (pairing token + config; phones will need re-pairing)?"; then
             sudo rm -rf "$ETC_DIR"
             note "removed $ETC_DIR"
+            # The agent-mutated config (TV pairings) lives in STATE_DIR now —
+            # remove it alongside, so a purge doesn't leave stale pairings.
+            sudo rm -rf "$STATE_DIR" 2>/dev/null || true
+            note "removed $STATE_DIR"
         else
             note "kept $ETC_DIR"
         fi
@@ -509,6 +520,23 @@ sudo chmod 600 "$TOKEN_FILE"
 sudo chown "$USER_NAME" "$TOKEN_FILE"
 
 # ---------------------------------------------------------------------------
+# (e0) State dir for the agent-mutated config (user-owned; see STATE_DIR note).
+# Older installs kept config.json inside the root-owned $ETC_DIR, where the
+# non-root agent couldn't write it (every TV pairing / launcher edit 500'd).
+# Create the user-owned state dir and migrate any legacy config into it.
+# ---------------------------------------------------------------------------
+sudo mkdir -p "$STATE_DIR"
+sudo chown "$USER_NAME" "$STATE_DIR"
+sudo chmod 700 "$STATE_DIR"
+LEGACY_CONFIG="${ETC_DIR}/config.json"
+if sudo test -s "$LEGACY_CONFIG" && ! sudo test -s "$CONFIG_FILE"; then
+    note "migrating config $LEGACY_CONFIG -> $CONFIG_FILE (pairings preserved)"
+    sudo mv "$LEGACY_CONFIG" "$CONFIG_FILE"
+    sudo chown "$USER_NAME" "$CONFIG_FILE"
+    sudo chmod 600 "$CONFIG_FILE"
+fi
+
+# ---------------------------------------------------------------------------
 # (e) Initial config.json (only if absent)
 # ---------------------------------------------------------------------------
 if sudo test -s "$CONFIG_FILE"; then
@@ -569,7 +597,9 @@ order += ["reboot", "poweroff"]
 
 print(json.dumps({"units": units, "actions": actions, "action_order": order}, indent=2))
 PYEOF
-    sudo install -m 0644 -o root -g root "$WORK_DIR/config.json" "$CONFIG_FILE"
+    # User-owned so the agent (running as the desktop user) can rewrite it on
+    # every TV pairing / launcher edit. 0600 — it holds TV client certs/keys.
+    sudo install -m 0600 -o "$USER_NAME" "$WORK_DIR/config.json" "$CONFIG_FILE"
 fi
 
 # ---------------------------------------------------------------------------
@@ -726,8 +756,16 @@ say "Installing systemd unit $UNIT_DST"
 DAEMON_PATH="$INSTALL_DIR/couchsided.py"
 sed -e "s|/home/__USER__/.local/opt/couchside/couchsided.py|__EXEC__|g" \
     -e "s|__EXEC__|$DAEMON_PATH|g" \
+    -e "s|__CONFIG__|$CONFIG_FILE|g" \
     -e "s|__USER__|$USER_NAME|g" -e "s|__UID__|$USER_UID|g" \
     "$WORK_DIR/couchside.service" > "$WORK_DIR/couchside.service.rendered"
+# Heal an older template whose ExecStart predates the user-owned config path:
+# without --config the agent would read the default /etc path where config no
+# longer lives (it moved to STATE_DIR), so append it.
+if ! grep -q -- '--config' "$WORK_DIR/couchside.service.rendered"; then
+    sed -i "s|^\(ExecStart=.*couchsided\.py\)[[:space:]]*\$|\1 --config $CONFIG_FILE|" \
+        "$WORK_DIR/couchside.service.rendered"
+fi
 sudo install -m 0644 -o root -g root "$WORK_DIR/couchside.service.rendered" "$UNIT_DST"
 sudo systemctl daemon-reload
 sudo systemctl enable couchside.service
@@ -765,7 +803,7 @@ cat > "$PAIR_SCRIPT" <<'PAIREOF'
 # The /pair page is served LOCALHOST-ONLY by the agent, so it must be opened
 # here on the box (never over the network). Reads PORT from the agent config.
 set -u
-CONFIG_FILE="/etc/couchside/config.json"
+CONFIG_FILE="/var/lib/couchside/config.json"
 PORT_DEFAULT=8787
 PORT="$(python3 - "$CONFIG_FILE" "$PORT_DEFAULT" <<'PYEOF' 2>/dev/null || echo "$PORT_DEFAULT"
 import json, sys
@@ -923,13 +961,15 @@ PY
     # Opt-in: let the phone app trigger an update (POST /api/update/apply).
     # OFF by default. Must be set HERE on the box (not by the app), so the
     # capability only exists when you consciously enable it. Edits config.json
-    # (root-owned) + restarts the agent.
+    # (user-owned state dir) + restarts the agent — no sudo: the desktop user
+    # owns the state dir, and a sudo write would re-root the file the agent must
+    # itself be able to rewrite.
     case "${2:-}" in
       on|off)
         val="false"; [ "$2" = "on" ] && val="true"
-        sudo python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
+        python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
 import json, os, sys
-p = "/etc/couchside/config.json"
+p = "/var/lib/couchside/config.json"
 val = sys.argv[1] == "true"
 try:
     with open(p) as f: d = json.load(f)
@@ -947,7 +987,7 @@ PY
         echo "App-triggered updates: ${2}"
         ;;
       ""|status)
-        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /etc/couchside/config.json 2>/dev/null \
+        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /var/lib/couchside/config.json 2>/dev/null \
           && echo "App-triggered updates: on" || echo "App-triggered updates: off"
         ;;
       *) echo "usage: couchside allow-updates on|off" >&2; exit 2 ;;


### PR DESCRIPTION
Integration of the reviewed, green feature branches into one tested drop (this is the built + on-device-verified `test/combined-v2` state). **Supersedes and closes #74, #75, #77, #78, #79, #80, #81, #82** — they overlap heavily on `couchsided.py` + `api.ts`, so they were integrated and tested together rather than merged one-by-one.

## Features
- **#74 Hardware volume buttons** — phone Vol +/- drive box/TV volume on **any** Pad tab surface (Pad/Swipe/Track/Remote), per-box target. Android default on, iOS experimental.
- **#75 webOS focus keyboard** — auto-pop the mobile keyboard when a text field is focused on a webOS TV (`text_focus_push` cap + IME watcher).
- **#77 TV-pairing config-writable fix** — agent warns on an unwritable config + reflects it in health; installer relocates config to user-owned `/var/lib/couchside` and migrates the legacy path (fixes the Google TV "could not reach the box" pairing failure).
- **#78 TV LAN discovery** — box scans the LAN (mDNS/SSDP) and the app offers a "Scan for TVs" picker.
- **#79 Box discovery + on-screen PIN pairing** — phone scans the LAN, box shows a PIN on its own screen, enter it to add the box (primary add-box flow; QR + "Add by IP" are fallbacks).
- **#80 TV SOURCE button** — sends the input-picker key where the backend supports it; neutral (non-danger) button styling.
- **#81 Wake-on-LAN `.default` fix** — react-native-udp interop (`udp.default ?? udp`).
- **#82 Check-for-updates button** — manual forced re-check in Setup → Account.

## Additional fixes folded in
- MUTE button color/icon now reflect the reported mute state (was hardcoded red / always "muted").
- SOURCE + keypad buttons use a neutral card border instead of the power button's red one.
- **Default input mode** writes through to the active box so the setting takes effect immediately (previously only seeded newly paired boxes).
- Hardware-volume hint corrected (works on any Pad surface, not only Remote).

## Versions
- App **2.9.2 → 2.9.3** (Android versionCode 28 → 29, iOS buildNumber 43 → 44).
- Agent **2.9.11 → 2.9.12** (discovery, PIN pairing, config-writable, source key, focus-push — all agent-side).

Typechecks clean; Android build produced + installed on a real device (mute fix, PIN-pair UI, discovery, SOURCE key all verified on-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)