### PR TITLE
feat(wake): WoL relay through an awake box + real build number

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.12"
+VERSION = "2.9.13"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -7861,6 +7861,23 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 result = ({"started": True, "log": "/tmp/couchside-update.log"}
                           if self.mock else update_apply())
+                self._send(200, result, started)
+                return
+
+            # POST /api/wol {"mac": "..."}: broadcast a Wake-on-LAN magic packet
+            # from THIS box, on behalf of a phone that cannot send one itself.
+            # iOS blocks UDP for apps entirely (broadcast AND unicast), so the
+            # phone's own magic packet never leaves the device; an already-awake
+            # box on the same LAN relays it to wake a sleeping sibling. Reveals
+            # nothing and needs the bearer token like any other control call.
+            if path == "/api/wol":
+                mac = body.get("mac") if isinstance(body, dict) else None
+                if not isinstance(mac, str) or not mac.strip():
+                    self._send(400, {"ok": False, "error": "mac required"}, started)
+                    return
+                result = ({"ok": True, "exit_code": 0, "stdout": "[mock] wol\n",
+                           "stderr": "", "duration_ms": 1}
+                          if self.mock else _wol_send(mac.strip()))
                 self._send(200, result, started)
                 return
 

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.3",
+    "version": "2.9.4",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -84,16 +84,21 @@ function pairingUrl(box: Box): string {
  */
 const QR_SIZE = 232;
 
-// About-row app version. `expoConfig` is embedded in store builds, so it
-// reflects the installed binary: the marketing version plus the native build
-// number (iOS buildNumber / Android versionCode).
-const APP_VERSION = Constants.expoConfig?.version ?? '—';
+// About-row app version. Read the NATIVE values — CFBundleShortVersionString /
+// CFBundleVersion on iOS, versionName / versionCode on Android — because
+// `expoConfig` is baked from app.json when the JS bundle is built and can lag
+// the actual binary: a TestFlight build 46 install reported "build 45", which
+// sent us chasing a phantom install problem. expoConfig is only a fallback
+// (e.g. Expo Go, where the native values are the host app's).
+const APP_VERSION =
+  Constants.nativeApplicationVersion ?? Constants.expoConfig?.version ?? '—';
 const APP_BUILD =
-  Platform.OS === 'ios'
+  Constants.nativeBuildVersion ??
+  (Platform.OS === 'ios'
     ? Constants.expoConfig?.ios?.buildNumber ?? ''
     : Constants.expoConfig?.android?.versionCode != null
       ? String(Constants.expoConfig.android.versionCode)
-      : '';
+      : '');
 
 // couchside.tv setup guide — how to install the agent on a box. New users who
 // grabbed the app from a store land here with no idea a box-side agent exists.

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -11,7 +11,7 @@ import { api, capsEqual, Displays, hostKey, PowerSchedule, Screensaver, Status, 
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac } from '@/lib/settings';
-import { useSettings } from '@/lib/SettingsContext';
+import { useBoxes, useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 import { sendWol, wolAvailable } from '@/lib/wol';
@@ -180,6 +180,9 @@ export function RemotePowerBar() {
   const styles = useThemedStyles(makeStyles);
   const insets = useSafeAreaInsets();
   const { settings, ready, update } = useSettings();
+  // Other boxes in the fleet are potential Wake-on-LAN relays: iOS blocks UDP
+  // for apps, so an awake box must broadcast the magic packet for a sleeping one.
+  const { boxes, activeBoxId } = useBoxes();
   const configured = settings.host.trim().length > 0;
   const [open, setOpen] = React.useState(false);
   const [sliderOpen, setSliderOpen] = React.useState(false);
@@ -460,23 +463,53 @@ export function RemotePowerBar() {
     hapticLight();
     setWaking(true);
     void (async () => {
-      try {
-        const ok = await sendWol(mac, { ip: settings.lastIp });
-        if (ok) {
-          hapticSuccess();
-          status.refresh();
-        } else {
-          hapticError();
-          Alert.alert('Wake failed', 'No magic packet could be sent on this network.');
+      let ok = false;
+      let phoneErr: string | null = null;
+
+      // 1) Relay through any OTHER box that's awake (agent >= 2.9.13). This is
+      //    the only path that works on iOS, where the OS blocks UDP for apps
+      //    entirely so the phone's own magic packet never leaves the device.
+      //    Asleep / older / unreachable boxes just fail and we try the next.
+      for (const b of boxes) {
+        if (b.id === activeBoxId) continue;
+        try {
+          const r = await api.wolRelay(
+            { host: b.host, port: b.port, token: b.token, lastIp: b.lastIp },
+            mac,
+          );
+          if (r?.ok) {
+            ok = true;
+            break;
+          }
+        } catch {
+          // that box can't relay — try the next one
         }
-      } catch (e: unknown) {
-        hapticError();
-        Alert.alert('Wake failed', e instanceof Error ? e.message : String(e));
-      } finally {
-        setWaking(false);
       }
+
+      // 2) Fall back to broadcasting from the phone (works on Android).
+      if (!ok && wolAvailable) {
+        try {
+          ok = await sendWol(mac, { ip: settings.lastIp });
+        } catch (e: unknown) {
+          phoneErr = e instanceof Error ? e.message : String(e);
+        }
+      }
+
+      if (ok) {
+        hapticSuccess();
+        status.refresh();
+      } else {
+        hapticError();
+        Alert.alert(
+          'Wake failed',
+          phoneErr ??
+            'No magic packet could be sent. Keep another box awake to wake this one — ' +
+              'iOS blocks phones from broadcasting wake packets directly.',
+        );
+      }
+      setWaking(false);
     })();
-  }, [settings.mac, settings.lastIp, status]);
+  }, [settings.mac, settings.lastIp, status, boxes, activeBoxId]);
 
   if (!ready || !configured) return null;
 
@@ -495,7 +528,9 @@ export function RemotePowerBar() {
   const canSourceBox = reachable && tv?.source_box === true;
   const canBlankScreen = reachable && tv?.screen_toggle === true;
   const canSuspend = reachable && hasSuspend;
-  const canWake = !reachable && !!settings.mac && wolAvailable;
+  // Wake works either from the phone's own broadcast (Android) or by relaying
+  // through another box in the fleet — the only route on iOS, which blocks UDP.
+  const canWake = !reachable && !!settings.mac && (wolAvailable || boxes.length > 1);
   const hasSaver = reachable && saver?.available === true;
   const hasCouch = reachable && displays?.available === true;
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -974,6 +974,22 @@ export const api = {
   },
 
   /**
+   * Ask THIS (awake) box to broadcast a Wake-on-LAN magic packet for `mac`,
+   * waking a different, sleeping box on the same LAN (agent >= 2.9.13).
+   *
+   * Needed because iOS blocks UDP for apps outright — broadcast AND unicast —
+   * so the phone's own magic packet never leaves the device. An awake box does
+   * it instead. 404s on older agents; callers fall back to the phone's own
+   * broadcast (which does work on Android).
+   */
+  wolRelay(settings: ConnSettings, mac: string): Promise<ActionResult> {
+    return request<ActionResult>(settings, '/api/wol', {
+      method: 'POST',
+      body: { mac },
+    });
+  },
+
+  /**
    * Image source for a Steam game's library cover art (agent >= 2.7.1). The
    * agent serves the art from the box's OWN local Steam cache, so the phone
    * never contacts Steam or any CDN — the app stays LAN-only (see PRIVACY.md).


### PR DESCRIPTION
Two fixes that both fall out of the iOS-blocks-UDP discovery (see #86).

## Wake-on-LAN relay (agent 2.9.13)
`lib/wol.ts` sends the magic packet by **UDP broadcast** — the exact thing iOS blocks for apps — so waking a sleeping box was silently impossible on iOS (`sendWol` resolved without erroring).

- **Agent:** new authenticated `POST /api/wol {"mac"}` that broadcasts the packet from *this* box (reuses the existing `_wol_send`, already used by the TV backends).
- **App:** `api.wolRelay()`; on wake, try every **other** box in the fleet as a relay first, then fall back to the phone's own broadcast (still the fast path on Android). 404/asleep boxes are skipped silently.
- `canWake` no longer requires the native UDP module — a relay is enough.

## Real build number
The about row read `expoConfig.ios.buildNumber`, which is baked from app.json when the JS bundle is built and can lag the actual binary — a **TestFlight build 46 install reported "build 45"**, which cost real debugging time chasing a phantom install problem. Now reads `Constants.nativeApplicationVersion` / `nativeBuildVersion` (CFBundleShortVersionString / CFBundleVersion; versionName / versionCode), with expoConfig only as an Expo-Go fallback.

App **2.9.3 → 2.9.4**, agent **2.9.12 → 2.9.13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)