### PR TITLE
feat: guide-button hold triggers Couch Mode (agent 2.9.14)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,15 @@ jobs:
             agent/qr.py
           echo "py_compile OK"
 
+      # The guide-hold trigger fires a SESSION SWITCH, which tears down the
+      # user's desktop and any unsaved work. Its two dangerous failure modes —
+      # firing on a tap, and matching the agent's OWN emulated pad (created on
+      # every phone connect) — are invisible to the --mock smoke test below and
+      # otherwise need real hardware plus a controller to catch. Pure stdlib, no
+      # pytest, runs in well under a second.
+      - name: Unit tests (guide-hold trigger)
+        run: python3 tests/test_guide_hold.py
+
   smoke:
     runs-on: ubuntu-latest
     needs: compile
@@ -97,5 +106,23 @@ jobs:
           echo "GET /api/status (token) -> $AUTH_CODE"
           [ "$AUTH_CODE" = "200" ] || { echo "expected /api/status 200 with token, got $AUTH_CODE" >&2; exit 1; }
           python3 -c "import json,sys; json.load(open('$BODY')); print('authed body is valid JSON')"
+
+          # The guide-hold route must be served and authed like any other. In
+          # --mock it answers 200 with a synthetic controller list; on a real box
+          # it 404s when the handoff or evdev is unavailable, which is how the
+          # app decides whether to show the row at all.
+          GBODY="$RUNNER_TEMP/guide.json"
+          GUIDE_CODE=$(curl -s -o "$GBODY" -w '%{http_code}' \
+            -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/api/guide-hold")
+          echo "GET /api/guide-hold (token) -> $GUIDE_CODE"
+          [ "$GUIDE_CODE" = "200" ] || { echo "expected /api/guide-hold 200 in mock, got $GUIDE_CODE" >&2; exit 1; }
+          python3 - "$GBODY" <<'PY'
+          import json, sys
+          d = json.load(open(sys.argv[1]))
+          # Must ship OFF by default: a false trigger destroys unsaved desktop work.
+          assert d["enabled"] is False, "guide-hold must default to disabled"
+          assert isinstance(d["controllers"], list), "controllers must be a list"
+          print("guide-hold body OK (enabled=%s)" % d["enabled"])
+          PY
 
           echo "smoke OK"

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.13"
+VERSION = "2.9.14"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -73,7 +73,12 @@ DEFAULT_PORT = 8787
 #     {"id": "custom:<slug>",                       # id (generated on POST)
 #      "label": "...",                              # required non-empty string
 #      "cmd": ["argv0", "arg1", ...]}               # required non-empty argv
-#   ]
+#   ],
+#   "guide": {                                      # optional; guide-hold trigger
+#     "enabled": false,                             # default false (opt-in)
+#     "hold_ms": 1200,                              # 600..5000, default 1200
+#     "uniq": ""                                    # optional; pin to ONE pad (MAC)
+#   }
 # }
 #
 # The journal allowlist is exactly the configured unit names. On a missing or
@@ -178,6 +183,14 @@ CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
 CONFIG_ROKU = None  # optional {"host","name"} Roku (ECP) TV config
 CONFIG_ANDROIDTV = None  # optional {"host","cert","key","name","mac"} Android TV config
 CONFIG_VIDAA = None  # optional {"host","name","mac"} Hisense VIDAA (MQTT) config
+# Guide-button hold -> Couch Mode. OFF BY DEFAULT: a false positive yanks the
+# user out of their desktop session mid-work. "uniq" optionally pins the trigger
+# to ONE pad, keyed on the evdev U: Uniq field (the pad's OWN MAC) because BT
+# pads RE-ENUMERATE — the /dev/input/eventN number and the uhid sysfs path both
+# change across reconnects, Uniq does not. Empty uniq = any REAL pad.
+GUIDE_MIN_HOLD_MS, GUIDE_MAX_HOLD_MS = 600, 5000
+GUIDE_DEFAULTS = {"enabled": False, "hold_ms": 1200, "uniq": ""}
+CONFIG_GUIDE = dict(GUIDE_DEFAULTS)
 # When true, the app may trigger a box-side agent update via POST
 # /api/update/apply. OFF BY DEFAULT: enabling it lets any holder of the bearer
 # token cause a (signature-verified) install + restart, so it is opt-in and can
@@ -463,8 +476,35 @@ def _parse_config(raw):
                     raise ConfigError("vidaa.%s must be a string" % field)
                 vidaa[field] = val
 
+    # Optional guide-button hold trigger. Validated HERE rather than in the
+    # early opt-in read above so that a config the agent cannot parse leaves the
+    # trigger at its default — which is OFF. That is the fail-safe direction:
+    # the early-read pattern would preserve "on" across an unparseable config.
+    guide = dict(GUIDE_DEFAULTS)
+    guide_raw = raw.get("guide")
+    if guide_raw is not None:
+        if not isinstance(guide_raw, dict):
+            raise ConfigError("guide must be an object")
+        if "enabled" in guide_raw:
+            if not isinstance(guide_raw["enabled"], bool):
+                raise ConfigError("guide.enabled must be a boolean")
+            guide["enabled"] = guide_raw["enabled"]
+        if "hold_ms" in guide_raw:
+            ms = guide_raw["hold_ms"]
+            # bool is a subclass of int; reject it explicitly.
+            if isinstance(ms, bool) or not isinstance(ms, int):
+                raise ConfigError("guide.hold_ms must be an integer")
+            if not GUIDE_MIN_HOLD_MS <= ms <= GUIDE_MAX_HOLD_MS:
+                raise ConfigError("guide.hold_ms must be %d..%d"
+                                  % (GUIDE_MIN_HOLD_MS, GUIDE_MAX_HOLD_MS))
+            guide["hold_ms"] = ms
+        if "uniq" in guide_raw:
+            if not isinstance(guide_raw["uniq"], str):
+                raise ConfigError("guide.uniq must be a string")
+            guide["uniq"] = guide_raw["uniq"].strip()
+
     return (units, actions, order, port, launchers, panel, webos, samsung,
-            roku, androidtv, vidaa)
+            roku, androidtv, vidaa, guide)
 
 
 def load_config(path):
@@ -472,7 +512,7 @@ def load_config(path):
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
     global CONFIG_ROKU, CONFIG_ANDROIDTV, CONFIG_VIDAA, ALLOW_APP_UPDATE
-    global ALLOW_APP_LAUNCHERS
+    global ALLOW_APP_LAUNCHERS, CONFIG_GUIDE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
@@ -483,7 +523,7 @@ def load_config(path):
             ALLOW_APP_UPDATE = bool(raw.get("allow_app_update", False))
             ALLOW_APP_LAUNCHERS = bool(raw.get("allow_app_launchers", False))
         (units, actions, order, port, launchers, panel, webos, samsung,
-         roku, androidtv, vidaa) = _parse_config(raw)
+         roku, androidtv, vidaa, guide) = _parse_config(raw)
     except FileNotFoundError:
         print("warning: config %s not found, using built-in generic defaults"
               % path, file=sys.stderr, flush=True)
@@ -504,6 +544,7 @@ def load_config(path):
     CONFIG_ROKU = roku
     CONFIG_ANDROIDTV = androidtv
     CONFIG_VIDAA = vidaa
+    CONFIG_GUIDE = guide
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
 
@@ -1390,6 +1431,28 @@ def _couchmode_session():
         return "desktop"
 
 
+def _couchmode_session_strict():
+    """'gamescope' | 'desktop' | None. Same probe as _couchmode_session but
+    UNKNOWN on error instead of assuming 'desktop'.
+
+    _couchmode_session() fails open to 'desktop' because the app only needs a
+    button label. The controller trigger cannot afford that: a pgrep timeout
+    while the box is IN Game Mode would otherwise re-run
+    steamos-session-select gamescope and can restart the session under a running
+    game — and GUIDE is held constantly in Game Mode, where it is Steam's own
+    QAM gesture. For the trigger, unknown must mean 'do nothing'."""
+    try:
+        r = subprocess.run(["pgrep", "-x", "gamescope(-wl)?"],
+                           capture_output=True, timeout=3)
+    except Exception:
+        return None
+    if r.returncode == 0:
+        return "gamescope"
+    if r.returncode == 1:
+        return "desktop"
+    return None          # pgrep itself failed (>=2): unknown
+
+
 def _output_forcing_supported():
     """True when this box's gamescope session honors $OUTPUT_CONNECTOR (so the
     app's display picker is AUTHORITATIVE, not advisory). Bazzite's
@@ -1622,6 +1685,48 @@ def desktop_mode():
     return {"ok": sw["ok"],
             "session": "desktop" if sw["ok"] else _couchmode_session(),
             "steps": steps}
+
+
+# Serialized session switching. couchmode_start() tears down a login session and
+# _set_preferred_output() rewrites a file non-atomically; the HTTP server is
+# threaded (BoundedThreadingHTTPServer) and the guide watcher adds a second,
+# non-HTTP caller. HTTP callers BLOCK — behaviour identical to today, just
+# serialized, so no new status code and no app change. The watcher never blocks:
+# it takes the lock non-blocking and honours a cooldown, so a controller press
+# during an in-flight switch is dropped rather than queued behind it.
+COUCH_LOCK = threading.Lock()
+_COUCH_LAST_SWITCH = 0.0
+
+
+def couchmode_enter(output="", hdr=False):
+    """Serialized couchmode_start() for HTTP callers. Blocks."""
+    global _COUCH_LAST_SWITCH
+    with COUCH_LOCK:
+        _COUCH_LAST_SWITCH = time.monotonic()
+        return couchmode_start(output, hdr)
+
+
+def couchmode_exit():
+    """Serialized desktop_mode() for HTTP callers. Blocks."""
+    global _COUCH_LAST_SWITCH
+    with COUCH_LOCK:
+        _COUCH_LAST_SWITCH = time.monotonic()
+        return desktop_mode()
+
+
+def couchmode_try_enter(output="", cooldown=0.0):
+    """Non-blocking couchmode_start() for the controller watcher. Returns None
+    when a switch is already in flight or one landed within `cooldown`."""
+    global _COUCH_LAST_SWITCH
+    if not COUCH_LOCK.acquire(False):
+        return None
+    try:
+        if cooldown and time.monotonic() - _COUCH_LAST_SWITCH < cooldown:
+            return None
+        _COUCH_LAST_SWITCH = time.monotonic()
+        return couchmode_start(output, False)
+    finally:
+        COUCH_LOCK.release()
 
 
 # ---------------------------------------------------------------------------
@@ -6697,6 +6802,400 @@ def clipboard_paste(text, kbd, mock, entry):
 
 
 # ---------------------------------------------------------------------------
+# Controller trigger: GUIDE-button hold -> Couch Mode (opt-in).
+#
+# Holding GUIDE (BTN_MODE) for ~1.2s on a REAL pad, while the box is in the
+# DESKTOP session, flings it into Game Mode. Off by default. ONE-DIRECTIONAL: a
+# hold in Game Mode does nothing (there GUIDE is Steam's own QAM gesture).
+#
+# Why a HOLD and not a tap: a guide TAP is already claimed by Steam — it opens
+# Big Picture inside the desktop session. Verified on hardware: the steam pid is
+# unchanged across a tap, no gamescope process appears, and steamos-session-select
+# is never invoked. Big Picture renders the same couch UI as Game Mode, so this
+# is easy to mistake for a session switch; it is not one. Steam keeps the tap,
+# we take the hold, and they never collide.
+#
+# We NEVER EVIOCGRAB: Steam reads these same nodes and an exclusive grab would
+# steal the user's controller. Read-only, so every event still reaches Steam.
+#
+# Why this and not controller-wake: reading /dev/input/event* needs only group
+# `input`, which couchside.service already grants (SupplementaryGroups=input).
+# Arming a wake source means writing /sys/.../power/wakeup, which needs root and
+# an installer change that Decky-installed boxes never run.
+#
+# REAL vs EMULATED — the single most important rule here. The naive test "reject
+# Sysfs under /devices/virtual/" is WRONG: Bluetooth pads route through uhid,
+# which is itself virtual, e.g.
+#   S: Sysfs=/devices/virtual/misc/uhid/0005:045E:0B22.000B/input/input963
+# The correct discriminator is "P: Phys non-empty OR U: Uniq non-empty".
+# Measured on hardware:
+#   real BT Xbox pad     Phys=ac:f2:3c:8b:64:fe   Uniq=44:16:22:1f:74:5d
+#   real wired pad       Phys=usb-0000:c3:00.4-1/input0   Uniq=(empty)
+#   Steam Input phantom  (28de:11ff)  Phys=(empty)  Uniq=(empty)
+#   OUR OWN uinput pad   (045e:028e)  Phys=(empty)  Uniq=(empty)
+# The agent creates its own "Microsoft X-Box 360 pad" on EVERY phone WebSocket
+# connect (UInputGamepad, above). This exclusion is STRUCTURAL, not heuristic:
+# the legacy uinput_user_dev descriptor (_UINPUT_USER_DEV) has no phys/uniq field
+# and this file defines no UI_SET_PHYS/UI_SET_UNIQ ioctl, so our pad can never
+# present one. If the filter ever matched it, connecting the phone app would tear
+# down the user's desktop session. Do NOT replace this with a name or VID/PID
+# check: GAMEPAD_DEV_NAME is byte-identical to a real Xbox 360 pad.
+# ---------------------------------------------------------------------------
+
+_PROC_INPUT_DEVICES = "/proc/bus/input/devices"
+_DEV_INPUT = "/dev/input"
+BTN_MODE = BTN_CODES["guide"]        # 316 / 0x13C
+_GUIDE_EV_SIZE = struct.calcsize(_INPUT_EVENT)   # 24 on 64-bit
+_GUIDE_TICK = 0.25                   # select() ceiling: bounds disarm latency
+_GUIDE_RESCAN_S = 3.0                # hotplug reconciliation cadence
+_GUIDE_STALE_HOLD_S = 8.0            # a press with no release this long is junk
+_GUIDE_SETTLE_S = 5.0                # post-fire quiet period
+_GUIDE_COOLDOWN_S = 30.0             # min spacing of controller-fired switches
+_GUIDE_LOCK = threading.Lock()       # _GUIDE_GEN += 1 is not atomic
+_GUIDE_GEN = 0
+_GUIDE_MOCK = False
+
+
+def _parse_input_devices(text):
+    """Parse /proc/bus/input/devices into
+    [{"name","phys","uniq","handlers":[...]}]. Tolerant of unknown lines.
+    partition(':') is used so a Phys like usb-0000:c3:00.4-1/input0 survives."""
+    recs, cur = [], None
+    for line in text.splitlines():
+        if not line.strip():
+            cur = None
+            continue
+        tag, _, val = line.partition(":")
+        val = val.strip()
+        if tag == "I":
+            cur = {"name": "", "phys": "", "uniq": "", "handlers": []}
+            recs.append(cur)
+        elif cur is None:
+            continue
+        elif tag == "N" and val.startswith("Name="):
+            cur["name"] = val[5:].strip().strip('"')
+        elif tag == "P" and val.startswith("Phys="):
+            cur["phys"] = val[5:].strip()
+        elif tag == "U" and val.startswith("Uniq="):
+            cur["uniq"] = val[5:].strip()
+        elif tag == "H" and val.startswith("Handlers="):
+            cur["handlers"] = val[9:].split()
+    return recs
+
+
+def list_real_pads():
+    """Physical game controllers present right now. Two filters, both required:
+      * a js* handler -> a joystick, not a keyboard/mouse/lid switch. NOTE the
+        token is "js2", not "js" — match with startswith. (Comparing for
+        equality against "js" matches nothing and was a real bug in the
+        prototype.)
+      * Phys or Uniq non-empty -> REAL, not uinput/Steam-Input emulated.
+    Returns [{"event","name","phys","uniq"}]; [] on any read error, since an
+    unreadable /proc must degrade to "no pads" rather than raise. Because of the
+    js* filter this never holds an fd on a keyboard: no keylogging surface."""
+    try:
+        with open(_PROC_INPUT_DEVICES, "r", errors="replace") as f:
+            text = f.read()
+    except OSError:
+        return []
+    pads = []
+    for rec in _parse_input_devices(text):
+        h = rec["handlers"]
+        if not any(t.startswith("js") for t in h):
+            continue
+        if not (rec["phys"] or rec["uniq"]):
+            continue                       # emulated; see the block comment
+        ev = next((t for t in h if t.startswith("event")), None)
+        if not ev:
+            continue
+        pads.append({"event": ev, "name": rec["name"],
+                     "phys": rec["phys"], "uniq": rec["uniq"]})
+    return pads
+
+
+def _guide_pad_matches(pad, uniq):
+    """uniq == "" means "any real pad". Otherwise an exact case-insensitive
+    match on the pad's own MAC — stable across BT re-enumeration, whereas Phys
+    is the HOST adapter's MAC and is identical for every BT pad, so it cannot
+    serve as an identity."""
+    return True if not uniq else pad["uniq"].lower() == uniq.lower()
+
+
+def guide_hold_available():
+    """Can this box watch for the hold? Requires the Couch Mode handoff plus
+    readable evdev. Answers "capable", NOT "enabled". Never raises."""
+    try:
+        return (couchmode_available()
+                and os.access(_PROC_INPUT_DEVICES, os.R_OK)
+                and os.access(_DEV_INPUT, os.R_OK | os.X_OK))
+    except Exception:
+        return False
+
+
+def _guide_hold_s():
+    try:
+        ms = int(CONFIG_GUIDE.get("hold_ms", GUIDE_DEFAULTS["hold_ms"]))
+    except (TypeError, ValueError):
+        ms = GUIDE_DEFAULTS["hold_ms"]
+    return max(GUIDE_MIN_HOLD_MS, min(GUIDE_MAX_HOLD_MS, ms)) / 1000.0
+
+
+def guide_hold_info():
+    """Body for GET /api/guide-hold. `readable` distinguishes "no controller
+    connected" from "the agent can't READ your controller" — the likely support
+    case, an agent user missing from group input."""
+    uniq = (CONFIG_GUIDE.get("uniq") or "").strip()
+    pads = list_real_pads()
+    return {"available": True,
+            "enabled": bool(CONFIG_GUIDE.get("enabled")),
+            "hold_ms": int(_guide_hold_s() * 1000),
+            "uniq": uniq,
+            "uniq_present": bool(uniq) and any(
+                p["uniq"].lower() == uniq.lower() for p in pads),
+            "session": _couchmode_session(),
+            "controllers": [
+                {"uniq": p["uniq"], "phys": p["phys"], "name": p["name"],
+                 "readable": os.access(os.path.join(_DEV_INPUT, p["event"]),
+                                       os.R_OK)}
+                for p in pads]}
+
+
+def _guide_save(enabled, hold_ms, uniq):
+    """Persist the guide settings and update CONFIG_GUIDE."""
+    global CONFIG_GUIDE
+    cfg = {"enabled": bool(enabled), "hold_ms": int(hold_ms),
+           "uniq": (uniq or "").strip()}
+    with CONFIG_LOCK:
+        _config_set_field("guide", cfg)
+        CONFIG_GUIDE = cfg
+
+
+def set_guide(mock):
+    """Arm/disarm the watcher from the current CONFIG_GUIDE. Idempotent — call
+    from main() (AFTER load_config) and from the settings route."""
+    global _GUIDE_MOCK
+    _GUIDE_MOCK = bool(mock)
+    start_guide_watch()
+
+
+def start_guide_watch():
+    """(Re)start the watcher. Bumping the generation retires any prior thread —
+    it notices within _GUIDE_TICK, closes its fds in finally, and exits — and a
+    new daemon thread starts only when the setting is on and the box is capable.
+    The lock matters: `+= 1` is not atomic, so two concurrent POSTs could
+    otherwise lose an increment and leave two live watchers both firing."""
+    global _GUIDE_GEN
+    with _GUIDE_LOCK:
+        _GUIDE_GEN += 1
+        gen = _GUIDE_GEN
+    if _GUIDE_MOCK or not CONFIG_GUIDE.get("enabled"):
+        return
+    if not guide_hold_available():
+        print("[guide] hold trigger is on but unavailable on this box",
+              flush=True)
+        return
+    threading.Thread(target=_guide_watch, args=(gen,), daemon=True,
+                     name="guide-hold").start()
+    print("[guide] armed (%dms, %s)"
+          % (int(_guide_hold_s() * 1000),
+             ("pad %s" % CONFIG_GUIDE["uniq"]) if CONFIG_GUIDE.get("uniq")
+             else "any real pad"), flush=True)
+
+
+def _guide_drop(state, fd):
+    """Close and forget one pad. Dropping the fd drops its in-flight press with
+    it, so a pad that vanishes mid-hold can never fire later."""
+    state.pop(fd, None)
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+def _guide_rescan(state, failed):
+    """Reconcile the open fds with the real-pad list, in place. Rebuilt BY PATH
+    every few seconds rather than opened once, because BT pads re-enumerate onto
+    a different eventN under a different uhid path. Unreadable nodes are skipped
+    — a mixed box may have one pad we cannot open.
+
+    `failed` is the set of nodes we have already warned about. Without it the
+    warning repeats on EVERY rescan: a Legion Go S's built-in pad is mode 000
+    (readable by nobody), so an unfiltered log spams the journal forever at the
+    rescan cadence. Entries are forgotten once the node goes away, so a genuinely
+    new failure still gets one line."""
+    uniq = (CONFIG_GUIDE.get("uniq") or "").strip()
+    want = {p["event"]: p for p in list_real_pads()
+            if _guide_pad_matches(p, uniq)}
+    for fd in list(state):
+        if state[fd]["event"] not in want:
+            _guide_drop(state, fd)          # unplugged, or no longer a match
+    failed &= set(want)                     # forget nodes that have vanished
+    have = {state[fd]["event"] for fd in state}
+    for ev, pad in want.items():
+        if ev in have:
+            continue
+        try:
+            # O_RDONLY, and NEVER EVIOCGRAB: Steam reads these same nodes.
+            fd = os.open(os.path.join(_DEV_INPUT, ev),
+                         os.O_RDONLY | os.O_NONBLOCK)
+        except OSError as e:
+            if ev not in failed:
+                failed.add(ev)
+                print("[guide] cannot open %s (%s)" % (ev, e), flush=True)
+            continue
+        failed.discard(ev)
+        state[fd] = {"event": ev, "uniq": pad["uniq"], "name": pad["name"],
+                     "down_at": None}
+        print("[guide] watching %s (%s, uniq=%s)"
+              % (ev, pad["name"] or "?", pad["uniq"] or "-"), flush=True)
+
+
+def _guide_read(state, fd, now):
+    """Drain <fd>, tracking BTN_MODE press/release. False when the node is gone.
+    value 2 is autorepeat and is IGNORED, so a repeat cannot restart or extend
+    the clock."""
+    st = state.get(fd)
+    if st is None:
+        return False
+    while True:
+        try:
+            chunk = os.read(fd, _GUIDE_EV_SIZE * 64)
+        except BlockingIOError:
+            return True
+        except OSError:
+            return False                    # ENODEV: pad vanished mid-read
+        if not chunk:
+            return False
+        for off in range(0, len(chunk) - _GUIDE_EV_SIZE + 1, _GUIDE_EV_SIZE):
+            _s, _us, etype, code, value = struct.unpack_from(
+                _INPUT_EVENT, chunk, off)
+            if etype != EV_KEY or code != BTN_MODE:
+                continue
+            if value == 1:
+                st["down_at"] = now         # press
+            elif value == 0:
+                st["down_at"] = None        # release CANCELS a pending hold
+        if len(chunk) < _GUIDE_EV_SIZE * 64:
+            return True                     # short read: nothing more queued
+
+
+def _guide_due(state, now):
+    """True when some pad's hold has matured. Also expires junk presses (a lost
+    release on a still-open fd). Clears EVERY pad's press when it fires, so two
+    pads held at once produce exactly one switch."""
+    hold = _guide_hold_s()
+    due = False
+    for st in state.values():
+        if st["down_at"] is None:
+            continue
+        elapsed = now - st["down_at"]
+        if elapsed > _GUIDE_STALE_HOLD_S:
+            st["down_at"] = None            # stuck key / lost release
+        elif elapsed >= hold:
+            due = True
+    if due:
+        for st in state.values():
+            st["down_at"] = None
+    return due
+
+
+def _guide_fire():
+    """A qualifying hold completed. EVERY guard lives here, because this path
+    bypasses the HTTP layer entirely — no bearer token, no route-level 404.
+    Returns True if a switch was attempted."""
+    try:
+        if not couchmode_available():
+            return False
+        # STRICT: unknown must NOT read as desktop. Firing while actually in Game
+        # Mode could restart the session under a running game, and GUIDE is held
+        # constantly there (it is Steam's own QAM gesture).
+        if _couchmode_session_strict() != "desktop":
+            return False
+        print("[guide] hold in desktop session -> couch mode", flush=True)
+        # No output pin: same as the app's default; gamescope picks its external
+        # via the hardcoded -O '*',eDP-1. On a multi-external box the phone's
+        # picker stays authoritative and this trigger is not.
+        r = couchmode_try_enter("", cooldown=_GUIDE_COOLDOWN_S)
+        if r is None:
+            return False                    # switch in flight, or cooling down
+        if not r.get("ok"):
+            print("[guide] couch mode not entered: %s"
+                  % ((r.get("steps", {}).get("session", {}) or {}).get("stderr")
+                     or "unknown"), flush=True)
+        return True
+    except Exception as e:                  # this thread must never die
+        print("[guide] fire failed: %s: %s" % (e.__class__.__name__, e),
+              flush=True)
+        return True
+
+
+def _guide_watch(gen):
+    """Watch every matching real pad for a guide hold. Runs until its generation
+    is superseded; any error closes everything and rebuilds with capped backoff.
+    Never raises out of the thread.
+
+    select() is deliberately NOT wrapped: a bad fd raises out to the outer
+    handler, which closes the whole set and rebuilds. Swallowing it here would
+    busy-spin at 100% CPU on a dead-but-still-listed node."""
+    backoff = 2
+    logged = False
+    while gen == _GUIDE_GEN:
+        state = {}                # fd -> {"event","uniq","name","down_at"}
+        failed = set()            # nodes already warned about (log-once)
+        fired = False
+        try:
+            next_scan = 0.0
+            while gen == _GUIDE_GEN:
+                now = time.monotonic()
+                if now >= next_scan:
+                    _guide_rescan(state, failed)
+                    next_scan = now + _GUIDE_RESCAN_S
+                    backoff, logged = 2, False
+                if not state:
+                    time.sleep(_GUIDE_TICK)     # no pad connected: cheap idle
+                    continue
+                # Wake exactly when the oldest hold matures, else on the tick, so
+                # fire latency is ~0ms past the threshold rather than up to a tick.
+                wait = _GUIDE_TICK
+                downs = [s["down_at"] for s in state.values()
+                         if s["down_at"] is not None]
+                if downs:
+                    wait = max(0.0, min(_GUIDE_TICK,
+                                        min(downs) + _guide_hold_s() - now))
+                r, _, _ = select.select(list(state), [], [], wait)
+                now = time.monotonic()
+                for fd in r:
+                    if not _guide_read(state, fd, now):
+                        _guide_drop(state, fd)
+                        next_scan = 0.0         # force an immediate resync
+                if _guide_due(state, time.monotonic()) and _guide_fire():
+                    fired = True
+                    break
+        except (IOError, OSError, ValueError) as e:
+            if not logged:
+                print("[guide] watch paused (%s: %s); retrying"
+                      % (e.__class__.__name__, e), flush=True)
+                logged = True
+        finally:
+            for fd in list(state):
+                _guide_drop(state, fd)
+        if gen != _GUIDE_GEN:
+            break
+        if fired:
+            # Let the session switch land, then rebuild from scratch. Reopening
+            # the nodes DISCARDS anything the kernel queued during the teardown
+            # (each open of an evdev node gets its own empty client buffer), so
+            # stale events cannot read as a fresh press. That is the debounce —
+            # no timestamp state needed. A user still holding GUIDE at reopen
+            # must release and re-press, because we never saw the DOWN.
+            time.sleep(_GUIDE_SETTLE_S)
+            backoff = 2
+        else:
+            time.sleep(backoff)
+            backoff = min(backoff * 2, 30)
+
+
+# ---------------------------------------------------------------------------
 # Minimal RFC6455 WebSocket support (server side, no fragmentation)
 # ---------------------------------------------------------------------------
 
@@ -7710,6 +8209,22 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, info, started)
                 else:
                     self._send(404, {"error": "screensaver not installed"}, started)
+            elif path == "/api/guide-hold":
+                # Probe-and-appear like /api/screensaver: 404 when the box can't
+                # do the handoff or can't read evdev, so the app hides the row.
+                # Older apps that never ask are unaffected.
+                if self.mock:
+                    self._send(200, {
+                        "available": True, "enabled": False, "hold_ms": 1200,
+                        "uniq": "", "uniq_present": False, "session": "desktop",
+                        "controllers": [
+                            {"uniq": "44:16:22:1f:74:5d", "phys": "ac:f2:3c:8b:64:fe",
+                             "name": "Xbox Wireless Controller", "readable": True}],
+                    }, started)
+                elif guide_hold_available():
+                    self._send(200, guide_hold_info(), started)
+                else:
+                    self._send(404, {"error": "guide hold unavailable"}, started)
             else:
                 self._send(404, {"error": "not found"}, started)
         except BrokenPipeError:
@@ -8325,7 +8840,7 @@ class Handler(BaseHTTPRequestHandler):
                                      "session": "gamescope",
                                      "steps": {"session": {"ok": True}}}, started)
                     return
-                self._send(200, couchmode_start(output, hdr), started)
+                self._send(200, couchmode_enter(output, hdr), started)
                 return
 
             # POST /api/desktop-mode: leave Game Mode back to the Plasma desktop.
@@ -8337,7 +8852,56 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, {"ok": True, "session": "desktop",
                                      "steps": {"session": {"ok": True}}}, started)
                     return
-                self._send(200, desktop_mode(), started)
+                self._send(200, couchmode_exit(), started)
+                return
+
+            # POST /api/guide-hold: opt into (or out of) the controller trigger.
+            # Partial patch — omitted keys keep their current value. No box-only
+            # gate: this is a user preference, not a security capability, and a
+            # bearer-token holder can already switch sessions via /api/couch-mode.
+            if path == "/api/guide-hold":
+                if not (self.mock or guide_hold_available()):
+                    self._send(404, {"error": "guide hold unavailable"}, started)
+                    return
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError
+                except (ValueError, UnicodeDecodeError):
+                    self._send(400, {"error": "json body required"}, started)
+                    return
+                cur = dict(CONFIG_GUIDE)
+                enabled = req.get("enabled", cur.get("enabled"))
+                hold_ms = req.get("hold_ms", cur.get("hold_ms"))
+                uniq = req.get("uniq", cur.get("uniq"))
+                if not isinstance(enabled, bool):
+                    self._send(400, {"error": "enabled must be a boolean"}, started)
+                    return
+                if isinstance(hold_ms, bool) or not isinstance(hold_ms, int):
+                    self._send(400, {"error": "hold_ms must be an integer"}, started)
+                    return
+                if not GUIDE_MIN_HOLD_MS <= hold_ms <= GUIDE_MAX_HOLD_MS:
+                    self._send(400, {"error": "hold_ms must be %d..%d"
+                                     % (GUIDE_MIN_HOLD_MS, GUIDE_MAX_HOLD_MS)},
+                               started)
+                    return
+                if not isinstance(uniq, str):
+                    self._send(400, {"error": "uniq must be a string"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "enabled": enabled,
+                                     "hold_ms": hold_ms, "uniq": uniq.strip()},
+                               started)
+                    return
+                try:
+                    _guide_save(enabled, hold_ms, uniq)
+                except Exception as e:
+                    self._send(500, {"error": "could not save: %s" % e}, started)
+                    return
+                set_guide(False)     # re-arm (or retire) the watcher in place
+                info = guide_hold_info()
+                info["ok"] = True
+                self._send(200, info, started)
                 return
 
             # POST /api/power/sleep: arm a delayed suspend/poweroff.
@@ -8935,6 +9499,7 @@ def main():
     set_screen(args.mock)
     set_power_schedule(args.mock)
     set_screensaver(args.mock)
+    set_guide(args.mock)  # arms the guide-hold watcher when opted in
     set_caps(args.mock)  # after the detectors above; snapshots CAPS
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6858,8 +6858,9 @@ _GUIDE_MOCK = False
 
 def _parse_input_devices(text):
     """Parse /proc/bus/input/devices into
-    [{"name","phys","uniq","handlers":[...]}]. Tolerant of unknown lines.
-    partition(':') is used so a Phys like usb-0000:c3:00.4-1/input0 survives."""
+    [{"name","phys","uniq","handlers":[...],"keybits":[...]}]. Tolerant of
+    unknown lines. partition(':') is used so a Phys like
+    usb-0000:c3:00.4-1/input0 survives."""
     recs, cur = [], None
     for line in text.splitlines():
         if not line.strip():
@@ -6868,7 +6869,8 @@ def _parse_input_devices(text):
         tag, _, val = line.partition(":")
         val = val.strip()
         if tag == "I":
-            cur = {"name": "", "phys": "", "uniq": "", "handlers": []}
+            cur = {"name": "", "phys": "", "uniq": "", "handlers": [],
+                   "keybits": []}
             recs.append(cur)
         elif cur is None:
             continue
@@ -6880,7 +6882,31 @@ def _parse_input_devices(text):
             cur["uniq"] = val[5:].strip()
         elif tag == "H" and val.startswith("Handlers="):
             cur["handlers"] = val[9:].split()
+        elif tag == "B" and val.startswith("KEY="):
+            cur["keybits"] = val[4:].split()
     return recs
+
+
+def _declares_key(rec, code):
+    """True when the device's EV_KEY bitmask advertises <code>.
+
+    /proc prints the bitmask as space-separated 64-bit hex words, MOST
+    significant word FIRST, so word 0 of the bit space is the LAST field. A
+    device with no 'B: KEY=' line declares no keys at all.
+
+    This is what separates a controller from its own sibling nodes: a USB
+    DualSense registers TWO js devices sharing one Uniq — the pad, and a
+    'Motion Sensors' node that declares no keys. Without this test the pad shows
+    up twice in the app's controller list. It also drops wheels and flight
+    panels, which are joysticks with no guide button."""
+    words = rec.get("keybits") or []
+    idx, bit = divmod(code, 64)
+    if idx >= len(words):
+        return False
+    try:
+        return bool(int(words[len(words) - 1 - idx], 16) >> bit & 1)
+    except ValueError:
+        return False
 
 
 def list_real_pads():
@@ -6905,6 +6931,8 @@ def list_real_pads():
             continue
         if not (rec["phys"] or rec["uniq"]):
             continue                       # emulated; see the block comment
+        if not _declares_key(rec, BTN_MODE):
+            continue                       # sibling sensor node / wheel / panel
         ev = next((t for t in h if t.startswith("event")), None)
         if not ev:
             continue

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -23,6 +23,7 @@ import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
 import { BoxScanPair } from '@/components/BoxScanPair';
+import { GuideHoldSetup } from '@/components/GuideHoldSetup';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -478,6 +479,10 @@ function BoxEditPanel({
         <SmartTvSetup settings={box} />
       </View>
 
+      <View style={styles.guideHoldWrap}>
+        <GuideHoldSetup settings={box} />
+      </View>
+
       <View style={styles.editFooter}>
         {box.lastIp != null && (
           <Text style={styles.editLastIp}>last seen at {box.lastIp}</Text>
@@ -500,7 +505,7 @@ export default function SetupScreen() {
 }
 
 /** A labeled on/off row for the Preferences card. */
-function TogglePref({
+export function TogglePref({
   label,
   sub,
   value,
@@ -531,7 +536,7 @@ function TogglePref({
 }
 
 /** A labeled segmented picker for the Preferences card. */
-function SegPref<T extends string | number>({
+export function SegPref<T extends string | number>({
   label,
   sub,
   options,
@@ -1598,6 +1603,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   editSteps: { marginTop: 14 },
   smartTvWrap: { marginTop: 14 },
+  guideHoldWrap: { marginTop: 14 },
   editError: {
     color: t.red,
     fontSize: 12,

--- a/app/components/GuideHoldSetup.tsx
+++ b/app/components/GuideHoldSetup.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { SegPref, TogglePref } from '@/app/(tabs)/setup';
+import { usePoll } from '@/hooks/usePoll';
+import { api, ApiError, ConnSettings, GuideHold, hostKey } from '@/lib/api';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/**
+ * Surface the box's own reason verbatim when it answered with an error status —
+ * a server-side failure that masquerades as a network error is hard to diagnose
+ * from a blanket "could not reach the box". Same shape as SmartTvSetup.
+ */
+function saveErr(e: unknown, fallback: string): string {
+  if (e instanceof ApiError) {
+    if (e.kind === 'http') return `${fallback} — box says: ${e.message}`;
+    return `${fallback} (${e.kind})`;
+  }
+  return fallback;
+}
+
+const HOLD_OPTIONS = [
+  { value: 800, label: 'Short' },
+  { value: 1200, label: 'Normal' },
+  { value: 2000, label: 'Long' },
+];
+
+/**
+ * Opt into the guide-button trigger: hold the guide button on a controller while
+ * the box is on the desktop, and it switches to Game Mode.
+ *
+ * Renders nothing when the box can't do it (older agent, no Couch Mode handoff,
+ * or the agent can't read controllers) — the endpoint 404s and `guideHold`
+ * resolves to null, same probe-and-appear pattern as the screensaver row.
+ */
+export function GuideHoldSetup({ settings }: { settings: ConnSettings }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [local, setLocal] = useState<GuideHold | null>(null);
+
+  const poll = useCallback(() => api.guideHold(settings), [settings]);
+  const { data } = usePoll(poll, 15000, true, hostKey(settings));
+  const view = local ?? data;
+
+  const patch = useCallback(
+    async (p: { enabled?: boolean; hold_ms?: number; uniq?: string }) => {
+      setBusy(true);
+      setErr(null);
+      try {
+        const next = await api.guideHoldSet(settings, p);
+        setLocal(next);
+      } catch (e) {
+        setErr(saveErr(e, 'Could not save that setting'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [settings],
+  );
+
+  if (!view) return null;
+
+  const pinned = view.uniq !== '';
+  // A pad the agent can see but cannot read is the likely support case: the
+  // agent user is missing from group `input`, which install.sh normally grants.
+  const unreadable = view.controllers.filter((c) => !c.readable);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.cardTitle}>CONTROLLER</Text>
+
+      <TogglePref
+        label="Guide button opens Couch Mode"
+        sub="Hold the guide button on your controller for about a second to move the box to the TV. Only works while the box is on the desktop — a quick tap still opens Steam as usual."
+        value={view.enabled}
+        onValueChange={(v) => patch({ enabled: v })}
+      />
+
+      {view.enabled && (
+        <>
+          <SegPref<number>
+            label="How long to hold"
+            sub="Longer is harder to trigger by accident."
+            options={HOLD_OPTIONS}
+            value={
+              HOLD_OPTIONS.some((o) => o.value === view.hold_ms) ? view.hold_ms : 1200
+            }
+            onSelect={(v) => patch({ hold_ms: v })}
+          />
+
+          <View style={styles.padSection}>
+            <Text style={styles.padHeading}>
+              {pinned ? 'Only this controller' : 'Any controller'}
+            </Text>
+            <Text style={styles.padSub}>
+              {pinned
+                ? 'Other controllers are ignored, even if they are connected.'
+                : 'Any controller the box can see will work.'}
+            </Text>
+
+            {view.controllers.length === 0 && (
+              <Text style={styles.padEmpty}>No controllers connected right now.</Text>
+            )}
+
+            {view.controllers.map((c) => {
+              const selected = pinned && c.uniq !== '' && c.uniq === view.uniq;
+              // A pad with no MAC (wired) can't be pinned — Uniq is the only
+              // identity stable across reconnects, and Phys is the host adapter.
+              const pinnable = c.uniq !== '';
+              return (
+                <Pressable
+                  key={c.uniq || c.phys}
+                  disabled={!pinnable || busy}
+                  onPress={() => patch({ uniq: selected ? '' : c.uniq })}
+                  style={[styles.padRow, selected && styles.padRowActive]}>
+                  <View style={styles.padBody}>
+                    <Text style={styles.padName}>{c.name || 'Controller'}</Text>
+                    <Text style={styles.padMeta}>
+                      {!c.readable
+                        ? "the box can't read this controller — re-run install.sh"
+                        : pinnable
+                          ? c.uniq
+                          : 'wired — cannot be pinned'}
+                    </Text>
+                  </View>
+                  {selected && <Text style={styles.padCheck}>✓</Text>}
+                </Pressable>
+              );
+            })}
+
+            {pinned && !view.uniq_present && (
+              <Text style={styles.padWarn}>
+                Waiting for your controller — it is not connected right now, so the
+                guide button will not do anything.
+              </Text>
+            )}
+          </View>
+
+          {unreadable.length > 0 && (
+            <Text style={styles.padWarn}>
+              The box can see {unreadable.length === 1 ? 'a controller' : 'some controllers'} it
+              is not allowed to read. Re-running the install script usually fixes this.
+            </Text>
+          )}
+        </>
+      )}
+
+      {busy && <ActivityIndicator color={t.blue} style={styles.spinner} />}
+      {err != null && <Text style={styles.err}>{err}</Text>}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: t.card,
+      borderRadius: 14,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+      padding: 14,
+    },
+    cardTitle: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1.2,
+      marginBottom: 6,
+    },
+    padSection: { marginTop: 10 },
+    padHeading: { color: t.text, fontSize: 14, fontWeight: '600' },
+    padSub: { color: t.textDim, fontSize: 12, marginTop: 2, marginBottom: 8 },
+    padEmpty: { color: t.textDim, fontSize: 13, fontStyle: 'italic', marginTop: 4 },
+    padRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: t.inset,
+      borderRadius: 10,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+      paddingVertical: 10,
+      paddingHorizontal: 12,
+      marginTop: 6,
+    },
+    padRowActive: { borderColor: t.blue },
+    padBody: { flex: 1 },
+    padName: { color: t.text, fontSize: 14, fontWeight: '600' },
+    padMeta: { color: t.textDim, fontSize: 11, marginTop: 2 },
+    padCheck: { color: t.blue, fontSize: 16, fontWeight: '700', marginLeft: 8 },
+    padWarn: { color: t.red, fontSize: 12, marginTop: 8 },
+    spinner: { marginTop: 10 },
+    err: { color: t.red, fontSize: 12, marginTop: 8 },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -356,6 +356,36 @@ export type DiscoveredTv = {
   host: string;
 };
 
+/**
+ * One physical controller the box can see. Emulated pads (the box's own virtual
+ * gamepad, Steam Input's) are filtered out agent-side and never appear here.
+ * `uniq` is the pad's own MAC and is stable across Bluetooth reconnects, so it
+ * is the identity used to pin the trigger to one controller; `readable` is false
+ * when the agent can see the pad but lacks permission to read its events.
+ */
+export type GuideController = {
+  uniq: string;
+  phys: string;
+  name: string;
+  readable: boolean;
+};
+
+/**
+ * Guide-hold trigger state (GET /api/guide-hold, agent >= 2.9.14). The route
+ * 404s when the box can't do the Couch Mode handoff or can't read evdev.
+ */
+export type GuideHold = {
+  available: boolean;
+  enabled: boolean;
+  hold_ms: number;
+  /** Empty = any real controller; otherwise the pinned pad's MAC. */
+  uniq: string;
+  /** True when a pinned pad is set AND currently connected. */
+  uniq_present: boolean;
+  session: 'gamescope' | 'desktop';
+  controllers: GuideController[];
+};
+
 /** TV-control probe result. The route 404s when no backend is available. */
 export type Tv = {
   available: boolean;
@@ -1340,6 +1370,23 @@ export const api = {
   /** Exit Couch Mode: return the box to its desktop session. */
   desktopMode(settings: ConnSettings): Promise<{ ok: boolean }> {
     return request(settings, '/api/desktop-mode', { method: 'POST' });
+  },
+
+  /**
+   * Guide-hold trigger settings, or null when the box can't do it (older agent,
+   * no Couch Mode handoff, or an agent that can't read /dev/input). null means
+   * "hide the row" — the same probe-and-appear shape as the screensaver.
+   */
+  guideHold(settings: ConnSettings): Promise<GuideHold | null> {
+    return probeOrNull(request<GuideHold>(settings, '/api/guide-hold'));
+  },
+
+  /** Patch the guide-hold settings. Omitted fields keep their current value. */
+  guideHoldSet(
+    settings: ConnSettings,
+    patch: { enabled?: boolean; hold_ms?: number; uniq?: string },
+  ): Promise<GuideHold & { ok: boolean }> {
+    return request(settings, '/api/guide-hold', { method: 'POST', body: patch });
   },
 
   /** Arm a delayed suspend/poweroff. */

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -217,7 +217,15 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // screensaver arrived later (agent 2.8.4): optional, so caps persisted from
   // a 2.8.2/2.8.3 box still round-trip. undefined = unknown -> the app probes.
   const screensaver = bool('screensaver');
-  return { gamepad, steam, media, tv, screen, power_schedule, screensaver };
+  // couchmode/desktop are declared on BoxCaps but were being dropped here, so
+  // they never survived a persist/reload and the app re-probed every launch.
+  // Optional like screensaver: absent stays undefined = unknown, never false.
+  const couchmode = bool('couchmode');
+  const desktop = bool('desktop');
+  return {
+    gamepad, steam, media, tv, screen, power_schedule,
+    screensaver, couchmode, desktop,
+  };
 }
 
 /** Coerce an arbitrary parsed value into a valid Box, or null if unusable. */

--- a/tests/test_guide_hold.py
+++ b/tests/test_guide_hold.py
@@ -63,6 +63,7 @@ S: Sysfs=/devices/pci0000:00/0000:c3:00.4/usb3/3-1/3-1:1.1/input/input12
 U: Uniq=
 H: Handlers=event2 js0
 B: EV=20000b
+B: KEY=7cdb000000000000 0 0 0 0
 
 I: Bus=0003 Vendor=28de Product=11ff Version=0001
 N: Name="Microsoft X-Box 360 pad 0"
@@ -71,6 +72,7 @@ S: Sysfs=/devices/virtual/input/input958
 U: Uniq=
 H: Handlers=event17 js1
 B: EV=20000b
+B: KEY=7cdb000000000000 0 0 0 0
 
 I: Bus=0005 Vendor=045e Product=0b22 Version=0522
 N: Name="Xbox Wireless Controller"
@@ -79,6 +81,24 @@ S: Sysfs=/devices/virtual/misc/uhid/0005:045E:0B22.000A/input/input962
 U: Uniq=44:16:22:1f:74:5d
 H: Handlers=sysrq kbd event20 js2
 B: EV=30001b
+B: KEY=7fff000000000000 1000000000000 8000000000 e080ffdf01cfffff fffffffffffffffe
+
+I: Bus=0003 Vendor=054c Product=0ce6 Version=8111
+N: Name="Sony Interactive Entertainment DualSense Wireless Controller"
+P: Phys=
+S: Sysfs=/devices/pci0000:00/0000:c3:00.3/usb5/5-2/5-2:1.0/0003:054C:0CE6.000D/input/input980
+U: Uniq=14:3a:9a:1b:e9:01
+H: Handlers=event24 js4
+B: EV=20000b
+B: KEY=7fdb000000000000 0 0 0 0
+
+I: Bus=0003 Vendor=054c Product=0ce6 Version=8111
+N: Name="Sony Interactive Entertainment DualSense Wireless Controller Motion Sensors"
+P: Phys=
+S: Sysfs=/devices/pci0000:00/0000:c3:00.3/usb5/5-2/5-2:1.0/0003:054C:0CE6.000D/input/input981
+U: Uniq=14:3a:9a:1b:e9:01
+H: Handlers=event25 js5
+B: EV=9
 
 I: Bus=0019 Vendor=0000 Product=0005 Version=0000
 N: Name="Lid Switch"
@@ -93,13 +113,22 @@ B: EV=21
 def test_pad_discrimination():
     print("real vs emulated pad discrimination")
     recs = cs._parse_input_devices(REAL_DUMP)
-    check("parses all 4 records", len(recs), 4)
+    check("parses all 6 records", len(recs), 6)
 
-    def accepted(r):
-        return (any(t.startswith("js") for t in r["handlers"])
-                and bool(r["phys"] or r["uniq"]))
-
-    names = [r["name"] for r in recs if accepted(r)]
+    # Drive the REAL list_real_pads() by pointing it at a fixture file, rather
+    # than reimplementing its filter here — a local copy of the logic passes
+    # even when the shipped filter has changed underneath it.
+    import tempfile
+    fd, path = tempfile.mkstemp()
+    with os.fdopen(fd, "w") as f:
+        f.write(REAL_DUMP)
+    orig = cs._PROC_INPUT_DEVICES
+    try:
+        cs._PROC_INPUT_DEVICES = path
+        names = [p["name"] for p in cs.list_real_pads()]
+    finally:
+        cs._PROC_INPUT_DEVICES = orig
+        os.unlink(path)
     check("real wired pad accepted (Phys set, Uniq EMPTY)",
           "Legion Go S" in names, True)
     check("real Bluetooth pad accepted (under /devices/virtual via uhid)",
@@ -108,15 +137,52 @@ def test_pad_discrimination():
     check("emulated pad REJECTED (no Phys, no Uniq)",
           "Microsoft X-Box 360 pad 0" in names, False)
     check("non-joystick (Lid Switch) rejected", "Lid Switch" in names, False)
+    # A USB DualSense registers TWO js devices sharing one Uniq. Only the pad
+    # declares BTN_MODE; the Motion Sensors node declares no keys at all. Without
+    # the key-bitmask test the same controller is listed twice in the app.
+    check("DualSense pad accepted (empty Phys, Uniq set)",
+          "Sony Interactive Entertainment DualSense Wireless Controller" in names,
+          True)
+    check("DualSense Motion Sensors sibling REJECTED",
+          any("Motion Sensors" in n for n in names), False)
+    check("exactly 3 real pads accepted", len(names), 3)
 
-    lg = next(r for r in recs if r["name"] == "Legion Go S")
+
+def test_declares_key():
+    print("BTN_MODE capability filter")
+    recs = {r["name"]: r for r in cs._parse_input_devices(REAL_DUMP)}
+    # /proc prints 64-bit words most-significant FIRST, so bit 316 lives in the
+    # first of five words (316 // 64 == 4 -> index 4 from the end).
+    check("Xbox pad declares BTN_MODE",
+          cs._declares_key(recs["Xbox Wireless Controller"], cs.BTN_MODE), True)
+    check("DualSense declares BTN_MODE",
+          cs._declares_key(
+              recs["Sony Interactive Entertainment DualSense Wireless Controller"],
+              cs.BTN_MODE), True)
+    check("Motion Sensors (no KEY line) declares nothing",
+          cs._declares_key(
+              recs["Sony Interactive Entertainment DualSense Wireless Controller "
+                   "Motion Sensors"], cs.BTN_MODE), False)
+    check("Lid Switch does not declare BTN_MODE",
+          cs._declares_key(recs["Lid Switch"], cs.BTN_MODE), False)
+    # A device whose bitmask is too short must not index out of range.
+    check("short bitmask is handled, not crashed",
+          cs._declares_key({"keybits": ["7fff000000000000"]}, cs.BTN_MODE), False)
+    check("garbage bitmask is handled, not crashed",
+          cs._declares_key({"keybits": ["zz", "0", "0", "0", "0"]}, cs.BTN_MODE),
+          False)
+
+    lg = recs["Legion Go S"]
     check("Phys containing colons survives parsing",
           lg["phys"], "usb-0000:c3:00.4-1/input0")
-    xb = next(r for r in recs if r["name"] == "Xbox Wireless Controller")
+    xb = recs["Xbox Wireless Controller"]
     check("Uniq (pad MAC, stable across BT reconnect) parsed",
           xb["uniq"], "44:16:22:1f:74:5d")
     check("js token matched by prefix, not equality ('js2' not 'js')",
           any(t.startswith("js") for t in xb["handlers"]), True)
+    ds = recs["Sony Interactive Entertainment DualSense Wireless Controller"]
+    check("DualSense over USB has EMPTY Phys (Phys-only rule would reject it)",
+          ds["phys"], "")
 
 
 def test_favourite_filter():
@@ -210,7 +276,8 @@ def test_config_defaults():
 
 
 if __name__ == "__main__":
-    for fn in (test_pad_discrimination, test_favourite_filter, test_hold_timing,
+    for fn in (test_pad_discrimination, test_declares_key,
+               test_favourite_filter, test_hold_timing,
                test_event_decoding, test_config_defaults):
         fn()
     print()

--- a/tests/test_guide_hold.py
+++ b/tests/test_guide_hold.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Unit tests for the guide-button hold trigger (controller -> Couch Mode).
+
+Run: python3 tests/test_guide_hold.py
+
+No pytest, no deps — the agent is pure stdlib and so is this, so CI can run it
+straight after py_compile.
+
+Why these tests exist: the trigger fires a SESSION SWITCH, which tears down the
+user's desktop and any unsaved work. The two ways that goes wrong are (a) firing
+when it shouldn't and (b) matching an emulated pad. Both are covered here
+against the real functions, because neither is observable in a --mock smoke test
+and both need real hardware to catch otherwise.
+"""
+import importlib.util
+import os
+import struct
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _press(state, fd, value, t):
+    """Apply one BTN_MODE event exactly as _guide_read would."""
+    if value == 1:
+        state[fd]["down_at"] = t
+    elif value == 0:
+        state[fd]["down_at"] = None
+
+
+def _state(n=1):
+    return {i: {"event": "event%d" % i, "uniq": "", "name": "pad%d" % i,
+                "down_at": None}
+            for i in range(n)}
+
+
+# --------------------------------------------------------------------------
+# Real-vs-emulated discrimination. The catastrophic failure mode: the agent
+# creates its OWN pad named "Microsoft X-Box 360 pad" on every phone WebSocket
+# connect, so a filter that matches it would tear down the desktop session every
+# time someone opens the app. Sample below is real hardware output.
+# --------------------------------------------------------------------------
+REAL_DUMP = '''\
+I: Bus=0003 Vendor=1a86 Product=e310 Version=0043
+N: Name="Legion Go S"
+P: Phys=usb-0000:c3:00.4-1/input0
+S: Sysfs=/devices/pci0000:00/0000:c3:00.4/usb3/3-1/3-1:1.1/input/input12
+U: Uniq=
+H: Handlers=event2 js0
+B: EV=20000b
+
+I: Bus=0003 Vendor=28de Product=11ff Version=0001
+N: Name="Microsoft X-Box 360 pad 0"
+P: Phys=
+S: Sysfs=/devices/virtual/input/input958
+U: Uniq=
+H: Handlers=event17 js1
+B: EV=20000b
+
+I: Bus=0005 Vendor=045e Product=0b22 Version=0522
+N: Name="Xbox Wireless Controller"
+P: Phys=ac:f2:3c:8b:64:fe
+S: Sysfs=/devices/virtual/misc/uhid/0005:045E:0B22.000A/input/input962
+U: Uniq=44:16:22:1f:74:5d
+H: Handlers=sysrq kbd event20 js2
+B: EV=30001b
+
+I: Bus=0019 Vendor=0000 Product=0005 Version=0000
+N: Name="Lid Switch"
+P: Phys=PNP0C0D/button/input0
+S: Sysfs=/devices/LNXSYSTM:00/button/input0
+U: Uniq=
+H: Handlers=event1
+B: EV=21
+'''
+
+
+def test_pad_discrimination():
+    print("real vs emulated pad discrimination")
+    recs = cs._parse_input_devices(REAL_DUMP)
+    check("parses all 4 records", len(recs), 4)
+
+    def accepted(r):
+        return (any(t.startswith("js") for t in r["handlers"])
+                and bool(r["phys"] or r["uniq"]))
+
+    names = [r["name"] for r in recs if accepted(r)]
+    check("real wired pad accepted (Phys set, Uniq EMPTY)",
+          "Legion Go S" in names, True)
+    check("real Bluetooth pad accepted (under /devices/virtual via uhid)",
+          "Xbox Wireless Controller" in names, True)
+    # The one that matters most.
+    check("emulated pad REJECTED (no Phys, no Uniq)",
+          "Microsoft X-Box 360 pad 0" in names, False)
+    check("non-joystick (Lid Switch) rejected", "Lid Switch" in names, False)
+
+    lg = next(r for r in recs if r["name"] == "Legion Go S")
+    check("Phys containing colons survives parsing",
+          lg["phys"], "usb-0000:c3:00.4-1/input0")
+    xb = next(r for r in recs if r["name"] == "Xbox Wireless Controller")
+    check("Uniq (pad MAC, stable across BT reconnect) parsed",
+          xb["uniq"], "44:16:22:1f:74:5d")
+    check("js token matched by prefix, not equality ('js2' not 'js')",
+          any(t.startswith("js") for t in xb["handlers"]), True)
+
+
+def test_favourite_filter():
+    print("favourite-pad filter")
+    pad = {"uniq": "44:16:22:1F:74:5D", "phys": "x", "name": "p", "event": "event20"}
+    other = {"uniq": "aa:bb:cc:dd:ee:ff", "phys": "x", "name": "q", "event": "event21"}
+    check("empty uniq matches any real pad", cs._guide_pad_matches(pad, ""), True)
+    check("favourite matches case-insensitively",
+          cs._guide_pad_matches(pad, "44:16:22:1f:74:5d"), True)
+    # Fail CLOSED: the user sets uniq to EXCLUDE another pad, so falling back to
+    # "any pad" would re-admit exactly what they excluded.
+    check("non-favourite pad excluded",
+          cs._guide_pad_matches(other, "44:16:22:1f:74:5d"), False)
+
+
+def test_hold_timing():
+    print("hold timing")
+    cs.CONFIG_GUIDE = {"enabled": True, "hold_ms": 1200, "uniq": ""}
+    check("threshold reads from config", cs._guide_hold_s(), 1.2)
+
+    s = _state()
+    _press(s, 0, 1, 100.0)
+    _press(s, 0, 0, 100.2)
+    check("quick TAP does not fire (Steam keeps the tap)",
+          cs._guide_due(s, 101.5), False)
+
+    s = _state()
+    _press(s, 0, 1, 100.0)
+    check("hold past threshold fires", cs._guide_due(s, 101.3), True)
+
+    s = _state()
+    _press(s, 0, 1, 100.0)
+    check("hold under threshold does not fire yet",
+          cs._guide_due(s, 101.1), False)
+
+    s = _state(2)
+    _press(s, 0, 1, 100.0)
+    _press(s, 1, 1, 100.1)
+    check("two pads held -> exactly one fire", cs._guide_due(s, 101.4), True)
+    check("...and no re-fire on the next tick", cs._guide_due(s, 101.5), False)
+
+    s = _state()
+    _press(s, 0, 1, 100.0)
+    cs._guide_due(s, 100.0 + cs._GUIDE_STALE_HOLD_S + 1)
+    check("stale press (lost release) expires rather than firing",
+          s[0]["down_at"], None)
+
+    # Clamping: a config outside the sane range must not produce a hair trigger.
+    cs.CONFIG_GUIDE = {"enabled": True, "hold_ms": 1, "uniq": ""}
+    check("hold_ms clamped up to the minimum",
+          cs._guide_hold_s(), cs.GUIDE_MIN_HOLD_MS / 1000.0)
+    cs.CONFIG_GUIDE = {"enabled": True, "hold_ms": 999999, "uniq": ""}
+    check("hold_ms clamped down to the maximum",
+          cs._guide_hold_s(), cs.GUIDE_MAX_HOLD_MS / 1000.0)
+    cs.CONFIG_GUIDE = {"enabled": True, "hold_ms": "nonsense", "uniq": ""}
+    check("non-numeric hold_ms falls back to the default",
+          cs._guide_hold_s(), cs.GUIDE_DEFAULTS["hold_ms"] / 1000.0)
+
+
+def test_event_decoding():
+    print("evdev event decoding")
+    check("input_event struct is 24 bytes on this arch",
+          struct.calcsize(cs._INPUT_EVENT), 24)
+    check("BTN_MODE is the guide button (316 / 0x13C)", cs.BTN_MODE, 316)
+    # A non-guide keypress must never arm the trigger.
+    s = _state()
+    packed = struct.pack(cs._INPUT_EVENT, 0, 0, cs.EV_KEY, 0x130, 1)  # BTN_SOUTH
+    _s, _us, etype, code, value = struct.unpack(cs._INPUT_EVENT, packed)
+    if etype == cs.EV_KEY and code == cs.BTN_MODE:
+        _press(s, 0, value, 100.0)
+    check("A button does not arm the trigger", cs._guide_due(s, 102.0), False)
+
+
+def test_config_defaults():
+    print("config validation")
+    check("trigger is OFF by default (opt-in)",
+          cs.GUIDE_DEFAULTS["enabled"], False)
+    # A config the agent cannot parse must leave the trigger OFF, not "on".
+    for bad in ({"guide": {"enabled": "yes"}},
+                {"guide": {"hold_ms": 10}},
+                {"guide": {"hold_ms": True}},
+                {"guide": {"uniq": 5}},
+                {"guide": "not-an-object"}):
+        try:
+            cs._parse_config(dict(bad, units=[], actions={}))
+            check("rejects bad config %r" % (bad,), "accepted", "ConfigError")
+        except cs.ConfigError:
+            check("rejects bad config %r" % (bad,), "ConfigError", "ConfigError")
+        except Exception as e:  # noqa: BLE001
+            check("rejects bad config %r" % (bad,), type(e).__name__, "ConfigError")
+
+
+if __name__ == "__main__":
+    for fn in (test_pad_discrimination, test_favourite_filter, test_hold_timing,
+               test_event_decoding, test_config_defaults):
+        fn()
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        sys.exit(1)
+    print("all guide-hold tests passed")


### PR DESCRIPTION
Hold the guide button on a controller for ~1.2s while the box is on the desktop, and it switches to Game Mode. **Off by default**, opt-in per box from the box editor.

## Why a hold, not a tap

A guide *tap* is already claimed by Steam — it opens Big Picture inside the desktop session. Verified on hardware: the steam pid is unchanged across a tap, no gamescope process appears, and `steamos-session-select` is never invoked. Big Picture renders the same couch UI as Game Mode, so it's easy to mistake for a session switch; it isn't one. Steam keeps the tap, Couchside takes the hold, and they never collide.

## Why the trigger and not controller-wake

Wake was prototyped first and abandoned. Reading `/dev/input/event*` needs only group `input`, which `couchside.service` already grants. Arming a wake source means writing `/sys/.../power/wakeup`, which needs root plus an installer change that **Decky-installed boxes never run**. Wake also assumes the box can sleep at all, which isn't true of every HTPC.

## The load-bearing rule: real vs emulated pads

The intuitive test — "reject `Sysfs` under `/devices/virtual/`" — is **wrong**. Bluetooth pads route through `uhid`, which is itself virtual, so that rule rejects every BT controller. The correct discriminator is **`Phys` or `Uniq` non-empty**; emulated pads have neither.

This matters because the agent creates its *own* pad named `Microsoft X-Box 360 pad` on every phone WebSocket connect. If the filter matched it, **opening the app would tear down the user's desktop session.** The exclusion is structural, not heuristic: `uinput_user_dev` has no phys/uniq field and the agent defines no `UI_SET_PHYS`/`UI_SET_UNIQ` ioctl, so its pad can never present one.

| device | Phys | Uniq | matched |
|---|---|---|---|
| Xbox pad (Bluetooth) | host MAC | pad MAC | yes |
| wired pad | `usb-0000:c3:00.4-1/input0` | *empty* | yes |
| Steam Input phantom `28de:11ff` | *empty* | *empty* | no |
| Couchside's own pad `045e:028e` | *empty* | *empty* | no |

## Also in here

- **`_couchmode_session_strict()`** — the existing oracle fails open to `"desktop"`, fine for a button label but it would let a `pgrep` timeout fire a session switch while actually *in* Game Mode, under a running game, with guide held constantly (it's Steam's own QAM gesture). Unknown now means "do nothing".
- **`COUCH_LOCK`** — `couchmode_start()` tears down a login session and rewrites a file non-atomically. The HTTP server is threaded and the watcher adds a second, non-HTTP caller, so switches are now serialized. HTTP callers block (behaviour identical to today — no new status code, no app change); the watcher takes the lock non-blocking with a cooldown, so a press during an in-flight switch is dropped rather than queued.
- **`normalizeCaps` fix** — `couchmode`/`desktop` were declared on `BoxCaps` but dropped on normalize, so they never survived a persist/reload.

## Verification

End-to-end on a docked Legion Go S (Bazzite), with a Bluetooth Xbox pad:

```
BTN_MODE DOWN/UP ×3        three quick taps: did NOT fire
BTN_MODE DOWN              the hold
*** HOLD MATURED -> available=True session=desktop ***
session before : desktop
session after  : gamescope
```

The pad was tracked across a Bluetooth re-enumeration (`event20` → `event22`) mid-test. The parser was also validated against a real 217-line `/proc/bus/input/devices` dump.

27 unit tests in `tests/test_guide_hold.py`, wired into CI, covering the two dangerous failure modes — firing on a tap, and matching an emulated pad — neither observable in the `--mock` smoke test.

## Known limits

- On a Legion Go S / Steam Deck the **built-in** controls are `mode 000` (SteamOS hides them), so only external pads can drive the trigger.
- Non-Xbox pads (DualSense, 8BitDo) are untested; the pad filter is driver-agnostic but the button *code* is not.
- The trigger requires an external output, since `couchmode_available()` does — an undocked handheld correctly hides the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)