### PR TITLE
fix(setup): 'Set up a box' opens the install command directly

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -109,7 +109,7 @@ const APP_BUILD =
 
 // couchside.tv setup guide — how to install the agent on a box. New users who
 // grabbed the app from a store land here with no idea a box-side agent exists.
-const SETUP_GUIDE_URL = 'https://couchside.tv/#how';
+const SETUP_GUIDE_URL = 'https://couchside.tv/#install';
 
 function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void }) {
   const styles = useThemedStyles(makeStyles);


### PR DESCRIPTION
**Reported:** the "Set up a box" button lands on the wrong part of couchside.tv — users have to hunt for the install script.

**Cause:** the button opened `https://couchside.tv/#how`, which is the **top of the three-steps section**; the actual one-line installer sits well below it. Compounding it, the site had a `position: sticky` nav and **no `scroll-margin` anywhere**, so every deep link scrolled its target to y=0 *underneath* the nav.

**Fixed in two places:**
- **couchside.tv** (ets3d `ac65bf4`, deployed + verified live on all 13 hostnames): `id="install"` on the step carrying the install command, plus `[id] { scroll-margin-top: 84px }` so anchors clear the ~69px sticky nav site-wide.
- **App (here):** point `SETUP_GUIDE_URL` at `https://couchside.tv/#install`.

Verified in a browser at 375×812: the jump puts the step at y=84 (15px clear of the nav) with the install command **fully on screen**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)