### PR TITLE
chore(app): reconcile build numbers to 60/44 (shipped 2.9.9)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "59",
+      "buildNumber": "60",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 43
+      "versionCode": 44
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
EAS autoincrement bumped iOS buildNumber 59→60 and Android versionCode 43→44 for the 2.9.9 build. Reconciling app.json (build-number drift hazard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)