### PR TITLE
feat(app): Couch Mode ceremony — staged progress UI

### DIFF
--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -9,10 +9,11 @@
  * poll.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useCallback, useEffect, useState } from 'react';
-import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { api, ConnSettings, Displays } from '@/lib/api';
+import { usePoll } from '@/hooks/usePoll';
+import { api, CeremonyStage, CeremonyStatus, ConnSettings, Displays, hostKey } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { mono, Palette, useTheme, useThemedStyles } from '@/lib/theme';
 
@@ -42,32 +43,80 @@ export function CouchModeSheet({
   const canPickOutput = outputs.length > 1 && displays?.output_forcing !== false;
   const [output, setOutput] = useState<string>(outputs[0] ?? '');
   const [busy, setBusy] = useState(false);
+  // We started a ceremony this session (POST returned a job). jobId pins which
+  // job is "ours" so a stale terminal frame from an earlier ceremony can't show.
+  const [started, setStarted] = useState(false);
+  const [jobId, setJobId] = useState<number | null>(null);
+
+  // Poll the ceremony status whenever the sheet is open — this is what lets a
+  // SECOND phone join a ceremony the first one started (catch-up is free; the
+  // agent returns the full stage array every poll). null on an older agent (404)
+  // -> we stay on the synchronous path.
+  const statusPoll = usePoll<CeremonyStatus | null>(
+    () => api.couchModeStatus(settings), 800, visible, hostKey(settings));
+  const job = statusPoll.data;
+
+  // Show the ceremony view while a job actively runs, OR at the terminal frame
+  // of the job WE started. A stale 'done' we didn't start is ignored -> picker.
+  const showCeremony =
+    job?.state === 'running' ||
+    (started && jobId != null && job?.id === jobId &&
+      (job?.state === 'done' || job?.state === 'failed'));
 
   // Seed the picker from the box's current outputs when the sheet OPENS — not
-  // on every background poll (which would fight a mid-selection change).
+  // on every background poll (which would fight a mid-selection change). Also
+  // reset ceremony bookkeeping so reopening after a run starts clean.
   const wasVisible = React.useRef(false);
   useEffect(() => {
     const opening = visible && !wasVisible.current;
     wasVisible.current = visible;
     if (!opening) return;
     setOutput((cur) => (outputs.includes(cur) ? cur : outputs[0] ?? ''));
+    setStarted(false);
+    setJobId(null);
+    setBusy(false);
   }, [visible, outputs]);
+
+  // Fire onChanged / haptics once, on the running->terminal edge (works for our
+  // own ceremony AND one we joined). onChanged updates the caller's optimistic
+  // session so the top-bar reflects reality without waiting on its slow poll.
+  const prevState = useRef<string | undefined>(undefined);
+  useEffect(() => {
+    const s = job?.state;
+    if (prevState.current === 'running' && s !== 'running') {
+      if (s === 'done') {
+        hapticSuccess();
+        onChanged(job?.session === 'desktop' ? 'desktop' : 'gamescope');
+      } else if (s === 'failed') {
+        hapticError();
+      }
+    }
+    prevState.current = s;
+  }, [job?.state, job?.session, onChanged]);
 
   const fling = useCallback(async () => {
     if (busy || !output) return;
     setBusy(true);
     hapticLight();
     try {
-      await api.couchModeStart(settings, output);
-      hapticSuccess();
-      onChanged('gamescope');
-      onClose();
+      const res = await api.couchModeStart(settings, output);
+      if (res && 'stages' in res && Array.isArray(res.stages)) {
+        // New agent: enter the ceremony; the poll drives the staged UI.
+        setJobId(res.id);
+        setStarted(true);
+        statusPoll.refresh();
+      } else {
+        // Old agent (synchronous {ok}): today's optimistic close.
+        hapticSuccess();
+        onChanged('gamescope');
+        onClose();
+      }
     } catch {
       hapticError();
     } finally {
       setBusy(false);
     }
-  }, [busy, output, settings, onChanged, onClose]);
+  }, [busy, output, settings, onChanged, onClose, statusPoll]);
 
   const toDesktop = useCallback(async () => {
     if (busy) return;
@@ -91,7 +140,10 @@ export function CouchModeSheet({
         <Pressable style={styles.sheet} onPress={() => {}}>
           <Text style={styles.title}>COUCH MODE</Text>
 
-          {inGameMode ? (
+          {showCeremony ? (
+            <CeremonyView job={job!} t={t} styles={styles} onClose={onClose}
+              onRetry={fling} />
+          ) : inGameMode ? (
             <>
               <View style={styles.armedRow}>
                 <Ionicons name="game-controller" size={18} color={t.green} />
@@ -152,6 +204,109 @@ export function CouchModeSheet({
   );
 }
 
+type Styles = ReturnType<typeof makeStyles>;
+
+/** Icon + color for a stage's state. running uses a spinner, handled by caller. */
+function stageIcon(stage: CeremonyStage, t: Palette): { name: string; color: string } {
+  if (stage.state === 'ok') return { name: 'checkmark-circle', color: t.green };
+  if (stage.state === 'failed') {
+    return stage.fatal
+      ? { name: 'close-circle', color: t.red }
+      : { name: 'warning', color: t.amber };
+  }
+  if (stage.state === 'skipped') {
+    return { name: 'remove-circle-outline', color: t.textFaint };
+  }
+  return { name: 'ellipse-outline', color: t.textFaint }; // pending
+}
+
+function StageRow({ stage, t, styles }: { stage: CeremonyStage; t: Palette; styles: Styles }) {
+  const icon = stageIcon(stage, t);
+  return (
+    <View style={styles.stageRow}>
+      {stage.state === 'running' ? (
+        <ActivityIndicator size="small" color={t.blue} style={styles.stageIcon} />
+      ) : (
+        <Ionicons name={icon.name as never} size={20} color={icon.color} style={styles.stageIcon} />
+      )}
+      <View style={styles.stageBody}>
+        <Text style={styles.stageLabel}>{stage.label}</Text>
+        {stage.reason ? <Text style={styles.stageReason}>{stage.reason}</Text> : null}
+      </View>
+    </View>
+  );
+}
+
+/** The staged progress view: one row per stage, then a state-aware footer. */
+function CeremonyView({
+  job,
+  t,
+  styles,
+  onClose,
+  onRetry,
+}: {
+  job: CeremonyStatus;
+  t: Palette;
+  styles: Styles;
+  onClose: () => void;
+  onRetry: () => void;
+}) {
+  const running = job.state === 'running';
+  const failed = job.state === 'failed';
+  // A completed ceremony where a non-fatal stage (audio) failed -> amber note.
+  const softFail = job.state === 'done' && job.stages.some(
+    (s) => s.state === 'failed' && !s.fatal);
+  const fatalStage = job.stages.find((s) => s.state === 'failed' && s.fatal);
+
+  return (
+    <>
+      <View style={styles.stageList}>
+        {job.stages.map((s) => <StageRow key={s.key} stage={s} t={t} styles={styles} />)}
+      </View>
+
+      {running && (
+        <Text style={styles.summaryRunning}>Flinging to the TV…</Text>
+      )}
+      {job.state === 'done' && !softFail && (
+        <Text style={[styles.summary, { color: t.green }]}>On the TV.</Text>
+      )}
+      {softFail && (
+        <Text style={[styles.summary, { color: t.amber }]}>
+          On the TV — but the sound didn&apos;t move. Check the audio row.
+        </Text>
+      )}
+      {failed && (
+        <Text style={[styles.summary, { color: t.red }]}>
+          Couldn&apos;t reach Game Mode{fatalStage?.reason ? ` — ${fatalStage.reason}` : ''}.
+        </Text>
+      )}
+
+      {!running && (
+        <View style={styles.ceremonyBtns}>
+          {failed && (
+            <Pressable
+              onPress={onRetry}
+              style={({ pressed }) => [styles.startBtn, styles.ceremonyBtn, pressed && styles.pressed]}>
+              <Ionicons name="refresh" size={18} color="#fff" />
+              <Text style={styles.startText}>Try again</Text>
+            </Pressable>
+          )}
+          <Pressable
+            onPress={onClose}
+            style={({ pressed }) => [
+              styles.startBtn,
+              styles.ceremonyBtn,
+              failed && styles.ceremonyBtnSecondary,
+              pressed && styles.pressed,
+            ]}>
+            <Text style={styles.startText}>{failed ? 'Close' : 'Done'}</Text>
+          </Pressable>
+        </View>
+      )}
+    </>
+  );
+}
+
 const makeStyles = (t: Palette) => StyleSheet.create({
   backdrop: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'flex-end' },
   sheet: {
@@ -205,4 +360,17 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     padding: 12,
   },
   armedText: { color: t.text, fontSize: 15 },
+
+  // Ceremony staged view
+  stageList: { marginTop: 8, gap: 2 },
+  stageRow: { flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 8 },
+  stageIcon: { width: 20, height: 20, alignItems: 'center', justifyContent: 'center' },
+  stageBody: { flex: 1 },
+  stageLabel: { color: t.text, fontSize: 15 },
+  stageReason: { color: t.textDim, fontSize: 12, marginTop: 2, lineHeight: 16 },
+  summary: { fontSize: 14, fontWeight: '600', marginTop: 10 },
+  summaryRunning: { color: t.textDim, fontSize: 14, marginTop: 10 },
+  ceremonyBtns: { flexDirection: 'row', gap: 10, marginTop: 6 },
+  ceremonyBtn: { flex: 1, marginTop: 8 },
+  ceremonyBtnSecondary: { backgroundColor: t.inset },
 });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -131,6 +131,40 @@ export type Displays = {
   output_forcing?: boolean;
 };
 
+/** One stage of the Couch Mode ceremony (GET /api/couch-mode/status, agent
+    >= 2.9.19). */
+export type CeremonyStage = {
+  key: 'tv_power_on' | 'tv_input' | 'output' | 'session' | 'audio';
+  label: string;
+  state: 'pending' | 'running' | 'ok' | 'skipped' | 'failed';
+  /** Why it was skipped/failed (SteamOS ignores the picker; the TV's HDMI sink
+      never woke; no TV backend…). */
+  reason?: string;
+  /** Only the session switch is fatal. A non-fatal `failed` (e.g. audio) is a
+      warning the UI renders amber, not red — Game Mode still came up. */
+  fatal?: boolean;
+};
+
+/** The Couch Mode ceremony job. Full array every poll, so a phone joining
+    mid-run catches up for free. */
+export type CeremonyStatus = {
+  id: number;
+  state: 'idle' | 'running' | 'done' | 'failed';
+  output?: string;
+  hdr?: boolean;
+  /** The VERIFIED session at a terminal state (not a fake-green assumption). */
+  session?: 'gamescope' | 'desktop' | null;
+  started_at?: number;
+  stages: CeremonyStage[];
+  // A new agent's POST response also carries legacy {ok, steps}; the new app
+  // ignores them and drives the UI from `stages`.
+};
+
+/** POST /api/couch-mode returns the initial ceremony job (agent >= 2.9.19) OR
+    the old synchronous {ok, ...} (older agent). The sheet feature-detects on
+    the presence of a `stages` array. */
+export type CouchModeStartResult = CeremonyStatus | { ok: boolean };
+
 /** GET/POST /api/screensaver state (agent >= 2.8.4). */
 export type Screensaver = {
   available: boolean;
@@ -1360,11 +1394,19 @@ export const api = {
     settings: ConnSettings,
     output: string,
     hdr = false,
-  ): Promise<{ ok: boolean }> {
+  ): Promise<CouchModeStartResult> {
     return request(settings, '/api/couch-mode', {
       method: 'POST',
       body: { output, hdr },
     });
+  },
+
+  /** Couch Mode ceremony status. Probe-and-appear: null on 404 (older agent, or
+      the box can't do the handoff) so the sheet degrades to the synchronous
+      path and never polls a route that isn't there. */
+  couchModeStatus(settings: ConnSettings): Promise<CeremonyStatus | null> {
+    return probeOrNull(
+      request<CeremonyStatus>(settings, '/api/couch-mode/status'));
   },
 
   /** Exit Couch Mode: return the box to its desktop session. */


### PR DESCRIPTION
Companion to couchside#106 (agent 2.9.19). The Couch button was a spinner that optimistically closed — a half-worked switch (Game Mode never came up, or audio stayed on the box) looked identical to success.

Now the sheet polls `GET /api/couch-mode/status` and renders one row per stage (TV power, TV input, Display, Game Mode, Audio) with per-state icons and the agent's reason lines, plus a state-aware footer (running / "On the TV." / amber "sound didn't move" / "Couldn't reach Game Mode — reason" + Try again).

- **Second phone joins**: polls whenever visible, agent returns the full stage array every poll — catch-up is free.
- **Both-direction degrade**: feature-detects `stages` in the POST response (new agent → ceremony; old agent → today's optimistic close); `couchModeStatus` 404s on old agents → never polled.
- `onChanged` fires once on the running→terminal edge so the top bar reflects the *verified* session.

Typechecks clean (only the 4 pre-existing missing-module errors remain). New `CeremonyStage`/`CeremonyStatus`/`CouchModeStartResult` types + `api.couchModeStatus()`. Exit + picker views unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)