### PR TITLE
copy: agent->service in the iOS Local-Network permission prompt

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.6",
+    "version": "2.9.7",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app.json
+++ b/app/app.json
@@ -17,7 +17,7 @@
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
         },
-        "NSLocalNetworkUsageDescription": "Couchside connects to the Couchside agent on your media center or Steam machine over your local network.",
+        "NSLocalNetworkUsageDescription": "Couchside connects to the Couchside service on your media center or Steam machine over your local network.",
         "NSBonjourServices": [
           "_http._tcp"
         ]

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "56",
+      "buildNumber": "57",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 40
+      "versionCode": 41
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
The last user-facing "Couchside **agent**" string → "Couchside **service**": `app.json` `NSLocalNetworkUsageDescription`, which shows in the iOS Local Network permission dialog. Reaches users with the next app build. Completes the agent→service rename across all shipped surfaces.

(The store-description WoL-wording fixes from the audit were applied to the local `store/*.md` drafts, which are gitignored — they're over-budget working supersets, not the literal uploaded copy, so they stay local for the next manual upload. The fuller store enrichment needs a char-budget reconcile — flagged for follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)