### PR TITLE
chore(app): 2.9.5 — version bump + store-true build floors

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.4",
+    "version": "2.9.5",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "44",
+      "buildNumber": "54",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 29
+      "versionCode": 38
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "54",
+      "buildNumber": "55",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 38
+      "versionCode": 39
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Bumps to **2.9.5** with build floors reconciled to what the stores actually hold: Play production is 2.9.4 at **vc37**, ASC at iOS build **53** — main's app.json said 44/29 (recent builds ran from a different checkout). Floors set to **54 / vc38**.

2.9.5 ships what's already merged: guide-hold toggle (#95), service rename (#92), Actions impact wording (#91), `#install` link fix, version-footer fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)