### PR TITLE
fix(about): read build number from expo-application (the #87 fix was a no-op)

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1,4 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Application from 'expo-application';
 import Constants from 'expo-constants';
 import * as Linking from 'expo-linking';
 import { useLocalSearchParams, useRouter } from 'expo-router';
@@ -90,10 +91,16 @@ const QR_SIZE = 232;
 // the actual binary: a TestFlight build 46 install reported "build 45", which
 // sent us chasing a phantom install problem. expoConfig is only a fallback
 // (e.g. Expo Go, where the native values are the host app's).
+//
+// These come from expo-application. `Constants.nativeBuildVersion` does NOT
+// exist in SDK 57 — expo-constants only carries a deprecation note pointing
+// here — and reading it off Constants silently yields undefined (it typechecks
+// only because those manifest types have a `Record<string, any>` index
+// signature), which would quietly reinstate the very bug this fixes.
 const APP_VERSION =
-  Constants.nativeApplicationVersion ?? Constants.expoConfig?.version ?? '—';
+  Application.nativeApplicationVersion ?? Constants.expoConfig?.version ?? '—';
 const APP_BUILD =
-  Constants.nativeBuildVersion ??
+  Application.nativeBuildVersion ??
   (Platform.OS === 'ios'
     ? Constants.expoConfig?.ios?.buildNumber ?? ''
     : Constants.expoConfig?.android?.versionCode != null

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
         "@expo/vector-icons": "^15.0.2",
         "buffer": "^6.0.3",
         "expo": "~57.0.1",
+        "expo-application": "~57.0.2",
         "expo-build-properties": "~57.0.2",
         "expo-constants": "~57.0.2",
         "expo-font": "~57.0.0",
@@ -3759,6 +3760,15 @@
         "react-native-webview": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-application": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-57.0.2.tgz",
+      "integrity": "sha512-q31YwcXyymviAmdrtDfAg3Dld4VMxLCNAfgMHip7vZpPX4lzF/AfwsywqBJUAjQnJknzaNAkzqvMVjO5XmKYDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-asset": {

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
     "@expo/vector-icons": "^15.0.2",
     "buffer": "^6.0.3",
     "expo": "~57.0.1",
+    "expo-application": "~57.0.2",
     "expo-build-properties": "~57.0.2",
     "expo-constants": "~57.0.2",
     "expo-font": "~57.0.0",


### PR DESCRIPTION
**#87's build-number fix did not work.** It read `Constants.nativeApplicationVersion` / `Constants.nativeBuildVersion` — **neither exists on `Constants` in SDK 57**. `expo-constants` carries only a `@deprecated` note pointing at `expo-application`; there's no such runtime export or type field.

So both were `undefined`, the code fell straight back to the same lagging `expoConfig` values, and the **"build 45 on a build 46 install"** bug would have survived untouched.

It compiled clean only because the manifest types carry a `Record<string, any>` index signature, so *any* property access typechecks. Verified against the installed SDK 57 type surface (`app/AGENTS.md` says to check the v57 docs first — this is exactly why).

**Fix:** use `expo-application`'s `nativeApplicationVersion` / `nativeBuildVersion` (`string | null`, the sanctioned SDK 57 API), with `expoConfig` retained only as the Expo Go fallback. Adds `expo-application@~57.0.2` (native module → needs a fresh build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)