### PR TITLE
chore(app): reconcile build numbers to 59/43 (shipped 2.9.8)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "58",
+      "buildNumber": "59",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 42
+      "versionCode": 43
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
EAS autoincrement bumped iOS buildNumber 58→59 and Android versionCode 42→43 for the 2.9.8 production build. Reconciling app.json so git matches what shipped (build-number drift hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)