### PR TITLE
feat(steamlink): native Steam Remote Play — 'Stream from PC' (agent 2.9.23)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Unit tests (couch ceremony)
         run: python3 tests/test_couch_ceremony.py
 
+      # Steam Remote Play discovery: parse remoteclients.vdf (streamable host
+      # games) + the v29 appinfo.vdf name cache (a synthetic fixture locks the
+      # binary parser), the most-recent-host de-dupe, the tool filter, and the
+      # launch allowlist gate. Native in-home streaming, no Steam Link install.
+      - name: Unit tests (steam link / remote play)
+        run: python3 tests/test_steamlink.py
+
   smoke:
     runs-on: ubuntu-latest
     needs: compile

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.22"
+VERSION = "2.9.23"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -931,7 +931,7 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver", "couchmode", "desktop")}
+                 "screensaver", "couchmode", "desktop", "steamlink")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -943,6 +943,7 @@ def set_caps(mock):
         "screensaver": safe(screensaver_available),
         "couchmode": safe(couchmode_available),
         "desktop": safe(desktop_available),
+        "steamlink": safe(steamlink_available),
     }
 
 
@@ -2752,6 +2753,279 @@ def discover_steam_games():
         return []
 
 
+# ---------------------------------------------------------------------------
+# Steam Remote Play — in-home streaming (/api/steamlink).
+#
+# The box's Steam client can stream games FROM another Steam machine on the LAN
+# (your gaming PC or another Deck) — the Steam client IS the streaming client,
+# so there is nothing to install. Steam caches every host it has streamed from,
+# and the appids that host offers, in config/remoteclients.vdf. We surface those
+# as one-tap "stream this game" tiles: launching steam://rungameid/<appid> for a
+# game that is NOT installed locally but that an online host offers makes Steam
+# stream it (verified on real hardware: a single rungameid brought up the
+# streaming_client, no install manifest). If the host is offline the launch is a
+# no-op on the box, so this is safe to fire optimistically.
+#
+# Names come from Steam's own appinfo.vdf cache (LAN-only, never a CDN — matches
+# the cover-art policy), so host-only games that were never installed still show
+# their real title. Cover art rides the existing /api/steam/<appid>/cover, which
+# 404s for uncached art; the app falls back to the title.
+# ---------------------------------------------------------------------------
+
+# appinfo.vdf name cache: parsing the (multi-MB) blob on every /api/steamlink
+# poll is wasteful, and it changes rarely. Cache the full {appid:int -> name}
+# map keyed by the file's mtime+size so a Steam metadata refresh invalidates it.
+_APPINFO_CACHE = {"key": None, "names": {}}
+_APPINFO_LOCK = threading.Lock()
+_APPINFO_MAGIC_V29 = 0x07564429
+_APPINFO_MAGIC_V28 = 0x07564428
+
+
+def _appinfo_path():
+    root = _steam_root()
+    if root is None:
+        return None
+    p = os.path.join(root, "appcache", "appinfo.vdf")
+    return p if os.path.isfile(p) else None
+
+
+def _parse_appinfo_names(data):
+    """{appid:int -> name:str} from an appinfo.vdf blob (v28 inline-key or v29
+    string-table). Defensive: a malformed app entry is skipped, never raised;
+    a wholly unparseable blob yields {}. Only common->name is extracted."""
+    names = {}
+    try:
+        magic = struct.unpack_from("<I", data, 0)[0]
+    except struct.error:
+        return names
+    if magic not in (_APPINFO_MAGIC_V29, _APPINFO_MAGIC_V28):
+        return names
+    v29 = magic == _APPINFO_MAGIC_V29
+    # string table (v29 only): keys in the KV blob are int32 indices into it.
+    name_idx = None
+    if v29:
+        try:
+            st_off = struct.unpack_from("<q", data, 8)[0]
+            count = struct.unpack_from("<I", data, st_off)[0]
+            strings, p = [], st_off + 4
+            for _ in range(count):
+                e = data.index(b"\x00", p)
+                strings.append(data[p:e])
+                p = e + 1
+            name_idx = strings.index(b"name")
+        except (struct.error, ValueError, IndexError):
+            return names
+        section = 16
+    else:
+        section = 12
+    # Within an app entry the KV blob begins after the fixed header fields:
+    # infoState(4) lastUpdated(4) picsToken(8) sha1(20) changeNumber(4)
+    # + v29's second (binary-vdf) sha1(20).
+    kv_off = 4 + 4 + 8 + 20 + 4 + (20 if v29 else 0)
+    n = len(data)
+    p = section
+    while p + 8 <= n:
+        try:
+            appid = struct.unpack_from("<I", data, p)[0]
+            if appid == 0:
+                break
+            size = struct.unpack_from("<I", data, p + 4)[0]
+            blob_start = p + 8
+            blob_end = blob_start + size
+            p = blob_end
+            names_val = _appinfo_find_name(data, blob_start + kv_off,
+                                           min(blob_end, n), name_idx, v29)
+            if names_val:
+                names[appid] = names_val
+        except (struct.error, ValueError, IndexError):
+            break
+    return names
+
+
+def _appinfo_find_name(data, start, end, name_idx, v29):
+    """The first string field named "name" in one app's KV blob, or None. Keys
+    are int32 string-table indices (v29) or inline NUL-terminated (v28)."""
+    p = start
+    depth = 0
+    try:
+        while p < end:
+            t = data[p]
+            p += 1
+            if t == 0x08:            # end of map
+                depth -= 1
+                if depth < 0:
+                    return None
+                continue
+            if v29:
+                key = struct.unpack_from("<I", data, p)[0]
+                p += 4
+            else:
+                e = data.index(b"\x00", p)
+                key = data[p:e]
+                p = e + 1
+            if t == 0x00:            # nested map
+                depth += 1
+                continue
+            if t == 0x01:            # string value
+                e = data.index(b"\x00", p)
+                val = data[p:e]
+                p = e + 1
+                if (name_idx is not None and key == name_idx) or \
+                        (name_idx is None and key == b"name"):
+                    return val.decode("utf-8", "replace")
+                continue
+            if t == 0x02:            # int32
+                p += 4
+                continue
+            if t == 0x07:            # int64
+                p += 8
+                continue
+            return None              # unknown type: stop this app safely
+    except (IndexError, struct.error):
+        return None
+    return None
+
+
+def _steam_appinfo_names():
+    """{appid:int -> name}, cached by appinfo.vdf mtime+size. {} on any error."""
+    path = _appinfo_path()
+    if path is None:
+        return {}
+    try:
+        st = os.stat(path)
+        key = (st.st_mtime, st.st_size)
+    except OSError:
+        return {}
+    with _APPINFO_LOCK:
+        if _APPINFO_CACHE["key"] == key:
+            return _APPINFO_CACHE["names"]
+    try:
+        with open(path, "rb") as f:
+            names = _parse_appinfo_names(f.read())
+    except OSError:
+        return {}
+    with _APPINFO_LOCK:
+        _APPINFO_CACHE["key"] = key
+        _APPINFO_CACHE["names"] = names
+    return names
+
+
+def _remoteclients_path():
+    root = _steam_root()
+    if root is None:
+        return None
+    p = os.path.join(root, "config", "remoteclients.vdf")
+    return p if os.path.isfile(p) else None
+
+
+def _vdf_line_val(line):
+    """The VALUE of a `"key"  "value"` text-VDF line (the last quoted token), or
+    None. Used for remoteclients.vdf, which has no nesting we care about."""
+    parts = line.split('"')
+    if len(parts) >= 4:
+        return parts[-2]
+    if len(parts) == 3:              # a lone `"token"` (e.g. the "apps" key)
+        return parts[1]
+    return None
+
+
+def _parse_remoteclients(text):
+    """[{host, last, apps:[appid_str,...]}] from a remoteclients.vdf blob. Text
+    line-scan (pure-stdlib agent, no VDF parser). Best-effort; [] on trouble."""
+    hosts = []
+    cur = None
+    in_apps = False
+    for raw in text.splitlines():
+        s = raw.strip()
+        if s.startswith('"hostname"'):
+            cur = {"host": _vdf_line_val(s) or "", "last": 0, "apps": []}
+            hosts.append(cur)
+            in_apps = False
+        elif cur is not None and s.startswith('"lastupdated"'):
+            try:
+                cur["last"] = int(_vdf_line_val(s) or "0")
+            except (TypeError, ValueError):
+                pass
+        elif s == '"apps"':
+            in_apps = True
+        elif in_apps:
+            if s.startswith("}"):
+                in_apps = False
+            elif cur is not None:
+                v = _vdf_line_val(s)
+                if v and v.isdigit():
+                    cur["apps"].append(v)
+    return hosts
+
+
+def discover_stream_games():
+    """Streamable host games as launcher dicts, most-recent host per appid.
+    Each -> {"id":"stream:<appid>","label":<name>,"kind":"stream",
+    "appid":<int>,"host":<hostname>}. Tools/runtimes skipped. Read-only,
+    best-effort: any failure yields []."""
+    try:
+        path = _remoteclients_path()
+        if path is None:
+            return []
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            hosts = _parse_remoteclients(f.read())
+        names = _steam_appinfo_names()
+        best = {}  # appid(str) -> (last_seen, host)
+        for h in hosts:
+            for a in h["apps"]:
+                prev = best.get(a)
+                if prev is None or h["last"] > prev[0]:
+                    best[a] = (h["last"], h["host"])
+        out = []
+        for a, (last, host) in best.items():
+            name = names.get(int(a), "")
+            if _is_steam_tool(a, name):
+                continue
+            out.append({
+                "id": "stream:%s" % a,
+                "label": name or ("App %s" % a),
+                "kind": "stream",
+                "appid": int(a),
+                "host": host,
+                "last": last,
+            })
+        out.sort(key=lambda l: (l["label"].lower(), l["appid"]))
+        return out
+    except Exception:
+        return []
+
+
+def _streamable_appids():
+    """Set of appid strings currently offered by any known host — the allowlist
+    the launch route validates against so only a real streamable game fires."""
+    return {str(g["appid"]) for g in discover_stream_games()}
+
+
+def steamlink_available():
+    """Steam present AND at least one host offers at least one streamable game.
+    Boot-time hint (rides caps); GET /api/steamlink is the live authority."""
+    return (_steam_root() is not None
+            and shutil.which("steam") is not None
+            and bool(discover_stream_games()))
+
+
+def steamlink_info():
+    """{available, hosts:[{host, last, games:[{appid,label}]}]} grouped by host,
+    newest host first. games are de-duped to their most-recent host, so a title
+    appears once even if several machines offer it."""
+    games = discover_stream_games()
+    by_host = {}
+    for g in games:
+        by_host.setdefault(g["host"], {"host": g["host"], "last": g["last"],
+                                       "games": []})
+        by_host[g["host"]]["games"].append(
+            {"appid": g["appid"], "label": g["label"]})
+    hosts = sorted(by_host.values(), key=lambda h: h["last"], reverse=True)
+    for h in hosts:
+        h["games"].sort(key=lambda g: g["label"].lower())
+    return {"available": bool(games), "hosts": hosts}
+
+
 def _acf_int(s):
     """Parse an ACF numeric string to int; 0 on missing/garbage (never raises)."""
     try:
@@ -2927,8 +3201,12 @@ def _launcher_argv(launcher_id):
     well-formed but not present (e.g. steam:<appid> for a game that isn't
     installed) resolves to None so the route returns 404 "unknown launcher".
 
-    steam:<appid>  -> ["steam", "steam://rungameid/<appid>"]
-    custom:<slug>  -> that launcher's stored cmd argv from config
+    steam:<appid>   -> ["steam", "steam://rungameid/<appid>"] (installed game)
+    stream:<appid>  -> ["steam", "steam://rungameid/<appid>"] (Remote Play from
+                       a host — same URL, but the appid is validated against the
+                       streamable set instead of the on-disk manifest, since a
+                       host game is by definition NOT installed locally)
+    custom:<slug>   -> that launcher's stored cmd argv from config
     """
     if launcher_id.startswith("steam:"):
         appid = launcher_id[len("steam:"):]
@@ -2939,6 +3217,16 @@ def _launcher_argv(launcher_id):
         # Validate the SPECIFIC appmanifest_<appid>.acf rather than globbing +
         # parsing every manifest on each launch.
         if _steam_game_installed(appid):
+            return ["steam", "steam://rungameid/%s" % appid]
+        return None
+    if launcher_id.startswith("stream:"):
+        appid = launcher_id[len("stream:"):]
+        if not appid.isdigit():
+            return None
+        # A host-streamable game is NOT installed locally, so gate on the
+        # remoteclients allowlist instead. Steam streams it iff a host that
+        # offers it is online; if not, the rungameid is a harmless no-op.
+        if appid in _streamable_appids():
             return ["steam", "steam://rungameid/%s" % appid]
         return None
     if _valid_launcher_id(launcher_id):
@@ -8687,6 +8975,16 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, info, started)
                 else:
                     self._send(404, {"error": "screensaver not installed"}, started)
+            elif path == "/api/steamlink":
+                # Steam Remote Play (in-home streaming) host list. Probe-and-
+                # appear: 404 when no host has ever been streamed from (nothing
+                # to offer) so the app hides the "Stream from PC" surface. Launch
+                # is the existing POST /api/launchers/stream:<appid>.
+                info = steamlink_info()
+                if info["available"]:
+                    self._send(200, info, started)
+                else:
+                    self._send(404, {"error": "no streamable hosts"}, started)
             elif path == "/api/guide-hold":
                 # Probe-and-appear like /api/screensaver: 404 when the box can't
                 # do the handoff or can't read evdev, so the app hides the row.

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -34,6 +34,7 @@ import {
   isActiveDownload,
   Launcher,
   SteamDownload,
+  SteamLink,
 } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
@@ -258,6 +259,74 @@ function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
   );
 }
 
+/**
+ * Steam Remote Play — "Stream from PC". Games another Steam machine on the LAN
+ * offers to stream (grouped by host, freshest host expanded). Tapping a game
+ * fires steam://rungameid on the box, which streams it natively — no Steam Link
+ * app to install. Probe-and-appear: the parent renders this only when the box
+ * reports at least one host. Covers aren't shown (host-only games have no local
+ * capsule), so it's a compact list rather than the cover grid below.
+ */
+function SteamLinkSection({
+  data,
+  onStream,
+}: {
+  data: SteamLink;
+  onStream: (appid: number, label: string) => void;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  // Expand the most-recently-seen host by default; the rest start collapsed.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(() =>
+    data.hosts.length ? { [data.hosts[0].host]: true } : {},
+  );
+  if (data.hosts.length === 0) return null;
+  return (
+    <View style={styles.dlCard}>
+      <View style={styles.dlHeader}>
+        <Ionicons name="tv-outline" size={14} color={t.blue} />
+        <Text style={styles.dlHeaderText}>STREAM FROM PC</Text>
+      </View>
+      <Text style={styles.slHint}>
+        Play a game from another Steam PC on your network. Make sure it&rsquo;s powered on and
+        running Steam.
+      </Text>
+      {data.hosts.map((h, i) => {
+        const open = !!expanded[h.host];
+        return (
+          <View key={h.host} style={i > 0 ? styles.dlHeaderGap : undefined}>
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                setExpanded((e) => ({ ...e, [h.host]: !e[h.host] }));
+              }}
+              style={({ pressed }) => [styles.slHostHeader, pressed && styles.pressed]}>
+              <Ionicons name="desktop-outline" size={14} color={t.textDim} />
+              <Text style={styles.slHostName} numberOfLines={1}>
+                {h.host}
+              </Text>
+              <Text style={styles.slHostCount}>{h.games.length}</Text>
+              <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={14} color={t.textDim} />
+            </Pressable>
+            {open &&
+              h.games.map((g) => (
+                <Pressable
+                  key={g.appid}
+                  onPress={() => onStream(g.appid, g.label)}
+                  style={({ pressed }) => [styles.slGameRow, pressed && styles.pressed]}>
+                  <Ionicons name="play-circle" size={16} color={t.blue} />
+                  <Text style={styles.slGameName} numberOfLines={1}>
+                    {g.label}
+                  </Text>
+                </Pressable>
+              ))}
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
 // ---------- Add-launcher form ----------
 
 type AddFormProps = {
@@ -419,6 +488,11 @@ function LaunchScreen() {
   const dl = usePoll<Downloads | null>(
     () => api.downloads(settings), active ? 5000 : 20000, ready && configured, boxKey);
   const downloads = useMemo(() => dl.data?.downloads ?? [], [dl.data]);
+
+  // ---- Steam Remote Play "Stream from PC" (probe-and-appear; 404 -> null) ----
+  const sl = usePoll<SteamLink | null>(
+    () => api.steamlink(settings), 30000, ready && configured, boxKey);
+  const steamlink = sl.data;
   const dlByAppid = useMemo(() => new Map(downloads.map((d) => [d.appid, d])), [downloads]);
 
   // Completion: an appid seen downloading/paused this session that then vanishes
@@ -474,6 +548,29 @@ function LaunchScreen() {
       } catch (e: unknown) {
         hapticError();
         showToast(e instanceof Error ? e.message : 'Launch failed');
+      }
+    },
+    [settings, showToast],
+  );
+
+  const streamLaunch = useCallback(
+    async (appid: number, label: string) => {
+      hapticMedium();
+      try {
+        // Launch reuses the launcher route; the agent's stream:<appid> id fires
+        // steam://rungameid, which Steam turns into a Remote Play stream when
+        // the game isn't installed locally but an online host offers it.
+        const res = await api.launch(settings, `stream:${appid}`);
+        if (res.ok) {
+          hapticSuccess();
+          showToast(`Streaming ${label}…`);
+        } else {
+          hapticError();
+          showToast(res.error ? `Failed: ${res.error}` : `Failed to stream ${label}`);
+        }
+      } catch (e: unknown) {
+        hapticError();
+        showToast(e instanceof Error ? e.message : 'Stream failed');
       }
     },
     [settings, showToast],
@@ -551,6 +648,11 @@ function LaunchScreen() {
         }>
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
         <DownloadsSection downloads={downloads} />
+
+        {/* Stream from PC (hidden when no host / agent < 2.9.23) */}
+        {steamlink?.available && (
+          <SteamLinkSection data={steamlink} onStream={streamLaunch} />
+        )}
 
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
         {!configured && (
@@ -693,6 +795,22 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   qRow: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingLeft: 19 },
   qName: { color: t.textDim, fontSize: 13, flex: 1, fontFamily: mono },
   qSize: { color: t.textFaint, fontSize: 11, fontFamily: mono },
+  // Steam Remote Play "Stream from PC"
+  slHint: { color: t.textFaint, fontSize: 12, lineHeight: 17, marginTop: -4 },
+  slHostHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 6 },
+  slHostName: { color: t.text, fontSize: 14, fontWeight: '700', fontFamily: mono, flex: 1 },
+  slHostCount: { color: t.textDim, fontSize: 12, fontFamily: mono },
+  slGameRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 9,
+    paddingLeft: 20,
+    borderTopColor: t.cardBorder,
+    borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  slGameName: { color: t.text, fontSize: 14, fontFamily: mono, flex: 1 },
+
   dlRow: { gap: 6 },
   dlTop: { flexDirection: 'row', alignItems: 'center' },
   dlName: { color: t.text, fontSize: 14, fontWeight: '600', flex: 1, fontFamily: mono },

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -108,6 +108,13 @@ export type BoxCaps = {
    * absent on agents < 2.9, so undefined reads as "not a desktop box here".
    */
   desktop?: boolean;
+  /**
+   * Steam Remote Play (in-home streaming): the box has streamed from at least
+   * one host, so there are games to offer. Gates the Launch tab's "Stream from
+   * PC" section. Optional: absent on agents < 2.9.23, so undefined reads as
+   * "unknown, probe" — only an explicit false skips the probe.
+   */
+  steamlink?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -292,6 +299,22 @@ export function isActiveDownload(d: SteamDownload): boolean {
 }
 
 export type Downloads = { downloads: SteamDownload[] };
+
+/**
+ * Steam Remote Play (in-home streaming), agent >= 2.9.23. A host is another
+ * Steam machine on the LAN (your gaming PC / another Deck) the box has streamed
+ * from; `games` are the titles it offers. Launch one with
+ * `api.launch(settings, `stream:${appid}`)` — Steam streams it natively, no
+ * Steam Link app to install. Probe-and-appear: 404 -> null hides the surface.
+ */
+export type StreamGame = { appid: number; label: string };
+export type StreamHost = {
+  host: string;
+  /** Unix seconds the box last saw this host (newest first in the list). */
+  last: number;
+  games: StreamGame[];
+};
+export type SteamLink = { available: boolean; hosts: StreamHost[] };
 
 /**
  * Box-side update check (agent >= 2.9.5), read over the LAN. The BOX contacts
@@ -1014,6 +1037,20 @@ export const api = {
   ): Promise<Downloads | null> {
     return probeGated(caps?.steam, () =>
       probeOrNull(request<Downloads>(settings, '/api/downloads')));
+  },
+
+  /**
+   * Steam Remote Play host + game list (agent >= 2.9.23). Probe-and-appear:
+   * null on a 404 (older agent, or the box has never streamed from a host) so
+   * the Launch tab hides the "Stream from PC" section. Launch a game with
+   * launch(settings, `stream:${appid}`).
+   */
+  steamlink(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<SteamLink | null> {
+    return probeGated(caps?.steamlink, () =>
+      probeOrNull(request<SteamLink>(settings, '/api/steamlink')));
   },
 
   /**

--- a/tests/test_steamlink.py
+++ b/tests/test_steamlink.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Tests for Steam Remote Play (in-home streaming) discovery — /api/steamlink.
+
+Run: python3 tests/test_steamlink.py
+
+The feature turns the games your gaming PC / another Deck offers to stream (which
+Steam caches in config/remoteclients.vdf) into one-tap tiles. Launching
+steam://rungameid/<appid> for a host game that is NOT installed locally makes
+Steam stream it — verified on real hardware. These tests drive the REAL parsers
+with only the file I/O stubbed, so the remoteclients text-VDF scan, the v29
+appinfo.vdf name resolver (built as a synthetic fixture below), the most-recent-
+host de-dupe, the tool filter, and the launch allowlist gate are all exercised
+for real. Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import os
+import struct
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_failures = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _failures.append(label)
+
+
+# --- synthetic v29 appinfo.vdf (locks the binary name parser) ----------------
+
+def _v29_appinfo(app_names):
+    """Build a minimal but real v29 appinfo.vdf: header + one section per
+    (appid, name) with a common->name string field + a terminating appid 0 +
+    the string table. Keys in the KV blob are int32 string-table indices."""
+    strings = [b"common", b"name"]              # common_idx=0, name_idx=1
+    common_idx, name_idx = 0, 1
+
+    def kv_blob(name):
+        b = bytearray()
+        b += b"\x00" + struct.pack("<I", common_idx)     # nested "common"
+        b += b"\x01" + struct.pack("<I", name_idx)       # string "name"
+        b += name.encode("utf-8") + b"\x00"
+        b += b"\x08"                                     # end common
+        b += b"\x08"                                     # end top map
+        return bytes(b)
+
+    sections = bytearray()
+    for appid, name in app_names:
+        blob = kv_blob(name)
+        header = b"\x00" * (4 + 4 + 8 + 20 + 4 + 20)     # 60-byte fixed header
+        size = len(header) + len(blob)
+        sections += struct.pack("<I", appid) + struct.pack("<I", size) + header + blob
+    sections += struct.pack("<I", 0)                     # terminating appid 0
+
+    st_off = 16 + len(sections)
+    out = bytearray()
+    out += struct.pack("<I", 0x07564429)                 # magic v29
+    out += struct.pack("<I", 1)                          # universe
+    out += struct.pack("<q", st_off)                     # string table offset
+    out += sections
+    out += struct.pack("<I", len(strings))
+    for s in strings:
+        out += s + b"\x00"
+    return bytes(out)
+
+
+REMOTECLIENTS = """
+"RemoteClientCache"
+{
+\t"aaaa1111"
+\t{
+\t\t"hostname"\t\t"gaming-pc"
+\t\t"lastupdated"\t\t"2000"
+\t\t"apps"
+\t\t{
+\t\t\t"0"\t\t"228980"
+\t\t\t"1"\t\t"1174180"
+\t\t\t"2"\t\t"1086940"
+\t\t}
+\t}
+\t"bbbb2222"
+\t{
+\t\t"hostname"\t\t"old-deck"
+\t\t"lastupdated"\t\t"1000"
+\t\t"apps"
+\t\t{
+\t\t\t"0"\t\t"1174180"
+\t\t\t"1"\t\t"570"
+\t\t}
+\t}
+}
+"""
+
+NAMES = {228980: "Steamworks Common Redistributables",
+         1174180: "Red Dead Redemption 2",
+         1086940: "Baldur's Gate 3",
+         570: "Dota 2"}
+
+
+def with_fixtures(fn):
+    """Run fn with the agent pointed at in-memory remoteclients + appinfo."""
+    import tempfile
+    d = tempfile.mkdtemp()
+    rc = os.path.join(d, "remoteclients.vdf")
+    ai = os.path.join(d, "appinfo.vdf")
+    with open(rc, "w") as f:
+        f.write(REMOTECLIENTS)
+    with open(ai, "wb") as f:
+        f.write(_v29_appinfo(list(NAMES.items())))
+    orig_rc, orig_ai, orig_root, orig_which = (
+        cs._remoteclients_path, cs._appinfo_path, cs._steam_root, cs.shutil.which)
+    cs._remoteclients_path = lambda: rc
+    cs._appinfo_path = lambda: ai
+    cs._steam_root = lambda: d
+    cs.shutil.which = lambda x: "/usr/bin/steam" if x == "steam" else orig_which(x)
+    cs._APPINFO_CACHE["key"] = None  # force re-parse of the fixture
+    try:
+        return fn()
+    finally:
+        cs._remoteclients_path, cs._appinfo_path = orig_rc, orig_ai
+        cs._steam_root, cs.shutil.which = orig_root, orig_which
+
+
+def test_appinfo_v29_names():
+    print("v29 appinfo name parser")
+    names = cs._parse_appinfo_names(_v29_appinfo(list(NAMES.items())))
+    check(names.get(1174180) == "Red Dead Redemption 2", "extracts RDR2 name")
+    check(names.get(1086940) == "Baldur's Gate 3", "extracts BG3 name (apostrophe)")
+    check(len(names) == len(NAMES), "every app named")
+    check(cs._parse_appinfo_names(b"garbage") == {}, "garbage -> {} not raise")
+
+
+def test_discovery():
+    print("stream game discovery")
+
+    def body():
+        games = cs.discover_stream_games()
+        by_id = {g["appid"]: g for g in games}
+        check(228980 not in by_id, "tool (Steamworks redist) filtered out")
+        check(by_id.get(1174180, {}).get("label") == "Red Dead Redemption 2",
+              "RDR2 present with real name")
+        # RDR2 is on both hosts; gaming-pc (last=2000) beats old-deck (1000).
+        check(by_id.get(1174180, {}).get("host") == "gaming-pc",
+              "dup appid resolves to the most-recently-seen host")
+        check(by_id.get(570, {}).get("host") == "old-deck",
+              "old-deck-only game still listed")
+        check(all(g["kind"] == "stream" and g["id"].startswith("stream:")
+                  for g in games), "all tagged kind=stream")
+        return games
+
+    with_fixtures(body)
+
+
+def test_info_grouping():
+    print("steamlink_info host grouping")
+
+    def body():
+        info = cs.steamlink_info()
+        check(info["available"] is True, "available when hosts offer games")
+        hosts = {h["host"]: h for h in info["hosts"]}
+        check("gaming-pc" in hosts and "old-deck" in hosts, "both hosts present")
+        check(info["hosts"][0]["host"] == "gaming-pc",
+              "newest host (gaming-pc) sorted first")
+        # gaming-pc offers RDR2 + BG3 (redist filtered); old-deck offers Dota 2
+        # (RDR2 dup went to gaming-pc).
+        check(len(hosts["gaming-pc"]["games"]) == 2, "gaming-pc has 2 games")
+        check(len(hosts["old-deck"]["games"]) == 1, "old-deck has 1 game")
+        return info
+
+    with_fixtures(body)
+
+
+def test_launch_gate():
+    print("launch allowlist gate")
+
+    def body():
+        argv = cs._launcher_argv("stream:1174180")
+        check(argv == ["steam", "steam://rungameid/1174180"],
+              "streamable appid -> rungameid argv")
+        check(cs._launcher_argv("stream:999999999") is None,
+              "unknown appid -> None (404)")
+        check(cs._launcher_argv("stream:228980") is None,
+              "a filtered tool is not streamable")
+        check(cs._launcher_argv("stream:notanumber") is None,
+              "non-numeric -> None")
+        return True
+
+    with_fixtures(body)
+
+
+def test_available_false_when_empty():
+    print("probe-and-appear")
+    # No remoteclients file -> not available (app hides the surface).
+    orig = cs._remoteclients_path
+    cs._remoteclients_path = lambda: None
+    try:
+        check(cs.discover_stream_games() == [], "no cache -> no games")
+        check(cs.steamlink_info()["available"] is False, "info reports unavailable")
+    finally:
+        cs._remoteclients_path = orig
+
+
+if __name__ == "__main__":
+    test_appinfo_v29_names()
+    test_discovery()
+    test_info_grouping()
+    test_launch_gate()
+    test_available_false_when_empty()
+    print()
+    if _failures:
+        print("FAILED: %d" % len(_failures))
+        for f in _failures:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all steamlink tests passed")


### PR DESCRIPTION
## What
One-tap **Stream from PC**: play games from another Steam machine on your LAN (your gaming rig / another Deck) on the box, using the Steam client's **own** in-home streaming — **nothing to install** (no Steam Link flatpak).

Built after @emerytech asked to *"leverage the box's existing built-in Steam Link"* rather than install a redundant app. It does exactly that.

## How
- Steam already caches, per host it has streamed from, the appids that host offers — in `config/remoteclients.vdf`. The agent parses that into a game list.
- Real titles come from Steam's `appinfo.vdf` (a v29 string-table + v28 inline-key binary parser, mtime-cached) — **LAN-only, never a CDN**, matching the existing cover-art policy — so host-only games that were never installed still show their name.
- Launch reuses the launcher route: `_launcher_argv` gains `stream:<appid>` (gated on the remoteclients allowlist, since a host game isn't installed locally) → `steam://rungameid/<appid>`, which Steam turns into a Remote Play stream.

## Verified
- **Hardware go/no-go**: a single `steam://rungameid/1174180` (RDR2, host-only) brought up `streaming_client` in ~7s, **no install manifest** → it streams, not installs.
- **Live on the box (agent 2.9.23)**: `/api/steamlink` returned 4 hosts / real game names (steamdeck 71, emery-pc 16, taylor-steamdeck 85, DESKTOP-MAGJDDS 2), `caps.steamlink = true`, bogus `stream:` id → 404.
- **Unit tests** (`tests/test_steamlink.py`, in CI): parsers driven for real, a **synthetic v29 `appinfo.vdf`** locks the binary name parser; de-dupe, tool filter, host grouping, launch gate.
- App typechecks clean.

## Surface
Launch tab gains a collapsible per-host "Stream from PC" list above the game grid (compact list — host-only games have no local cover capsule). Rides the existing Launch-tab entitlement gate. Probe-and-appear: hidden on boxes that have never streamed from a host / agents < 2.9.23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)