### PR TITLE
feat(agent): Restart Decky action — recover a vanished QAM from the app (2.9.16)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.15"
+VERSION = "2.9.16"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -163,6 +163,21 @@ SUSPEND_ACTION = {
     "cmd": ["sudo", "systemctl", "suspend"],
     "user_env": False,
     "detached": True,
+}
+
+# Decky Loader's plugin_loader.service dies whenever Steam's CEF context goes
+# away (a Steam restart, a session switch) and exits CLEANLY, so systemd never
+# auto-restarts it — the Decky panel just silently vanishes from the Quick
+# Access Menu until the next reboot. Observed in the field within hours of it
+# mattering. This action lets the phone fix it. Injected only when the unit
+# exists AND the sudoers grant is present (see _inject_decky_action).
+DECKY_RESTART_ACTION = {
+    "label": "Restart Decky",
+    "description": "Restart Decky Loader when its menu has vanished from Quick Access",
+    "danger": "low",
+    "cmd": ["sudo", "systemctl", "restart", "plugin_loader"],
+    "user_env": False,
+    "detached": False,
 }
 
 # Custom launcher limits (see the SECURITY NOTE in the launcher routes).
@@ -611,6 +626,41 @@ def _inject_suspend_action(mock):
     ACTIONS["suspend"] = dict(SUSPEND_ACTION)
     if "suspend" not in ACTION_ORDER:
         ACTION_ORDER.append("suspend")
+
+
+def _can_sudo_decky_restart():
+    """True when sudoers permits `systemctl restart plugin_loader` without a
+    password. Same probe pattern as _can_sudo_suspend: `sudo -n -l` lists the
+    permission without running anything. False on any failure, so a box whose
+    installer predates the grant omits the action instead of offering a dead
+    one."""
+    try:
+        r = subprocess.run(["sudo", "-n", "-l", "/usr/bin/systemctl",
+                            "restart", "plugin_loader"],
+                           capture_output=True, timeout=4)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def _inject_decky_action(mock):
+    """Add the Restart Decky action on boxes that have Decky Loader installed
+    AND the sudoers grant to restart it. Both gates matter: without the unit
+    the action is meaningless, and without the grant it would just fail — a
+    dead button costs more trust than a missing one. In --mock it is always
+    added so the app's Actions tab can be developed off-box. Called after
+    load_config; idempotent; a config-defined action of the same id wins."""
+    global ACTIONS, ACTION_ORDER
+    if "restart-decky" in ACTIONS:
+        return
+    if not mock:
+        if not os.path.exists("/etc/systemd/system/plugin_loader.service"):
+            return
+        if not _can_sudo_decky_restart():
+            return
+    ACTIONS["restart-decky"] = dict(DECKY_RESTART_ACTION)
+    if "restart-decky" not in ACTION_ORDER:
+        ACTION_ORDER.append("restart-decky")
 
 # ---------------------------------------------------------------------------
 # Real-mode data collection (Linux; each helper degrades gracefully)
@@ -9532,6 +9582,7 @@ def main():
         check_config_writable()  # warn loudly if pairings/launchers can't persist
     _inject_session_actions()
     _inject_suspend_action(args.mock)
+    _inject_decky_action(args.mock)
     set_tv(args.mock)
     set_mpris(args.mock)
     set_screen(args.mock)

--- a/install.sh
+++ b/install.sh
@@ -665,6 +665,14 @@ $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl suspend
+# Decky Loader's plugin_loader.service dies whenever Steam's CEF restarts and
+# exits cleanly, so systemd never revives it — the Decky panel silently
+# vanishes until reboot. This fixed-argument grant lets the app's "Restart
+# Decky" action recover it. Granted even when Decky isn't installed yet: the
+# agent only OFFERS the action when the unit file exists, and a restart of a
+# nonexistent unit is a no-op — while a box that gains Decky later would
+# otherwise need install.sh re-run before the recovery action could appear.
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart plugin_loader
 # System-journal reads go through a fixed-argument, root-owned wrapper that
 # validates the unit + line count and calls journalctl with a locked-down
 # option set. Granting the wrapper (never journalctl itself) is the only way to


### PR DESCRIPTION
Decky's `plugin_loader.service` exits **cleanly** whenever Steam's CEF restarts, so systemd never revives it — the Decky panel silently vanishes until reboot. Observed live tonight on the Legion Go.

New injected action (Suspend's pattern), double-gated: unit file present **and** passwordless `systemctl restart plugin_loader` grant (`sudo -n -l` probe). Either gate missing → no action; a dead button costs more trust than a missing one. `danger: low`. Always present in `--mock`.

`install.sh` adds the fixed-argument grant unconditionally (agent still gates on the unit file; restarting a nonexistent unit is a no-op; a box that gains Decky later shouldn't need install.sh re-run). The plugin adds the same grant itself in couchside-decky — that's what heals existing Decky boxes on plugin update.

Zero app changes — the Actions tab renders what the agent lists. Verified in mock:
```
{'id': 'restart-decky', 'label': 'Restart Decky', 'danger': 'low', ...}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)