### PR TITLE
copy(app): rename agent -> service + fix stale/under-selling copy

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -147,8 +147,8 @@ function ActionsScreen() {
           <View style={styles.emptyCard}>
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -130,7 +130,7 @@ function ConsoleScreen() {
             {s?.hostname ?? (configured ? settings.host : 'Couchside')}
           </Text>
           <Text style={styles.headerSub}>
-            {reachable ? `agent v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
+            {reachable ? `service v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
           </Text>
         </View>
 
@@ -139,8 +139,8 @@ function ConsoleScreen() {
           <View style={styles.emptyCard}>
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -558,8 +558,8 @@ function LaunchScreen() {
             <Ionicons name="rocket" size={40} color={t.textFaint} />
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -314,7 +314,7 @@ function BoxEditPanel({
     setAuthStep({ state: 'running' });
     try {
       const st = await api.status(s);
-      setAuthStep({ state: 'ok', detail: `${st.hostname} · agent v${st.agent_version}` });
+      setAuthStep({ state: 'ok', detail: `${st.hostname} · service v${st.agent_version}` });
     } catch (e: unknown) {
       setAuthStep({ state: 'fail', detail: errDetail(e) });
     }
@@ -754,7 +754,7 @@ function SetupBody() {
         const st = await api.status(s);
         setAuthStep({
           state: 'ok',
-          detail: `${st.hostname} · agent v${st.agent_version}`,
+          detail: `${st.hostname} · service v${st.agent_version}`,
         });
         setAgentVersion(st.agent_version);
       } catch (e: unknown) {
@@ -869,8 +869,8 @@ function SetupBody() {
         {boxes.length === 0 ? (
           <View style={styles.card}>
             <Text style={styles.emptyText}>
-              No boxes yet. Pair your first machine below: enter its host, port,
-              and token, or scan a QR from the agent.
+              No boxes yet. Tap Scan for boxes below — your box shows a PIN on its
+              own screen and you type it here. No IP or token needed.
             </Text>
             {/* The box needs the agent installed before it can be paired at
                 all — surface the setup guide right where a new user gets stuck. */}
@@ -882,7 +882,7 @@ function SetupBody() {
               style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
               <Ionicons name="hardware-chip-outline" size={15} color={t.blue} />
               <Text style={styles.emptyLinkText}>
-                Haven&apos;t installed the agent? Setup guide
+                Haven&apos;t installed the Couchside service? Setup guide
               </Text>
               <Ionicons name="open-outline" size={13} color={t.blue} />
             </Pressable>
@@ -1063,7 +1063,7 @@ function SetupBody() {
           <StepRow label="2 · /api/status (Bearer token)" step={authStep} />
           {agentVersion != null && (
             <View style={styles.versionRow}>
-              <Text style={styles.versionLabel}>agent version</Text>
+              <Text style={styles.versionLabel}>service version</Text>
               <Text style={styles.versionValue}>{agentVersion}</Text>
             </View>
           )}
@@ -1318,7 +1318,7 @@ function SetupBody() {
               />
               <TogglePref
                 label="Ask before switching control"
-                sub="When another phone joins a box you're controlling, it asks and you tap Pass — instead of taking over instantly. Needs agent 2.9.2+."
+                sub="When another phone joins a box you're controlling, it asks and you tap Pass — instead of taking over instantly. Needs the Couchside service 2.9.2 or newer."
                 value={askToSwitchControl}
                 onValueChange={(v) => {
                   void setPref('askToSwitchControl', v);
@@ -1414,7 +1414,7 @@ function SetupBody() {
               <View style={styles.rateBody}>
                 <Text style={styles.rateTitle}>Set up a box</Text>
                 <Text style={styles.rateSub}>
-                  Install the agent — instructions at couchside.tv.
+                  Install the Couchside service — instructions at couchside.tv.
                 </Text>
               </View>
               <Ionicons name="open-outline" size={16} color={t.textDim} />
@@ -1429,7 +1429,7 @@ function SetupBody() {
             </View>
 
             <Text style={styles.hint}>
-              Each agent listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
+              Each box&apos;s Couchside service listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
               /api/ping require the bearer token.
             </Text>
           </>

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -104,10 +104,10 @@ export function AgentUpdateBanner() {
           {checking
             ? 'Checking…'
             : status == null
-              ? 'Agent updates'
+              ? 'Service updates'
               : status.available
-                ? `Update available — agent ${status.latest}`
-                : `Up to date — agent ${status.installed}`}
+                ? `Update available — service ${status.latest}`
+                : `Up to date — service ${status.installed}`}
         </Text>
         <Pressable
           onPress={() => {
@@ -129,7 +129,7 @@ export function AgentUpdateBanner() {
       <View style={styles.header}>
         <Ionicons name="arrow-up-circle" size={18} color={t.blue} />
         <Text style={styles.title} numberOfLines={1}>
-          Agent update available{check.latest ? ` — ${check.latest}` : ''}
+          Box update available{check.latest ? ` — ${check.latest}` : ''}
         </Text>
         {!applying && (
           <Pressable

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -101,7 +101,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
         ok: false,
         text:
           e instanceof ApiError && e.kind === 'http' && e.status === 404
-            ? 'This box’s agent is too old to scan — update it, or enter the IP below.'
+            ? 'This box’s Couchside service is too old to scan — update it, or enter the IP below.'
             : 'Scan failed — enter the IP below.',
       });
     } finally {
@@ -184,8 +184,9 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     <View style={styles.card}>
       <Text style={styles.title}>Smart TV remote</Text>
       <Text style={styles.sub}>
-        Control a networked TV — LG webOS, Samsung, Roku, or Google TV — from the Pad tab. The
-        D-pad and on-screen keyboard light up once it’s connected.
+        Control a networked TV — LG webOS, Samsung, Roku, Google TV, or Hisense — from the Pad
+        tab. The D-pad, SOURCE key, volume, power, and on-screen keyboard all light up once it’s
+        connected, and your phone’s volume buttons drive the TV too.
       </Text>
 
       {active ? (


### PR DESCRIPTION
User feedback: **"agent" makes people think of AI.** For a program you install on your gaming PC via `curl | bash`, that invites exactly the wrong worry. Renamed to **"service"** in user-facing copy — literally accurate (systemd service / Windows service), understood by both audiences, and reassuringly boring.

**Deliberately NOT renamed** (wire/protocol — renaming breaks installers + update checks in the field): the `couchside-agent` string in `/api/ping`, `agent-version.txt`, `couchside.service`, `agent_version` JSON fields, and all code identifiers.

Found via a parallel audit of the app, site, docs and Decky plugin. Also fixed here:

| Gap | Why it mattered |
|---|---|
| Pairing empty state said "enter its host, port, and token, or scan a QR" | Scan + on-screen PIN has been the primary flow since 2.9.12; host/port/token is collapsed behind "Add by IP (advanced)". New users were pointed at the advanced fallback. |
| Smart TV blurb listed 4 brands | The selector one line below renders **5** — Hisense shipped but unadvertised |
| Same blurb claimed only "D-pad and on-screen keyboard" | Omitted SOURCE key, TV volume, TV power, and phone hardware volume buttons |
| Three "No box configured" empty states | The app's only first-run pitch, and it never mentioned TV control |

Remaining audit findings (site, README, Decky, store listings) are tracked separately — two of them need a product decision (pricing, Samsung Tizen validation status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)