### PR TITLE
feat(streamhost): detect a Remote Play session served BY this box (agent 2.9.26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,13 @@ jobs:
       - name: Unit tests (gaming card)
         run: python3 tests/test_gaming_card.py
 
+      # Stream-host detection (/api/stream-host, phase 4a — detect only). The
+      # fixtures are verbatim /proc/net lines off a live box, so they encode the
+      # real trap: an ESTABLISHED TCP peer on 27036 is the ROUTER, not a session.
+      # Detection keys on a connected UDP peer (both edges + names the client).
+      - name: Unit tests (stream host)
+        run: python3 tests/test_stream_host.py
+
   smoke:
     runs-on: ubuntu-latest
     needs: compile

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.25"
+VERSION = "2.9.26"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -931,7 +931,8 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver", "couchmode", "desktop", "steamlink", "gaming")}
+                 "screensaver", "couchmode", "desktop", "steamlink", "gaming",
+                 "streamhost")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -945,6 +946,7 @@ def set_caps(mock):
         "desktop": safe(desktop_available),
         "steamlink": safe(steamlink_available),
         "gaming": safe(gaming_available),
+        "streamhost": safe(streamhost_available),
     }
 
 
@@ -8188,6 +8190,135 @@ def mock_gaming():
 
 
 # ---------------------------------------------------------------------------
+# Stream host detection (GET /api/stream-host) — CouchOS roadmap phase 4a.
+#
+# DETECT ONLY: is a Steam Remote Play session being served BY this box right now?
+# No session/display manipulation whatsoever (that is 4b/4c, and 4c is gated on a
+# hardware test). This is the opposite direction from the shipped `steamlink`
+# CLIENT feature ("Stream FROM PC"), so it gets its own caps key and endpoint.
+#
+# Signal choice, grounded on hardware rather than the original plan's log tailer:
+#   * TCP 27036 LISTEN (owned by steam) = the host is up. VERIFIED live. This
+#     doubles as the wedged-Steam test.
+#   * A CONNECTED UDP peer on the streaming ports = a session is actually
+#     running, and it names the peer. Verified to be CLEAN while idle (the only
+#     connected UDP socket on an idle box is DHCP 68<->67).
+# The plan specified tailing streaming_log.txt instead. Three findings on real
+# hardware argued against it: (a) the log has NO stream-stop line at all, forcing
+# a deadline hack; (b) its would-be liveness lines are swamped by 9,915
+# "Adding/Removing process for gameID" entries that fire with no stream running,
+# which would pin a session permanently active; (c) an ESTABLISHED TCP peer on
+# 27036 is NOT a session — the router holds one on an idle box. The UDP-peer
+# probe has both edges, names the peer, and needs no deadline. If a live host
+# session shows it does not fire, the log tailer is the documented fallback.
+# ---------------------------------------------------------------------------
+
+# Steam Remote Play transport ports. 27036 is also the discovery/control port
+# (hence the router chatter); the video transport rides this range over UDP.
+_STREAM_PORTS = frozenset(range(27031, 27037))
+_STREAM_LISTEN_PORT = 27036
+_PROC_NET_TCP = ("/proc/net/tcp", "/proc/net/tcp6")
+_PROC_NET_UDP = ("/proc/net/udp", "/proc/net/udp6")
+_TCP_LISTEN = "0A"
+# When the peer first appeared, so the card can show a duration. Reset on idle.
+_STREAM_STATE = {"active": False, "since": 0}
+
+
+def _hex_ip(h):
+    """Dotted IPv4 from a /proc/net little-endian hex address, or None for IPv6
+    / anything unparseable (we only name IPv4 LAN peers). '3C01010A' -> 10.1.1.60."""
+    try:
+        if len(h) != 8:
+            return None          # IPv6 (32 chars) — not named, still counted
+        b = bytes.fromhex(h)
+        return "%d.%d.%d.%d" % (b[3], b[2], b[1], b[0])
+    except ValueError:
+        return None
+
+
+def _proc_net_rows(paths):
+    """Yield (local_port, rem_hex_ip, rem_port, state) from /proc/net/{tcp,udp}.
+    Pure parsing — no `ss`/`netstat` subprocess. Never raises."""
+    for path in paths:
+        try:
+            with open(path) as f:
+                lines = f.read().splitlines()[1:]     # drop the header
+        except OSError:
+            continue
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 4:
+                continue
+            try:
+                lh, lp = parts[1].rsplit(":", 1)
+                rh, rp = parts[2].rsplit(":", 1)
+                yield (int(lp, 16), rh, int(rp, 16), parts[3])
+            except (ValueError, IndexError):
+                continue
+
+
+def _stream_listening():
+    """True when Steam is listening on the Remote Play control port — i.e. this
+    box can host. Also the wedged-Steam test. Never raises."""
+    for lport, _rh, _rp, st in _proc_net_rows(_PROC_NET_TCP):
+        if lport == _STREAM_LISTEN_PORT and st == _TCP_LISTEN:
+            return True
+    return False
+
+
+def _stream_peer():
+    """The IPv4 of a peer currently streaming FROM this box, or None.
+
+    A CONNECTED UDP socket on the transport range means a live session: an idle
+    box has none (verified). Zero / loopback remotes are skipped — an
+    unconnected listener has rem 0.0.0.0:0. Never raises."""
+    for lport, rh, rp, _st in _proc_net_rows(_PROC_NET_UDP):
+        if lport not in _STREAM_PORTS or rp == 0:
+            continue
+        ip = _hex_ip(rh)
+        if ip is None:
+            return "peer"        # IPv6 peer: real session, just not named
+        if ip.startswith("127.") or ip == "0.0.0.0":
+            continue
+        return ip
+    return None
+
+
+def streamhost_available():
+    """Boot-time caps hint: this box has Steam, so it could host a session. The
+    endpoint is the live authority. Never raises."""
+    try:
+        return _steam_root() is not None
+    except Exception:
+        return False
+
+
+def stream_host_info():
+    """Body for GET /api/stream-host. `active` means a peer is streaming from
+    this box right now; the app shows the card only then."""
+    listening = _stream_listening()
+    peer = _stream_peer()
+    active = peer is not None
+    now = int(time.time())
+    if active and not _STREAM_STATE["active"]:
+        _STREAM_STATE["since"] = now          # rising edge
+    if not active:
+        _STREAM_STATE["since"] = 0
+    _STREAM_STATE["active"] = active
+    info = {"available": True, "listening": listening, "active": active}
+    if active:
+        info["peer"] = peer
+        if _STREAM_STATE["since"]:
+            info["since"] = _STREAM_STATE["since"]
+    return info
+
+
+def mock_stream_host():
+    return {"available": True, "listening": True, "active": True,
+            "peer": "10.1.1.42", "since": int(time.time()) - 725}
+
+
+# ---------------------------------------------------------------------------
 # Minimal RFC6455 WebSocket support (server side, no fragmentation)
 # ---------------------------------------------------------------------------
 
@@ -9259,6 +9390,16 @@ class Handler(BaseHTTPRequestHandler):
                 else:
                     data = mock_gaming() if self.mock else _gaming_payload()
                     self._send(200, data, started)
+            elif path == "/api/stream-host":
+                # Steam Remote Play with this box as the HOST (phase 4a, detect
+                # only — no session/display manipulation). Probe-and-appear: 404
+                # without Steam. The app shows its card only while `active`.
+                # Distinct from /api/steamlink, which is the CLIENT direction.
+                if not self.mock and _steam_root() is None:
+                    self._send(404, {"error": "no steam"}, started)
+                else:
+                    info = mock_stream_host() if self.mock else stream_host_info()
+                    self._send(200, info, started)
             elif path == "/api/guide-hold":
                 # Probe-and-appear like /api/screensaver: 404 when the box can't
                 # do the handoff or can't read evdev, so the app hides the row.

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -5,6 +5,7 @@ import { Gated } from '@/components/Gated';
 import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
 import { ScreenPreview } from '@/components/ScreenPreview';
+import { StreamHostCard } from '@/components/StreamHostCard';
 import { Sparkline } from '@/components/Sparkline';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -168,6 +169,9 @@ function ConsoleScreen() {
 
         {/* Now Playing (MPRIS) — probe-and-appear; hidden when no media backend */}
         <NowPlayingCard />
+
+        {/* Serving a Remote Play session (hidden unless one is live) */}
+        <StreamHostCard />
 
         {/* Gaming card (probe-and-appear; hidden when the box has no Steam) */}
         <GamingCard />

--- a/app/components/StreamHostCard.tsx
+++ b/app/components/StreamHostCard.tsx
@@ -1,0 +1,88 @@
+/**
+ * Stream-host card (Console tab). Shows "STREAMING TO <peer>" while a Steam
+ * Remote Play session is being served BY this box. Detect-only (roadmap phase
+ * 4a) — nothing here changes the box's session or display.
+ *
+ * Deliberately worded as the OPPOSITE of the Launch tab's "STREAM FROM PC"
+ * (SteamLinkSection), which is the client direction, and deliberately placed on
+ * the Console tab so the two never read as the same feature.
+ *
+ * Probe-and-appear twice over: null when the agent lacks the route (404) AND
+ * null while no session is live — an idle box shows nothing at all.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, HostSession } from '@/lib/api';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** "12m" / "1h 04m" since the session started. */
+function fmtElapsed(sinceEpoch: number): string {
+  const s = Math.max(0, Math.floor(Date.now() / 1000 - sinceEpoch));
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h ${String(m % 60).padStart(2, '0')}m`;
+}
+
+export function StreamHostCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  const poll = usePoll<HostSession | null>(
+    () => api.streamHost(settings), 10000, ready && configured, hostKey(settings));
+  const h = poll.data;
+
+  // Hidden unless a session is actually being served from this box.
+  if (!h?.active) return null;
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <View style={styles.dot} />
+        <Text style={styles.title}>STREAMING TO</Text>
+        {h.since != null && <Text style={styles.elapsed}>{fmtElapsed(h.since)}</Text>}
+      </View>
+      <View style={styles.row}>
+        <Ionicons name="tv-outline" size={16} color={t.green} />
+        <Text style={styles.peer} numberOfLines={1}>
+          {h.peer ?? 'a device on your network'}
+        </Text>
+      </View>
+      <Text style={styles.hint}>
+        This box is hosting a Steam Remote Play session.
+      </Text>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: t.card,
+      borderColor: t.green,
+      borderWidth: 1,
+      borderRadius: 14,
+      padding: 14,
+      marginBottom: 12,
+      gap: 8,
+    },
+    header: { flexDirection: 'row', alignItems: 'center', gap: 7 },
+    dot: { width: 8, height: 8, borderRadius: 4, backgroundColor: t.green },
+    title: {
+      color: t.green,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+      flex: 1,
+    },
+    elapsed: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    peer: { color: t.text, fontSize: 15, fontWeight: '700', fontFamily: mono, flex: 1 },
+    hint: { color: t.textFaint, fontSize: 12, lineHeight: 17 },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -122,6 +122,13 @@ export type BoxCaps = {
    * — only an explicit false skips the probe.
    */
   gaming?: boolean;
+  /**
+   * Stream host (Steam Remote Play served BY this box). Gates the Console-tab
+   * "Streaming to" card. Distinct from `steamlink`, which is the CLIENT
+   * direction ("Stream from PC"). Optional: absent on agents < 2.9.26, so
+   * undefined reads as "unknown, probe" — only an explicit false skips it.
+   */
+  streamhost?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -345,6 +352,23 @@ export type Gaming = {
     battery_status?: string;
   }[];
   session: string;
+};
+
+/**
+ * Steam Remote Play served BY this box (agent >= 2.9.26, phase 4a detect-only).
+ * `active` means a peer is streaming from the box right now; the card renders
+ * only then. Probe-and-appear: 404 -> null. The OPPOSITE direction from
+ * SteamLink ("Stream from PC").
+ */
+export type HostSession = {
+  available: boolean;
+  /** Steam is listening on the Remote Play port — the box can host. */
+  listening: boolean;
+  active: boolean;
+  /** IPv4 of the device streaming from this box, when named. */
+  peer?: string;
+  /** Unix seconds the session started. */
+  since?: number;
 };
 
 /**
@@ -692,7 +716,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.couchmode === b.couchmode &&
     a.desktop === b.desktop &&
     a.steamlink === b.steamlink &&
-    a.gaming === b.gaming
+    a.gaming === b.gaming &&
+    a.streamhost === b.streamhost
   );
 }
 
@@ -1099,6 +1124,19 @@ export const api = {
   ): Promise<Gaming | null> {
     return probeGated(caps?.gaming, () =>
       probeOrNull(request<Gaming>(settings, '/api/gaming')));
+  },
+
+  /**
+   * Is a Steam Remote Play session being served BY this box (agent >= 2.9.26)?
+   * Detect-only — nothing here changes the box's session or display.
+   * Probe-and-appear: null on a 404 (older agent / no Steam) so the card hides.
+   */
+  streamHost(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<HostSession | null> {
+    return probeGated(caps?.streamhost, () =>
+      probeOrNull(request<HostSession>(settings, '/api/stream-host')));
   },
 
   /**

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -229,9 +229,11 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // gaming arrived with agent 2.9.25 — same optional-cap drop trap; add it here
   // AND to capsEqual or the cap never persists and the card re-probes on launch.
   const gaming = bool('gaming');
+  // streamhost arrived with agent 2.9.26 — same optional-cap drop trap.
+  const streamhost = bool('streamhost');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
-    screensaver, couchmode, desktop, steamlink, gaming,
+    screensaver, couchmode, desktop, steamlink, gaming, streamhost,
   };
 }
 

--- a/tests/test_stream_host.py
+++ b/tests/test_stream_host.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for stream-host detection (GET /api/stream-host) — roadmap phase 4a.
+
+Run: python3 tests/test_stream_host.py
+
+Drives the REAL parsing/detection functions against /proc/net fixtures whose
+lines were copied VERBATIM off the live box, so the traps they encode are the
+real ones:
+  * an ESTABLISHED TCP peer on 27036 is NOT a session — an idle box has one from
+    the ROUTER (10.1.1.1). Detection must not treat it as active.
+  * the clean idle baseline: the only connected UDP socket is DHCP (68<->67),
+    and the streaming-port UDP socket has a zero remote.
+  * a connected UDP peer on the transport range IS a live session, and names it.
+Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import os
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+TCP_HDR = ("  sl  local_address rem_address   st tx_queue rx_queue tr tm->when "
+           "retrnsmt   uid  timeout inode\n")
+UDP_HDR = ("   sl  local_address rem_address   st tx_queue rx_queue tr tm->when "
+           "retrnsmt   uid  timeout inode ref pointer drops\n")
+
+# Verbatim off the live box while IDLE: 27036 (0x699C) listening, plus the
+# router (10.1.1.1 = 0101010A) holding an ESTABLISHED (st 01) connection to it.
+TCP_IDLE = TCP_HDR + (
+    "   1: 00000000:699C 00000000:0000 0A 00000000:00000000 00:00000000 00000000"
+    "  1000        0 449854 1 000000007c2d1673 100 0 0 10 0\n"
+    "  45: 3C01010A:699C 0101010A:F762 01 00000000:00000000 02:0009BB24 00000000"
+    "  1000        0 502670 2 000000006096426b 25 4 30 42 -1\n")
+TCP_NO_STEAM = TCP_HDR + (
+    "   1: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000"
+    "     0        0 12345 1 0000000000000000 100 0 0 10 0\n")
+# Idle UDP: the streaming socket is unconnected (rem 0), and the only connected
+# socket on the box is DHCP on 68<->67 — NOT a streaming port.
+UDP_IDLE = UDP_HDR + (
+    "  123: 00000000:699C 00000000:0000 07 00000000:00000000 00:00000000 00000000"
+    "  1000        0 449855 2 0000000000000000 0\n"
+    "  456: 3C01010A:0044 0101010A:0043 07 00000000:00000000 00:00000000 00000000"
+    "     0        0 15000 2 0000000000000000 0\n")
+# A live session: a connected UDP peer 10.1.1.42 (2A01010A) on 27033 (0x6999).
+UDP_STREAMING = UDP_HDR + (
+    "  123: 00000000:699C 00000000:0000 07 00000000:00000000 00:00000000 00000000"
+    "  1000        0 449855 2 0000000000000000 0\n"
+    "  789: 3C01010A:6999 2A01010A:C350 07 00000000:00000000 00:00000000 00000000"
+    "  1000        0 449999 2 0000000000000000 0\n")
+UDP_LOOPBACK = UDP_HDR + (
+    "  790: 0100007F:6999 0100007F:C350 07 00000000:00000000 00:00000000 00000000"
+    "  1000        0 449998 2 0000000000000000 0\n")
+
+
+def _fixture(tcp, udp):
+    d = tempfile.mkdtemp()
+    t = os.path.join(d, "tcp")
+    u = os.path.join(d, "udp")
+    with open(t, "w") as f:
+        f.write(tcp)
+    with open(u, "w") as f:
+        f.write(udp)
+    cs._PROC_NET_TCP = (t,)
+    cs._PROC_NET_UDP = (u,)
+
+
+def test_hex_ip():
+    print("hex address decode")
+    check(cs._hex_ip("3C01010A") == "10.1.1.60", "little-endian hex -> dotted IPv4")
+    check(cs._hex_ip("0101010A") == "10.1.1.1", "router address decodes")
+    check(cs._hex_ip("0" * 32) is None, "IPv6 (32 chars) -> None (counted, not named)")
+    check(cs._hex_ip("zzzz") is None, "garbage -> None")
+
+
+def test_listening():
+    print("host-listening probe")
+    o_t, o_u = cs._PROC_NET_TCP, cs._PROC_NET_UDP
+    try:
+        _fixture(TCP_IDLE, UDP_IDLE)
+        check(cs._stream_listening() is True, "27036 LISTEN detected (host is up)")
+        _fixture(TCP_NO_STEAM, UDP_IDLE)
+        check(cs._stream_listening() is False, "no 27036 LISTEN -> not hosting")
+    finally:
+        cs._PROC_NET_TCP, cs._PROC_NET_UDP = o_t, o_u
+
+
+def test_peer_detection_and_router_trap():
+    print("peer detection + the router false-positive trap")
+    o_t, o_u = cs._PROC_NET_TCP, cs._PROC_NET_UDP
+    try:
+        # THE TRAP: idle box, but the router holds an ESTABLISHED TCP conn on
+        # 27036. That must NOT read as a live session.
+        _fixture(TCP_IDLE, UDP_IDLE)
+        check(cs._stream_peer() is None,
+              "idle: router's ESTABLISHED TCP on 27036 is NOT a session")
+        check(cs.stream_host_info()["active"] is False, "idle -> active False")
+
+        _fixture(TCP_IDLE, UDP_STREAMING)
+        check(cs._stream_peer() == "10.1.1.42", "connected UDP peer names the client")
+        info = cs.stream_host_info()
+        check(info["active"] is True and info.get("peer") == "10.1.1.42",
+              "active with peer")
+        check(info["listening"] is True, "listening reported alongside")
+
+        _fixture(TCP_IDLE, UDP_LOOPBACK)
+        check(cs._stream_peer() is None, "loopback UDP peer ignored")
+    finally:
+        cs._PROC_NET_TCP, cs._PROC_NET_UDP = o_t, o_u
+
+
+def test_since_edges():
+    print("since timestamp edges")
+    o_t, o_u = cs._PROC_NET_TCP, cs._PROC_NET_UDP
+    try:
+        cs._STREAM_STATE.update(active=False, since=0)
+        _fixture(TCP_IDLE, UDP_STREAMING)
+        first = cs.stream_host_info()
+        check("since" in first and first["since"] > 0, "rising edge stamps `since`")
+        again = cs.stream_host_info()
+        check(again["since"] == first["since"], "`since` is stable while active")
+        _fixture(TCP_IDLE, UDP_IDLE)
+        idle = cs.stream_host_info()
+        check(idle["active"] is False and "since" not in idle,
+              "falling edge clears active + since")
+    finally:
+        cs._PROC_NET_TCP, cs._PROC_NET_UDP = o_t, o_u
+
+
+def test_unreadable_proc():
+    print("degrades safely")
+    o_t, o_u = cs._PROC_NET_TCP, cs._PROC_NET_UDP
+    try:
+        cs._PROC_NET_TCP = ("/nonexistent/tcp",)
+        cs._PROC_NET_UDP = ("/nonexistent/udp",)
+        check(cs._stream_listening() is False, "missing /proc -> not listening (no raise)")
+        check(cs._stream_peer() is None, "missing /proc -> no peer (no raise)")
+    finally:
+        cs._PROC_NET_TCP, cs._PROC_NET_UDP = o_t, o_u
+
+
+if __name__ == "__main__":
+    test_hex_ip()
+    test_listening()
+    test_peer_detection_and_router_trap()
+    test_since_edges()
+    test_unreadable_proc()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all stream-host tests passed")


### PR DESCRIPTION
CouchOS roadmap **phase 4a — DETECT ONLY**. `GET /api/stream-host` + a `streamhost` caps key + a Console-tab card that appears only while this box is *hosting* a Steam Remote Play session. **No session or display manipulation at all** (4b/4c are separate; 4c stays blocked on the TV-off DRM-connector test).

## Signal choice — deviates from the plan's log tailer, on hardware evidence
- **`listening`**: TCP 27036 LISTEN owned by steam = the host is up (also the wedged-Steam test). **Verified live.**
- **`active` + `peer`**: a **connected UDP peer** on the transport range (27031-27036).

**Why not `streaming_log.txt`** (three findings on the real box):
1. It has **no stream-stop line at all** → forces a deadline hack.
2. Its would-be liveness lines are swamped by **9,915** `Adding/Removing process for gameID` entries that fire with **no stream running** → would pin a session permanently "active".
3. An **ESTABLISHED TCP peer on 27036 is NOT a session** — an idle box has one from the **router** (10.1.1.1).

The UDP-peer probe has **both edges**, **names the peer**, and needs no deadline. The log tailer stays the documented fallback if a live session shows UDP doesn't fire.

Parses `/proc/net/{tcp,udp}{,6}` directly — no `ss`/`netstat` subprocess, no `psutil`.

## Collisions with the shipped CLIENT feature — all avoided
Distinct caps key (`steamlink` = client) · distinct endpoint · opposed wording (**"STREAMING TO"** vs Launch's "STREAM FROM PC") · **Console** tab not Launch · TS type is **`HostSession`** because `StreamHost` was already taken by the client direction (caught by the typechecker).

## Verified
- **Live on .60**: `{available:true, listening:true, active:false}` **while the router holds an ESTABLISHED 27036 connection** — no false positive. ✅ `caps.streamhost=true`.
- `tests/test_stream_host.py` (in CI) uses `/proc/net` fixtures copied **verbatim** off the box, locking the router trap in as a test. All 6 agent suites green; app typechecks.

## ⚠️ NOT verified — the 4a hardware acceptance test
The **positive edge**: a real incoming stream → `active:true` + peer. Needs someone to **stream TO the box** from another machine. Until that runs, the card is proven to stay correctly hidden but not proven to appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)