### PR TITLE
chore(app): reconcile build numbers to 61/45 (shipped 2.9.10)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "60",
+      "buildNumber": "61",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 44
+      "versionCode": 45
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Local builds autoincremented iOS 60→61 and Android vc44→45. Reconciling app.json (build-number drift hazard). Both artifacts built on the Mac — no EAS charge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)