### PR TITLE
chore(app): reconcile build numbers to 64/48 (2.9.11 rebuild)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "63",
+      "buildNumber": "64",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 47
+      "versionCode": 48
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Rebuilt to carry the Steam-menu body-encoding fix (#137). `autoIncrement` moved the numbers again.

Verified from the artifacts rather than the log:
- IPA `CFBundleVersion` → **64**
- AAB `versionCode` → **48**

Build **63** is dead — it reached TestFlight with the broken chip tap and is superseded. **vc47** was never uploaded (I held the Play submission when the bug surfaced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)