### PR TITLE
copy(ios): 'agent' → 'service' in the Local-Network permission prompt

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -17,7 +17,7 @@
         "NSAppTransportSecurity": {
           "NSAllowsLocalNetworking": true
         },
-        "NSLocalNetworkUsageDescription": "Couchside connects to the Couchside agent on your media center or Steam machine over your local network.",
+        "NSLocalNetworkUsageDescription": "Couchside connects to the Couchside service on your media center or Steam machine over your local network.",
         "NSBonjourServices": [
           "_http._tcp"
         ]


### PR DESCRIPTION
Applies just the copy change from #109 (agent→service in NSLocalNetworkUsageDescription) onto current main, dropping #109's stale version bumps (2.9.6→2.9.7 / 56→57 / 40→41) that conflicted with the shipped 2.9.9 (60/44). Version fields untouched.

Closes #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)