### PR TITLE
fix(streamhost): clear a session that ended without a stop marker (2.9.29)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,8 +73,11 @@ jobs:
 
       # Stream-host detection (/api/stream-host, phase 4a — detect only). The
       # fixtures are verbatim /proc/net lines off a live box, so they encode the
-      # real trap: an ESTABLISHED TCP peer on 27036 is the ROUTER, not a session.
-      # Detection keys on a connected UDP peer (both edges + names the client).
+      # real trap: an ESTABLISHED TCP peer on 27036 is the ROUTER, not a session,
+      # and a client's connection outlives its stream. Detection is log-driven
+      # (both edges + names the client), cross-checked against the data port
+      # (udp/27031) so a host that dies WITHOUT writing its stop marker does not
+      # leave the card advertising a dead session for 12 hours.
       - name: Unit tests (stream host)
         run: python3 tests/test_stream_host.py
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.28"
+VERSION = "2.9.29"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -8325,6 +8325,7 @@ def mock_gaming():
 # is up; it doubles as the wedged-Steam test. Verified live.
 _STREAM_LISTEN_PORT = 27036
 _PROC_NET_TCP = ("/proc/net/tcp", "/proc/net/tcp6")
+_PROC_NET_UDP = ("/proc/net/udp", "/proc/net/udp6")
 _TCP_LISTEN = "0A"
 
 # Session edges, read off streaming_log.txt. BOTH edges exist — captured from a
@@ -8338,9 +8339,14 @@ _TCP_LISTEN = "0A"
 _STREAM_START_MARK = ">>> Starting desktop stream"
 _STREAM_STOP_MARK = ">>> Stopped desktop stream"
 _STREAM_CLIENT_MARK = ">>> Client video decoder set to "
-# A session left "started" with no stop line (Steam killed mid-stream) must not
-# stick forever; `listening` also cross-checks, this is the backstop.
+# Absolute backstop for a session left "started" with no stop line. It is NOT
+# the real recovery path — 12h is far too coarse for that; _stream_data_bound()
+# catches a dirty end within one poll. This only bounds the pathological case
+# where the data port somehow stays bound forever.
 _STREAM_MAX_S = 12 * 3600
+# The Remote Play DATA port. Bound for the life of a session and released when
+# it ends, cleanly or not — see _stream_data_bound().
+_STREAM_DATA_PORT = 27031
 _STREAM_LOCK = threading.Lock()
 _STREAM_STATE = {"active": False, "since": 0, "client": None, "pos": 0}
 
@@ -8436,6 +8442,35 @@ def _stream_listening():
     return False
 
 
+def _stream_data_bound():
+    """True while Steam holds the Remote Play DATA socket open (udp/27031).
+
+    THE RECOVERY SIGNAL for a session that ended dirty. Steam writes
+    ">>> Stopped desktop stream" only on a GRACEFUL stop — a stream host that
+    crashes or gets replaced never writes one, so the session stayed "active"
+    until _STREAM_MAX_S (12 HOURS) expired. Observed in the wild: a card still
+    claiming a live macOS stream 27 minutes after the client disconnected.
+
+    Measured on hardware in BOTH states, which is the bar this detector failed
+    to clear the first time around:
+        streaming live   udp6 :27031 present  (even with the log idle 41s)
+        session dead     27031 absent entirely, while Steam kept running and
+                         kept its 27037 discovery listener plus three LAN peers
+
+    It binds BEFORE the start marker is written ("Streaming initialized and
+    listening on port 27031" precedes ">>> Starting desktop stream" by ~4s), so
+    cross-checking it cannot suppress a session that is merely starting up.
+
+    Rejected alternative: log mtime staleness. Measured 41s of silence DURING a
+    healthy stream, so any threshold tight enough to be useful would hide live
+    sessions. Note the port binds on udp6 in practice — check both families.
+    Never raises."""
+    for lport, _rh, _rp, _st in _proc_net_rows(_PROC_NET_UDP):
+        if lport == _STREAM_DATA_PORT:
+            return True
+    return False
+
+
 def streamhost_available():
     """Boot-time caps hint: Steam is present, so this box could host. The
     endpoint is the live authority. Never raises."""
@@ -8449,10 +8484,12 @@ def stream_host_info():
     """Body for GET /api/stream-host. `active` = a Remote Play session is being
     served BY this box right now; the app shows its card only then.
 
-    Only the log markers decide. An ESTABLISHED TCP peer on 27036 is NOT a
-    session (an idle box has one from the router, plus one per Steam client on
-    the LAN), and `listening` is context only — Steam drops that listener around
-    a session, so gating on it would hide a live stream."""
+    The log markers open a session; the log marker OR a released data port
+    closes it. An ESTABLISHED TCP peer on 27036/27037 is NOT a session (an idle
+    box has one from the router, plus one per Steam client on the LAN — a
+    client's connection outlives its stream by design), and `listening` is
+    context only: Steam drops that listener around a session, so gating on it
+    would hide a live stream."""
     _stream_scan_log()
     listening = _stream_listening()
     with _STREAM_LOCK:
@@ -8461,6 +8498,18 @@ def stream_host_info():
         client = _STREAM_STATE["client"]
     if active and since and int(time.time()) - since > _STREAM_MAX_S:
         active = False                      # stale "started" with no stop line
+    if active and not _stream_data_bound():
+        # Dirty end: the host process died or was replaced without ever writing
+        # a stop marker, so the log alone would keep this session "live" for
+        # hours. Clear the shared state too, not just the local flag, so `client`
+        # and `since` stop being reported. The byte cursor is deliberately left
+        # alone — resetting it would re-read the whole log on the next poll.
+        active = False
+        with _STREAM_LOCK:
+            if _STREAM_STATE["active"]:
+                _STREAM_STATE["active"] = False
+                _STREAM_STATE["since"] = 0
+                _STREAM_STATE["client"] = None
     # NOTE: `active` is deliberately NOT gated on `listening`. Verified on real
     # hardware: Steam drops its 0.0.0.0:27036 TCP listener around a streaming
     # session (present before, gone after) while the client stays connected — so

--- a/tests/test_stream_host.py
+++ b/tests/test_stream_host.py
@@ -6,10 +6,16 @@ Run: python3 tests/test_stream_host.py
 Drives the REAL detection functions against fixtures whose lines are copied
 VERBATIM from a live box, including a genuine macOS Remote Play session it
 served. The traps encoded here are all real and all cost something once:
-  * BOTH session edges exist in streaming_log.txt (">>> Starting/Stopped desktop
-    stream"). An earlier draft keyed on a connected UDP peer in 27031-27036
-    instead — that signal did NOT fire during the real session and silently
-    missed it, which is why detection is log-driven now.
+  * Both session edges exist in streaming_log.txt (">>> Starting/Stopped desktop
+    stream") — but ONLY on a graceful stop. An earlier draft keyed on a
+    connected UDP peer in 27031-27036 instead; that signal did NOT fire during
+    the real session and silently missed it, which is why detection is
+    log-driven. A later revision then claimed both edges ALWAYS exist, which is
+    false: a stream host that crashes or is replaced never writes its stop line,
+    and the card advertised a dead macOS session for 27 minutes. Hence the
+    data-port cross-check (udp/27031), measured in BOTH states this time.
+  * Log mtime staleness is NOT a liveness signal: measured 41 seconds of silence
+    during a healthy stream, so any useful threshold would hide live sessions.
   * "Adding/Removing process for gameID" dominates the log (9,915 lines on the
     live box) and fires with NO stream running — it must never read as activity.
   * An ESTABLISHED TCP peer on 27036 is NOT a session: an idle box has one from
@@ -61,9 +67,27 @@ TCP_NO_STEAM = (
     "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt\n"
     "   1: 00000000:0016 00000000:0000 0A 00000000:00000000 00:00000000 00000000\n")
 
+# The Remote Play DATA socket, 27031 = 0x6997. Bound for the life of a session
+# and released when it ends — cleanly or not — which is the only signal that
+# recovers from a stream host that died without writing its stop marker. It
+# binds on udp6 in practice, so the fixture uses a v6 local address.
+UDP_STREAMING = (
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt\n"
+    " 512: 00000000000000000000000000000000:6997"
+    " 00000000000000000000000000000000:0000 07 00000000:00000000 00:00000000\n")
+# What a box with Steam running but NO live session shows: the 27036 discovery
+# socket only. Measured on hardware — 27031 was absent entirely.
+UDP_IDLE = (
+    "  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt\n"
+    " 511: 00000000:699C 00000000:0000 07 00000000:00000000 00:00000000\n")
 
-def _setup(log_text, tcp_text=TCP_LISTENING):
-    """Point the agent at a fixture log + /proc/net/tcp, with fresh state."""
+
+def _setup(log_text, tcp_text=TCP_LISTENING, udp_text=UDP_STREAMING):
+    """Point the agent at a fixture log + /proc/net/{tcp,udp}, with fresh state.
+
+    udp defaults to the data port BOUND — "a session really is running" — so the
+    marker tests below exercise the markers rather than tripping the cross-check.
+    """
     d = tempfile.mkdtemp()
     log = os.path.join(d, "streaming_log.txt")
     with open(log, "w") as f:
@@ -71,8 +95,12 @@ def _setup(log_text, tcp_text=TCP_LISTENING):
     tcp = os.path.join(d, "tcp")
     with open(tcp, "w") as f:
         f.write(tcp_text)
+    udp = os.path.join(d, "udp")
+    with open(udp, "w") as f:
+        f.write(udp_text)
     cs._stream_log_path = lambda: log
     cs._PROC_NET_TCP = (tcp,)
+    cs._PROC_NET_UDP = (udp,)
     cs._STREAM_STATE.update(active=False, since=0, client=None, pos=0)
     return log
 
@@ -92,7 +120,8 @@ def test_timestamp_parse():
 
 def test_session_edges():
     print("session start/stop edges")
-    o_path, o_tcp = cs._stream_log_path, cs._PROC_NET_TCP
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
     try:
         log = _setup(NOISE)
         info = cs.stream_host_info()
@@ -111,11 +140,13 @@ def test_session_edges():
         check("client" not in info and "since" not in info, "session fields cleared")
     finally:
         cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
 
 
 def test_noise_never_activates():
     print("the 9,915-line noise trap")
-    o_path, o_tcp = cs._stream_log_path, cs._PROC_NET_TCP
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
     try:
         log = _setup(START + STOP)          # settled: a finished session
         cs.stream_host_info()
@@ -124,11 +155,13 @@ def test_noise_never_activates():
               "Adding/Removing/Game Recording never re-activates a session")
     finally:
         cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
 
 
 def test_rotation():
     print("log rotation")
-    o_path, o_tcp = cs._stream_log_path, cs._PROC_NET_TCP
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
     try:
         log = _setup(NOISE * 30 + START + CLIENT)
         check(cs.stream_host_info()["active"] is True, "active before rotation")
@@ -143,11 +176,13 @@ def test_rotation():
         check(info["active"] is False, "post-rotation content re-read correctly")
     finally:
         cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
 
 
 def test_listening_crosscheck():
     print("listening cross-check + router trap")
-    o_path, o_tcp = cs._stream_log_path, cs._PROC_NET_TCP
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
     try:
         # Steam drops its 27036 listener AROUND a session (verified live: present
         # before the stream, gone after) — so a live session must still read as
@@ -168,20 +203,87 @@ def test_listening_crosscheck():
               "router's ESTABLISHED 27036 conn is not a session")
     finally:
         cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
+
+
+def test_dirty_end_recovery():
+    print("dirty end (host died, no stop marker)")
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
+    try:
+        # A session that started and is genuinely live: markers say go, data
+        # port bound. This is the state that must NOT regress.
+        log = _setup(START + CLIENT)
+        info = cs.stream_host_info()
+        check(info["active"] is True, "live session stays active while 27031 is bound")
+        check(info.get("client") == "macOS", "client still reported")
+
+        # THE BUG: the host dies. No stop line is ever written — the log simply
+        # stops growing — but the data port is released.
+        with open(os.path.join(os.path.dirname(log), "udp"), "w") as f:
+            f.write(UDP_IDLE)
+        info = cs.stream_host_info()
+        check(info["active"] is False,
+              "data port released -> session cleared with NO stop marker")
+        check("client" not in info and "since" not in info,
+              "stale client/since not reported after a dirty end")
+        check(cs._STREAM_STATE["active"] is False,
+              "shared state cleared, not just the returned flag")
+        check(cs._STREAM_STATE["pos"] > 0,
+              "byte cursor preserved (no full re-read of the log next poll)")
+
+        # And it stays cleared across polls rather than flapping.
+        check(cs.stream_host_info()["active"] is False, "still inactive next poll")
+
+        # A brand-new session after the dirty end is detected normally.
+        with open(os.path.join(os.path.dirname(log), "udp"), "w") as f:
+            f.write(UDP_STREAMING)
+        _append(log, START + CLIENT)
+        check(cs.stream_host_info()["active"] is True,
+              "a fresh session after a dirty end still activates")
+    finally:
+        cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
+
+
+def test_data_port_does_not_suppress_start():
+    print("data port never suppresses a real session")
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
+    try:
+        # Steam binds 27031 ~4s BEFORE writing ">>> Starting desktop stream"
+        # ("Streaming initialized and listening on port 27031" precedes it), so
+        # the cross-check can never race a session that is merely starting.
+        _setup(START + CLIENT, udp_text=UDP_STREAMING)
+        check(cs.stream_host_info()["active"] is True,
+              "port bound + start marker -> active")
+
+        # Unreadable /proc must not silently kill a live session... it does clear
+        # it, which is the SAFE direction (a hidden card, not a lying one).
+        _setup(START + CLIENT)
+        cs._PROC_NET_UDP = ("/nonexistent/udp",)
+        check(cs.stream_host_info()["active"] is False,
+              "unreadable /proc/net/udp fails closed, not open")
+    finally:
+        cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
 
 
 def test_missing_log():
     print("degrades safely")
-    o_path, o_tcp = cs._stream_log_path, cs._PROC_NET_TCP
+    o_path, o_tcp, o_udp = (cs._stream_log_path, cs._PROC_NET_TCP,
+                            cs._PROC_NET_UDP)
     try:
         cs._stream_log_path = lambda: None
         cs._PROC_NET_TCP = ("/nonexistent/tcp",)
+        cs._PROC_NET_UDP = ("/nonexistent/udp",)
         cs._STREAM_STATE.update(active=False, since=0, client=None, pos=0)
         info = cs.stream_host_info()
         check(info["active"] is False and info["listening"] is False,
               "no log + no /proc -> inactive, no raise")
     finally:
         cs._stream_log_path, cs._PROC_NET_TCP = o_path, o_tcp
+        cs._PROC_NET_UDP = o_udp
 
 
 if __name__ == "__main__":
@@ -190,6 +292,8 @@ if __name__ == "__main__":
     test_noise_never_activates()
     test_rotation()
     test_listening_crosscheck()
+    test_dirty_end_recovery()
+    test_data_port_does_not_suppress_start()
     test_missing_log()
     print()
     if _fail:


### PR DESCRIPTION
> Supersedes #130, which GitHub auto-closed when its stacked base branch was deleted on merge of #129. Same commits, rebased onto `main`.

## The bug

The STREAMING TO card advertised a live macOS Remote Play session **27 minutes after the client disconnected**. Reported from the field, then reproduced and captured on the box.

## Root cause — and a correction to #126

#126 states, in the test file's own docstring, that *"BOTH session edges exist in streaming_log.txt"*. **That is false.** `>>> Stopped desktop stream` is written only on a **graceful** stop. A stream host that crashes or gets replaced never writes one:

```
[18:56:54][2751.763369] >>> Starting desktop stream
[18:56:54][2751.893963] >>> Client video decoder set to macOS Metal
   (no stop line, ever)
[18:57:33][   6.835011] ... new process, relative clock reset from 2767
```

With no stop marker the only remaining escape was `_STREAM_MAX_S` — **12 hours**.

## The fix

Cross-check the Remote Play **data** port (`udp/27031`), which Steam holds for the life of a session and releases when it ends, cleanly or not.

Measured in **both** states — the bar the first version failed to clear:

| state | observation |
|---|---|
| streaming live | `udp6 :27031` present, even with the log idle 41s |
| session dead | `27031` absent entirely, while Steam kept running and kept its 27037 listener + 3 LAN peers |

It binds ~4s *before* the start marker, so the cross-check cannot suppress a session that is merely starting. It binds on **udp6** in practice, so both families are checked.

## Alternatives rejected — measured, not reasoned about

- **TCP peer state.** The client's 27037 connection *outlives* its stream. The Mac still held an ESTABLISHED connection 25 minutes after disconnecting.
- **Log mtime staleness.** Observed **41 seconds of silence during a healthy stream**. Any threshold tight enough to be useful would hide live sessions. This was my first instinct; the measurement killed it.

`_STREAM_MAX_S` stays at 12h but is now only a pathological backstop.

## Verification

- **10 new assertions**, all passing, including the regression guard (a live session stays active while the port is bound) and fail-closed behaviour on unreadable `/proc/net/udp`.
- **Live box, stream running:** new agent and old 2.9.27 both report `active: true`, `27031` bound. No regression.
- **Live box, clean stop:** stop marker written, both agents clear, `27031` released.

## Not demonstrated live

The **dirty end itself** was not reproduced on hardware — the test stream ended cleanly. Evidence is: the failure state was measured in the wild (`27031` absent while 2.9.27 reported `active: true`), and the new rule is only "active and port unbound → clear". Sound inference, stated plainly rather than claimed as a hardware demo. Owner has signed off on shipping without forcing it (would require SIGKILLing the stream host mid-session).

Also corrects the stale CI step comment, which still described the UDP-peer detector replaced before this shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)