### PR TITLE
fix(app): Steam menu taps were double-encoding the request body

### DIFF
--- a/app/components/SteamMenusPanel.tsx
+++ b/app/components/SteamMenusPanel.tsx
@@ -2,27 +2,52 @@
  * "Steam" sub-tab of the Actions screen — jump straight to one of Steam's
  * settings panels on the box.
  *
- * Deliberately its own sub-tab rather than ~19 injected Actions: as Actions
- * they would swamp the list and bury Reboot / Power Off, which are the entries
- * someone is usually hunting for in a hurry.
+ * Layout: Bluetooth is pulled out as a hero row, because "pair a controller" is
+ * the reason this surface exists — it is the one job you cannot do WITH a
+ * controller. The rest are grouped so 19 chips read as a menu rather than a
+ * wall of pills.
  *
- * Probe-and-appear (agent >= 2.9.31): the parent hides the whole sub-tab (and
- * the tab strip with it) on an older agent or a box without Steam, so those
- * boxes see exactly the screen they see today. Panels come from the AGENT,
- * never hardcoded here — the slug list was established by firing each URL at
- * real hardware and screen-capturing where it landed, because Steam builds its
- * settings route from the panel name and no slug appears in its JS bundle.
- * Keeping the list server-side means a correction ships as an agent update
- * alone, with no app release.
+ * Grouping is CLIENT-SIDE on purpose. Labels still come from the agent (the
+ * slug list was established by firing each URL at real hardware and screen-
+ * capturing where it landed, so it must stay server-owned), but grouping is
+ * presentation. An id this app has never heard of still renders — it lands in
+ * MORE — so an agent that learns new panels is never blocked on an app release.
+ *
+ * Probe-and-appear (agent >= 2.9.31): the parent hides the whole sub-tab, and
+ * the tab strip with it, when the box returns no menus.
  */
 import { Ionicons } from '@expo/vector-icons';
-import React, { useCallback, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api, SteamMenu } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+const HERO_ID = 'bluetooth';
+
+/** Presentation only — an unlisted id falls into MORE rather than vanishing. */
+const GROUPS: { title: string; ids: string[] }[] = [
+  { title: 'INPUT', ids: ['controller', 'keyboard'] },
+  { title: 'DISPLAY & SOUND', ids: ['display', 'audio', 'power'] },
+  {
+    title: 'LIBRARY & STORAGE',
+    ids: ['home', 'library', 'store', 'downloads', 'storage', 'gamerecording'],
+  },
+  {
+    title: 'SYSTEM',
+    ids: [
+      'network',
+      'cloud',
+      'security',
+      'family',
+      'friends',
+      'accessibility',
+      'customization',
+    ],
+  },
+];
 
 export function SteamMenusPanel({ menus }: { menus: SteamMenu[] }) {
   const t = useTheme();
@@ -32,16 +57,38 @@ export function SteamMenusPanel({ menus }: { menus: SteamMenu[] }) {
   const [opened, setOpened] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
-  const onTap = useCallback(
+  const { hero, sections } = useMemo(() => {
+    const byId = new Map(menus.map((m) => [m.id, m]));
+    const heroMenu = byId.get(HERO_ID) ?? null;
+    const claimed = new Set<string>(heroMenu ? [HERO_ID] : []);
+    const out: { title: string; items: SteamMenu[] }[] = [];
+    for (const g of GROUPS) {
+      const items: SteamMenu[] = [];
+      for (const id of g.ids) {
+        const m = byId.get(id);
+        if (m) {
+          items.push(m);
+          claimed.add(id);
+        }
+      }
+      if (items.length) out.push({ title: g.title, items });
+    }
+    const rest = menus.filter((m) => !claimed.has(m.id));
+    if (rest.length) out.push({ title: 'MORE', items: rest });
+    return { hero: heroMenu, sections: out };
+  }, [menus]);
+
+  const open = useCallback(
     async (m: SteamMenu) => {
       hapticLight();
       setBusy(m.id);
       setErr(null);
+      setOpened(null);
       try {
         await api.openSteamMenu(settings, m.id);
         hapticSuccess();
-        // The result is on the TV, not the phone — say what happened, since
-        // otherwise a successful tap looks identical to one that did nothing.
+        // The result lands on the TV, not the phone — without saying so, a
+        // successful tap and a no-op look identical.
         setOpened(m.label);
       } catch (e) {
         hapticError();
@@ -57,60 +104,100 @@ export function SteamMenusPanel({ menus }: { menus: SteamMenu[] }) {
 
   return (
     <View style={styles.wrap}>
-      <Text style={styles.hint}>
-        Opens the page on your box&rsquo;s screen — handy when the thing you need to
-        configure is the controller itself.
-      </Text>
+      {hero && (
+        <Pressable
+          onPress={() => open(hero)}
+          disabled={busy != null}
+          style={({ pressed }) => [styles.hero, pressed && styles.pressed]}>
+          <View style={styles.heroIcon}>
+            {busy === hero.id ? (
+              <ActivityIndicator size="small" color={t.blue} />
+            ) : (
+              <Ionicons name="bluetooth" size={20} color={t.blue} />
+            )}
+          </View>
+          <View style={styles.heroText}>
+            <Text style={styles.heroTitle}>{hero.label}</Text>
+            <Text style={styles.heroSub}>Pair a controller, headset or keyboard</Text>
+          </View>
+          <Ionicons name="chevron-forward" size={16} color={t.textFaint} />
+        </Pressable>
+      )}
 
       {err != null ? (
-        <View style={styles.errBox}>
-          <Text style={styles.errText}>{err}</Text>
+        <View style={styles.banner}>
+          <Ionicons name="alert-circle-outline" size={14} color={t.red} />
+          <Text style={styles.bannerErrText}>{err}</Text>
         </View>
       ) : opened != null ? (
-        <View style={styles.okBox}>
+        <View style={styles.banner}>
           <Ionicons name="tv-outline" size={14} color={t.green} />
-          <Text style={styles.okText}>{opened} is open on the box</Text>
+          <Text style={styles.bannerOkText}>
+            <Text style={styles.bannerStrong}>{opened}</Text> is open on the box
+          </Text>
         </View>
-      ) : null}
+      ) : (
+        <Text style={styles.hint}>Opens the page on your box&rsquo;s screen.</Text>
+      )}
 
-      <View style={styles.grid}>
-        {menus.map((m) => (
-          <Pressable
-            key={m.id}
-            onPress={() => onTap(m)}
-            disabled={busy != null}
-            style={({ pressed }) => [
-              styles.chip,
-              pressed && styles.pressed,
-              busy === m.id && styles.chipBusy,
-            ]}>
-            <Text style={styles.chipText} numberOfLines={1}>
-              {m.label}
-            </Text>
-          </Pressable>
-        ))}
-      </View>
+      {sections.map((sec) => (
+        <View key={sec.title} style={styles.section}>
+          <Text style={styles.sectionTitle}>{sec.title}</Text>
+          <View style={styles.grid}>
+            {sec.items.map((m) => (
+              <Pressable
+                key={m.id}
+                onPress={() => open(m)}
+                disabled={busy != null}
+                style={({ pressed }) => [
+                  styles.chip,
+                  pressed && styles.pressed,
+                  busy === m.id && styles.chipBusy,
+                ]}>
+                {busy === m.id && (
+                  <ActivityIndicator size="small" color={t.textDim} style={styles.chipSpin} />
+                )}
+                <Text style={styles.chipText} numberOfLines={1}>
+                  {m.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </View>
+      ))}
     </View>
   );
 }
 
 const makeStyles = (t: Palette) =>
   StyleSheet.create({
-    wrap: { gap: 12, paddingTop: 4 },
-    hint: { color: t.textDim, fontSize: 12, lineHeight: 17 },
-    grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-    chip: {
-      borderWidth: StyleSheet.hairlineWidth,
-      borderColor: t.cardBorder,
+    wrap: { gap: 14, paddingTop: 2 },
+
+    hero: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
       backgroundColor: t.card,
-      borderRadius: 999,
-      paddingVertical: 10,
-      paddingHorizontal: 15,
+      borderWidth: 1,
+      borderColor: t.blue,
+      borderRadius: 14,
+      paddingVertical: 14,
+      paddingHorizontal: 14,
     },
-    chipBusy: { opacity: 0.5 },
-    chipText: { color: t.text, fontSize: 13, fontFamily: mono },
-    pressed: { opacity: 0.6 },
-    okBox: {
+    heroIcon: {
+      width: 34,
+      height: 34,
+      borderRadius: 17,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: t.inset,
+    },
+    heroText: { flex: 1, gap: 2 },
+    heroTitle: { color: t.text, fontSize: 16, fontWeight: '700', fontFamily: mono },
+    heroSub: { color: t.textDim, fontSize: 12 },
+
+    hint: { color: t.textFaint, fontSize: 12 },
+    banner: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: 8,
@@ -119,12 +206,32 @@ const makeStyles = (t: Palette) =>
       paddingVertical: 9,
       paddingHorizontal: 12,
     },
-    okText: { color: t.green, fontSize: 12, flex: 1 },
-    errBox: {
-      backgroundColor: t.inset,
-      borderRadius: 10,
-      paddingVertical: 9,
-      paddingHorizontal: 12,
+    bannerOkText: { color: t.textDim, fontSize: 12, flex: 1 },
+    bannerStrong: { color: t.green, fontWeight: '700' },
+    bannerErrText: { color: t.red, fontSize: 12, flex: 1 },
+
+    section: { gap: 8 },
+    sectionTitle: {
+      color: t.textFaint,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1.1,
+      fontFamily: mono,
     },
-    errText: { color: t.red, fontSize: 12 },
+    grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+    chip: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 6,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+      backgroundColor: t.card,
+      borderRadius: 10,
+      paddingVertical: 10,
+      paddingHorizontal: 14,
+    },
+    chipBusy: { opacity: 0.6 },
+    chipSpin: { marginRight: 2 },
+    chipText: { color: t.text, fontSize: 13, fontFamily: mono },
+    pressed: { opacity: 0.6 },
   });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1130,7 +1130,9 @@ export const api = {
   openSteamMenu(settings: ConnSettings, id: string): Promise<{ ok: boolean }> {
     return request<{ ok: boolean }>(settings, '/api/steam/menus', {
       method: 'POST',
-      body: JSON.stringify({ id }),
+      // request() stringifies this itself — passing a string here double-
+      // encodes it and the agent rejects the body as 'not a JSON object'.
+      body: { id },
     });
   },
 


### PR DESCRIPTION
## The bug

Every chip tap failed on device:

```
HTTP 400: body must be a JSON object
```

`request()` already stringifies `opts.body` itself (`api.ts:1019`), and every other caller passes a plain object:

```js
body: { mac }             // wol
body: { level, target }   // tv volume
body: JSON.stringify({ id })   // ← mine, double-encoded
```

So the agent received a JSON *string* rather than an object and correctly rejected it. **The agent was right; the app was wrong.** No agent change.

## How it escaped

The web harness rendered the tab perfectly, and I shipped it having written, in the previous PR, that a chip tap *"is exercised for the first time by the builds this PR is cut for."*

Rendering a control is not exercising it. The harness could have driven the tap — I just didn't ask it to. This is the second time today a verification gap sat exactly where I'd flagged one and moved on anyway.

**Caught before the Play production upload**, which was the next step. That would have shipped a dead tab to every Android user.

## Polish

The panel read as an undifferentiated wall of 19 pills:

- **Bluetooth is now a hero row.** Pairing is the reason this surface exists — the one job you cannot do *with* a controller — so it shouldn't be the 10th pill in a grid.
- The rest group under **INPUT / DISPLAY & SOUND / LIBRARY & STORAGE / SYSTEM**.
- Per-chip spinner while a tap is in flight; confirmation names the panel ("Storage is open on the box"), since the result lands on the TV and a no-op otherwise looks identical to success.

Grouping is **client-side deliberately**: labels stay agent-owned (the slug list is hardware-verified and must remain server-side), but an id this app has never seen still renders — it falls into `MORE` — so an agent that learns new panels is never blocked on an app release.

## Verification

- Tapped in the harness against a `--mock` agent → success banner, no 400
- Tapped through the **same bundle against the REAL box** (proxy repointed at `10.1.1.60:8787`) → *"Game Recording is open on the box"*, agent returned 200

Typecheck clean.

## Release impact

- **iOS build 63 is already on TestFlight and has this bug** — needs a rebuild.
- **Android was never uploaded** — I held the Play production submission when the bug surfaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)