### PR TITLE
fix(agent): reuse a session's virtual pad on re-promotion (2.9.16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,13 @@ jobs:
       - name: Unit tests (guide-hold trigger)
         run: python3 tests/test_guide_hold.py
 
+      # Gamepad handoff lifecycle: a re-promoted session must REUSE its virtual
+      # pad. The old always-create path orphaned a pad per Pass/take-back cycle
+      # (fd left open -> phantom controller until the agent exits), and the
+      # resulting churn corrupted a real box's Steam desktop controller config.
+      - name: Unit tests (gamepad handoff)
+        run: python3 tests/test_gamepad_handoff.py
+
   smoke:
     runs-on: ubuntu-latest
     needs: compile

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.15"
+VERSION = "2.9.16"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -7419,13 +7419,23 @@ def _make_holder(entry, mock):
     first swipe / keypress of EVERY session (measured 508/525ms). A create
     failure here is non-fatal — the slot stays None and the lazy path in
     _handle_frame retries on first use, reporting the error to the client."""
-    try:
-        entry["device"] = MockGamepad() if mock else UInputGamepad()
-    except Exception as e:
-        print("[gamepad] device create failed: %s" % e, flush=True)
-        _wsend_json(entry, {"t": "err", "msg": "uinput unavailable: %s" % e})
-        _wsend_op(entry, WS_OP_CLOSE)
-        return False
+    # REUSE the session's existing pad on re-promotion. A session that passes
+    # control away keeps its device (nothing destroys it at demotion — only
+    # disconnect does), so a Pass/take-back ping-pong used to hit this line
+    # again and OVERWRITE the ref: the old pad object was orphaned with its fd
+    # open, leaving a phantom "Microsoft X-Box 360 pad N" alive until the agent
+    # exited (three were found on a box after one afternoon). Each orphan is
+    # also a controller Steam re-enumerates — enough churn corrupted a real
+    # box's desktop controller config. Reuse fixes the leak AND means a handoff
+    # ping-pong presents ONE stable controller to Steam instead of a parade.
+    if entry.get("device") is None:
+        try:
+            entry["device"] = MockGamepad() if mock else UInputGamepad()
+        except Exception as e:
+            print("[gamepad] device create failed: %s" % e, flush=True)
+            _wsend_json(entry, {"t": "err", "msg": "uinput unavailable: %s" % e})
+            _wsend_op(entry, WS_OP_CLOSE)
+            return False
     entry["held"] = True
     entry["requested"] = False
     _wsend_json(entry, {"t": "hello", "dev": entry["device"].name,

--- a/tests/test_gamepad_handoff.py
+++ b/tests/test_gamepad_handoff.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Regression tests for the gamepad handoff device lifecycle.
+
+Run: python3 tests/test_gamepad_handoff.py
+
+Why this exists: _make_holder() used to assign a fresh virtual pad on EVERY
+promotion. A session that passed control away and later took it back got a
+second pad, orphaning the first with its uinput fd open — a phantom
+"Microsoft X-Box 360 pad N" that lived until the agent exited. Three of them
+were found on a real box after one afternoon of two-phone handoff testing, and
+the resulting controller churn corrupted that box's Steam desktop controller
+config (trackpad mapping lost, stick-mouse drift added). The fix is reuse:
+a session keeps ONE pad for its whole life.
+
+Pure stdlib, no pytest — same style as test_guide_hold.py so CI just runs it.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# _make_holder writes hello frames to the session's socket; stub the frame
+# senders so the test needs no socket. Everything else runs for real (mock=True
+# uses MockGamepad/MockMouse/MockKeyboard, which are plain objects).
+_sent = []
+cs._wsend_json = lambda entry, obj: _sent.append(obj)
+cs._wsend_op = lambda entry, op, payload=b"": None
+
+
+def test_repromotion_reuses_pad():
+    print("re-promotion reuses the session's pad")
+    entry = {"name": "test-phone"}
+    ok = cs._make_holder(entry, mock=True)
+    check("first promotion succeeds", ok, True)
+    first_pad = entry.get("device")
+    check("pad created on first promotion", first_pad is not None, True)
+    first_mouse = entry.get("mouse")
+    first_kbd = entry.get("keyboard")
+
+    # Simulate demotion (control passed away): held drops, devices REMAIN.
+    entry["held"] = False
+
+    ok = cs._make_holder(entry, mock=True)
+    check("second promotion succeeds", ok, True)
+    # The regression: this used to be a NEW object, orphaning first_pad.
+    check("same pad object reused (no orphan)",
+          entry.get("device") is first_pad, True)
+    check("mouse not recreated either", entry.get("mouse") is first_mouse, True)
+    check("keyboard not recreated either",
+          entry.get("keyboard") is first_kbd, True)
+    check("session marked held again", entry.get("held"), True)
+
+
+def test_fresh_session_still_gets_devices():
+    print("fresh session still gets a pad")
+    entry = {"name": "fresh-phone"}
+    ok = cs._make_holder(entry, mock=True)
+    check("promotion succeeds", ok, True)
+    check("pad present", entry.get("device") is not None, True)
+    check("mouse pre-created", entry.get("mouse") is not None, True)
+    check("keyboard pre-created", entry.get("keyboard") is not None, True)
+    hello = [m for m in _sent if m.get("t") == "hello"]
+    check("hello sent on promotion", len(hello) >= 1, True)
+
+
+if __name__ == "__main__":
+    for fn in (test_repromotion_reuses_pad, test_fresh_session_still_gets_devices):
+        fn()
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        sys.exit(1)
+    print("all gamepad-handoff tests passed")


### PR DESCRIPTION
A session that passed control away and later took it back got a **fresh virtual pad each time** — the old one was orphaned with its uinput fd open. Found live: three phantom `Microsoft X-Box 360 pad N` devices on a box after an afternoon of two-phone handoff testing.

The churn is the real damage: every pad create/destroy makes Steam requeue controller-config activation, and on the test box enough of it **corrupted the Steam desktop controller layout** (trackpad-as-mouse mapping lost, a drifting stick-as-mouse added, cursor pinned in a corner) — which presented as "the trackpad stopped working" and cost a long debugging session.

Fix: `_make_holder` creates devices only when the session doesn't already have them. One stable controller per session for its whole life, regardless of how many times control ping-pongs. Disconnect cleanup unchanged — it already ran in a `finally`; the leak was the overwritten reference it never saw.

Regression tests (mock devices, no uinput needed) wired into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)