### PR TITLE
feat(gaming): live gaming card on the Console tab (agent 2.9.25)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
       - name: Unit tests (steam link / remote play)
         run: python3 tests/test_steamlink.py
 
+      # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
+      # dir must not be read as a GPU), the reaper AppId matcher incl. the
+      # [oom_reaper] reject, the empty-power_supply desktop case + the uniq (never
+      # phys) battery join, and per-field probe-and-appear. Drives the real
+      # functions against sysfs/proc fixtures via the module-constant roots.
+      - name: Unit tests (gaming card)
+        run: python3 tests/test_gaming_card.py
+
   smoke:
     runs-on: ubuntu-latest
     needs: compile

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.24"
+VERSION = "2.9.25"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -931,7 +931,7 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver", "couchmode", "desktop", "steamlink")}
+                 "screensaver", "couchmode", "desktop", "steamlink", "gaming")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -944,6 +944,7 @@ def set_caps(mock):
         "couchmode": safe(couchmode_available),
         "desktop": safe(desktop_available),
         "steamlink": safe(steamlink_available),
+        "gaming": safe(gaming_available),
     }
 
 
@@ -7932,6 +7933,261 @@ def _guide_watch(gen):
 
 
 # ---------------------------------------------------------------------------
+# Gaming card (GET /api/gaming). A live "what's running right now" panel:
+# discrete-GPU temp/VRAM, the running Steam game (+ cover via the existing cover
+# route), the active display output, connected controllers with battery, and the
+# session (Game Mode vs desktop). EVERY field is independently optional — the
+# only boxes reachable to test on are Intel i915 with NO hwmon under the DRM
+# device, so the GPU block simply does not appear rather than blanking the card.
+# The amdgpu sysfs paths follow the documented layout but are UNVERIFIED on
+# hardware (no AMD box on the LAN), and degrade to "no GPU block" on anything
+# that is not amdgpu (Intel exposes no device hwmon; NVIDIA would need NVML).
+# ---------------------------------------------------------------------------
+
+_GAMING_TTL = 2.0
+_GAMING_CACHE = {"val": None, "at": 0.0}
+_GAMING_LOCK = threading.Lock()
+# Sysfs roots, as module constants so tests can point them at fixtures (the same
+# pattern as _PROC_INPUT_DEVICES for the pad list).
+_DRM_DIR = "/sys/class/drm"
+_POWER_SUPPLY_DIR = "/sys/class/power_supply"
+
+
+def _read_int(path):
+    """int from a one-line sysfs file, or None (never raises)."""
+    try:
+        with open(path) as f:
+            return int(f.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def gaming_available():
+    """Boot-time caps hint: a box with Steam can have a gaming session worth
+    showing. GET /api/gaming is the live authority (per-field probe-and-appear).
+    Never raises."""
+    try:
+        return _steam_root() is not None
+    except Exception:
+        return False
+
+
+def _gpu_sensors():
+    """Discrete-GPU temp + VRAM from amdgpu sysfs, or {} when absent. Intel i915
+    exposes no DRM-device hwmon; NVIDIA needs NVML — both degrade here to "no GPU
+    block", never to a CPU number mislabelled as GPU. Every field independently
+    optional. Read-only, best-effort; never raises."""
+    try:
+        drm = _DRM_DIR
+        # Real cards only: cardN. The connector dirs (cardN-DP-1) ALSO match a
+        # bare card* glob AND carry a `device` symlink (to the DRM card, not the
+        # PCI GPU), so mem_info_*/hwmon are not under them — re.fullmatch(card\d+)
+        # is the documented fix for that trap.
+        cards = [b for b in os.listdir(drm) if re.fullmatch(r"card\d+", b)]
+    except OSError:
+        return {}
+    for card in sorted(cards):
+        dev = os.path.join(drm, card, "device")
+        hw_name, temp_path = None, None
+        # hwmon index is not stable across boxes: match on the name file, never a
+        # hardcoded hwmonN (as read_cpu_temp_c does).
+        for nf in sorted(glob.glob(os.path.join(dev, "hwmon", "hwmon*", "name"))):
+            try:
+                with open(nf) as f:
+                    nm = f.read().strip()
+            except OSError:
+                continue
+            if nm == "amdgpu":
+                hw_name = nm
+                cand = os.path.join(os.path.dirname(nf), "temp1_input")
+                temp_path = cand if os.path.exists(cand) else None
+                break
+        if hw_name is None:
+            continue  # Intel/NVIDIA/virtual card: no amdgpu hwmon here
+        gpu = {"name": hw_name}
+        if temp_path:
+            milli = _read_int(temp_path)
+            if milli is not None:
+                gpu["temp_c"] = round(milli / 1000.0, 1)
+        # VRAM is documented as BYTES but was not observable this session. Sanity-
+        # gate the magnitude before trusting the unit — a total under ~64 MB is
+        # almost certainly not bytes, so drop it rather than report a lie.
+        total = _read_int(os.path.join(dev, "mem_info_vram_total"))
+        used = _read_int(os.path.join(dev, "mem_info_vram_used"))
+        if total is not None and total > (64 << 20):
+            gpu["vram_total_mb"] = total >> 20
+            if used is not None:
+                gpu["vram_used_mb"] = used >> 20
+        return gpu
+    return {}
+
+
+_REAPER_APPID_RE = re.compile(r"\bAppId=(\d+)")
+
+
+def _appid_from_cmdline(cmdline):
+    """Steam AppId from a /proc/<pid>/cmdline blob (NUL-separated tokens), or
+    None. Requires the real Steam launch wrapper — a `reaper` executable token
+    AND a steamapps/ path (the game binary) — so a stray "AppId=" elsewhere does
+    not register. Rejects a bracketed argv[0] ([oom_reaper] and other kernel
+    threads; those also have an empty cmdline, but guard explicitly). Never
+    raises."""
+    try:
+        args = [a for a in cmdline.split("\x00") if a]
+        if not args or args[0].startswith("["):
+            return None
+        if not any(os.path.basename(a) == "reaper" for a in args):
+            return None
+        joined = " ".join(args)
+        if "steamapps" not in joined:
+            return None
+        m = _REAPER_APPID_RE.search(joined)
+        return m.group(1) if m else None
+    except Exception:
+        return None
+
+
+def _running_game():
+    """{"appid": int[, "label": str]} for the Steam game running now, or None.
+    Scans /proc/*/cmdline for the reaper wrapper; label from the appinfo cache
+    (LAN-only, same source the Steam Link list uses). Best-effort; never raises."""
+    try:
+        for entry in glob.glob("/proc/[0-9]*/cmdline"):
+            try:
+                with open(entry, "r", errors="replace") as f:
+                    cmd = f.read()
+            except OSError:
+                continue
+            appid = _appid_from_cmdline(cmd)
+            if appid:
+                game = {"appid": int(appid)}
+                name = _steam_appinfo_names().get(int(appid))
+                if name:
+                    game["label"] = name
+                return game
+    except Exception:
+        pass
+    return None
+
+
+def _norm_mac(s):
+    """A MAC-ish string lowercased with all separators stripped, for fuzzy joins
+    across the many power_supply naming schemes."""
+    return re.sub(r"[^0-9a-f]", "", (s or "").lower())
+
+
+def _pad_battery(uniq):
+    """{"battery_pct": int[, "battery_status": str]} joined to a pad's uniq via
+    /sys/class/power_supply, or {} when there is no match. An EMPTY power_supply
+    directory is the normal mains-desktop case, NOT an error. Pad-battery naming
+    varies (hid-<MAC>-battery, sony_controller_battery_<MAC>, …) so join fuzzily:
+    the pad MAC (separators stripped) appearing in the supply's own name or its
+    uevent. Read-only, best-effort; never raises."""
+    key = _norm_mac(uniq)
+    if not key:
+        return {}
+    try:
+        supplies = os.listdir(_POWER_SUPPLY_DIR)
+    except OSError:
+        return {}
+    for name in supplies:
+        base = os.path.join(_POWER_SUPPLY_DIR, name)
+        if key not in _norm_mac(name):
+            try:
+                with open(os.path.join(base, "uevent")) as f:
+                    uev = f.read()
+            except OSError:
+                uev = ""
+            if key not in _norm_mac(uev):
+                continue
+        out = {}
+        pct = _read_int(os.path.join(base, "capacity"))
+        if pct is not None:
+            out["battery_pct"] = max(0, min(100, pct))
+        try:
+            with open(os.path.join(base, "status")) as f:
+                st = f.read().strip()
+            if st:
+                out["battery_status"] = st
+        except OSError:
+            pass
+        if out:
+            return out
+    return {}
+
+
+def _gaming_controllers():
+    """Real pads (deduped — one device can present several nodes) with a best-
+    effort battery join. Keyed on uniq, NEVER phys (phys is the shared host-
+    adapter MAC, identical for every BT pad)."""
+    seen, out = set(), []
+    for p in list_real_pads():
+        u = p.get("uniq") or ""
+        dedupe = u.lower() or (p.get("phys") or "").lower() or p.get("event", "")
+        if dedupe in seen:
+            continue
+        seen.add(dedupe)
+        ctrl = {"uniq": u, "name": p.get("name", "")}
+        ctrl.update(_pad_battery(u))
+        out.append(ctrl)
+    return out
+
+
+def _active_output():
+    """The display the game is on: the first external connected output, else the
+    first internal, else None. From _connected_outputs (works in any session)."""
+    outs = _connected_outputs()
+    if not outs:
+        return None
+    ext = [o for o in outs if not o["internal"]]
+    return (ext or outs)[0]
+
+
+def _gaming_payload():
+    """The /api/gaming body — every field independently optional; omit anything
+    that could not be read rather than emit a null the app must special-case.
+    TTL-memoized so the app's ~5s poll does not re-scan sysfs/proc each time."""
+    now = time.monotonic()
+    with _GAMING_LOCK:
+        c = _GAMING_CACHE
+        if c["val"] is not None and now - c["at"] <= _GAMING_TTL:
+            return c["val"]
+    payload = {"session": _couchmode_session()}
+    gpu = _gpu_sensors()
+    if gpu:
+        payload["gpu"] = gpu
+    game = _running_game()
+    if game:
+        payload["game"] = game
+    output = _active_output()
+    if output:
+        payload["output"] = output
+    ctrls = _gaming_controllers()
+    if ctrls:
+        payload["controllers"] = ctrls
+    with _GAMING_LOCK:
+        _GAMING_CACHE["val"] = payload
+        _GAMING_CACHE["at"] = now
+    return payload
+
+
+def mock_gaming():
+    """A full payload for --mock so the app's render path is exercised without
+    hardware: GPU block populated (as an AMD box would), a running game, an
+    external output, a pad with battery, Game Mode."""
+    return {
+        "gpu": {"name": "amdgpu", "temp_c": 61.0,
+                "vram_used_mb": 3300, "vram_total_mb": 8192},
+        "game": {"appid": 1091500, "label": "Cyberpunk 2077"},
+        "output": {"name": "DP-1", "internal": False},
+        "controllers": [{"uniq": "dc:2c:26:aa:bb:cc",
+                         "name": "Xbox Wireless Controller",
+                         "battery_pct": 62, "battery_status": "Discharging"}],
+        "session": "gamescope",
+    }
+
+
+# ---------------------------------------------------------------------------
 # Minimal RFC6455 WebSocket support (server side, no fragmentation)
 # ---------------------------------------------------------------------------
 
@@ -8993,6 +9249,16 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, info, started)
                 else:
                     self._send(404, {"error": "no streamable hosts"}, started)
+            elif path == "/api/gaming":
+                # Live "what's running now" card. Probe-and-appear: 404 when this
+                # box has no Steam (nothing to report) so old/non-gaming boxes
+                # hide the card. The payload is per-field optional — a box with no
+                # discrete GPU (Intel i915) simply omits the "gpu" key.
+                if not self.mock and _steam_root() is None:
+                    self._send(404, {"error": "no gaming context"}, started)
+                else:
+                    data = mock_gaming() if self.mock else _gaming_payload()
+                    self._send(200, data, started)
             elif path == "/api/guide-hold":
                 # Probe-and-appear like /api/screensaver: 404 when the box can't
                 # do the handoff or can't read evdev, so the app hides the row.

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
+import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
 import { ScreenPreview } from '@/components/ScreenPreview';
 import { Sparkline } from '@/components/Sparkline';
@@ -167,6 +168,9 @@ function ConsoleScreen() {
 
         {/* Now Playing (MPRIS) — probe-and-appear; hidden when no media backend */}
         <NowPlayingCard />
+
+        {/* Gaming card (probe-and-appear; hidden when the box has no Steam) */}
+        <GamingCard />
 
         {s && (
           <>

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -1,0 +1,214 @@
+/**
+ * Gaming card (Console tab). Polls /api/gaming and shows a live "what's running
+ * now" panel: discrete-GPU temp/VRAM, the running Steam game with cover art, the
+ * active display output, connected controllers with battery, and the session
+ * (Game Mode vs desktop). Probe-and-appear: renders nothing when the agent lacks
+ * the route or has no Steam (404 -> null). EVERY payload field is independently
+ * optional — a box with no discrete GPU (Intel i915) simply has no GPU block,
+ * not a blank one. Poll is fast while a game runs, slow when idle.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useEffect, useState } from 'react';
+import { Image, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, Gaming, hostKey } from '@/lib/api';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, pctColor, tempColor, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** Battery semantics are INVERTED vs temp/usage: low is bad. */
+function batteryColor(pct: number, t: Palette): string {
+  if (pct <= 15) return t.red;
+  if (pct <= 30) return t.amber;
+  return t.green;
+}
+
+function GameCover({ appid, label }: { appid: number; label?: string }) {
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const source = api.steamCoverSource(settings, appid);
+  const [failed, setFailed] = useState(false);
+  // Clear the failed latch when the cover URL changes (box switch / new game) so
+  // a now-available cover repaints instead of error-looping.
+  useEffect(() => setFailed(false), [source.uri]);
+  return (
+    <View style={styles.gameRow}>
+      {!failed ? (
+        <Image
+          source={source}
+          style={styles.cover}
+          resizeMode="cover"
+          onError={() => setFailed(true)}
+        />
+      ) : (
+        <View style={[styles.cover, styles.coverFallback]}>
+          <Ionicons name="game-controller" size={20} color="#8aa" />
+        </View>
+      )}
+      <Text style={styles.gameLabel} numberOfLines={2}>
+        {label || `App ${appid}`}
+      </Text>
+    </View>
+  );
+}
+
+export function GamingCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  // Adaptive cadence: fast while a game is running, slow when idle. `fast` is
+  // declared before the poll that reads it and flipped by the effect below.
+  const [fast, setFast] = useState(false);
+  const poll = usePoll<Gaming | null>(
+    () => api.gaming(settings), fast ? 5000 : 20000, ready && configured, hostKey(settings));
+  const g = poll.data;
+  useEffect(() => {
+    setFast(g?.game != null);
+  }, [g?.game]);
+
+  // Probe-and-appear: hidden until the box reports a gaming payload.
+  if (!g) return null;
+
+  const gpu = g.gpu;
+  const vramPct =
+    gpu?.vram_used_mb != null && gpu?.vram_total_mb
+      ? Math.round((gpu.vram_used_mb / gpu.vram_total_mb) * 100)
+      : null;
+  const inGameMode = g.session === 'gamescope';
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>GAMING</Text>
+        <View style={[styles.sessionPill, inGameMode && styles.sessionPillOn]}>
+          <Ionicons
+            name={inGameMode ? 'tv' : 'desktop-outline'}
+            size={11}
+            color={inGameMode ? t.bg : t.textDim}
+          />
+          <Text style={[styles.sessionText, inGameMode && { color: t.bg }]}>
+            {inGameMode ? 'Game Mode' : 'Desktop'}
+          </Text>
+        </View>
+      </View>
+
+      {g.game && <GameCover appid={g.game.appid} label={g.game.label} />}
+
+      {gpu && (
+        <View style={styles.block}>
+          <View style={styles.lineRow}>
+            <Text style={styles.lineLabel}>GPU</Text>
+            {gpu.temp_c != null && (
+              <Text style={[styles.lineVal, { color: tempColor(gpu.temp_c, t) }]}>
+                {gpu.temp_c.toFixed(1)}°C
+              </Text>
+            )}
+          </View>
+          {vramPct != null && gpu.vram_total_mb != null && (
+            <>
+              <View style={styles.barLabelRow}>
+                <Text style={styles.dim}>
+                  {(gpu.vram_used_mb! / 1024).toFixed(1)} / {(gpu.vram_total_mb / 1024).toFixed(1)} GB
+                </Text>
+                <Text style={[styles.dim, { color: pctColor(vramPct, t) }]}>{vramPct}%</Text>
+              </View>
+              <View style={styles.barTrack}>
+                <View
+                  style={[
+                    styles.barFill,
+                    { width: `${Math.min(100, vramPct)}%`, backgroundColor: pctColor(vramPct, t) },
+                  ]}
+                />
+              </View>
+            </>
+          )}
+        </View>
+      )}
+
+      {g.output && (
+        <View style={styles.lineRow}>
+          <Text style={styles.lineLabel}>OUTPUT</Text>
+          <Text style={styles.lineVal}>
+            {g.output.name}
+            <Text style={styles.dim}>{g.output.internal ? '  built-in' : '  external'}</Text>
+          </Text>
+        </View>
+      )}
+
+      {g.controllers?.map((c) => (
+        <View key={c.uniq || c.name} style={styles.lineRow}>
+          <Ionicons name="game-controller-outline" size={14} color={t.textDim} />
+          <Text style={styles.ctrlName} numberOfLines={1}>
+            {c.name || 'Controller'}
+          </Text>
+          {c.battery_pct != null ? (
+            <Text style={[styles.lineVal, { color: batteryColor(c.battery_pct, t) }]}>
+              {c.battery_pct}%
+              {c.battery_status === 'Charging' ? ' ⚡' : ''}
+            </Text>
+          ) : (
+            <Text style={styles.dim}>connected</Text>
+          )}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 14,
+      padding: 14,
+      marginBottom: 12,
+      gap: 10,
+    },
+    header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    cardTitle: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+    sessionPill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 4,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingVertical: 3,
+      paddingHorizontal: 9,
+    },
+    sessionPillOn: { backgroundColor: t.green, borderColor: t.green },
+    sessionText: { color: t.textDim, fontSize: 11, fontWeight: '700', fontFamily: mono },
+
+    gameRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+    cover: { width: 46, height: 69, borderRadius: 6, backgroundColor: t.inset },
+    coverFallback: { alignItems: 'center', justifyContent: 'center' },
+    gameLabel: { color: t.text, fontSize: 15, fontWeight: '700', fontFamily: mono, flex: 1 },
+
+    block: { gap: 6 },
+    lineRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    lineLabel: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 0.8,
+      fontFamily: mono,
+      minWidth: 52,
+    },
+    lineVal: { color: t.text, fontSize: 14, fontFamily: mono, marginLeft: 'auto' },
+    ctrlName: { color: t.text, fontSize: 14, fontFamily: mono, flex: 1 },
+    dim: { color: t.textFaint, fontSize: 12, fontFamily: mono },
+
+    barLabelRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    barTrack: { height: 6, borderRadius: 3, backgroundColor: t.cardBorder, overflow: 'hidden' },
+    barFill: { height: '100%', borderRadius: 3 },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -115,6 +115,13 @@ export type BoxCaps = {
    * "unknown, probe" — only an explicit false skips the probe.
    */
   steamlink?: boolean;
+  /**
+   * Gaming card: this box has Steam, so a "what's running now" card (GPU/game/
+   * output/controllers/session) is worth showing. Gates the Console-tab card.
+   * Optional: absent on agents < 2.9.25, so undefined reads as "unknown, probe"
+   * — only an explicit false skips the probe.
+   */
+  gaming?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -315,6 +322,30 @@ export type StreamHost = {
   games: StreamGame[];
 };
 export type SteamLink = { available: boolean; hosts: StreamHost[] };
+
+/**
+ * Live gaming card payload (agent >= 2.9.25). EVERY field is independently
+ * optional — the agent omits what it cannot read, so a box with no discrete GPU
+ * (Intel i915) has no `gpu` key at all. `session` is the only field always
+ * present. Cover art for `game.appid` via steamCoverSource (box cache, LAN-only).
+ */
+export type Gaming = {
+  gpu?: {
+    name: string;
+    temp_c?: number;
+    vram_used_mb?: number;
+    vram_total_mb?: number;
+  };
+  game?: { appid: number; label?: string };
+  output?: { name: string; internal: boolean };
+  controllers?: {
+    uniq: string;
+    name: string;
+    battery_pct?: number;
+    battery_status?: string;
+  }[];
+  session: string;
+};
 
 /**
  * Box-side update check (agent >= 2.9.5), read over the LAN. The BOX contacts
@@ -660,7 +691,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.screensaver === b.screensaver &&
     a.couchmode === b.couchmode &&
     a.desktop === b.desktop &&
-    a.steamlink === b.steamlink
+    a.steamlink === b.steamlink &&
+    a.gaming === b.gaming
   );
 }
 
@@ -1052,6 +1084,21 @@ export const api = {
   ): Promise<SteamLink | null> {
     return probeGated(caps?.steamlink, () =>
       probeOrNull(request<SteamLink>(settings, '/api/steamlink')));
+  },
+
+  /**
+   * Live "what's running now" gaming card (agent >= 2.9.25). Probe-and-appear:
+   * null on a 404 (older agent, or a box with no Steam) so the card hides. Every
+   * payload field is independently optional — a box with no discrete GPU (Intel)
+   * omits `gpu` entirely; render only what resolved. Cover art for `game.appid`
+   * comes from the box's own cache via steamCoverSource (LAN-only).
+   */
+  gaming(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<Gaming | null> {
+    return probeGated(caps?.gaming, () =>
+      probeOrNull(request<Gaming>(settings, '/api/gaming')));
   },
 
   /**

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -226,9 +226,12 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // (and to capsEqual) or the "Stream from PC" cap never persists. Optional:
   // absent stays undefined = unknown, so the app probes.
   const steamlink = bool('steamlink');
+  // gaming arrived with agent 2.9.25 — same optional-cap drop trap; add it here
+  // AND to capsEqual or the cap never persists and the card re-probes on launch.
+  const gaming = bool('gaming');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
-    screensaver, couchmode, desktop, steamlink,
+    screensaver, couchmode, desktop, steamlink, gaming,
   };
 }
 

--- a/tests/test_gaming_card.py
+++ b/tests/test_gaming_card.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Tests for the gaming card (GET /api/gaming) building blocks.
+
+Run: python3 tests/test_gaming_card.py
+
+Drives the REAL agent functions against filesystem/string fixtures — the sysfs
+roots are module constants (_DRM_DIR, _POWER_SUPPLY_DIR) and the pad list reads
+_PROC_INPUT_DEVICES, all of which the tests repoint, so nothing is
+reimplemented. Covers the traps the plan flagged as live:
+  * the card* glob (a connector dir cardN-DP-1 must NOT be read as a GPU),
+  * the reaper AppId matcher incl. the [oom_reaper]/no-steamapps rejects,
+  * the empty-power_supply desktop case + the uniq (never phys) battery join,
+  * per-field probe-and-appear (Intel i915 -> no gpu block, card still renders).
+Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import os
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def _write(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(text)
+
+
+# --- reaper AppId matcher (pure) ---------------------------------------------
+
+def test_appid_from_cmdline():
+    print("reaper AppId matcher")
+    real = "\x00".join([
+        "/home/deck/.steam/steam/ubuntu12_32/reaper", "SteamLaunch",
+        "AppId=1091500", "--",
+        "/home/deck/.steam/steam/steamapps/common/Cyberpunk 2077/bin/x64/game.exe",
+    ])
+    check(cs._appid_from_cmdline(real) == "1091500", "real reaper form -> appid")
+    # kernel thread the ps-based scan false-positives on; cmdline is bracketed.
+    check(cs._appid_from_cmdline("[oom_reaper]") is None, "[oom_reaper] rejected")
+    check(cs._appid_from_cmdline("") is None, "empty cmdline -> None")
+    # AppId present but no reaper wrapper / no steamapps path -> not a launch.
+    check(cs._appid_from_cmdline("steam\x00-applaunch\x00AppId=440") is None,
+          "AppId without the reaper wrapper -> None")
+    no_steamapps = "\x00".join(["/usr/bin/reaper", "AppId=440", "--", "/usr/bin/thing"])
+    check(cs._appid_from_cmdline(no_steamapps) is None,
+          "reaper without a steamapps path -> None")
+
+
+# --- GPU sensors (the card* glob trap) ---------------------------------------
+
+def test_gpu_sensors():
+    print("GPU sensors + card* glob trap")
+    d = tempfile.mkdtemp()
+    orig = cs._DRM_DIR
+    cs._DRM_DIR = d
+    try:
+        # A real amdgpu card...
+        dev = os.path.join(d, "card1", "device")
+        _write(os.path.join(dev, "hwmon", "hwmon5", "name"), "amdgpu\n")
+        _write(os.path.join(dev, "hwmon", "hwmon5", "temp1_input"), "61000\n")
+        _write(os.path.join(dev, "mem_info_vram_total"), str(8 * 1024**3) + "\n")
+        _write(os.path.join(dev, "mem_info_vram_used"), str(3300 * 1024**2) + "\n")
+        # ...and a CONNECTOR dir that also matches a bare card* glob and also has
+        # a `device` with bogus VRAM. re.fullmatch(card\d+) must skip it.
+        cdev = os.path.join(d, "card1-DP-1", "device")
+        _write(os.path.join(cdev, "mem_info_vram_total"), "999999999999999\n")
+        _write(os.path.join(d, "renderD128", "noise"), "x")  # unrelated node
+
+        gpu = cs._gpu_sensors()
+        check(gpu.get("name") == "amdgpu", "reads the amdgpu card")
+        check(gpu.get("temp_c") == 61.0, "temp from the matched hwmon (not hwmonN)")
+        check(gpu.get("vram_total_mb") == 8192, "vram_total in MB from card1, NOT the connector")
+        check(gpu.get("vram_used_mb") == 3300, "vram_used in MB")
+
+        # Intel i915: a device hwmon that is not amdgpu -> no GPU block at all.
+        d2 = tempfile.mkdtemp()
+        cs._DRM_DIR = d2
+        _write(os.path.join(d2, "card0", "device", "hwmon", "hwmon1", "name"), "i915\n")
+        check(cs._gpu_sensors() == {}, "Intel i915 -> {} (no GPU block, not CPU temp)")
+    finally:
+        cs._DRM_DIR = orig
+
+
+def test_vram_sanity():
+    print("VRAM magnitude sanity gate")
+    d = tempfile.mkdtemp()
+    orig = cs._DRM_DIR
+    cs._DRM_DIR = d
+    try:
+        dev = os.path.join(d, "card1", "device")
+        _write(os.path.join(dev, "hwmon", "hwmon0", "name"), "amdgpu\n")
+        # A total under ~64 MB is almost certainly not bytes -> drop VRAM, keep
+        # the (present) name so the block still renders what it can.
+        _write(os.path.join(dev, "mem_info_vram_total"), "4096\n")
+        gpu = cs._gpu_sensors()
+        check("vram_total_mb" not in gpu, "implausibly small VRAM total dropped")
+        check(gpu.get("name") == "amdgpu", "GPU still reported (name present)")
+    finally:
+        cs._DRM_DIR = orig
+
+
+# --- controller battery join (uniq, never phys) ------------------------------
+
+XBOX_PAD = """\
+I: Bus=0005 Vendor=045e Product=0b13 Version=0513
+N: Name="Xbox Wireless Controller"
+P: Phys=ac:f2:3c:8b:64:fe
+S: Sysfs=/devices/virtual/misc/uhid/0005:045E:0B13.0009/input/input39
+U: Uniq=44:16:22:1f:74:5d
+H: Handlers=sysrq kbd event20 js2
+B: PROP=0
+B: EV=120013
+B: KEY=7fff000000000000 1000000000000 8000000000 e080ffdf01cfffff fffffffffffffffe
+"""
+
+
+def test_controllers_and_battery():
+    print("controller battery join")
+    proc = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+    proc.write(XBOX_PAD)
+    proc.close()
+    ps = tempfile.mkdtemp()
+    # Battery supply named with the pad's MAC (uppercase, no colons — the join is
+    # separator- and case-insensitive; keeping the fixture colon-free stays
+    # portable across the CI/dev filesystems).
+    supply = os.path.join(ps, "hid-4416221F745D-battery")
+    _write(os.path.join(supply, "capacity"), "62\n")
+    _write(os.path.join(supply, "status"), "Discharging\n")
+
+    o_proc, o_ps = cs._PROC_INPUT_DEVICES, cs._POWER_SUPPLY_DIR
+    cs._PROC_INPUT_DEVICES = proc.name
+    cs._POWER_SUPPLY_DIR = ps
+    try:
+        ctrls = cs._gaming_controllers()
+        check(len(ctrls) == 1, "the one real pad is listed")
+        c = ctrls[0] if ctrls else {}
+        check(c.get("uniq") == "44:16:22:1f:74:5d", "keyed on uniq, not phys")
+        check(c.get("battery_pct") == 62, "battery percent joined by uniq")
+        check(c.get("battery_status") == "Discharging", "battery status joined")
+
+        # Empty power_supply (mains desktop, no pad battery) is NOT an error.
+        cs._POWER_SUPPLY_DIR = tempfile.mkdtemp()
+        check(cs._pad_battery("44:16:22:1f:74:5d") == {}, "empty power_supply -> {} (no error)")
+        again = cs._gaming_controllers()
+        check(len(again) == 1 and "battery_pct" not in again[0],
+              "pad still listed with no battery fields")
+    finally:
+        cs._PROC_INPUT_DEVICES, cs._POWER_SUPPLY_DIR = o_proc, o_ps
+        os.unlink(proc.name)
+
+
+# --- active output pick ------------------------------------------------------
+
+def test_active_output():
+    print("active output pick")
+    orig = cs._connected_outputs
+    try:
+        cs._connected_outputs = lambda: [
+            {"name": "eDP-1", "internal": True},
+            {"name": "DP-1", "internal": False},
+        ]
+        check(cs._active_output() == {"name": "DP-1", "internal": False},
+              "external preferred over internal")
+        cs._connected_outputs = lambda: [{"name": "eDP-1", "internal": True}]
+        check(cs._active_output() == {"name": "eDP-1", "internal": True},
+              "internal-only box reports its panel")
+        cs._connected_outputs = lambda: []
+        check(cs._active_output() is None, "headless -> None (field omitted)")
+    finally:
+        cs._connected_outputs = orig
+
+
+# --- payload shape: per-field optional ---------------------------------------
+
+def test_payload_omits_absent_fields():
+    print("payload per-field probe-and-appear")
+    o_gpu, o_game, o_out, o_ctrl, o_sess = (
+        cs._gpu_sensors, cs._running_game, cs._active_output,
+        cs._gaming_controllers, cs._couchmode_session)
+    cs._GAMING_CACHE["val"] = None
+    try:
+        # An idle Intel box in desktop: no gpu, no game, no pad — but a session.
+        cs._gpu_sensors = lambda: {}
+        cs._running_game = lambda: None
+        cs._active_output = lambda: {"name": "DP-1", "internal": False}
+        cs._gaming_controllers = lambda: []
+        cs._couchmode_session = lambda: "desktop"
+        p = cs._gaming_payload()
+        check("gpu" not in p, "no gpu key when GPU absent (no blank block)")
+        check("game" not in p, "no game key when nothing running")
+        check("controllers" not in p, "no controllers key when no pad")
+        check(p.get("output") == {"name": "DP-1", "internal": False}, "output present")
+        check(p.get("session") == "desktop", "session always present")
+    finally:
+        (cs._gpu_sensors, cs._running_game, cs._active_output,
+         cs._gaming_controllers, cs._couchmode_session) = (
+            o_gpu, o_game, o_out, o_ctrl, o_sess)
+        cs._GAMING_CACHE["val"] = None
+
+
+if __name__ == "__main__":
+    test_appid_from_cmdline()
+    test_gpu_sensors()
+    test_vram_sanity()
+    test_controllers_and_battery()
+    test_active_output()
+    test_payload_omits_absent_fields()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all gaming-card tests passed")


### PR DESCRIPTION
CouchOS roadmap **phase 3**. A live "what's running now" card: GPU temp/VRAM, the running Steam game (cover art), active display output, controllers + battery, session.

## Built to the plan's corrections
- **Per-field probe-and-appear**, not all-or-nothing. Both reachable boxes are **Intel i915** (no DRM-device hwmon), so the card renders session/output/game/controllers and **omits the GPU block** — never blank, never a CPU temp mislabelled GPU, never a whole-card 404.
- **Controllers reuse `list_real_pads()`** (shipped, hardware-proven). Only the `/sys/class/power_supply` battery join is new, **keyed on `uniq`, never `phys`**.
- **5 caps edit-sites** via the `b8b9b1a` template; the cap persists (`normalizeCaps`/`capsEqual`), no re-probe each launch.
- LAN-only cover art (existing `steamCoverSource`); label from the appinfo cache.

## Traps handled (all in tests)
`card*` glob (`re.fullmatch(card\d+)` so a `cardN-DP-1` connector isn't read as a GPU) · hwmon-index instability (match the `name` file) · `[oom_reaper]` false positive (require the real reaper wrapper + a `steamapps` path, reject bracketed argv) · VRAM magnitude sanity.

## Verified
- **Live on the Intel box .60**: `/api/gaming` → `{session:"gamescope", output:{DP-1,external}}`, **GPU block omitted**, `caps.gaming=true`. ✅
- `--mock` renders the full payload (GPU + game + output + pad + Game Mode).
- `tests/test_gaming_card.py` (in CI) drives the **real** functions against sysfs/proc fixtures. All 5 agent suites green; app typechecks.

## ⚠️ NOT hardware-verified
The **amdgpu GPU block** (temp/VRAM). **No AMD box is reachable** — the Legion Go S (`10.1.1.195`) + 3 others are off-LAN. The amdgpu sysfs paths follow the documented layout and pass the fixture tests, but need a real AMD box to confirm on hardware. Everything else is live-proved on Intel. **Do not market until a store build ships it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)