### PR TITLE
chore(app): 2.9.10 — gaming card + stream-host card

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.9",
+    "version": "2.9.10",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,3 +1,4 @@
-New in 2.9.9
+New in 2.9.10
 
-• Stream from PC: play games from another Steam PC or Steam Deck on your network, right on the box. Open the Launch tab, pick the machine, and tap a game — nothing extra to install.
+• Gaming card on the Console tab: see what's running right now — the game with its cover art, your controllers and their battery, the active display, and whether the box is in Game Mode.
+• When another device is streaming from your box, the Console tab now shows that too.


### PR DESCRIPTION
Marketing version bump for **2.9.10**, carrying agent **2.9.27**: the Console-tab gaming card (#124) and stream-host detection (#125 + the #126 fix). Play 'What's new' updated. Build numbers left for autoincrement (floors: iOS 61 / vc45).

Built **locally** (Mac) this round — EAS credits are exhausted and charging overage. iOS is TestFlight-only from this beta-macOS machine (ITMS-90111 blocks App Store review); an App-Store-eligible iOS build waits for a cloud build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)