### PR TITLE
copy(docs): agent -> service + document shipped features in README/store

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -2,13 +2,13 @@
 
 *Last updated: July 2026*
 
-Couchside is a companion app for a small open-source agent you install on your own Linux home-theater PC. The short version: **we don't collect anything, because there is nothing to collect.**
+Couchside is a companion app for a small open-source service you install on your own Linux home-theater PC. The short version: **we don't collect anything, because there is nothing to collect.**
 
-- The app communicates **only** with the Couchside agent running on your own machine, over your own local network. There is no cloud service, no relay server, and no third-party endpoint of any kind.
-- **Steam cover art** shown on the Launch tab is served by your own agent from the box's local Steam cache. The app never contacts Steam or any content-delivery network for images.
+- The app communicates **only** with the Couchside service running on your own machine, over your own local network. There is no cloud service, no relay server, and no third-party endpoint of any kind.
+- **Steam cover art** shown on the Launch tab is served by your own service from the box's local Steam cache. The app never contacts Steam or any content-delivery network for images.
 - **No data is collected.** No analytics, no crash reporting, no telemetry, no advertising identifiers.
 - **No accounts.** There is nothing to sign up for and no personal information is ever requested.
-- The pairing token you use to authenticate with your agent is stored in the **iOS Keychain** on your device and is sent only to your agent.
+- The pairing token you use to authenticate with your service is stored in the **iOS Keychain** on your device and is sent only to your service.
 - The **camera is not used** by the app. QR pairing uses the standard iPhone camera app, which opens Couchside via a deep link.
 - No third-party SDKs or services process your data, because your data never leaves your local network.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Your phone is the dashboard, remote console, and game controller for your living-room Linux box.**
 
-Couchside pairs a native iOS & Android app with a tiny, dependency-free Python agent that runs on a SteamOS / Bazzite HTPC, a Steam Deck, or any systemd Linux machine. When gamescope wedges into a black screen and the TV shows nothing, Couchside is the screen: see live vitals, read the logs, restart the display session, or become an Xbox 360 controller, all from the couch and entirely on your own LAN. No cloud, no accounts, no analytics.
+Couchside pairs a native iOS & Android app with a tiny, dependency-free Python service that runs on a SteamOS / Bazzite HTPC, a Steam Deck, or any systemd Linux machine. When gamescope wedges into a black screen and the TV shows nothing, Couchside is the screen: see live vitals, read the logs, restart the display session, or become an Xbox 360 controller, all from the couch and entirely on your own LAN. No cloud, no accounts, no analytics.
 
 ## See it in action
 
@@ -25,37 +25,45 @@ The gamepad UI on the phone and the Steam sidebar responding on the TV, at the s
 ## Features
 
 - **Live console:** hostname, uptime, CPU temperature, load averages, memory and per-disk usage with color-coded bars, refreshed every few seconds. A big red BOX UNREACHABLE banner (with last-seen time) when the box drops off the network, which is exactly when you need it.
-- **systemd unit health:** a watchlist of system and user units (display manager, the Couchside agent itself, your own services) with active/failed state at a glance.
-- **One-tap runbook actions:** grouped by danger level, every action confirmed before it runs and *double*-confirmed if it's destructive:
+- **systemd unit health:** a watchlist of system and user units (display manager, the Couchside service itself, your own services) with active/failed state at a glance.
+- **One-tap runbook actions:** grouped by what they interrupt, every action confirmed before it runs and *double*-confirmed when it ends your session:
   - **Restart display session** fixes the classic wedged-gamescope black screen without touching anything else.
   - **Reboot** / **Power off** are clean and fire-and-forget.
 - **Journal viewer:** the last journald lines for any watchlist unit, newest first, straight from the phone.
-- **Virtual game controller:** the agent creates a real virtual **Xbox 360 pad** via `/dev/uinput`; games and Steam Big Picture see genuine wired-360 input. Four input modes, switchable with one tap:
+- **Virtual game controller:** the service creates a real virtual **Xbox 360 pad** via `/dev/uinput`; games and Steam Big Picture see genuine wired-360 input. Four input modes, switchable with one tap:
   - **Gamepad:** full layout with dual analog sticks, D-pad, ABXY, bumpers, analog triggers, Start/Select/Guide, and haptic feedback.
   - **Swipe:** an Apple-TV-remote-style surface. Swipe to move through menus, tap to select, plus Back / Guide / Menu buttons. Perfect for Kodi and Big Picture navigation.
   - **Trackpad:** a relative-mouse trackpad with tap-to-click, two-finger right-click and scroll, for desktop sessions.
   - **Remote:** a classic TV-remote layout — a big circular D-pad with OK, Back/Menu/Home/Settings keys, volume and brightness rockers, and Steam/QAM shortcuts. On an RS-232 panel it adds input-source buttons and a BOX/TV toggle that drives either the box (as the virtual gamepad) or the TV's own factory remote over serial.
-- **QR pairing:** the installer prints a QR code; scan it with the phone camera and the app opens with host, port, and token prefilled.
+- **Pairing without typing:** tap **Scan for boxes** and Couchside finds them on your network; the one you pick shows a **PIN on its own screen** and you type that in. The installer's QR code still works, and host/port/token lives behind *Add by IP (advanced)* for anyone who wants it.
+- **Multi-box Fleet:** pair as many machines as you like and switch between them from the Fleet tab — each remembers its own input mode and volume target.
+- **Couch Mode:** hand a desktop session off to the TV and into Steam Game Mode from the phone, then back again.
+- **Media keys and now-playing:** MPRIS transport control (play/pause/next/previous) with the current track surfaced in the app.
+- **Steam download progress**, **live screen preview**, and an **aerial screensaver** you can start from the couch.
+- **Controller handoff:** when a second phone joins a box you're already driving, it asks and you tap Pass — instead of silently stealing input.
+- **Stay current from the couch:** the app can ask the box whether a newer signed release exists and — if you opted in at the box — install it, verifying the maintainer signature first.
+- **Wake a sleeping box:** send a Wake-on-LAN magic packet from the phone, or have an **already-awake box wake a sleeping one** for you (the only route on iOS, where the OS blocks apps from broadcasting).
 - **Volume, mute, and box power.** A control next to the device picker adjusts the box's own OS volume and mute (a real drag-to-set 0–100 slider on SteamOS/Bazzite). On an HDMI-CEC or RS-232 setup you can switch it to drive the TV/panel instead — and on an RS-232 panel, also switch the display's input source, blank the screen without cutting power to an OPS box, and pass factory-remote keys. The same control suspends the box and, once it is offline, wakes it back up with a Wake-on-LAN magic packet.
 
 ## Control your TV
 
-Couchside can also drive a **networked smart TV directly** — no HDMI-CEC and no serial cable. Add one under **Setup → Boxes → Smart TV remote**; the D-pad and on-screen keyboard on the Pad tab light up once it's connected.
+Couchside can also drive a **networked smart TV directly** — no HDMI-CEC and no serial cable. Add one under **Setup → Boxes → Smart TV remote**: tap **Scan for TVs** and Couchside finds the sets on your network, so you don't have to hunt for an IP (you can still type one). Once it's connected the Pad tab lights up with the D-pad, **power, volume, the input/SOURCE key**, and an on-screen keyboard — and your phone's own **volume buttons** drive the TV too.
 
 - **LG webOS** — enter the TV's IP, then accept the pairing prompt that appears on the TV (once). An optional MAC address enables Wake-on-LAN power-on.
 - **Samsung (Tizen)** _(beta — not yet validated on real hardware)_ — enter the IP, then approve the "Allow" prompt on the TV. Optional MAC for Wake-on-LAN.
 - **Roku** — enter the IP; no pairing. **If the D-pad doesn't respond after adding, the Roku is blocking app control:** on the Roku, set _Settings → System → Advanced system settings → Control by mobile apps → Network access_ to **Permissive**.
 - **Android / Google TV** — enter the IP, then type the 6-digit code the TV shows. Optional MAC for Wake-on-LAN.
+- **Hisense (VIDAA)** — enter the IP, then approve the pairing code the TV displays. Note that Hisense sets running **Google TV** pair as Android / Google TV above, not as VIDAA.
 
-These network backends run on the Linux agent. The Windows agent supports **Roku** (from `0.3.6-win`); LG/Samsung/Google TV are Linux-only for now. TV control also works **through the box** when it has an HDMI-CEC link or an RS-232 serial panel (power, volume, input source, on-screen remote) — see the volume/power control above.
+These network backends run on the Linux service. The Windows service supports **Roku** (from `0.3.6-win`); LG / Samsung / Google TV / Hisense are Linux-only for now. TV control also works **through the box** when it has an HDMI-CEC link or an RS-232 serial panel (power, volume, input source, on-screen remote) — see the volume/power control above.
 
 ## Requirements
 
-- A **SteamOS, Bazzite, or other systemd-based Linux** machine on your home network (HTPC, Steam Deck in desktop/docked use, mini PC…). The agent is pure Python 3 stdlib: no pip, and it works on immutable/ostree systems.
-  - **Windows HTPC?** There's a Windows agent with the same API ([`agent/win/`](agent/win/README.md)) — services, Event Log, Steam launching + Big Picture, volume, and a ViGEm virtual gamepad. Install it in one line from PowerShell: `irm https://couchside.tv/install.ps1 | iex`.
+- A **SteamOS, Bazzite, or other systemd-based Linux** machine on your home network (HTPC, Steam Deck in desktop/docked use, mini PC…). The service is pure Python 3 stdlib: no pip, and it works on immutable/ostree systems.
+  - **Windows HTPC?** There's a Windows service with the same API ([`agent/win/`](agent/win/README.md)) — services, Event Log, Steam launching + Big Picture, volume, and a ViGEm virtual gamepad. Install it in one line from PowerShell: `irm https://couchside.tv/install.ps1 | iex`.
 - An **iPhone or Android phone** on the same LAN.
 
-## Install the agent
+## Install the service
 
 On the box (or over SSH):
 
@@ -63,7 +71,7 @@ On the box (or over SSH):
 curl -fsSL https://couchside.tv/install.sh | bash
 ```
 
-The installer copies the agent to `~/.local/opt/couchside/`, generates a token at `/etc/couchside/token`, installs a scoped sudoers rule, enables `couchside.service`, opens `8787/tcp` in the local firewall, and finishes by printing a pairing QR code.
+The installer copies the service to `~/.local/opt/couchside/`, generates a token at `/etc/couchside/token`, installs a scoped sudoers rule, enables `couchside.service`, opens `8787/tcp` in the local firewall, and finishes by printing a pairing QR code.
 
 ## Get the app
 
@@ -74,20 +82,22 @@ Free 7-day trial with every feature unlocked, then a one-time unlock ($4.99 summ
 
 ## Pairing
 
-**QR (recommended):** point the phone camera at the QR code the installer prints. It's a `couchside://setup?host=…&port=…&token=…` deep link, so the app opens on the Setup tab with everything prefilled and runs a connection test automatically. Nothing is saved until you tap **SAVE**.
+**Scan + PIN (recommended):** on the Setup tab tap **Scan for boxes**. Couchside finds the boxes on your network, and the one you pick shows a **PIN on its own screen** — type that PIN into the app and it pairs itself. No IP, no port, no token to copy. The PIN appearing on the box's own display is the proof that you're the person sitting in front of it.
 
-**Manual:** on the Setup tab enter the host (e.g. `mybox.local`), port (`8787`), and the contents of `/etc/couchside/token`, tap **TEST**, then **SAVE**.
+**QR:** point the phone camera at the QR code the installer prints. It's a `couchside://setup?host=…&port=…&token=…` deep link, so the app opens on the Setup tab with everything prefilled and runs a connection test automatically. Nothing is saved until you tap **SAVE**.
+
+**Manual (advanced):** under **Add by IP (advanced)** enter the host (e.g. `mybox.local`), port (`8787`), and the contents of `/etc/couchside/token`, tap **TEST**, then **SAVE**.
 
 ## Security model
 
 Couchside is deliberately small and boring about security:
 
 - **Bearer token auth.** Every API route except the reachability ping requires `Authorization: Bearer <token>`; the gamepad WebSocket authenticates before the handshake completes. Comparisons are constant-time (`hmac.compare_digest`). The token file is `chmod 600`; on the phone it lives in the iOS Keychain / Android Keystore.
-- **Scoped sudo, nothing more.** The installer writes a `visudo`-validated sudoers rule granting the agent user passwordless sudo for exactly five things: `systemctl restart sddm`, `systemctl reboot`, `systemctl poweroff`, `systemctl suspend`, and `journalctl`. Nothing else. The **privileged** actions are a fixed table; there is no route that runs an arbitrary command **as root**.
+- **Scoped sudo, nothing more.** The installer writes a `visudo`-validated sudoers rule granting the service user passwordless sudo for exactly five things: `systemctl restart sddm`, `systemctl reboot`, `systemctl poweroff`, `systemctl suspend`, and `journalctl`. Nothing else. The **privileged** actions are a fixed table; there is no route that runs an arbitrary command **as root**.
 - **Launchers run as you, and creating them remotely is opt-in.** Beyond the fixed privileged actions, the app can *trigger* launchers — auto-discovered Steam games plus any custom commands the box owner defined. A launcher's command runs as the **desktop user, never root**. Because a custom launcher is an arbitrary command, *creating* one over the network is **off by default**: run `couchside allow-launchers on` to enable it, otherwise a bearer token can only trigger launchers you set up on the box, not mint new ones. (The same token can already synthesize keystrokes through the virtual gamepad, so treat the token as user-level trust on a machine you control — which is why it stays on your LAN.)
 - **Journal access is allowlisted.** Only units on the configured watchlist can be read, with line counts clamped server-side, so a leaked token can't be used to trawl the whole system journal.
-- **LAN-only by design.** The API is plain HTTP on port 8787 and is meant to stay on your local network. The firewall rule opens the port locally; **do not port-forward it**. There is no relay, no cloud endpoint, and the app never talks to anything except your agent.
-- No client-addressable file routes. The agent serves image bytes on two routes only: the album-art image a running media player advertises (realpath-allowlisted, image-sniffed, 2 MiB cap; client passes a player id, never a path) and an on-demand screen-preview frame captured to a tmpfs file that's deleted right after (rate-clamped, off by default in the app). Subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
+- **LAN-only by design.** The API is plain HTTP on port 8787 and is meant to stay on your local network. The firewall rule opens the port locally; **do not port-forward it**. There is no relay, no cloud endpoint, and the app never talks to anything except your service.
+- No client-addressable file routes. The service serves image bytes on two routes only: the album-art image a running media player advertises (realpath-allowlisted, image-sniffed, 2 MiB cap; client passes a player id, never a path) and an on-demand screen-preview frame captured to a tmpfs file that's deleted right after (rate-clamped, off by default in the app). Subprocesses run with `shell=False`, errors return brief JSON, never tracebacks.
 
 ## Uninstall
 
@@ -112,13 +122,13 @@ Then delete the app from your phone.
 
 ```
 agent/   couchsided.py: pure-stdlib Python 3 daemon (HTTP API + gamepad WebSocket)
-agent/win/  Windows port of the agent (same API; SendInput + ViGEmBus)
-app/     Expo / React Native app for iOS & Android (tabs: Console, Actions, Pad, Launch, Setup; the journal viewer lives inside Setup)
+agent/win/  Windows port of the service (same API; SendInput + ViGEmBus)
+app/     Expo / React Native app for iOS & Android (tabs: Console, Fleet, Actions, Pad, Launch, Setup; the journal viewer lives inside Setup)
 docs/    privacy policy, images
 store/   App Store & Google Play metadata, review notes, screenshot plan
 ```
 
-Develop the app without hardware using the agent's mock mode on your Mac:
+Develop the app without hardware using the service's mock mode on your Mac:
 
 ```sh
 python3 agent/couchsided.py --mock --host 127.0.0.1 --port 8787 --token devtoken
@@ -128,9 +138,9 @@ Mock mode serves believable fake data and never executes real commands. The HTTP
 
 ## Pricing & license
 
-**The agent is free and open source. The app's source is public. The official app builds are a free 7-day trial, then a one-time unlock: $4.99 summer launch price, rising to $7.99 on September 1.**
+**The service is free and open source. The app's source is public. The official app builds are a free 7-day trial, then a one-time unlock: $4.99 summer launch price, rising to $7.99 on September 1.**
 
-- **Agent, installer, brand, docs: MIT.** Use them anywhere, for anything — including building your own client against the protocol. See [LICENSE](LICENSE).
+- **Service, installer, brand, docs: MIT.** Use them anywhere, for anything — including building your own client against the protocol. See [LICENSE](LICENSE).
 - **The mobile app (`app/`): source-available under the PolyForm Noncommercial License 1.0.0.** Read it, audit it, `npx expo run:ios` / `npx expo run:android` it onto your own phone, and modify it for personal, noncommercial use. What you can't do is sell it or redistribute it commercially. See [app/LICENSE](app/LICENSE). The trial gate ships in this public source; self-built personal copies without a store build are treated as unlocked by design, and that's fine.
 - **The official builds on the [App Store](https://apps.apple.com/app/id6786884115) and [Google Play](https://play.google.com/store/apps/details?id=com.ets3d.rescueremote) are free to download** with everything unlocked for 7 days, then a **one-time in-app unlock: $4.99 through the summer, rising to $7.99 on September 1**. No subscription, no accounts. Unlock before September 1 to keep a permanent **Early Adopter** badge. You're paying for signed, notarized, auto-updating builds and a setup that goes from `curl` to couch in under ten minutes. It's also the only funding this project has, so thank you.
 

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -147,8 +147,8 @@ function ActionsScreen() {
           <View style={styles.emptyCard}>
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -130,7 +130,7 @@ function ConsoleScreen() {
             {s?.hostname ?? (configured ? settings.host : 'Couchside')}
           </Text>
           <Text style={styles.headerSub}>
-            {reachable ? `agent v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
+            {reachable ? `service v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
           </Text>
         </View>
 
@@ -139,8 +139,8 @@ function ConsoleScreen() {
           <View style={styles.emptyCard}>
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -558,8 +558,8 @@ function LaunchScreen() {
             <Ionicons name="rocket" size={40} color={t.textFaint} />
             <Text style={styles.emptyTitle}>No box configured</Text>
             <Text style={styles.emptyText}>
-              Open the Setup tab to pair with the Couchside agent on your media center or Steam
-              machine.
+              Open the Setup tab to pair with the Couchside service on your media center,
+              Steam machine, or PC — then add your TV for one remote that drives both.
             </Text>
           </View>
         )}

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -314,7 +314,7 @@ function BoxEditPanel({
     setAuthStep({ state: 'running' });
     try {
       const st = await api.status(s);
-      setAuthStep({ state: 'ok', detail: `${st.hostname} · agent v${st.agent_version}` });
+      setAuthStep({ state: 'ok', detail: `${st.hostname} · service v${st.agent_version}` });
     } catch (e: unknown) {
       setAuthStep({ state: 'fail', detail: errDetail(e) });
     }
@@ -754,7 +754,7 @@ function SetupBody() {
         const st = await api.status(s);
         setAuthStep({
           state: 'ok',
-          detail: `${st.hostname} · agent v${st.agent_version}`,
+          detail: `${st.hostname} · service v${st.agent_version}`,
         });
         setAgentVersion(st.agent_version);
       } catch (e: unknown) {
@@ -869,8 +869,8 @@ function SetupBody() {
         {boxes.length === 0 ? (
           <View style={styles.card}>
             <Text style={styles.emptyText}>
-              No boxes yet. Pair your first machine below: enter its host, port,
-              and token, or scan a QR from the agent.
+              No boxes yet. Tap Scan for boxes below — your box shows a PIN on its
+              own screen and you type it here. No IP or token needed.
             </Text>
             {/* The box needs the agent installed before it can be paired at
                 all — surface the setup guide right where a new user gets stuck. */}
@@ -882,7 +882,7 @@ function SetupBody() {
               style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
               <Ionicons name="hardware-chip-outline" size={15} color={t.blue} />
               <Text style={styles.emptyLinkText}>
-                Haven&apos;t installed the agent? Setup guide
+                Haven&apos;t installed the Couchside service? Setup guide
               </Text>
               <Ionicons name="open-outline" size={13} color={t.blue} />
             </Pressable>
@@ -1063,7 +1063,7 @@ function SetupBody() {
           <StepRow label="2 · /api/status (Bearer token)" step={authStep} />
           {agentVersion != null && (
             <View style={styles.versionRow}>
-              <Text style={styles.versionLabel}>agent version</Text>
+              <Text style={styles.versionLabel}>service version</Text>
               <Text style={styles.versionValue}>{agentVersion}</Text>
             </View>
           )}
@@ -1318,7 +1318,7 @@ function SetupBody() {
               />
               <TogglePref
                 label="Ask before switching control"
-                sub="When another phone joins a box you're controlling, it asks and you tap Pass — instead of taking over instantly. Needs agent 2.9.2+."
+                sub="When another phone joins a box you're controlling, it asks and you tap Pass — instead of taking over instantly. Needs the Couchside service 2.9.2 or newer."
                 value={askToSwitchControl}
                 onValueChange={(v) => {
                   void setPref('askToSwitchControl', v);
@@ -1414,7 +1414,7 @@ function SetupBody() {
               <View style={styles.rateBody}>
                 <Text style={styles.rateTitle}>Set up a box</Text>
                 <Text style={styles.rateSub}>
-                  Install the agent — instructions at couchside.tv.
+                  Install the Couchside service — instructions at couchside.tv.
                 </Text>
               </View>
               <Ionicons name="open-outline" size={16} color={t.textDim} />
@@ -1429,7 +1429,7 @@ function SetupBody() {
             </View>
 
             <Text style={styles.hint}>
-              Each agent listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
+              Each box&apos;s Couchside service listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
               /api/ping require the bearer token.
             </Text>
           </>

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -104,10 +104,10 @@ export function AgentUpdateBanner() {
           {checking
             ? 'Checking…'
             : status == null
-              ? 'Agent updates'
+              ? 'Service updates'
               : status.available
-                ? `Update available — agent ${status.latest}`
-                : `Up to date — agent ${status.installed}`}
+                ? `Update available — service ${status.latest}`
+                : `Up to date — service ${status.installed}`}
         </Text>
         <Pressable
           onPress={() => {
@@ -129,7 +129,7 @@ export function AgentUpdateBanner() {
       <View style={styles.header}>
         <Ionicons name="arrow-up-circle" size={18} color={t.blue} />
         <Text style={styles.title} numberOfLines={1}>
-          Agent update available{check.latest ? ` — ${check.latest}` : ''}
+          Box update available{check.latest ? ` — ${check.latest}` : ''}
         </Text>
         {!applying && (
           <Pressable

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -101,7 +101,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
         ok: false,
         text:
           e instanceof ApiError && e.kind === 'http' && e.status === 404
-            ? 'This box’s agent is too old to scan — update it, or enter the IP below.'
+            ? 'This box’s Couchside service is too old to scan — update it, or enter the IP below.'
             : 'Scan failed — enter the IP below.',
       });
     } finally {
@@ -184,8 +184,9 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     <View style={styles.card}>
       <Text style={styles.title}>Smart TV remote</Text>
       <Text style={styles.sub}>
-        Control a networked TV — LG webOS, Samsung, Roku, or Google TV — from the Pad tab. The
-        D-pad and on-screen keyboard light up once it’s connected.
+        Control a networked TV — LG webOS, Samsung, Roku, Google TV, or Hisense — from the Pad
+        tab. The D-pad, SOURCE key, volume, power, and on-screen keyboard all light up once it’s
+        connected, and your phone’s volume buttons drive the TV too.
       </Text>
 
       {active ? (


### PR DESCRIPTION
Second half of the copy pass (app was #92, couchside.tv is deployed).

**Rename:** 44 prose sites across README, PRIVACY, and both store listings. **Protected/untouched:** `agent/` paths, `agent-version*.txt`, `couchside.service`, `couchsided.py`, `couchside-agent`, `agent_version`, and `install.ps1`'s `"Couchside Agent"` scheduled-task name — renaming that would orphan the task on every existing Windows install.

**Substance, found by audit:**

| Gap | Fix |
|---|---|
| Pairing documented QR + manual host/port/token only | **Scan + on-screen PIN** now leads (primary since 2.9.12); QR and Add-by-IP are fallbacks |
| Hisense shipped but undocumented | Added, with the note that Hisense sets running *Google TV* pair as Google TV, not VIDAA |
| Every TV backend said "enter the TV's IP" | **TV discovery** ("Scan for TVs") documented |
| SOURCE key + phone volume buttons missing | Added |
| Store said **"Three modes"** with 3 bullets | There are **four** — the Remote layout was missing from both listings |
| Store had **zero** smart-TV mentions | Added a living-room section, scoped honestly: smart-TV backends are Linux; Roku on Windows |
| Fleet, Couch Mode, media keys, screen preview, screensaver, Steam downloads, controller handoff, update check, WoL relay | All shipped, none documented — added |
| "grouped by danger level" | Now "grouped by what they interrupt", matching the app (#91) |

Samsung keeps its *"beta — not yet validated on real hardware"* caveat pending confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)