### PR TITLE
chore(app): 2.9.9 release — Steam Link 'Stream from PC'

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.8",
+    "version": "2.9.9",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,4 +1,3 @@
-New in 2.9.8
+New in 2.9.9
 
-• More reliable reconnect: after you update a box from the app, it comes back on its own instead of showing "offline" until you reopen the app.
-• Boxes you added by name now keep a working backup address, so they stay reachable when Wi-Fi gets flaky.
+• Stream from PC: play games from another Steam PC or Steam Deck on your network, right on the box. Open the Launch tab, pick the machine, and tap a game — nothing extra to install.


### PR DESCRIPTION
Marketing version bump for the **2.9.9** release carrying the native Steam Remote Play feature ([#116](https://github.com/emerytech/couchside/pull/116), agent 2.9.23). Play 'What's new' updated. Build numbers left for EAS autoincrement (iOS 60 / vc44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)