### PR TITLE
feat(app): Steam settings shortcuts as an Actions sub-tab (2.9.11)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.10",
+    "version": "2.9.11",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "61",
+      "buildNumber": "62",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 45
+      "versionCode": 46
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -9,12 +9,21 @@ import {
   View,
 } from 'react-native';
 
+import { Ionicons } from '@expo/vector-icons';
+
 import { Gated } from '@/components/Gated';
+import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
-import { hapticError, hapticHeavy, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { ActionInfo, ActionResult, api, Danger, hostKey, SteamMenus } from '@/lib/api';
+import {
+  hapticError,
+  hapticHeavy,
+  hapticLight,
+  hapticSelection,
+  hapticSuccess,
+} from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -56,6 +65,41 @@ type RunRecord = {
   running: boolean;
 };
 
+type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
+
+/** Sub-tabs across the top of Actions, mirroring the Setup screen's strip. */
+type SubTab = 'actions' | 'steam';
+const SUB_TABS: { key: SubTab; label: string; icon: IoniconName }[] = [
+  { key: 'actions', label: 'Actions', icon: 'flash-outline' },
+  { key: 'steam', label: 'Steam', icon: 'settings-outline' },
+];
+
+function SubTabs({ tab, onTab }: { tab: SubTab; onTab: (t: SubTab) => void }) {
+  const pal = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View style={styles.subTabBar}>
+      {SUB_TABS.map((t) => {
+        const active = t.key === tab;
+        return (
+          <Pressable
+            key={t.key}
+            onPress={() => {
+              hapticSelection();
+              onTab(t.key);
+            }}
+            style={[styles.subTabItem, active && styles.subTabItemActive]}>
+            <Ionicons name={t.icon} size={15} color={active ? pal.text : pal.textFaint} />
+            <Text style={[styles.subTabLabel, active && styles.subTabLabelActive]}>
+              {t.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
 export default function ActionsTab() {
   useLockOrientation('portrait');
   return (
@@ -88,6 +132,28 @@ function ActionsScreen() {
     ready && configured,
     hostKey(settings), // clear the previous box's actions on switch
   );
+
+  // Steam settings deep links (agent >= 2.9.31). Static list, so poll rarely —
+  // probe-and-appear leaves data null on an older agent and the section hides.
+  // Sub-tab, mirroring the Setup screen's category strip. The strip is only
+  // rendered when the box actually offers Steam menus — see hasSteamMenus.
+  // Steam is the default: the danger-grouped Actions are rare, deliberate
+  // operations, while the Steam shortcuts are the everyday reason to open this
+  // tab. Falls back to 'actions' automatically when the box offers no menus.
+  const [sub, setSub] = useState<SubTab>('steam');
+
+  const steamMenus = usePoll<SteamMenus | null>(
+    () => api.steamMenus(settings),
+    300000,
+    ready && configured,
+    hostKey(settings),
+  );
+
+  const hasSteamMenus = !!steamMenus.data?.menus?.length;
+  // If the Steam sub-tab disappears while it is selected (box swapped for one
+  // without Steam, agent downgraded), fall back rather than render a blank
+  // screen. Never trust `sub` alone.
+  const activeSub: SubTab = hasSteamMenus ? sub : 'actions';
 
   const execute = useCallback(
     async (action: ActionInfo) => {
@@ -165,7 +231,12 @@ function ActionsScreen() {
         {configured && !actions.data && actions.error == null && (
           <Text style={styles.dim}>loading…</Text>
         )}
-        {groups.map((g) => (
+        {hasSteamMenus && <SubTabs tab={activeSub} onTab={setSub} />}
+        {activeSub === 'steam' ? (
+          <SteamMenusPanel menus={steamMenus.data!.menus} />
+        ) : null}
+        {activeSub === 'actions' &&
+          groups.map((g) => (
           <View key={g.danger} style={styles.group}>
             <Text style={[styles.groupTitle, { color: DANGER_COLOR[g.danger] }]}>
               {GROUP_TITLE[g.danger]}
@@ -184,8 +255,8 @@ function ActionsScreen() {
                 <Text style={styles.cardDesc}>{a.description}</Text>
               </Pressable>
             ))}
-          </View>
-        ))}
+            </View>
+          ))}
       </ScrollView>
 
       {/* Result panel */}
@@ -235,6 +306,38 @@ function ActionsScreen() {
 
 const makeStyles = (t: Palette) => StyleSheet.create({
   screen: { flex: 1, backgroundColor: t.bg, paddingHorizontal: 14 },
+  subTabBar: {
+    flexDirection: 'row',
+    gap: 4,
+    padding: 4,
+    borderRadius: 12,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    marginBottom: 14,
+  },
+  subTabItem: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    paddingVertical: 9,
+    borderRadius: 9,
+  },
+  subTabItemActive: {
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  subTabLabel: {
+    color: t.textFaint,
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+    fontFamily: mono,
+  },
+  subTabLabelActive: { color: t.text },
   title: { color: t.text, fontSize: 26, fontWeight: '700', marginBottom: 12, fontFamily: mono },
   list: { flex: 1 },
   group: { marginBottom: 16 },

--- a/app/components/SteamMenusPanel.tsx
+++ b/app/components/SteamMenusPanel.tsx
@@ -1,0 +1,130 @@
+/**
+ * "Steam" sub-tab of the Actions screen — jump straight to one of Steam's
+ * settings panels on the box.
+ *
+ * Deliberately its own sub-tab rather than ~19 injected Actions: as Actions
+ * they would swamp the list and bury Reboot / Power Off, which are the entries
+ * someone is usually hunting for in a hurry.
+ *
+ * Probe-and-appear (agent >= 2.9.31): the parent hides the whole sub-tab (and
+ * the tab strip with it) on an older agent or a box without Steam, so those
+ * boxes see exactly the screen they see today. Panels come from the AGENT,
+ * never hardcoded here — the slug list was established by firing each URL at
+ * real hardware and screen-capturing where it landed, because Steam builds its
+ * settings route from the panel name and no slug appears in its JS bundle.
+ * Keeping the list server-side means a correction ships as an agent update
+ * alone, with no app release.
+ */
+import { Ionicons } from '@expo/vector-icons';
+import React, { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { api, SteamMenu } from '@/lib/api';
+import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function SteamMenusPanel({ menus }: { menus: SteamMenu[] }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const [busy, setBusy] = useState<string | null>(null);
+  const [opened, setOpened] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onTap = useCallback(
+    async (m: SteamMenu) => {
+      hapticLight();
+      setBusy(m.id);
+      setErr(null);
+      try {
+        await api.openSteamMenu(settings, m.id);
+        hapticSuccess();
+        // The result is on the TV, not the phone — say what happened, since
+        // otherwise a successful tap looks identical to one that did nothing.
+        setOpened(m.label);
+      } catch (e) {
+        hapticError();
+        setErr(e instanceof Error ? e.message : String(e));
+      } finally {
+        setBusy(null);
+      }
+    },
+    [settings],
+  );
+
+  if (!menus.length) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.hint}>
+        Opens the page on your box&rsquo;s screen — handy when the thing you need to
+        configure is the controller itself.
+      </Text>
+
+      {err != null ? (
+        <View style={styles.errBox}>
+          <Text style={styles.errText}>{err}</Text>
+        </View>
+      ) : opened != null ? (
+        <View style={styles.okBox}>
+          <Ionicons name="tv-outline" size={14} color={t.green} />
+          <Text style={styles.okText}>{opened} is open on the box</Text>
+        </View>
+      ) : null}
+
+      <View style={styles.grid}>
+        {menus.map((m) => (
+          <Pressable
+            key={m.id}
+            onPress={() => onTap(m)}
+            disabled={busy != null}
+            style={({ pressed }) => [
+              styles.chip,
+              pressed && styles.pressed,
+              busy === m.id && styles.chipBusy,
+            ]}>
+            <Text style={styles.chipText} numberOfLines={1}>
+              {m.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { gap: 12, paddingTop: 4 },
+    hint: { color: t.textDim, fontSize: 12, lineHeight: 17 },
+    grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+    chip: {
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+      backgroundColor: t.card,
+      borderRadius: 999,
+      paddingVertical: 10,
+      paddingHorizontal: 15,
+    },
+    chipBusy: { opacity: 0.5 },
+    chipText: { color: t.text, fontSize: 13, fontFamily: mono },
+    pressed: { opacity: 0.6 },
+    okBox: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      backgroundColor: t.inset,
+      borderRadius: 10,
+      paddingVertical: 9,
+      paddingHorizontal: 12,
+    },
+    okText: { color: t.green, fontSize: 12, flex: 1 },
+    errBox: {
+      backgroundColor: t.inset,
+      borderRadius: 10,
+      paddingVertical: 9,
+      paddingHorizontal: 12,
+    },
+    errText: { color: t.red, fontSize: 12 },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -116,6 +116,12 @@ export type BoxCaps = {
    */
   steamlink?: boolean;
   /**
+   * Steam settings deep links (agent >= 2.9.31). Every slug the box offers was
+   * confirmed on hardware — an unknown slug is NOT an error in Steam, it just
+   * opens the default page, so the agent ships an allowlist rather than guesses.
+   */
+  steammenus?: boolean;
+  /**
    * Gaming card: this box has Steam, so a "what's running now" card (GPU/game/
    * output/controllers/session) is worth showing. Gates the Console-tab card.
    * Optional: absent on agents < 2.9.25, so undefined reads as "unknown, probe"
@@ -336,6 +342,10 @@ export type SteamLink = { available: boolean; hosts: StreamHost[] };
  * (Intel i915) has no `gpu` key at all. `session` is the only field always
  * present. Cover art for `game.appid` via steamCoverSource (box cache, LAN-only).
  */
+/** One Steam settings panel the box can jump to (agent >= 2.9.31). */
+export type SteamMenu = { id: string; label: string };
+export type SteamMenus = { menus: SteamMenu[] };
+
 export type Gaming = {
   gpu?: {
     name: string;
@@ -717,7 +727,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.desktop === b.desktop &&
     a.steamlink === b.steamlink &&
     a.gaming === b.gaming &&
-    a.streamhost === b.streamhost
+    a.streamhost === b.streamhost &&
+    a.steammenus === b.steammenus
   );
 }
 
@@ -1103,6 +1114,26 @@ export const api = {
    * the Launch tab hides the "Stream from PC" section. Launch a game with
    * launch(settings, `stream:${appid}`).
    */
+  /**
+   * Steam's settings panels, as deep links (agent >= 2.9.31). Probe-and-appear:
+   * null on a 404 (older agent, or a box with no Steam) so the section hides.
+   */
+  steamMenus(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<SteamMenus | null> {
+    return probeGated(caps?.steammenus, () =>
+      probeOrNull(request<SteamMenus>(settings, '/api/steam/menus')));
+  },
+
+  /** Open one Steam settings panel on the box's own screen. */
+  openSteamMenu(settings: ConnSettings, id: string): Promise<{ ok: boolean }> {
+    return request<{ ok: boolean }>(settings, '/api/steam/menus', {
+      method: 'POST',
+      body: JSON.stringify({ id }),
+    });
+  },
+
   steamlink(
     settings: ConnSettings,
     caps: BoxCaps | undefined = cachedCaps(settings),

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -231,9 +231,13 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   const gaming = bool('gaming');
   // streamhost arrived with agent 2.9.26 — same optional-cap drop trap.
   const streamhost = bool('streamhost');
+  // steammenus arrived with agent 2.9.31 — same optional-cap drop trap as every
+  // key above it: omit it here and the cap never persists, so the app re-probes
+  // /api/steam/menus on every launch.
+  const steammenus = bool('steammenus');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
-    screensaver, couchmode, desktop, steamlink, gaming, streamhost,
+    screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
   };
 }
 


### PR DESCRIPTION
Surfaces agent 2.9.31's `/api/steam/menus` — 19 Steam settings panels, one tap each, opened on the box's own screen.

Actions now carries a sub-tab strip mirroring the Setup screen's, with **Steam as the default**: the danger-grouped Actions are rare, deliberate operations (Reboot, Power Off), while the Steam shortcuts are the everyday reason to open this tab.

| Actions sub-tab | Steam sub-tab |
|---|---|
| danger groups, unchanged | 19 shortcut chips, no scrolling |

## Why a sub-tab rather than Actions entries

19 injected Actions would swamp the list and bury **Power Off** — the entry someone is usually hunting for in a hurry. The split keeps both surfaces legible.

## Degrades cleanly

- **Probe-and-appear:** the strip renders *only* when the box returns menus. An older agent or a non-Steam box sees exactly the screen it sees today — no empty tab, no dead control.
- **Can't go blank:** `activeSub` is derived, not read straight from state, so swapping to a box without Steam while the Steam tab is selected falls back to Actions rather than rendering nothing.
- **Backwards compatible both ways** — verified separately that shipped app 2.9.10 runs fine against agent 2.9.31 (`normalizeCaps` whitelists, so the unknown `steammenus` key is simply dropped).

## Labels come from the agent

Never hardcoded here. The slug list was established by firing each URL at real hardware and screen-capturing where it landed — Steam builds its settings route from the panel name, so no slug is a literal in its JS bundle and grepping finds none of them.

Keeping it server-side means the three panels whose slugs are still unknown (**Notifications**, **In Game**, **Remote Play**) can be added by an *agent update alone*, with no app release.

## Feedback on tap

Reports "*Storage* is open on the box". The result appears on the TV, not the phone — without it, a successful tap and a no-op are indistinguishable.

## Caps plumbing

Adds the three client sites for `steammenus` (`BoxCaps`, `normalizeCaps`, `capsEqual`). Omitting the latter two is the documented trap that has bitten `screensaver`, `couchmode`, `desktop`, `steamlink`, `gaming` and `streamhost` in turn — each time silently re-probing on every launch.

## Verification

Typecheck clean. Rendered and driven in the web harness from #133 against a `--mock` agent: strip renders, tab switching works, all 19 chips lay out at phone width without scrolling.

**Not verified:** a chip tap through this UI. The `POST /api/steam/menus` path itself is proven on the real box (parked the TV on Audio, posted `storage`, screen landed on Storage), but the app→agent tap is exercised for the first time by the builds this PR is cut for.

Version **2.9.11**, iOS build **62**, Android versionCode **46** — the floors left by 2.9.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)