### PR TITLE
chore(app): 2.9.11 Play release notes

### DIFF
--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,4 +1,6 @@
-New in 2.9.10
+New in 2.9.11
 
-• Gaming card on the Console tab: see what's running right now — the game with its cover art, your controllers and their battery, the active display, and whether the box is in Game Mode.
-• When another device is streaming from your box, the Console tab now shows that too.
+• Steam settings shortcuts: the Actions tab now has a Steam sub-tab that jumps straight to any Steam settings page on your box — Bluetooth, Controller, Display, Storage and more.
+• Pair a controller from the couch. Bluetooth gets its own button, because pairing is the one thing you can't do with the controller you're trying to pair.
+• Your Steam Controller now shows up on the gaming card.
+• Fixed a "streaming to" card that could keep showing a session long after it ended.


### PR DESCRIPTION
The notes file still carried the 2.9.10 text, so the first release-notes push for vc48 published *"New in 2.9.10"* describing the gaming card.

Corrected and re-applied to the same versionCode before rollout, so users see the 2.9.11 notes.

Caught by reading the script's echo of what it actually published, rather than treating a zero exit as proof the right content went out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)