### PR TITLE
fix(gaming): detect the Steam Controller on the gaming card (agent 2.9.28)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.27"
+VERSION = "2.9.28"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -7569,8 +7569,8 @@ _GUIDE_MOCK = False
 
 def _parse_input_devices(text):
     """Parse /proc/bus/input/devices into
-    [{"name","phys","uniq","handlers":[...],"keybits":[...]}]. Tolerant of
-    unknown lines. partition(':') is used so a Phys like
+    [{"name","phys","uniq","vendor","product","handlers":[...],"keybits":[...]}].
+    Tolerant of unknown lines. partition(':') is used so a Phys like
     usb-0000:c3:00.4-1/input0 survives."""
     recs, cur = [], None
     for line in text.splitlines():
@@ -7581,8 +7581,19 @@ def _parse_input_devices(text):
         val = val.strip()
         if tag == "I":
             cur = {"name": "", "phys": "", "uniq": "", "handlers": [],
-                   "keybits": []}
+                   "keybits": [], "vendor": "", "product": ""}
             recs.append(cur)
+            # "Bus=0003 Vendor=28de Product=11ff Version=0001". VID:PID is the
+            # only thing that separates a Steam Input phantom from the pad it
+            # republishes — both are phys-less and both are named after a real
+            # Xbox pad. Lowercased: /proc prints hex lowercase, but don't rely
+            # on it. Missing/garbled fields stay "" and simply never match.
+            for tok in val.split():
+                k, _, v = tok.partition("=")
+                if k == "Vendor":
+                    cur["vendor"] = v.strip().lower()
+                elif k == "Product":
+                    cur["product"] = v.strip().lower()
         elif cur is None:
             continue
         elif tag == "N" and val.startswith("Name="):
@@ -8118,10 +8129,90 @@ def _pad_battery(uniq):
     return {}
 
 
+# Steam Input republishes every controller it manages as its own virtual pad
+# under this VID:PID. The Puck is the wireless dongle the 2025 Steam Controller
+# pairs through; its presence is what lets us name an otherwise anonymous
+# phantom. Both measured on a live box, 2026-07-19.
+_STEAM_INPUT_ID = ("28de", "11ff")
+_STEAM_PUCK_ID = ("28de", "1304")
+
+
+def _read_input_devices():
+    """Parsed /proc/bus/input/devices, [] on any read error."""
+    try:
+        with open(_PROC_INPUT_DEVICES, "r", errors="replace") as f:
+            return _parse_input_devices(f.read())
+    except OSError:
+        return []
+
+
+def _is_pad(rec):
+    """A joystick node with a guide button — same shape test list_real_pads
+    applies, minus its phys/uniq requirement."""
+    return (any(t.startswith("js") for t in rec.get("handlers", []))
+            and _declares_key(rec, BTN_MODE))
+
+
+def _steam_input_pads(recs):
+    """Pads Steam Input is currently republishing (VID:PID 28de:11ff).
+
+    MEASURED ON HARDWARE, all three cases producing exactly one phantom each:
+    a real pad carrying a Phys, a phys-less pad, and the agent's OWN uinput
+    pad. So this count is (real pads) + (agent pads) + (pads only Steam can
+    see) — never a subset. That is what makes the subtraction below sound."""
+    return [r for r in recs
+            if (r.get("vendor"), r.get("product")) == _STEAM_INPUT_ID
+            and _is_pad(r)]
+
+
+def _own_pad_count():
+    """Virtual gamepads the agent itself has open right now.
+
+    Counts entries whose device slot is filled, NOT len(GAMEPAD_SESSIONS) —
+    waiters sit in that list with device None, and an entry is appended before
+    any device is created. Normally 0 or 1 (only the holder owns a pad); it can
+    briefly read 2 during a handoff, between promoting the new holder and
+    releasing the old one, since both run outside GAMEPAD_LOCK. A transient
+    over-count only hides a controller for one 2s poll, which is why this is
+    allowed to race rather than take a heavier lock."""
+    try:
+        with GAMEPAD_LOCK:
+            return sum(1 for s in GAMEPAD_SESSIONS
+                       if s.get("device") is not None)
+    except Exception:
+        return 0
+
+
 def _gaming_controllers():
-    """Real pads (deduped — one device can present several nodes) with a best-
-    effort battery join. Keyed on uniq, NEVER phys (phys is the shared host-
-    adapter MAC, identical for every BT pad)."""
+    """Controllers the user could actually play with, deduped, with a best-
+    effort battery join.
+
+    TWO sources, because neither sees every pad on its own:
+
+      * REAL pads (list_real_pads) — carry a Phys or Uniq, so they have honest
+        names and can be battery-joined.
+      * Steam Input phantoms — a Steam Controller NEVER exposes a gamepad node
+        of its own. The Puck presents only lizard-mode mouse/keyboard nodes;
+        Steam consumes the HID and republishes it phys-less. Those phantoms are
+        invisible to list_real_pads BY DESIGN: our own uinput pad is phys-less
+        too, and a filter that matched it would tear down the user's desktop
+        session every time a phone connected.
+
+    Steam wraps everything it manages, so whatever is left after subtracting
+    the pads we can already see and the pads we created ourselves is exactly
+    what list_real_pads cannot reach:
+
+        total = max(len(real), phantoms - our_pads)
+
+    max() rather than plain subtraction so real pads still show when Steam is
+    not running at all and there are no phantoms. Verified against a live box
+    in every state that was reachable:
+
+        idle, Steam Controller on   real 0  phantom 1  ours 0  -> 1
+        phone gamepad connected     real 0  phantom 2  ours 1  -> 1  (not 2)
+        + a pad carrying a Phys     real 1  phantom 2  ours 0  -> 2
+        Steam not running           real 1  phantom 0  ours 0  -> 1
+    """
     seen, out = set(), []
     for p in list_real_pads():
         u = p.get("uniq") or ""
@@ -8132,6 +8223,23 @@ def _gaming_controllers():
         ctrl = {"uniq": u, "name": p.get("name", "")}
         ctrl.update(_pad_battery(u))
         out.append(ctrl)
+
+    recs = _read_input_devices()
+    hidden = max(0, len(_steam_input_pads(recs)) - _own_pad_count() - len(out))
+    if hidden:
+        # The phantom is anonymous ("Microsoft X-Box 360 pad 0") and carries no
+        # Uniq, so there is nothing real to name or battery-join it by. Name it
+        # from the dongle when that is present. No battery either way: the 2025
+        # controller publishes NO power_supply node (its charge is readable only
+        # over HID, in userspace), so there is nothing for _pad_battery to find.
+        label = ("Steam Controller"
+                 if any((r.get("vendor"), r.get("product")) == _STEAM_PUCK_ID
+                        for r in recs)
+                 else "Controller")
+        for i in range(hidden):
+            # Synthetic uniq: the app keys its controller list on uniq, so two
+            # hidden pads must not collide on "".
+            out.append({"uniq": "steam-input-%d" % i, "name": label})
     return out
 
 
@@ -8567,15 +8675,17 @@ def _make_holder(entry, mock):
     first swipe / keypress of EVERY session (measured 508/525ms). A create
     failure here is non-fatal — the slot stays None and the lazy path in
     _handle_frame retries on first use, reporting the error to the client."""
-    # REUSE the session's existing pad on re-promotion. A session that passes
-    # control away keeps its device (nothing destroys it at demotion — only
-    # disconnect does), so a Pass/take-back ping-pong used to hit this line
-    # again and OVERWRITE the ref: the old pad object was orphaned with its fd
-    # open, leaving a phantom "Microsoft X-Box 360 pad N" alive until the agent
-    # exited (three were found on a box after one afternoon). Each orphan is
-    # also a controller Steam re-enumerates — enough churn corrupted a real
-    # box's desktop controller config. Reuse fixes the leak AND means a handoff
-    # ping-pong presents ONE stable controller to Steam instead of a parade.
+    # REUSE the session's existing pad on re-promotion, when one survived.
+    # (_release_devices DOES destroy the pad at demotion, so usually none has —
+    # an earlier version of this comment claimed otherwise.) The guard is what
+    # stops a re-promotion from OVERWRITING a live ref: that orphaned the old
+    # pad object with its fd still open, leaving a phantom "Microsoft X-Box 360
+    # pad N" alive until the agent exited (three were found on a box after one
+    # afternoon). Each orphan is also a controller Steam re-enumerates — enough
+    # churn corrupted a real box's desktop controller config, and each one now
+    # also inflates _own_pad_count and so hides a real controller from the
+    # gaming card. Reuse keeps a handoff ping-pong presenting ONE stable
+    # controller to Steam instead of a parade.
     if entry.get("device") is None:
         try:
             entry["device"] = MockGamepad() if mock else UInputGamepad()

--- a/tests/test_gaming_card.py
+++ b/tests/test_gaming_card.py
@@ -129,6 +129,121 @@ B: KEY=7fff000000000000 1000000000000 8000000000 e080ffdf01cfffff ffffffffffffff
 """
 
 
+# --- Steam Input phantom accounting ------------------------------------------
+# Every block below is verbatim off a live Bazzite box (2026-07-19). A 2025
+# Steam Controller NEVER presents a gamepad node: it pairs through the Puck
+# dongle, which publishes only lizard-mode mouse/keyboard nodes, and Steam
+# republishes the pad itself phys-less under 28de:11ff. list_real_pads cannot
+# see that by design (our own uinput pad is phys-less too), so the card counts
+# phantoms and subtracts the pads it already knows about.
+
+
+def _phantom(n):
+    """One Steam Input phantom. KEY word 0 bit 60 is BTN_MODE — real bits, so
+    _declares_key does actual work here rather than being fixture theatre."""
+    return ('I: Bus=0003 Vendor=28de Product=11ff Version=0001\n'
+            'N: Name="Microsoft X-Box 360 pad %d"\n'
+            'P: Phys=\n'
+            'S: Sysfs=/devices/virtual/input/input%d\n'
+            'U: Uniq=\n'
+            'H: Handlers=event%d js%d\n'
+            'B: PROP=0\n'
+            'B: EV=20000b\n'
+            'B: KEY=7cdb000000000000 0 0 0 0\n'
+            'B: ABS=3003f\n'
+            'B: FF=10000 0\n' % (n, 331 + n, 15 + n, n))
+
+
+STEAM_PUCK = """\
+I: Bus=0003 Vendor=28de Product=1304 Version=0111
+N: Name="Valve Software Steam Controller Puck Mouse"
+P: Phys=usb-0000:00:14.0-2/input2
+U: Uniq=FXB99616032A7
+H: Handlers=mouse0 event4
+B: PROP=0
+B: EV=17
+B: KEY=30000 0 0 0 0
+"""
+
+
+def _ctrls_for(blocks, own=0):
+    """_gaming_controllers() over a fixtured /proc + a fixtured count of pads
+    the agent itself has open. Empty power_supply = the mains-desktop case."""
+    proc = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
+    proc.write("\n".join(blocks))
+    proc.close()
+    o_proc, o_ps, o_sess = (cs._PROC_INPUT_DEVICES, cs._POWER_SUPPLY_DIR,
+                            cs.GAMEPAD_SESSIONS)
+    cs._PROC_INPUT_DEVICES = proc.name
+    cs._POWER_SUPPLY_DIR = tempfile.mkdtemp()
+    # A waiter sits in GAMEPAD_SESSIONS with device None and must NOT count.
+    cs.GAMEPAD_SESSIONS = ([{"device": object()} for _ in range(own)]
+                           + [{"device": None}])
+    try:
+        return cs._gaming_controllers()
+    finally:
+        cs._PROC_INPUT_DEVICES, cs._POWER_SUPPLY_DIR = o_proc, o_ps
+        cs.GAMEPAD_SESSIONS = o_sess
+        os.unlink(proc.name)
+
+
+def test_steam_input_phantoms():
+    print("Steam Input phantom accounting")
+
+    c = _ctrls_for([STEAM_PUCK, _phantom(0)])
+    check(len(c) == 1, "Steam Controller (phantom only) is listed at all")
+    check(c and c[0]["name"] == "Steam Controller",
+          "named from the Puck dongle, not the phantom's Xbox name")
+    check(c and "battery_pct" not in c[0],
+          "no battery invented for it (publishes no power_supply node)")
+
+    # THE REGRESSION THIS EXISTS FOR: Steam wraps the agent's own pad too, so a
+    # connected phone must not read as a second controller.
+    c = _ctrls_for([STEAM_PUCK, _phantom(0), _phantom(1)], own=1)
+    check(len(c) == 1, "phone's own pad subtracted — still ONE controller")
+
+    c = _ctrls_for([STEAM_PUCK, _phantom(0)], own=1)
+    check(len(c) == 0, "phone connected, no real controller -> none listed")
+
+    # A real pad Steam has wrapped: seen twice, counted once, named honestly.
+    c = _ctrls_for([XBOX_PAD, _phantom(0)])
+    check(len(c) == 1, "real pad + its own phantom counted once")
+    check(c and c[0]["name"] == "Xbox Wireless Controller",
+          "real pad keeps its real name")
+
+    c = _ctrls_for([STEAM_PUCK, XBOX_PAD, _phantom(0), _phantom(1)])
+    check(len(c) == 2, "real pad + Steam Controller = two")
+    check(sorted(x["name"] for x in c)
+          == ["Steam Controller", "Xbox Wireless Controller"],
+          "one named row each")
+    check(len(set(x["uniq"] for x in c)) == 2,
+          "uniqs distinct (the app keys its list on uniq)")
+
+    c = _ctrls_for([XBOX_PAD])
+    check(len(c) == 1, "Steam not running (no phantoms) -> real pad still shown")
+
+    c = _ctrls_for([_phantom(0)])
+    check(c and c[0]["name"] == "Controller",
+          "no Puck -> generic name, not a guessed Steam Controller")
+
+    c = _ctrls_for([STEAM_PUCK])
+    check(len(c) == 0, "Puck present but controller off -> nothing listed")
+
+
+def test_own_pad_count():
+    print("own-pad count")
+    o_sess = cs.GAMEPAD_SESSIONS
+    try:
+        cs.GAMEPAD_SESSIONS = []
+        check(cs._own_pad_count() == 0, "no sessions -> 0")
+        cs.GAMEPAD_SESSIONS = [{"device": None}, {"device": None}]
+        check(cs._own_pad_count() == 0, "waiters hold no device -> 0")
+        cs.GAMEPAD_SESSIONS = [{"device": object()}, {"device": None}]
+        check(cs._own_pad_count() == 1, "only the holder's pad counts")
+    finally:
+        cs.GAMEPAD_SESSIONS = o_sess
+
+
 def test_controllers_and_battery():
     print("controller battery join")
     proc = tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False)
@@ -218,6 +333,8 @@ if __name__ == "__main__":
     test_gpu_sensors()
     test_vram_sanity()
     test_controllers_and_battery()
+    test_steam_input_phantoms()
+    test_own_pad_count()
     test_active_output()
     test_payload_omits_absent_fields()
     print()


### PR DESCRIPTION
## The problem

A 2025 Steam Controller, powered on and connected, never appeared in the gaming card's controller list. `/api/gaming` returned no `controllers` key at all.

Not a bug in the battery join or the matcher — the pad is **structurally invisible** to `list_real_pads()`.

The controller pairs through the Puck dongle (`28de:1304`), which publishes only lizard-mode mouse/keyboard nodes. Steam consumes the pad's HID and republishes it phys-less under its own VID:PID (`28de:11ff`):

```
I: Bus=0003 Vendor=28de Product=11ff Version=0001
N: Name="Microsoft X-Box 360 pad 0"
P: Phys=                                   <- empty
U: Uniq=                                   <- empty
H: Handlers=event15 js0
```

`list_real_pads()` requires `Phys` or `Uniq` non-empty. That exclusion is deliberate and load-bearing — our own uinput pad is phys-less too, and a filter matching it would tear down the user's desktop session on every phone connect.

## Why the obvious fix is wrong

"Count `28de:11ff` phantoms" was the first idea. Measured it against a live box before writing any code, and it **fails**:

```
APPEARED when a phone connected as a gamepad:
  + 045e:028e | Microsoft X-Box 360 pad     <- ours (uinput)
  + 28de:11ff | Microsoft X-Box 360 pad 1   <- Steam wrapping OURS

phantoms  before=1  during=2
```

Steam Input wraps the agent's own pad. Counting phantoms would report two controllers when there is one controller and one phone.

A second probe — a synthetic uinput pad created *with* a `Phys`, to stand in for a real pad — showed Steam wraps real pads too. So `phantoms = real + ours + Steam-only`, and the arithmetic closes:

```
total = max(len(real), phantoms - our_pads)
```

`max()` rather than plain subtraction so real pads still show when Steam is not running and there are no phantoms.

## Verified states

Every state reachable on the hardware, including the regression this exists to prevent:

| state | real | phantoms | ours | result |
|---|---|---|---|---|
| idle, Steam Controller on | 0 | 1 | 0 | 1 ✅ |
| phone gamepad connected | 0 | 2 | 1 | 1 ✅ (not 2) |
| + a pad carrying a Phys | 1 | 2 | 0 | 2 ✅ |
| Steam not running | 1 | 0 | 0 | 1 ✅ |

**Live box, new agent, controller on:**

```json
{
  "session": "gamescope",
  "output": { "name": "DP-1", "internal": false },
  "controllers": [ { "uniq": "steam-input-0", "name": "Steam Controller" } ]
}
```

## Notes

- Phantoms are anonymous and carry no Uniq, so they are named from the dongle when present (else "Controller") and get a synthetic uniq — the app keys its controller list on uniq, so two hidden pads must not collide on `""`.
- **No battery for them, ever.** `/sys/class/power_supply/` is completely empty on the box; the 2025 controller publishes no node at all (charge is readable only over HID, in userspace). This closes the long-standing "controller battery row unproven" item as *unprovable on this hardware*, not broken.
- `_parse_input_devices` now keeps `Vendor`/`Product`, which it previously discarded.
- Corrects a stale comment in `_make_holder` claiming nothing destroys a pad at demotion — `_release_devices` does, and pad lifetime now feeds `_own_pad_count`.

## Not verified

The `real > 0` case was exercised with a **synthetic** uinput pad carrying a Phys, not a genuine second physical controller. The arithmetic is identical either way, but saying so rather than claiming hardware proof I don't have.

## Scope

Agent-only. The payload matches the existing `Gaming` type and `GamingCard.tsx` already renders the name with "connected" when there is no battery — shipped app 2.9.10 picks this up as soon as the agent updates. No app release needed.

Tests: 12 new assertions in `tests/test_gaming_card.py` driving the real functions against verbatim-from-hardware fixtures. Already wired into CI via the existing gaming-card step. All six suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)