### PR TITLE
chore(app): reconcile build numbers to 63/47 (as built for 2.9.11)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "62",
+      "buildNumber": "63",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 46
+      "versionCode": 47
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
EAS `autoIncrement` is on for the production profile and bumps the **local** `app.json` before building, so the artifacts don't carry the numbers that were committed for them:

```
Bumping expo.android.versionCode from 46 to 47
Bumping expo.ios.buildNumber from 62 to 63
```

Verified against the **artifacts**, not just the log:

| artifact | evidence | value |
|---|---|---|
| IPA | `Info.plist` → `CFBundleVersion` | **63** |
| AAB | bundle manifest → `1a02 3437` = ASCII `"47"` | **47** |

Both clear the floors 2.9.10 left (iOS ≥62, vc ≥46).

Committing what was actually built, so the repo stops drifting from the stores — the documented hazard from the 2.8.x builds where local `app.json` and the store record silently diverged.

Worth noting I nearly shipped this wrong: I named the artifacts `vc46`/`b62` from the values I *intended*, and only caught the mismatch by extracting the real numbers out of the binaries. The filenames were renamed to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)