### PR TITLE
fix: sudoers ordering — zz-couchside + last-match-aware probe (2.9.18)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.17"
+VERSION = "2.9.18"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -600,23 +600,46 @@ def _inject_session_actions():
                 ACTION_ORDER.append(aid)
 
 
-def _sudo_nopasswd_allows(needle):
-    """True when sudoers permits the command WITHOUT a password.
+def _nopasswd_last_match(rules_text, needle):
+    """Pure last-match-wins evaluation of `sudo -l` rule output.
 
-    `sudo -n -l <cmd>` is NOT a sufficient probe: it exits 0 when ANY rule
-    allows the command — including a wheel-style "(ALL) ALL" rule that still
-    prompts. That false positive shipped a Restart Decky button that appeared
-    on a box and then failed with "sudo: a password is required" (field
-    screenshot, 2026-07-19). Parse the actual rule list instead and require a
-    NOPASSWD rule that names the command. False on any failure: a missing
-    grant must HIDE the action, never offer a dead one."""
+    Two field failures taught this function its shape, one per naive version:
+      * `sudo -n -l <cmd>` exit-code probing: exits 0 for ANY allowing rule,
+        including wheel's password-requiring "(ALL) ALL". Shipped a Restart
+        Decky button that appeared and then failed "a password is required".
+      * "any NOPASSWD line names the command": sudoers is LAST-match-wins, and
+        sudoers.d files load in lexical order — a box's `wheel` file
+        ("(ALL) ALL", password) sorted after our `couchside` file and silently
+        shadowed EVERY NOPASSWD grant for three days. The rules were all
+        visible in `sudo -l`; only the ordering made them dead. (This is also
+        why the installers now write `zz-couchside`: it must sort LAST.)
+
+    So: walk the rule lines in order, track the LAST rule that matches the
+    command — a rule naming it, or an ALL rule which matches everything — and
+    answer whether THAT rule is NOPASSWD."""
+    allowed = None
+    for line in rules_text.splitlines():
+        line = line.strip()
+        if not line.startswith("("):
+            continue                      # not a rule line (Defaults, headers)
+        body = line.split(")", 1)[1].strip() if ")" in line else line
+        matches_all = (body == "ALL" or body == "NOPASSWD: ALL"
+                       or body.endswith(": ALL"))
+        if matches_all or needle in line:
+            allowed = "NOPASSWD" in line
+    return bool(allowed)
+
+
+def _sudo_nopasswd_allows(needle):
+    """True when sudoers ACTUALLY permits the command without a password —
+    last-match evaluated (see _nopasswd_last_match). False on any failure: a
+    missing grant must HIDE an action, never offer a dead one."""
     try:
         r = subprocess.run(["sudo", "-n", "-l"], capture_output=True,
                            timeout=4, text=True)
         if r.returncode != 0:
             return False
-        return any("NOPASSWD" in line and needle in line
-                   for line in r.stdout.splitlines())
+        return _nopasswd_last_match(r.stdout, needle)
     except Exception:
         return False
 

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,14 @@ CONFIG_FILE="${STATE_DIR}/config.json"
 # injected to read arbitrary files as root. Lives in the root-owned ETC_DIR so
 # the desktop user can execute but never modify it.
 JOURNAL_WRAPPER="${ETC_DIR}/couchside-journal"
-SUDOERS_FILE="/etc/sudoers.d/couchside"
+# zz- prefix is LOAD-BEARING: sudoers.d files apply in lexical order and
+# sudoers is last-match-wins, so a distro/user "wheel" file ("(ALL) ALL",
+# password required) sorting AFTER ours silently shadowed every NOPASSWD grant
+# on a real box for three days — the rules were visible in `sudo -l` and dead
+# in practice. zz- sorts after any conventional file name, making our
+# fixed-argument grants the last (winning) match for exactly their commands.
+SUDOERS_FILE="/etc/sudoers.d/zz-couchside"
+SUDOERS_FILE_LEGACY="/etc/sudoers.d/couchside"
 UNIT_DST="/etc/systemd/system/couchside.service"
 
 # Decky Loader's plugin directory (root-owned). The optional Game Mode panel is
@@ -373,9 +380,9 @@ if [ "$UNINSTALL" -eq 1 ]; then
             note "kept $ETC_DIR"
         fi
     fi
-    if sudo test -e "$SUDOERS_FILE"; then
+    if sudo test -e "$SUDOERS_FILE" || sudo test -e "$SUDOERS_FILE_LEGACY"; then
         if ask_yn "Remove sudoers rule $SUDOERS_FILE?"; then
-            sudo rm -f "$SUDOERS_FILE"
+            sudo rm -f "$SUDOERS_FILE" "$SUDOERS_FILE_LEGACY"
             note "removed $SUDOERS_FILE"
         else
             note "kept $SUDOERS_FILE"
@@ -685,6 +692,9 @@ SUDOERS
     echo "------------------------------------------------------------------"
     sudo visudo -cf "$WORK_DIR/couchside-sudoers"
     sudo install -m 0440 -o root -g root "$WORK_DIR/couchside-sudoers" "$SUDOERS_FILE"
+    # Retire the pre-rename file: leaving it costs nothing functionally (the
+    # zz- copy wins), but two files with overlapping rules is a debugging trap.
+    sudo rm -f "$SUDOERS_FILE_LEGACY"
 fi
 
 # ---------------------------------------------------------------------------

--- a/tests/test_guide_hold.py
+++ b/tests/test_guide_hold.py
@@ -275,10 +275,34 @@ def test_config_defaults():
             check("rejects bad config %r" % (bad,), type(e).__name__, "ConfigError")
 
 
+def test_sudo_last_match():
+    """The NOPASSWD probe must honor sudoers' last-match-wins semantics.
+
+    Field failure: a `wheel` sudoers.d file ("(ALL) ALL", password) sorted
+    after ours and shadowed every NOPASSWD grant — visible in `sudo -l`, dead
+    in practice. The probe must judge the LAST matching rule, not any rule.
+    """
+    print("sudo last-match evaluation")
+    f = cs._nopasswd_last_match
+    grant = "    (root) NOPASSWD: /usr/bin/systemctl reboot"
+    wheel = "    (ALL) ALL"
+    check("grant then shadowing (ALL) ALL -> DENIED (the field bug)",
+          f(grant + "\n" + wheel, "systemctl reboot"), False)
+    check("(ALL) ALL then grant -> allowed (zz- ordering)",
+          f(wheel + "\n" + grant, "systemctl reboot"), True)
+    check("NOPASSWD: ALL as last match -> allowed",
+          f(grant + "\n    (ALL) NOPASSWD: ALL", "systemctl reboot"), True)
+    check("no matching rule -> denied", f("    (root) NOPASSWD: /usr/bin/foo",
+                                          "systemctl reboot"), False)
+    check("non-rule lines ignored",
+          f("Defaults!visudo env_keep\n" + grant, "systemctl reboot"), True)
+
+
 if __name__ == "__main__":
     for fn in (test_pad_discrimination, test_declares_key,
                test_favourite_filter, test_hold_timing,
-               test_event_decoding, test_config_defaults):
+               test_event_decoding, test_config_defaults,
+               test_sudo_last_match):
         fn()
     print()
     if FAILURES:


### PR DESCRIPTION
Layer three of the NOPASSWD saga: sudoers.d loads lexically and sudoers is **last-match-wins** — a `wheel` file (`(ALL) ALL`, password) sorting after `couchside` silently shadowed every grant for three days while `sudo -l` displayed them all. The app's detached Reboot showed exit 0 while nothing happened; `mv couchside zz-couchside` revived everything instantly on the live box.

- installers write **`zz-couchside`** (sorts last → our fixed-arg rules win for exactly their commands); legacy file removed on install and uninstall
- probe now evaluates like sudo does: last matching rule (command-named or `ALL`) decides, and it must be NOPASSWD
- unit tests pin the exact field bug + the recovery ordering

Companion plugin PR migrates Decky boxes as root (no password needed there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)