### PR TITLE
chore(app): enable the web target for driving UI against mock data

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "1.0.0",
       "dependencies": {
+        "@expo/metro-runtime": "~57.0.6",
         "@expo/vector-icons": "^15.0.2",
         "buffer": "^6.0.3",
         "expo": "~57.0.1",
@@ -1269,9 +1270,9 @@
       }
     },
     "node_modules/@expo/dom-webview": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-57.0.0.tgz",
-      "integrity": "sha512-zBZw52KnaHf9zGVp1eJk8kNfc+5ArGf+KvTL3SeMsr03K6tPJtLbgycVLjrAiLMfhzqGVjPD2G+rbNwpbLUxcg==",
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/dom-webview/-/dom-webview-57.0.1.tgz",
+      "integrity": "sha512-lAKsME4SAq+8sf56oN0DX5TBYyruupoRxbWbD2xf9RnKY8y6x8eb9LCE5pxSN0qyWdqnp+0wmyWzDkKboThKAw==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",
@@ -1390,17 +1391,17 @@
       }
     },
     "node_modules/@expo/log-box": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.0.tgz",
-      "integrity": "sha512-tt9x76IEE8hp2FWTLPfEArrTyD7GCoUe3TpohESy+SPZ/OqkUnSXz40xnUuE0XbE132z8c5CRCfXQLM9DTEknQ==",
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/log-box/-/log-box-57.0.1.tgz",
+      "integrity": "sha512-fuVNHhOerdRWtpq27gD6JTSVYESsfRu+SMdrNCWxW+gFnusS6dGKfx3lKGBZ4ZkMNiLWn8maBHo39YKzJNXFYQ==",
       "license": "MIT",
       "dependencies": {
-        "@expo/dom-webview": "^57.0.0",
+        "@expo/dom-webview": "^57.0.1",
         "anser": "^1.4.9",
         "stacktrace-parser": "^0.1.10"
       },
       "peerDependencies": {
-        "@expo/dom-webview": "^57.0.0",
+        "@expo/dom-webview": "^57.0.1",
         "expo": "*",
         "react": "*",
         "react-native": "*"
@@ -1497,19 +1498,19 @@
       }
     },
     "node_modules/@expo/metro-runtime": {
-      "version": "57.0.2",
-      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-57.0.2.tgz",
-      "integrity": "sha512-sjmbXlGl7807YQ6vYsufkvGItNt/ldXcYnEyF2ERdl0aTs8+xKEarYZ1yefYc3vZvuu7564ToKhtvpEimI8A2w==",
+      "version": "57.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/metro-runtime/-/metro-runtime-57.0.6.tgz",
+      "integrity": "sha512-x/lAtmPBkZGI3YrGirKQ77Ybmd2N4wI6zHE5v1Top08xiYPH28aUTNAu4vf3MBrf4MYnq7327Nj20hzIgzlRmw==",
       "license": "MIT",
       "dependencies": {
-        "@expo/log-box": "^57.0.0",
+        "@expo/log-box": "^57.0.1",
         "anser": "^1.4.9",
         "pretty-format": "^29.7.0",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0"
       },
       "peerDependencies": {
-        "@expo/log-box": "^57.0.0",
+        "@expo/log-box": "^57.0.1",
         "expo": "*",
         "react": "*",
         "react-dom": "*",

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@expo/metro-runtime": "~57.0.6",
     "@expo/vector-icons": "^15.0.2",
     "buffer": "^6.0.3",
     "expo": "~57.0.1",

--- a/scripts/web-dev-proxy.py
+++ b/scripts/web-dev-proxy.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""DEV ONLY. Single-origin server for the app's web target.
+
+Serves the exported web bundle AND proxies /api to a locally-running agent, so
+the browser sees ONE origin.
+
+WHY THIS EXISTS INSTEAD OF CORS HEADERS ON THE AGENT: the agent is a LAN-only,
+token-authed service that deliberately sends no Access-Control-Allow-Origin.
+Adding CORS to it so a dev browser can talk to it would widen the production
+attack surface for a test convenience -- any page the user visits could then
+script their box. Solving it in a dev-only proxy keeps that boundary intact.
+
+NOT FOR DEPLOYMENT. Binds loopback only, no TLS, and forwards the Authorization
+header verbatim. It exists so the app's UI can be driven against `--mock` data
+on a laptop -- see scripts/web-dev.sh.
+
+Not proxied: /ws/gamepad. WebSocket upgrade needs real tunnelling, and the Pad
+surfaces are native-gesture territory that a desktop browser cannot exercise
+faithfully anyway. Verify those on a device.
+
+Usage: web-dev-proxy.py <dist_dir> <listen_port> <agent_host:agent_port>
+"""
+import http.client
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+if len(sys.argv) != 4:
+    raise SystemExit(__doc__.strip().splitlines()[-1])
+
+DIST, PORT, AGENT = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+AGENT_HOST, AGENT_PORT = AGENT.rsplit(":", 1)[0], int(AGENT.rsplit(":", 1)[1])
+PROXY_PREFIXES = ("/api", "/pair")
+
+MIME = {".html": "text/html", ".js": "application/javascript",
+        ".css": "text/css", ".json": "application/json", ".png": "image/png",
+        ".jpg": "image/jpeg", ".svg": "image/svg+xml", ".ico": "image/x-icon",
+        ".woff": "font/woff", ".woff2": "font/woff2", ".ttf": "font/ttf",
+        ".map": "application/json"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        pass                                  # keep the console readable
+
+    def _proxy(self, method):
+        body = None
+        n = int(self.headers.get("Content-Length") or 0)
+        if n:
+            body = self.rfile.read(n)
+        conn = http.client.HTTPConnection(AGENT_HOST, AGENT_PORT, timeout=20)
+        # Drop hop-by-hop headers; keep Authorization so the token still works.
+        hdrs = {k: v for k, v in self.headers.items()
+                if k.lower() not in ("host", "connection", "accept-encoding")}
+        try:
+            conn.request(method, self.path, body=body, headers=hdrs)
+            r = conn.getresponse()
+            data = r.read()
+        except Exception as e:
+            self.send_response(502)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            print("proxy error %s %s: %s" % (method, self.path, e))
+            return
+        finally:
+            conn.close()
+        self.send_response(r.status)
+        for k, v in r.getheaders():
+            if k.lower() in ("transfer-encoding", "connection", "content-length"):
+                continue
+            self.send_header(k, v)
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _static(self):
+        rel = self.path.split("?", 1)[0].lstrip("/") or "index.html"
+        # Contain the path: a traversal must not escape the export directory.
+        path = os.path.normpath(os.path.join(DIST, rel))
+        if not path.startswith(os.path.abspath(DIST)):
+            self.send_response(403)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        if os.path.isdir(path):
+            path = os.path.join(path, "index.html")
+        if not os.path.isfile(path):
+            # expo-router emits <route>.html; fall back, then to the SPA shell.
+            alt = path + ".html"
+            path = alt if os.path.isfile(alt) else os.path.join(DIST, "index.html")
+        try:
+            with open(path, "rb") as f:
+                data = f.read()
+        except OSError:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type",
+                         MIME.get(os.path.splitext(path)[1], "text/plain"))
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def do_GET(self):
+        if self.path.startswith(PROXY_PREFIXES):
+            return self._proxy("GET")
+        self._static()
+
+    def do_POST(self):
+        return self._proxy("POST")
+
+    def do_OPTIONS(self):
+        return self._proxy("OPTIONS")
+
+
+if __name__ == "__main__":
+    DIST = os.path.abspath(DIST)
+    print("serving %s on http://127.0.0.1:%d  (/api -> %s)" % (DIST, PORT, AGENT))
+    ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/scripts/web-dev.sh
+++ b/scripts/web-dev.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# DEV ONLY. Drive the app's UI in a desktop browser against --mock agent data.
+#
+# Exports the web bundle, boots a mock agent, and serves both from ONE origin
+# (see web-dev-proxy.py for why a proxy rather than CORS on the agent). Prints a
+# URL and a localStorage snippet that points the app at itself.
+#
+#   scripts/web-dev.sh [port]        # default 8099
+#
+# WHAT THIS IS FOR: presentational work -- card layouts, empty/loading/error
+# states, caps gating, theming, impact groupings. It renders payload states the
+# hardware cannot produce on demand (a controller battery percentage, a hot GPU,
+# a game running) so they can be checked without a TestFlight cycle.
+#
+# WHAT IT CANNOT COVER -- verify these on a real device:
+#   * Pad / trackpad / gamepad: no WebSocket proxying, and mouse != touch
+#   * iOS Local Network permission, and the no-UDP behaviour
+#   * app backgrounding (iPhone Mirroring suspends WS sends)
+#   * safe-area insets, status bar, keyboard avoidance
+#   * the purchase flow (expo-iap is a no-op on web by design)
+# A web build that looks perfect says nothing about any of the above.
+set -euo pipefail
+
+PORT="${1:-8099}"
+AGENT_PORT=$((PORT + 1))
+TOKEN="web-dev-$RANDOM"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST="$ROOT/app/dist"
+
+cleanup() {
+  [ -n "${AGENT_PID:-}" ] && kill "$AGENT_PID" 2>/dev/null || true
+  [ -n "${PROXY_PID:-}" ] && kill "$PROXY_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+echo "==> exporting the web bundle (this takes a minute)"
+(cd "$ROOT/app" && npx expo export -p web >/dev/null)
+
+echo "==> starting mock agent on 127.0.0.1:$AGENT_PORT"
+python3 "$ROOT/agent/couchsided.py" --mock --host 127.0.0.1 \
+  --port "$AGENT_PORT" --token "$TOKEN" >/tmp/couchside-web-dev-agent.log 2>&1 &
+AGENT_PID=$!
+
+for _ in $(seq 1 30); do
+  curl -fsS "http://127.0.0.1:$AGENT_PORT/api/ping" >/dev/null 2>&1 && break
+  sleep 0.3
+done
+
+echo "==> serving on http://127.0.0.1:$PORT"
+python3 "$ROOT/scripts/web-dev-proxy.py" "$DIST" "$PORT" "127.0.0.1:$AGENT_PORT" &
+PROXY_PID=$!
+
+cat <<EOF
+
+  Open:  http://127.0.0.1:$PORT
+
+  The app starts with no box configured. Paste this in the browser console,
+  then reload -- it points the app at this same origin, so the proxy forwards
+  /api to the mock agent and no CORS is involved:
+
+localStorage.setItem('couchpilot.boxes.v1', JSON.stringify({
+  boxes: [{ id: 'web-dev', name: 'mock box', host: '127.0.0.1',
+            port: $PORT, token: '$TOKEN', padMode: 'trackpad' }],
+  activeBoxId: 'web-dev' }));
+
+  Ctrl-C to stop both processes. Re-run after changing app code (no HMR --
+  the bundle is a static export).
+
+EOF
+
+wait $PROXY_PID


### PR DESCRIPTION
## What

Adds `@expo/metro-runtime` (the one missing piece for `expo export -p web`) plus two **dev-only** scripts, so the app's UI can be driven in a desktop browser against a `--mock` agent instead of waiting on a TestFlight cycle.

```
scripts/web-dev.sh 8099
  ==> exporting the web bundle
  ==> starting mock agent on 127.0.0.1:8100
  ==> serving on http://127.0.0.1:8099
```

## Why a proxy instead of CORS on the agent

The agent is a LAN-only, token-authed service that deliberately sends no `Access-Control-Allow-Origin`. Adding CORS so a dev browser could reach it would widen the **production** attack surface for a test convenience — any page the user visited could then script their box.

Solving it in a dev-only proxy keeps that boundary intact. The proxy binds loopback only and contains path traversal to the export directory (verified with raw `--path-as-is` requests and percent-encoded variants; no leak, encoded forms fall through to the SPA shell).

## Proven end to end

Not a script I wrote and didn't run — `scripts/web-dev.sh` was executed as committed:

- Console tab renders fully against mock data, **including a controller battery row at 62%** — a state the hardware physically cannot produce, since the 2025 Steam Controller publishes no `power_supply` node at all.
- Actions tab renders the new **"Pair a controller"** entry under its `CHANGES WHAT'S ON SCREEN` grouping — verified without a device build.

## Two predicted blockers were already solved

I expected `expo-secure-store` and `expo-iap` to break the web target. Both were already handled by whoever wrote the app:

- `lib/settings.ts:99` — *"expo-secure-store on native, localStorage on web"*
- `lib/purchase.ts:5` — *"every exported function is safe to call on web"*

Only the missing dep and CORS were real. Worth stating: I predicted four blockers and reading first would have shown two were imaginary.

## What this deliberately does NOT cover

Called out prominently in the script header so a clean web run is never mistaken for a passing device test:

- **Pad / trackpad / gamepad** — no WebSocket proxying, and mouse ≠ touch
- **iOS Local Network permission**, and the no-UDP behaviour
- **App backgrounding** (iPhone Mirroring suspends WS sends)
- **Safe-area insets, status bar, keyboard avoidance**
- **The purchase flow** — `expo-iap` is a no-op on web by design

That list is precisely the historical bug surface, so this is a fast inner loop for presentational work, not a replacement for device testing.

## Scope

No app or agent behaviour changes. One dependency, two scripts under `scripts/`. `app/dist/` is already gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)