### PR TITLE
fix(discovery): directed /24 broadcast so box scan works on iOS

### DIFF
--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -10,6 +10,7 @@
  * is reliable. Mirrors lib/wol.ts's use of the same native module.
  */
 import { Buffer } from 'buffer';
+import * as Network from 'expo-network';
 
 import { DEFAULT_PORT } from './settings';
 
@@ -60,14 +61,34 @@ function broadcastTargets(ip?: string): string[] {
  * replies for `timeoutMs`. Resolves the deduped list (by IP). Throws only when
  * the native UDP module is missing; a bind/send failure resolves an empty list.
  */
-export function scanForBoxes(
+/**
+ * The device's own LAN IPv4, so a scan can derive the /24 DIRECTED broadcast.
+ * iOS silently drops the global 255.255.255.255 broadcast, so with only the
+ * global target a scan finds nothing on iOS (Android is permissive). Best-effort
+ * — resolves undefined if expo-network can't read a usable address.
+ */
+async function selfIp(): Promise<string | undefined> {
+  try {
+    const ip = await Network.getIpAddressAsync();
+    return typeof ip === 'string' && /^\d+\.\d+\.\d+\.\d+$/.test(ip) && ip !== '0.0.0.0'
+      ? ip
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function scanForBoxes(
   opts: { ip?: string; port?: number; timeoutMs?: number } = {},
 ): Promise<FoundBox[]> {
   if (!dgram) throw new Error('Box discovery needs a fresh native build of the app');
   const port = opts.port ?? DEFAULT_PORT;
   const timeoutMs = opts.timeoutMs ?? 2500;
   const probe = Buffer.from(PROBE);
-  const targets = broadcastTargets(opts.ip);
+  // Prefer a directed /24 broadcast (caller-supplied IP, else the phone's own)
+  // so iOS — which drops the global broadcast — still reaches boxes on the LAN.
+  // broadcastTargets keeps 255.255.255.255 too, for Android.
+  const targets = broadcastTargets(opts.ip ?? (await selfIp()));
 
   return new Promise<FoundBox[]>((resolve) => {
     const socket = dgram!.createSocket({ type: 'udp4' });

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -17,6 +17,7 @@
         "expo-haptics": "~57.0.0",
         "expo-iap": "^4.3.6",
         "expo-linking": "~57.0.1",
+        "expo-network": "~57.0.1",
         "expo-router": "~57.0.2",
         "expo-screen-orientation": "~57.0.0",
         "expo-secure-store": "~57.0.0",
@@ -3936,6 +3937,16 @@
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-network": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-network/-/expo-network-57.0.1.tgz",
+      "integrity": "sha512-ndg+FbDDlz6XTpQ6aVuVgyvrYQwMkpcUAvZIXbwrGBbLTSWNzYC/gawYu1BAeDN7O6JTGY98GBVJBov/JH7LgQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*"
       }
     },
     "node_modules/expo-router": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "expo-haptics": "~57.0.0",
     "expo-iap": "^4.3.6",
     "expo-linking": "~57.0.1",
+    "expo-network": "~57.0.1",
     "expo-router": "~57.0.2",
     "expo-screen-orientation": "~57.0.0",
     "expo-secure-store": "~57.0.0",


### PR DESCRIPTION
**Bug:** "Scan for boxes" always returns *No boxes found* on iOS (works on Android).

**Root cause:** `boxDiscovery.scanForBoxes` only broadcast the probe to the global `255.255.255.255`. iOS silently drops the global broadcast; Android allows it. Local Network permission + LAN HTTP (add-by-IP) were confirmed working on the device — the only failure was the broadcast address.

**Fix:** read the phone's own IPv4 (`expo-network` `getIpAddressAsync`) and broadcast to its `/24` directed address (e.g. `10.1.1.255`), which iOS permits. The global `255.255.255.255` is kept as an additional target for Android. Verified the box's UDP responder replies to the directed broadcast.

App-only; no agent change. Adds `expo-network` (native), so needs a fresh build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)