### PR TITLE
chore(app): 2.9.7 — Couch Mode ceremony UI (iOS 57 / vc 41)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.6",
+    "version": "2.9.7",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "56",
+      "buildNumber": "57",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 40
+      "versionCode": 41
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Ships the staged Couch Mode progress view (#107): each stage (TV power, input, display, Game Mode, audio) with honest per-stage results instead of a spinner, driven by the agent's job-status endpoint (agent 2.9.19, already live on box channels). Degrades to today's optimistic switch on older agents. EAS-built actuals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)