### PR TITLE
chore(app): 2.9.6 — the reliability build (iOS 56 / vc 40)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "55",
+      "buildNumber": "56",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 39
+      "versionCode": 40
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.5",
+    "version": "2.9.6",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",


### PR DESCRIPTION
Version cut for tonight's audit fixes: pong watchdog (#102), takeover card (#100), global caps sync (#99), Restart Decky action (#101 UI side arrives via agent), leak fix agent 2.9.16 already live. Numbers are the EAS-built actuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)