### PR TITLE
fix(app): global caps sync — stale couchmode:false no longer hides the Couch button

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, Tabs, useSegments } from 'expo-router';
 import { useEffect, useRef } from 'react';
 
+import { useCapsSync } from '@/hooks/useCapsSync';
 import { hapticSelection } from '@/lib/haptics';
 import { useBoxes } from '@/lib/SettingsContext';
 import { useTheme } from '@/lib/theme';
@@ -16,6 +17,10 @@ export default function TabLayout() {
   const t = useTheme();
   const { boxes, activeBox, ready } = useBoxes();
   const segments = useSegments();
+  // Always-mounted caps safety net: heals a stale persisted caps snapshot
+  // (e.g. couchmode:false cached before the box became capable) no matter
+  // which tab the user lives on. See hooks/useCapsSync.ts for the field bug.
+  useCapsSync();
 
   // A "server box" (headless: no virtual gamepad, no Steam) reports these false
   // in /api/status caps, so its gaming tabs are hidden. Undefined caps (unknown,

--- a/app/hooks/useCapsSync.ts
+++ b/app/hooks/useCapsSync.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect } from 'react';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, capsEqual, hostKey, Status } from '@/lib/api';
+import { useSettings } from '@/lib/SettingsContext';
+
+/**
+ * Keep the ACTIVE box's persisted caps in sync with what its service actually
+ * reports, from a hook that is always mounted (the tab layout) — not only
+ * where RemotePowerBar happens to render (Console/Setup).
+ *
+ * Why this exists: since caps persistence learned couchmode/desktop, a stale
+ * `false` cached before a box BECAME capable sticks until something re-learns
+ * caps. The only learner used to be RemotePowerBar, so a user who lived on the
+ * Pad tab kept a hidden Couch button indefinitely while the box itself
+ * advertised couchmode:true (observed in the field on Android 2.9.5 after the
+ * box's 2.9.15 service made undocked handhelds couch-capable).
+ *
+ * Slow cadence on purpose — this is a safety net, not the primary status poll.
+ * Same guards as the RemotePowerBar learner: value-equality (caps is a fresh
+ * object every poll) so storage is written once per real change, and hostKey
+ * as resetKey so a stale instance can never attribute one box's caps to
+ * another (that exact mis-attribution once ping-ponged writes forever).
+ */
+const CAPS_SYNC_MS = 30_000;
+
+export function useCapsSync(): void {
+  const { settings, ready, update } = useSettings();
+  const configured = settings.host.trim().length > 0;
+  const poll = useCallback(() => api.status(settings), [settings]);
+  const status = usePoll<Status>(
+    poll, CAPS_SYNC_MS, ready && configured, hostKey(settings));
+  const caps = status.data?.caps;
+  useEffect(() => {
+    if (caps && !capsEqual(caps, settings.caps)) {
+      void update({ caps });
+    }
+  }, [caps, settings.caps, update]);
+}


### PR DESCRIPTION
2.9.5's caps persistence made a stale `couchmode:false` sticky: the only re-learner was `RemotePowerBar` (Console/Setup tabs), so a user living on the Pad tab kept a hidden Couch button while the box itself advertised `couchmode:true`. Reproduced in the field on Android 2.9.5 vc39 within hours of release.

`useCapsSync()` mounts in the tab layout — alive on every tab — polling status at a slow 30s safety-net cadence and persisting caps on real change, with the same value-equality + `hostKey` reset guards the RemotePowerBar learner uses (including against the historical cross-box mis-attribution ping-pong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)