### PR TITLE
fix(discovery): HTTP /api/ping sweep — the path iOS actually allows

### DIFF
--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -1,13 +1,18 @@
 /**
- * LAN box discovery: broadcast a probe and collect replies from Couchside
- * agents, so the user can pick a box to pair instead of typing an IP. Pairs
- * with the agent's UDP responder (agent >= 2.9.12): the box replies with its
- * identity + HTTP port. Reveals existence only — pairing still needs the PIN
- * shown on the box's own screen (see api.pairStart/pairFinish).
+ * LAN box discovery. Two independent probes run in parallel and their results
+ * merge by IP:
  *
- * UDP broadcast (not mDNS) is deliberate: Android multicast RX needs a
- * MulticastLock and is flaky, while a directed/global broadcast + unicast reply
- * is reliable. Mirrors lib/wol.ts's use of the same native module.
+ *  1. An HTTP sweep of the phone's /24 for the agent's unauthenticated
+ *     GET /api/ping. This is the RELIABLE path — plain TCP/HTTP is the one
+ *     thing iOS reliably allows on the local network once the Local Network
+ *     permission is granted (proven on-device: the app reaches a box by IP and
+ *     reads its version, while every UDP probe comes back empty).
+ *  2. A UDP broadcast + unicast probe (agent >= 2.9.12 answers it). Fast — a
+ *     couple of datagrams — and works on Android, so it's kept as a quick path.
+ *     Silently contributes nothing where the platform blocks UDP.
+ *
+ * Reveals existence only — pairing still needs the PIN shown on the box's own
+ * screen (see api.pairStart/pairFinish).
  */
 import { Buffer } from 'buffer';
 import * as Network from 'expo-network';
@@ -15,10 +20,11 @@ import * as Network from 'expo-network';
 import { DEFAULT_PORT } from './settings';
 
 // Native module; require in a try/catch so a build predating the dependency
-// disables scanning instead of crashing at startup (see scanAvailable).
+// disables the UDP probe instead of crashing at startup. The HTTP sweep does
+// not need it, so discovery still works without it.
 // react-native-udp does `module.exports = UdpSockets` AND `export default`, so
 // depending on interop `.default` may be undefined and the module itself is the
-// dgram object — accept either (a bare `.default` silently disabled this).
+// dgram object — accept either.
 let dgram: typeof import('react-native-udp').default | null = null;
 try {
   const udp = require('react-native-udp');
@@ -27,8 +33,9 @@ try {
   dgram = null;
 }
 
-/** True when the UDP native module is present, so a scan can run. */
-export const scanAvailable = dgram != null;
+/** Discovery no longer depends on the native UDP module — the HTTP sweep works
+ * on any build — so scanning is always offered. */
+export const scanAvailable = true;
 
 const PROBE = 'COUCHSIDE_DISCOVER?';
 
@@ -37,7 +44,7 @@ export type FoundBox = {
   name: string;
   /** mDNS name (e.g. steamdeck.local) for the stored host. */
   host: string;
-  /** The IP the reply actually came from (the direct-connect fallback). */
+  /** The IP the box actually answered on (the direct-connect fallback). */
   ip: string;
   /** The box's HTTP/agent port. */
   port: number;
@@ -45,27 +52,9 @@ export type FoundBox = {
   version: string;
 };
 
-/** The /24 directed broadcast for a LAN IP, plus the global broadcast. */
-function broadcastTargets(ip?: string): string[] {
-  const t: string[] = [];
-  if (ip) {
-    const m = /^(\d+)\.(\d+)\.(\d+)\.\d+$/.exec(ip);
-    if (m) t.push(`${m[1]}.${m[2]}.${m[3]}.255`);
-  }
-  t.push('255.255.255.255');
-  return Array.from(new Set(t));
-}
-
 /**
- * Broadcast the discovery probe on `port` (the agent port) and collect box
- * replies for `timeoutMs`. Resolves the deduped list (by IP). Throws only when
- * the native UDP module is missing; a bind/send failure resolves an empty list.
- */
-/**
- * The device's own LAN IPv4, so a scan can derive the /24 DIRECTED broadcast.
- * iOS silently drops the global 255.255.255.255 broadcast, so with only the
- * global target a scan finds nothing on iOS (Android is permissive). Best-effort
- * — resolves undefined if expo-network can't read a usable address.
+ * The device's own LAN IPv4, used to derive the /24 to sweep. Best-effort —
+ * resolves undefined if expo-network can't read a usable address.
  */
 export async function selfIp(): Promise<string | undefined> {
   try {
@@ -78,42 +67,101 @@ export async function selfIp(): Promise<string | undefined> {
   }
 }
 
-/**
- * Every host address in `ip`'s /24 (x.y.z.1 … x.y.z.254). iOS drops UDP
- * broadcast — BOTH the global 255.255.255.255 AND the subnet-directed x.y.z.255
- * — so a broadcast-only scan finds nothing there even on the right subnet.
- * Unicasting the probe to each host is the reliable LAN sweep on iOS (the same
- * path add-by-IP uses); 254 tiny datagrams is cheap. Empty if `ip` is unusable.
- */
-function sweepTargets(ip?: string): string[] {
-  if (!ip) return [];
+/** The "x.y.z." prefix of `ip`'s /24, or null when unusable. */
+function subnetBase(ip?: string): string | null {
+  if (!ip) return null;
   const m = /^(\d+)\.(\d+)\.(\d+)\.\d+$/.exec(ip);
-  if (!m) return [];
-  const base = `${m[1]}.${m[2]}.${m[3]}.`;
-  const out: string[] = [];
-  for (let h = 1; h <= 254; h++) out.push(base + h);
-  return out;
+  return m ? `${m[1]}.${m[2]}.${m[3]}.` : null;
 }
 
-export async function scanForBoxes(
-  opts: { ip?: string; port?: number; timeoutMs?: number } = {},
+/** The /24 directed broadcast for a LAN IP, plus the global broadcast. */
+function broadcastTargets(ip?: string): string[] {
+  const t: string[] = [];
+  const base = subnetBase(ip);
+  if (base) t.push(`${base}255`);
+  t.push('255.255.255.255');
+  return Array.from(new Set(t));
+}
+
+/**
+ * Ask one host whether it's a Couchside agent via the unauthenticated
+ * GET /api/ping. Resolves the box or null. Never throws.
+ */
+async function pingHost(ip: string, port: number, timeoutMs: number): Promise<FoundBox | null> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(`http://${ip}:${port}/api/ping`, { signal: ctrl.signal });
+    if (!res.ok) return null;
+    const d = await res.json();
+    if (!d || d.app !== 'couchside-agent') return null;
+    const short = typeof d.host === 'string' && d.host ? d.host : ip;
+    return {
+      name: short,
+      // Prefer the mDNS name for the stored host (survives DHCP changes), but
+      // fall back to the IP we actually reached it on.
+      host: typeof d.host === 'string' && d.host ? `${d.host}.local` : ip,
+      ip,
+      port,
+      version: typeof d.version === 'string' ? d.version : '',
+    };
+  } catch {
+    return null; // unreachable / not an agent / timed out
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * HTTP-sweep every host in `base`'s /24 for the agent's /api/ping, `conc` at a
+ * time. Dead IPs just time out; live agents answer in milliseconds.
+ */
+async function httpSweep(
+  base: string,
+  port: number,
+  perHostTimeoutMs: number,
 ): Promise<FoundBox[]> {
-  if (!dgram) throw new Error('Box discovery needs a fresh native build of the app');
-  const port = opts.port ?? DEFAULT_PORT;
-  const timeoutMs = opts.timeoutMs ?? 3000;
+  const ips: string[] = [];
+  for (let h = 1; h <= 254; h++) ips.push(base + h);
+  const found: FoundBox[] = [];
+  const CONC = 64;
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      const i = next++;
+      if (i >= ips.length) return;
+      const box = await pingHost(ips[i], port, perHostTimeoutMs);
+      if (box) found.push(box);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONC, ips.length) }, worker));
+  return found;
+}
+
+/**
+ * UDP probe: broadcast (directed + global) and collect replies for `timeoutMs`.
+ * Resolves an empty list on any failure — the HTTP sweep is the reliable path.
+ */
+function udpProbe(myIp: string | undefined, port: number, timeoutMs: number): Promise<FoundBox[]> {
+  if (!dgram) return Promise.resolve([]);
   const probe = Buffer.from(PROBE);
-  const myIp = opts.ip ?? (await selfIp());
-  // iOS drops UDP broadcast (global AND directed), so a broadcast-only scan
-  // finds nothing there. Unicast-sweep the phone's /24 (reliable on iOS), and
-  // keep the broadcasts for Android where they're one fast packet.
-  const targets = [...broadcastTargets(myIp), ...sweepTargets(myIp)];
+  const targets = broadcastTargets(myIp);
 
   return new Promise<FoundBox[]>((resolve) => {
-    const socket = dgram!.createSocket({ type: 'udp4' });
-    const found = new Map<string, FoundBox>(); // by IP
+    let socket: ReturnType<NonNullable<typeof dgram>['createSocket']>;
+    try {
+      socket = dgram!.createSocket({ type: 'udp4' });
+    } catch {
+      resolve([]);
+      return;
+    }
+    const found = new Map<string, FoundBox>();
     let timer: ReturnType<typeof setTimeout> | null = null;
+    let done = false;
 
     const finish = () => {
+      if (done) return;
+      done = true;
       if (timer) clearTimeout(timer);
       timer = null;
       try {
@@ -142,25 +190,52 @@ export async function scanForBoxes(
       }
     });
 
-    socket.bind(0, (bindErr?: Error) => {
-      if (bindErr) {
-        finish();
-        return;
-      }
-      try {
-        socket.setBroadcast(true);
-      } catch {
-        // some platforms reject before the first send; the send still works
-      }
-      try {
-        for (const addr of targets) {
-          socket.send(probe, 0, probe.length, port, addr, () => {});
+    try {
+      socket.bind(0, (bindErr?: Error) => {
+        if (bindErr) {
+          finish();
+          return;
         }
-      } catch {
-        finish();
-        return;
-      }
-      timer = setTimeout(finish, timeoutMs);
-    });
+        try {
+          socket.setBroadcast(true);
+        } catch {
+          // some platforms reject this before the first send
+        }
+        for (const addr of targets) {
+          try {
+            socket.send(probe, 0, probe.length, port, addr, () => {});
+          } catch {
+            // a blocked target must not abort the rest
+          }
+        }
+        timer = setTimeout(finish, timeoutMs);
+      });
+    } catch {
+      finish();
+    }
   });
+}
+
+/**
+ * Discover Couchside boxes on the LAN. Runs the HTTP sweep and the UDP probe
+ * together and merges by IP (HTTP wins, since it proves the agent answered).
+ * Throws only when no usable local IP could be determined AND UDP is absent.
+ */
+export async function scanForBoxes(
+  opts: { ip?: string; port?: number; timeoutMs?: number } = {},
+): Promise<FoundBox[]> {
+  const port = opts.port ?? DEFAULT_PORT;
+  const timeoutMs = opts.timeoutMs ?? 3000;
+  const myIp = opts.ip ?? (await selfIp());
+  const base = subnetBase(myIp);
+
+  const [sweep, udp] = await Promise.all([
+    base ? httpSweep(base, port, 1500) : Promise.resolve([]),
+    udpProbe(myIp, port, Math.min(timeoutMs, 2500)),
+  ]);
+
+  const found = new Map<string, FoundBox>();
+  for (const b of udp) found.set(b.ip, b);
+  for (const b of sweep) found.set(b.ip, b); // HTTP result wins
+  return Array.from(found.values());
 }


### PR DESCRIPTION
**Third and final root cause.** Verified on-device (iPhone, build 48):

- The app **can** reach a box over the LAN — the in-app connection test hит `GET /api/ping` at `10.1.1.195:8787` and read back `couchside-agent v2.9.12`. So Local Network permission is granted and TCP/HTTP works.
- Every **UDP** probe returns nothing: global broadcast (#83), subnet-directed broadcast (#84), and per-host unicast sweep (#85) all found zero, even though steamdeck answers those exact probes from a Mac on the same subnet, and the sweep targeted the correct `10.1.1.94/24`.
- The native UDP module **is** linked into the IPA (`UdpSockets`, `GCDAsyncUdpSocket`) — its errors were just swallowed by the scan and surfaced as "no boxes found".

**Fix:** discover via an **HTTP sweep** of the phone's /24 for the agent's unauthenticated `GET /api/ping` (64 concurrent, 1.5 s/host) — the exact request already proven to work on iOS. The UDP probe is kept and merged as a fast path where it works (Android). `scanAvailable` no longer gates on the native UDP module.

App-only; no agent change (uses the existing `/api/ping`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)