### PR TITLE
fix(reconnect): learn box LAN IP from /api/status — app 2.9.8 / agent 2.9.22

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.21"
+VERSION = "2.9.22"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -8541,6 +8541,17 @@ class Handler(BaseHTTPRequestHandler):
 
             if path == "/api/status":
                 data = mock_status() if self.mock else real_status()
+                # The LAN IP the phone actually reached us on. The app caches it
+                # as the box's fallback address and REFRESHES it every poll, so a
+                # box added by hostname gets a working fallback and a box whose
+                # DHCP lease drifts stays reachable when mDNS (.local) breaks —
+                # e.g. right after an agent restart, when Game Mode WiFi
+                # power-save has dropped the multicast mDNS needs. Same value as
+                # /api/ping's "ip"; here it rides the poll the app already makes.
+                try:
+                    data["ip"] = self.connection.getsockname()[0]
+                except OSError:
+                    pass
                 self._send(200, data, started)
             elif path == "/api/units":
                 units = mock_units() if self.mock else real_units()

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.7",
+    "version": "2.9.8",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "57",
+      "buildNumber": "58",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 41
+      "versionCode": 42
     },
     "web": {
       "bundler": "metro",

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -10,7 +10,7 @@ import { usePoll } from '@/hooks/usePoll';
 import { api, capsEqual, Displays, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
-import { normalizeMac } from '@/lib/settings';
+import { normalizeMac, isValidLanIp } from '@/lib/settings';
 import { useBoxes, useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
@@ -209,6 +209,16 @@ export function RemotePowerBar() {
     const mac = normalizeMac(s?.net?.mac);
     if (mac && mac !== settings.mac) void update({ mac });
   }, [s?.net?.mac, settings.mac, update]);
+
+  // Learn + REFRESH the box's LAN IP from status (agent >= 2.9.22). lastIp is
+  // otherwise written only at pairing, so a box added by hostname never got one
+  // and a box whose DHCP lease drifted kept a stale one — leaving raceGet's
+  // cached-IP fallback unable to engage when mDNS (.local) breaks, e.g. right
+  // after an agent restart. Refreshing every poll keeps the fallback live.
+  React.useEffect(() => {
+    const ip = s?.ip;
+    if (ip && isValidLanIp(ip) && ip !== settings.lastIp) void update({ lastIp: ip });
+  }, [s?.ip, settings.lastIp, update]);
 
   // Learn + persist the box's capability summary from status (agent >= 2.8.2),
   // so the tab bar can hide gaming tabs on a server box immediately on next

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -198,6 +198,10 @@ export type Status = {
   disks: DiskInfo[];
   /** Network facts for the power/Wake-on-LAN path (agent >= 2.6). */
   net?: NetInfo;
+  /** The LAN IP the phone reached the box on (agent >= 2.9.22). The app learns
+      it into the box's lastIp every poll, so the cached-IP fallback stays fresh
+      and works for boxes added by hostname. */
+  ip?: string;
   agent_version: string;
   /** Optional-feature summary (agent >= 2.8.2); undefined on older agents. See BoxCaps. */
   caps?: BoxCaps;


### PR DESCRIPTION
## Problem (#11)
App stuck **offline** after an app-triggered box update until the app was restarted.

**Root cause:** `Box.lastIp` — the cached fallback `raceGet()` uses when mDNS (`.local`) breaks — was written **only at pairing**. A box added by hostname (e.g. `bazzite.local`) never got one; a box whose DHCP lease drifted kept a stale one. So right after the agent restarts — when Game-Mode WiFi power-save has dropped the multicast mDNS needs — the fallback had no live address and the app hung on the dead `.local` name.

## Fix (mirrors the existing MAC learner)
- **agent** (`2.9.21 → 2.9.22`): `/api/status` returns `"ip"` = `self.connection.getsockname()[0]`, the LAN IP the phone actually reached the box on (same value `/api/ping` returns, here riding the poll the app already makes).
- **app**: `RemotePowerBar` learns + persists `status.ip` into the active box's `lastIp` **every poll**, gated by `isValidLanIp`. `gamepad.ts` already re-reads a refreshed `lastIp`, so WS reconnects pick it up too.
- **app version** → `2.9.8` (iOS build 58 / Android vc42).

## Verification
- Agent tests green (`test_guide_hold`, `test_gamepad_handoff`, `test_couch_ceremony`).
- Mock smoke: `/api/status` now carries `ip`.
- App typechecks clean (pre-existing missing-dep errors only).

Fixes the durable reconnect path; needs both an agent release (2.9.22 → channels) and an app build to reach a live box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)