### PR TITLE
fix(caps): persist the steamlink capability

### DIFF
--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -659,7 +659,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.power_schedule === b.power_schedule &&
     a.screensaver === b.screensaver &&
     a.couchmode === b.couchmode &&
-    a.desktop === b.desktop
+    a.desktop === b.desktop &&
+    a.steamlink === b.steamlink
   );
 }
 

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -222,9 +222,13 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // Optional like screensaver: absent stays undefined = unknown, never false.
   const couchmode = bool('couchmode');
   const desktop = bool('desktop');
+  // steamlink arrived with agent 2.9.23 and had the SAME drop bug — add it here
+  // (and to capsEqual) or the "Stream from PC" cap never persists. Optional:
+  // absent stays undefined = unknown, so the app probes.
+  const steamlink = bool('steamlink');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
-    screensaver, couchmode, desktop,
+    screensaver, couchmode, desktop, steamlink,
   };
 }
 


### PR DESCRIPTION
`steamlink` (agent 2.9.23) was dropped by `normalizeCaps` + ignored by `capsEqual` — same regression class as the couchmode/desktop fix. Cap never persisted → app re-probed `/api/steamlink` every launch. Minor (feature still works), so it rides the next release, not a rebuild of the finished 2.9.9 binaries.

Found by a parallel session reviewing the 2.9.9 ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)