### PR TITLE
feat(app): cyberpunk Console + Fleet via a swappable skin seam

### DIFF
--- a/app/app/(tabs)/fleet.tsx
+++ b/app/app/(tabs)/fleet.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { AppState, AppStateStatus, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
-import { Sparkline } from '@/components/Sparkline';
 import { TabScreen } from '@/components/TabScreen';
 import { useFocusEffect } from 'expo-router';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, Status } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
 import { Box } from '@/lib/settings';
+import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { useBoxes } from '@/lib/SettingsContext';
 import { mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
@@ -139,69 +139,78 @@ function fmtLastSeen(ts: number | null): string {
   return `${Math.floor(m / 60)}h ${m % 60}m ago`;
 }
 
-function Tile({ box, entry, active, onPress }: {
+function Tile({ box, entry, active, index, onPress }: {
   box: Box;
   entry: FleetEntry | undefined;
   active: boolean;
+  index: number;
   onPress: () => void;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const { Card, Dot, Spark } = useSkinKit();
   const s = entry?.status ?? null;
   const up = entry != null && entry.error == null && s != null;
   const memPct = s ? Math.round((s.mem.used_mb / s.mem.total_mb) * 100) : 0;
 
-  return (
-    <Pressable
-      onPress={onPress}
-      style={({ pressed }) => [
-        styles.tile,
-        active && styles.tileActive,
-        !up && entry != null && styles.tileDown,
-        pressed && styles.pressed,
-      ]}>
-      <View style={styles.tileHeader}>
-        <View style={[styles.dot, { backgroundColor: up ? t.green : t.red }]} />
-        <Text style={styles.tileName} numberOfLines={1}>
-          {s?.hostname ?? box.name}
-        </Text>
-        {active && <Text style={styles.activeTag}>active</Text>}
-      </View>
-      <Text style={styles.tileHost} numberOfLines={1}>
-        {box.host}:{box.port}
-      </Text>
+  // Each tile carries its OWN vitals: one box idling next to one under load
+  // should visibly differ. A box that is down is not alive, whatever it last
+  // reported.
+  const vitals = React.useMemo(
+    () => ({ v: up ? vitality(s?.load?.[0], s?.cpu_temp_c) : 0, alive: up }),
+    [up, s?.load, s?.cpu_temp_c],
+  );
 
-      {up && s ? (
-        <>
-          <View style={styles.metricsRow}>
-            <View style={styles.metric}>
-              <Text style={styles.metricLabel}>TEMP</Text>
-              <Text style={[styles.metricValue, { color: tempColor(s.cpu_temp_c, t) }]}>
-                {s.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}°` : '—'}
-              </Text>
-            </View>
-            <View style={styles.metric}>
-              <Text style={styles.metricLabel}>LOAD</Text>
-              <Text style={[styles.metricValue, { color: t.text }]}>
-                {s.load[0].toFixed(2)}
-              </Text>
-            </View>
-            <View style={styles.metric}>
-              <Text style={styles.metricLabel}>MEM</Text>
-              <Text style={[styles.metricValue, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
-            </View>
-          </View>
-          {/* Load trend, indented to align with the metrics row. */}
-          <View style={styles.sparkWrap}>
-            <Sparkline values={s.history?.load} color={t.blue} height={16} />
-          </View>
-        </>
-      ) : (
-        <Text style={styles.downText}>
-          {entry == null ? 'probing…' : `DOWN · last seen ${fmtLastSeen(entry.lastSuccess)}`}
+  return (
+    <VitalsContext.Provider value={vitals}>
+      <Card
+        onPress={onPress}
+        selected={active}
+        index={index}
+        tone={!up && entry != null ? 'down' : 'default'}>
+        <View style={styles.tileHeader}>
+          <Dot color={up ? t.green : t.red} size={9} live={up} />
+          <Text style={styles.tileName} numberOfLines={1}>
+            {s?.hostname ?? box.name}
+          </Text>
+          {active && <Text style={styles.activeTag}>active</Text>}
+        </View>
+        <Text style={styles.tileHost} numberOfLines={1}>
+          {box.host}:{box.port}
         </Text>
-      )}
-    </Pressable>
+
+        {up && s ? (
+          <>
+            <View style={styles.metricsRow}>
+              <View style={styles.metric}>
+                <Text style={styles.metricLabel}>TEMP</Text>
+                <Text style={[styles.metricValue, { color: tempColor(s.cpu_temp_c, t) }]}>
+                  {s.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}°` : '—'}
+                </Text>
+              </View>
+              <View style={styles.metric}>
+                <Text style={styles.metricLabel}>LOAD</Text>
+                <Text style={[styles.metricValue, { color: t.text }]}>
+                  {s.load[0].toFixed(2)}
+                </Text>
+              </View>
+              <View style={styles.metric}>
+                <Text style={styles.metricLabel}>MEM</Text>
+                <Text style={[styles.metricValue, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
+              </View>
+            </View>
+            {/* Load trend, indented to align with the metrics row. */}
+            <View style={styles.sparkWrap}>
+              <Spark values={s.history?.load} color={t.blue} height={16} />
+            </View>
+          </>
+        ) : (
+          <Text style={styles.downText}>
+            {entry == null ? 'probing…' : `DOWN · last seen ${fmtLastSeen(entry.lastSuccess)}`}
+          </Text>
+        )}
+      </Card>
+    </VitalsContext.Provider>
   );
 }
 
@@ -221,26 +230,30 @@ function FleetScreen() {
   const statusInterval = usePref('statusIntervalMs');
   const fleet = useFleetStatus(boxes, statusInterval);
   const styles = useThemedStyles(makeStyles);
+  const { Screen, SectionTitle } = useSkinKit();
 
   return (
     <ScrollView
       style={styles.scroll}
       contentContainerStyle={{ paddingTop: 12, paddingBottom: 32, paddingHorizontal: 14 }}>
-      <Text style={styles.sectionTitle}>YOUR FLEET</Text>
-      {boxes.map((box) => (
-        <Tile
-          key={box.id}
-          box={box}
-          entry={fleet[box.id]}
-          active={box.id === activeBoxId}
-          onPress={() => {
-            switchBox(box.id);
-            // Land on the box's Console; a box whose gaming tabs are hidden
-            // still always has Console.
-            router.replace('/(tabs)');
-          }}
-        />
-      ))}
+      <Screen>
+        <SectionTitle>YOUR FLEET</SectionTitle>
+        {boxes.map((box, i) => (
+          <Tile
+            key={box.id}
+            box={box}
+            entry={fleet[box.id]}
+            active={box.id === activeBoxId}
+            index={i}
+            onPress={() => {
+              switchBox(box.id);
+              // Land on the box's Console; a box whose gaming tabs are hidden
+              // still always has Console.
+              router.replace('/(tabs)');
+            }}
+          />
+        ))}
+      </Screen>
     </ScrollView>
   );
 }

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -6,40 +6,16 @@ import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
 import { ScreenPreview } from '@/components/ScreenPreview';
 import { StreamHostCard } from '@/components/StreamHostCard';
-import { Sparkline } from '@/components/Sparkline';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { usePref } from '@/lib/prefs';
+import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { noteBoxReachable } from '@/lib/review';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
-
-function Bar({ pct, color }: { pct: number; color: string }) {
-  const styles = useThemedStyles(makeStyles);
-  return (
-    <View style={styles.barTrack}>
-      <View
-        style={[
-          styles.barFill,
-          { width: `${Math.min(100, Math.max(0, pct))}%`, backgroundColor: color },
-        ]}
-      />
-    </View>
-  );
-}
-
-function Card({ title, children }: { title: string; children: React.ReactNode }) {
-  const styles = useThemedStyles(makeStyles);
-  return (
-    <View style={styles.card}>
-      <Text style={styles.cardTitle}>{title}</Text>
-      {children}
-    </View>
-  );
-}
 
 function unitColor(active: string, t: Palette): string {
   if (active === 'active') return t.green;
@@ -88,6 +64,7 @@ export default function ConsoleTab() {
 function ConsoleScreen() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const { Screen, Card, Bar, Dot, Spark, BigMetric } = useSkinKit();
   const { settings, ready } = useSettings();
 
   // No host yet (fresh install): don't poll, and show the pairing hint
@@ -111,7 +88,15 @@ function ConsoleScreen() {
     if (reachable) void noteBoxReachable();
   }, [reachable]);
 
+  // How hard the box is working, 0..1. Skins use this to set the RATE of their
+  // idle motion -- a busy box breathes faster. Never a colour input.
+  const vitals = React.useMemo(
+    () => ({ v: vitality(s?.load?.[0], s?.cpu_temp_c), alive: reachable }),
+    [s?.load, s?.cpu_temp_c, reachable],
+  );
+
   return (
+    <VitalsContext.Provider value={vitals}>
     <View style={styles.screen}>
       <ScrollView
         style={styles.scroll}
@@ -120,14 +105,10 @@ function ConsoleScreen() {
           paddingBottom: 32,
           paddingHorizontal: 14,
         }}>
+        <Screen>
         {/* Status header */}
         <View style={styles.header}>
-          <View
-            style={[
-              styles.dot,
-              { backgroundColor: reachable ? t.green : t.red },
-            ]}
-          />
+          <Dot color={reachable ? t.green : t.red} size={14} live={reachable} />
           <Text style={styles.hostname}>
             {s?.hostname ?? (configured ? settings.host : 'Couchside')}
           </Text>
@@ -180,23 +161,24 @@ function ConsoleScreen() {
           <>
             <View style={styles.row}>
               <View style={styles.half}>
-                <Card title="CPU TEMP">
-                  <Text style={[styles.bigMetric, { color: tempColor(s.cpu_temp_c, t) }]}>
-                    {s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
-                  </Text>
-                  <Sparkline values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
+                <Card title="CPU TEMP" index={0}>
+                  <BigMetric
+                    value={s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
+                    numeric={s.cpu_temp_c}
+                    color={tempColor(s.cpu_temp_c, t)}
+                  />
+                  <Spark values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
                 </Card>
               </View>
               <View style={styles.half}>
-                <Card title="UPTIME">
-                  <Text style={[styles.bigMetric, { color: t.text }]}>
-                    {humanizeUptime(s.uptime_s)}
-                  </Text>
+                <Card title="UPTIME" index={1}>
+                  {/* Not numeric: "1d 2h 7m" must never be interpolated. */}
+                  <BigMetric value={humanizeUptime(s.uptime_s)} numeric={null} color={t.text} />
                 </Card>
               </View>
             </View>
 
-            <Card title="LOAD 1m / 5m / 15m">
+            <Card title="LOAD 1m / 5m / 15m" index={2}>
               <View style={styles.loadRow}>
                 {s.load.map((l, i) => (
                   <Text key={i} style={styles.loadVal}>
@@ -204,10 +186,10 @@ function ConsoleScreen() {
                   </Text>
                 ))}
               </View>
-              <Sparkline values={s.history?.load} color={t.blue} />
+              <Spark values={s.history?.load} color={t.blue} />
             </Card>
 
-            <Card title="MEMORY">
+            <Card title="MEMORY" index={3}>
               <View style={styles.barLabelRow}>
                 <Text style={styles.barLabel}>
                   {(s.mem.used_mb / 1024).toFixed(1)} / {(s.mem.total_mb / 1024).toFixed(1)} GB
@@ -217,10 +199,10 @@ function ConsoleScreen() {
               <Bar pct={memPct} color={pctColor(memPct, t)} />
               {/* Fixed 0-100 scale: a memory sparkline that auto-scales would
                   make a 2% wiggle look like a cliff. */}
-              <Sparkline values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
+              <Spark values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
             </Card>
 
-            <Card title="DISKS">
+            <Card title="DISKS" index={4}>
               {s.disks.map((d) => (
                 <View key={d.mount} style={styles.diskRow}>
                   <View style={styles.barLabelRow}>
@@ -243,7 +225,7 @@ function ConsoleScreen() {
 
         {/* Units */}
         {configured && (
-          <Card title="UNITS">
+          <Card title="UNITS" index={5}>
             {units.error != null && !units.data ? (
               <Text style={styles.unitErr}>{units.error.message}</Text>
             ) : units.data ? (
@@ -263,8 +245,10 @@ function ConsoleScreen() {
             </Text>
           </Card>
         )}
+        </Screen>
       </ScrollView>
     </View>
+    </VitalsContext.Provider>
   );
 }
 

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -13,6 +13,7 @@ import { Image, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
 import { api, Gaming, hostKey } from '@/lib/api';
+import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, pctColor, tempColor, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -55,6 +56,7 @@ function GameCover({ appid, label }: { appid: number; label?: string }) {
 export function GamingCard() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const { Card, Bar } = useSkinKit();
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
@@ -79,7 +81,7 @@ export function GamingCard() {
   const inGameMode = g.session === 'gamescope';
 
   return (
-    <View style={styles.card}>
+    <Card index={2}>
       <View style={styles.header}>
         <Text style={styles.cardTitle}>GAMING</Text>
         <View style={[styles.sessionPill, inGameMode && styles.sessionPillOn]}>
@@ -114,14 +116,7 @@ export function GamingCard() {
                 </Text>
                 <Text style={[styles.dim, { color: pctColor(vramPct, t) }]}>{vramPct}%</Text>
               </View>
-              <View style={styles.barTrack}>
-                <View
-                  style={[
-                    styles.barFill,
-                    { width: `${Math.min(100, vramPct)}%`, backgroundColor: pctColor(vramPct, t) },
-                  ]}
-                />
-              </View>
+              <Bar pct={vramPct} color={pctColor(vramPct, t)} height={6} />
             </>
           )}
         </View>
@@ -153,7 +148,7 @@ export function GamingCard() {
           )}
         </View>
       ))}
-    </View>
+    </Card>
   );
 }
 

--- a/app/components/NowPlayingCard.tsx
+++ b/app/components/NowPlayingCard.tsx
@@ -12,6 +12,7 @@ import { Image, LayoutChangeEvent, Pressable, StyleSheet, Text, View } from 'rea
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
 import { hapticLight, hapticMedium } from '@/lib/haptics';
+import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -25,6 +26,7 @@ function fmtTime(ms: number): string {
 export function NowPlayingCard() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
@@ -115,8 +117,7 @@ export function NowPlayingCard() {
   const playing = active.status === 'Playing';
 
   return (
-    <View style={styles.card}>
-      <Text style={styles.cardTitle}>NOW PLAYING</Text>
+    <Card title="NOW PLAYING" index={0}>
 
       {players.length > 1 && (
         <View style={styles.pills}>
@@ -188,7 +189,7 @@ export function NowPlayingCard() {
           onPress={() => send('next')}
         />
       </View>
-    </View>
+    </Card>
   );
 }
 

--- a/app/components/StreamHostCard.tsx
+++ b/app/components/StreamHostCard.tsx
@@ -16,6 +16,7 @@ import { StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, HostSession } from '@/lib/api';
+import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -30,6 +31,7 @@ function fmtElapsed(sinceEpoch: number): string {
 export function StreamHostCard() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
 
@@ -41,7 +43,9 @@ export function StreamHostCard() {
   if (!h?.active) return null;
 
   return (
-    <View style={styles.card}>
+    // tone="live": this box is actively serving a session, and the skin's live
+    // treatment (green frame) is what carried that meaning before.
+    <Card tone="live" accentColor={t.green}>
       <View style={styles.header}>
         <View style={styles.dot} />
         <Text style={styles.title}>STREAMING TO</Text>
@@ -56,7 +60,7 @@ export function StreamHostCard() {
       <Text style={styles.hint}>
         This box is hosting a Steam Remote Play session.
       </Text>
-    </View>
+    </Card>
   );
 }
 

--- a/app/lib/skin/classic.tsx
+++ b/app/lib/skin/classic.tsx
@@ -1,0 +1,129 @@
+/**
+ * CLASSIC skin -- today's look, exactly.
+ *
+ * This is the experiment's control. Every value here was lifted verbatim from
+ * the pre-refactor styles in app/(tabs)/index.tsx and app/(tabs)/fleet.tsx. It
+ * must render pixel-identical to the shipped 2.9.11 build: if it doesn't, the
+ * kit refactor changed something on its own and any judgement about the new
+ * directions is measuring the wrong thing.
+ *
+ * Zero animation, by definition.
+ */
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { Sparkline } from '@/components/Sparkline';
+import { mono, useThemedStyles, type Palette } from '@/lib/theme';
+import type { BarProps, CardProps, DotProps, MetricProps, SkinKit, SparkProps } from './kit';
+
+function Screen({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}
+
+function Card({ title, tone = 'default', accentColor, onPress, selected, style, children }: CardProps) {
+  const styles = useThemedStyles(makeStyles);
+  const body = (
+    <>
+      {title != null && <Text style={styles.cardTitle}>{title}</Text>}
+      {children}
+    </>
+  );
+  const frame = [
+    styles.card,
+    tone === 'live' && styles.cardLive,
+    tone === 'down' && styles.cardDown,
+    selected && styles.cardSelected,
+    accentColor != null && { borderColor: accentColor },
+    style,
+  ];
+
+  if (onPress == null) return <View style={frame}>{body}</View>;
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [...frame, pressed && styles.pressed]}>
+      {body}
+    </Pressable>
+  );
+}
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  const styles = useThemedStyles(makeStyles);
+  return <Text style={styles.sectionTitle}>{children}</Text>;
+}
+
+function BigMetric({ value, color }: MetricProps) {
+  const styles = useThemedStyles(makeStyles);
+  return <Text style={[styles.bigMetric, { color }]}>{value}</Text>;
+}
+
+function Bar({ pct, color, height = 10 }: BarProps) {
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View style={[styles.barTrack, { height, borderRadius: height / 2 }]}>
+      <View
+        style={[
+          styles.barFill,
+          {
+            width: `${Math.min(100, Math.max(0, pct))}%`,
+            backgroundColor: color,
+            borderRadius: height / 2,
+          },
+        ]}
+      />
+    </View>
+  );
+}
+
+function Spark(props: SparkProps) {
+  return <Sparkline {...props} />;
+}
+
+function Dot({ color, size = 14 }: DotProps) {
+  return (
+    <View style={{ width: size, height: size, borderRadius: size / 2, backgroundColor: color }} />
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 14,
+      marginBottom: 10,
+    },
+    // StreamHostCard's live treatment: green border, slightly rounder.
+    cardLive: { borderColor: t.green, borderRadius: 14 },
+    cardDown: { borderColor: t.redDeep },
+    cardSelected: { borderColor: t.blue },
+    pressed: { opacity: 0.7 },
+    cardTitle: {
+      color: t.textFaint,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1.2,
+      marginBottom: 8,
+    },
+    sectionTitle: {
+      color: t.textFaint,
+      fontFamily: mono,
+      fontSize: 11,
+      letterSpacing: 1.5,
+      marginBottom: 10,
+    },
+    bigMetric: { fontSize: 28, fontWeight: '700', fontFamily: mono, fontVariant: ['tabular-nums'] },
+    barTrack: { backgroundColor: t.inset, overflow: 'hidden' },
+    barFill: { height: '100%' },
+  });
+
+export const classicSkin: SkinKit = {
+  label: 'Classic',
+  Screen,
+  Card,
+  SectionTitle,
+  BigMetric,
+  Bar,
+  Spark,
+  Dot,
+};

--- a/app/lib/skin/index.tsx
+++ b/app/lib/skin/index.tsx
@@ -1,0 +1,102 @@
+/**
+ * Skin registry + the hook screens use.
+ *
+ * DEV SELECTION: the whole point of the seam is comparing directions without a
+ * rebuild. The web export reads `?skin=<key>` (sticky -- it writes through to
+ * localStorage) so the harness can flip looks by navigating, with no 90s
+ * re-export between shots. Native has no switcher UI; it takes DEFAULT_SKIN.
+ */
+import React, { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import { classicSkin } from './classic';
+import { reactorSkin } from './reactor';
+import type { SkinKit } from './kit';
+
+export * from './kit';
+export * from './motion';
+
+export type SkinKey = 'classic' | 'reactor';
+
+/**
+ * The two surviving directions. 'vitals' (motion-only, life-support) and 'hud'
+ * (corner brackets, scanlines) were built and compared alongside these and are
+ * recoverable from git history if the look is ever revisited.
+ */
+export const SKINS: Record<SkinKey, SkinKit> = {
+  classic: classicSkin,
+  reactor: reactorSkin,
+};
+
+export const SKIN_KEYS = Object.keys(SKINS) as SkinKey[];
+
+/**
+ * What ships. 'classic' is kept as a comparison control: it is today's exact
+ * pre-redesign look, so `?skin=classic` in the web harness is a live A/B
+ * against the shipped 2.9.11 dashboard rather than a screenshot from memory.
+ */
+const DEFAULT_SKIN: SkinKey = 'reactor';
+
+const STORAGE_KEY = 'couchside.skin.dev';
+
+function isSkinKey(v: unknown): v is SkinKey {
+  return typeof v === 'string' && (SKIN_KEYS as string[]).includes(v);
+}
+
+/** Resolve the dev override once at module load (web only). */
+function initialSkin(): SkinKey {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return DEFAULT_SKIN;
+  try {
+    const q = new URLSearchParams(window.location.search).get('skin');
+    if (isSkinKey(q)) {
+      window.localStorage?.setItem(STORAGE_KEY, q);
+      return q;
+    }
+    const stored = window.localStorage?.getItem(STORAGE_KEY);
+    if (isSkinKey(stored)) return stored;
+  } catch {
+    // storage/URL unavailable: fall through to the default
+  }
+  return DEFAULT_SKIN;
+}
+
+let current: SkinKey = initialSkin();
+const listeners = new Set<() => void>();
+
+export function getSkin(): SkinKey {
+  return current;
+}
+
+export function setSkin(key: SkinKey): void {
+  if (current === key) return;
+  current = key;
+  if (Platform.OS === 'web' && typeof window !== 'undefined') {
+    try {
+      window.localStorage?.setItem(STORAGE_KEY, key);
+    } catch {
+      // in-memory only this session
+    }
+  }
+  for (const l of listeners) l();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+export function useSkinKey(): SkinKey {
+  return useSyncExternalStore(
+    subscribe,
+    () => current,
+    () => current,
+  );
+}
+
+/** The active skin's components. */
+export function useSkinKit(): SkinKit {
+  const key = useSkinKey();
+  return SKINS[key];
+}

--- a/app/lib/skin/kit.ts
+++ b/app/lib/skin/kit.ts
@@ -1,0 +1,124 @@
+/**
+ * The skin kit: the seam that lets the Console and Fleet tabs be restyled
+ * wholesale without either screen knowing which look is active.
+ *
+ * WHY A SEAM AND NOT JUST EDITING THE SCREENS: the owner wants to compare
+ * several distinct cyberpunk directions side by side before committing. Each
+ * direction is an independent module implementing this one interface, so they
+ * can be built and swapped without touching index.tsx / fleet.tsx again -- and
+ * so the CLASSIC skin can stay in the build as a pixel-identical control. If
+ * classic ever drifts, the refactor broke something and every comparison
+ * against it is worthless.
+ *
+ * SEMANTIC COLOUR IS NOT THE SKIN'S TO CHOOSE. Callers pass the already-
+ * resolved colour from tempColor()/pctColor()/batteryColor(). A skin may
+ * decorate with it (glow, pulse, border) but must never substitute its own --
+ * green/amber/red carry meaning, and battery is inverted.
+ */
+import React from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Component contracts
+// ---------------------------------------------------------------------------
+
+export type CardProps = {
+  /** Small caps heading. Omitted for cards that draw their own header. */
+  title?: string;
+  /**
+   * Ordinal within the screen, for staggered mount. Cards probe-and-appear at
+   * arbitrary times, so this is a hint for delay, never an array index that
+   * must stay stable.
+   */
+  index?: number;
+  /**
+   * Semantic emphasis. 'alert' is the unreachable banner; 'live' is a card
+   * reporting something actively happening (a stream being served); 'down' is
+   * a Fleet tile for a box that is not answering.
+   */
+  tone?: 'default' | 'live' | 'alert' | 'down';
+  /** Border/emphasis colour override, already semantically resolved. */
+  accentColor?: string;
+  /** Present on Fleet tiles: the card is a button that switches box. */
+  onPress?: () => void;
+  /** The active box's tile. Drives the selected border treatment. */
+  selected?: boolean;
+  style?: StyleProp<ViewStyle>;
+  children: React.ReactNode;
+};
+
+export type MetricProps = {
+  /** Pre-formatted display string ("58.7°C", "1d 2h 7m"). */
+  value: string;
+  /** Already-resolved semantic colour. */
+  color: string;
+  /**
+   * Numeric value behind `value`, when there is one, so skins can animate
+   * changes (count-up, flicker on delta). Null for non-numeric readouts.
+   */
+  numeric?: number | null;
+};
+
+export type BarProps = {
+  /** 0..100. */
+  pct: number;
+  /** Already-resolved semantic colour. */
+  color: string;
+  height?: number;
+};
+
+export type SparkProps = {
+  values: (number | null)[] | undefined;
+  color: string;
+  height?: number;
+  min?: number;
+  max?: number;
+};
+
+export type DotProps = {
+  color: string;
+  size?: number;
+  /**
+   * Whether this dot represents something currently alive. Skins use it to
+   * decide whether to animate; a DOWN box should not have a healthy pulse.
+   */
+  live?: boolean;
+};
+
+/**
+ * One complete visual direction. Every screen-level chrome decision lives
+ * here; index.tsx / fleet.tsx only compose these.
+ */
+export type SkinKit = {
+  /** Human label, for the dev skin switcher. */
+  label: string;
+  /**
+   * Wraps a screen's scrolling content. Lets a skin paint a full-bleed
+   * background layer (grid, scanlines, reactor sheen) behind everything.
+   */
+  Screen: React.ComponentType<{ children: React.ReactNode }>;
+  Card: React.ComponentType<CardProps>;
+  /** Small caps label used for card titles and section headings. */
+  SectionTitle: React.ComponentType<{ children: React.ReactNode }>;
+  BigMetric: React.ComponentType<MetricProps>;
+  Bar: React.ComponentType<BarProps>;
+  Spark: React.ComponentType<SparkProps>;
+  Dot: React.ComponentType<DotProps>;
+};
+
+// ---------------------------------------------------------------------------
+// Vitals: the machine's exertion, shared down the tree
+// ---------------------------------------------------------------------------
+
+export type Vitals = {
+  /** 0..1 exertion. Drives motion RATE and intensity only, never colour. */
+  v: number;
+  /** True when the box is answering. A dead box must not look alive. */
+  alive: boolean;
+};
+
+export const VitalsContext = React.createContext<Vitals>({ v: 0, alive: false });
+
+export function useVitals(): Vitals {
+  return React.useContext(VitalsContext);
+}

--- a/app/lib/skin/motion.ts
+++ b/app/lib/skin/motion.ts
@@ -1,0 +1,154 @@
+/**
+ * Shared motion primitives for the Console/Fleet skins.
+ *
+ * THE RULES THIS FILE ENFORCES (see the redesign plan):
+ *  * "Breathing" runs off a LOCAL animation clock, never off poll arrival.
+ *    Polls land every ~5s with jitter; driving motion from them stutters.
+ *  * One clock per screen, shared by every card. N cards must not mean N timers
+ *    -- this runs on a phone while the box is streaming.
+ *  * Reduced motion is a hard stop, not a slowdown. When the OS asks for less
+ *    motion the shared values sit at their mid-point and nothing is scheduled.
+ */
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo, Platform } from 'react-native';
+import {
+  Easing,
+  useDerivedValue,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+
+// ---------------------------------------------------------------------------
+// Reduced motion
+// ---------------------------------------------------------------------------
+
+/**
+ * DEV: `?motion=off` forces the reduced-motion path in the web harness.
+ *
+ * WHY THIS EXISTS: the screenshot harness renders in a browser tab that is
+ * never visible (document.visibilityState === 'hidden'), so the browser never
+ * fires requestAnimationFrame -- MEASURED at 0 fps, not assumed. Every
+ * rAF-driven animation therefore freezes at whatever frame it was on, and a
+ * card that ENTERS from opacity 0 photographs as a blank or half-faded box.
+ * That is an artifact of the harness, not of the app.
+ *
+ * Forcing the reduced-motion path makes skins render their settled final
+ * state immediately, which is what a still screenshot should show anyway --
+ * and it exercises the accessibility path we have to support regardless.
+ */
+function motionForcedOff(): boolean {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return false;
+  try {
+    return new URLSearchParams(window.location.search).get('motion') === 'off';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The OS "reduce motion" setting, live. On web RN-Web maps this to the
+ * prefers-reduced-motion media query.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(motionForcedOff);
+
+  useEffect(() => {
+    // The dev override wins outright: don't let the OS query switch it back on.
+    if (motionForcedOff()) return;
+    let alive = true;
+    void AccessibilityInfo.isReduceMotionEnabled().then((v) => {
+      if (alive) setReduced(!!v);
+    });
+    const sub = AccessibilityInfo.addEventListener('reduceMotionChanged', (v) => {
+      setReduced(!!v);
+    });
+    return () => {
+      alive = false;
+      sub.remove();
+    };
+  }, []);
+
+  return reduced;
+}
+
+// ---------------------------------------------------------------------------
+// The breath clock
+// ---------------------------------------------------------------------------
+
+/** Mid-point of the breath curve: what a stopped clock rests at. */
+export const BREATH_REST = 0.5;
+
+/**
+ * A shared value oscillating 0 -> 1 -> 0 forever with the given period.
+ *
+ * `periodMs` may change at runtime (load-driven breathing speeds up under
+ * load); the animation is restarted on change rather than interpolated, which
+ * is imperceptible at these periods and keeps the worklet trivial.
+ *
+ * Returns a value pinned at BREATH_REST when reduced motion is on -- callers
+ * do not need to branch, their interpolations just land mid-range.
+ */
+export function useBreath(periodMs: number, enabled = true): SharedValue<number> {
+  const v = useSharedValue(BREATH_REST);
+  const reduced = useReducedMotion();
+  const on = enabled && !reduced;
+
+  useEffect(() => {
+    if (!on) {
+      // Cancel any in-flight repeat by overwriting with a static value.
+      v.value = withTiming(BREATH_REST, { duration: 200 });
+      return;
+    }
+    v.value = BREATH_REST;
+    v.value = withRepeat(
+      withTiming(1, {
+        duration: Math.max(200, periodMs) / 2,
+        easing: Easing.inOut(Easing.sin),
+      }),
+      -1,
+      true,
+    );
+  }, [on, periodMs, v]);
+
+  return v;
+}
+
+/**
+ * Map a 0..1 breath onto an arbitrary range without every caller writing the
+ * same worklet. `useDerivedValue` keeps the maths on the UI thread.
+ */
+export function useBreathRange(
+  breath: SharedValue<number>,
+  from: number,
+  to: number,
+): SharedValue<number> {
+  return useDerivedValue(() => from + (to - from) * breath.value, [from, to]);
+}
+
+// ---------------------------------------------------------------------------
+// Vitality: how hard the machine is working, 0..1
+// ---------------------------------------------------------------------------
+
+/**
+ * Collapse load + temperature into a single 0..1 "exertion" figure that skins
+ * use to drive breath RATE (a busy box breathes faster) and glow intensity.
+ *
+ * Deliberately NOT a semantic colour input: colour meaning stays with
+ * tempColor/pctColor. This only ever drives motion.
+ */
+export function vitality(load1: number | undefined, tempC: number | null | undefined): number {
+  // Load is per-core-ish and unbounded; 0..2 covers the interesting range.
+  const l = load1 == null ? 0 : Math.min(1, Math.max(0, load1 / 2));
+  // 40C idle -> 90C hot.
+  const t = tempC == null ? 0 : Math.min(1, Math.max(0, (tempC - 40) / 50));
+  return Math.min(1, Math.max(0, 0.6 * l + 0.4 * t));
+}
+
+/** Resting breath period, in ms, for a given 0..1 vitality. Idle is slow. */
+export function breathPeriod(v: number): number {
+  const IDLE = 5200;
+  const BUSY = 1700;
+  return Math.round(IDLE + (BUSY - IDLE) * Math.min(1, Math.max(0, v)));
+}

--- a/app/lib/skin/reactor.tsx
+++ b/app/lib/skin/reactor.tsx
@@ -1,0 +1,794 @@
+/**
+ * REACTOR skin -- "neon core". The loud direction.
+ *
+ * The premise: the box is a reactor and its glow tells you how hard it is
+ * working. Light and heat carry the whole design, so every element that has
+ * been handed a semantic colour wears a halo in THAT colour whose intensity
+ * scales with how bad the reading is. Cool green barely smoulders; red blooms.
+ *
+ * HOW THE LIGHT IS BUILT (there is no gradient/blur/SVG dependency here):
+ *  * Static bloom is the `boxShadow` string style (RN 0.86). It cannot be
+ *    animated -- it is a string -- so anything that must breathe is a second,
+ *    absolutely-positioned sibling View sitting BEHIND the element, carrying the
+ *    glow colour at low alpha, whose opacity/scale is driven by
+ *    `useAnimatedStyle` off the shared breath value. All the maths happens in
+ *    the worklet; nothing is recomputed in JS per frame.
+ *  * "Gradient" edges are faked: three hairline Views stacked down the card's
+ *    top edge at decreasing alpha, which reads as a top-lit bevel.
+ *
+ * LIGHT MODE IS NOT DARK MODE WITH A DIFFERENT BACKGROUND. A halo on #f6f8fc is
+ * invisible at low alpha and muddy at high alpha, and the chromatic-bleed ghost
+ * on the big metric reads as a rendering bug on white. So the whole "glow"
+ * vocabulary is re-expressed in light mode as saturation, border weight and a
+ * tinted backing -- see `light` branches throughout. Every colour is derived
+ * from the palette via `rgba()`; there is not one neon hex in this file.
+ *
+ * SEMANTIC COLOUR IS THE CALLER'S. tempColor/pctColor/batteryColor arrive
+ * pre-resolved (battery is inverted -- low is bad). The glow takes its hue from
+ * whatever was passed and never substitutes the accent for a semantic red.
+ * `severityOf` reads that colour back against the palette purely to decide how
+ * ANGRY the light should be, never to change what colour it is.
+ *
+ * MOTION BUDGET: this runs on a phone while the box streams a game. One breath
+ * clock for the whole screen (created in `Screen`, shared by context), one hum
+ * layer, and per-element animations that are pure UI-thread `useAnimatedStyle`.
+ * No setInterval, no per-frame JS, no unbounded View counts.
+ */
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withTiming,
+  type SharedValue,
+} from 'react-native-reanimated';
+
+import {
+  mono,
+  numeric,
+  useResolvedScheme,
+  useTheme,
+  useThemedStyles,
+  type Palette,
+} from '@/lib/theme';
+import { useVitals } from './kit';
+import type { BarProps, CardProps, DotProps, MetricProps, SkinKit, SparkProps } from './kit';
+import { BREATH_REST, breathPeriod, useBreath, useReducedMotion } from './motion';
+
+// ---------------------------------------------------------------------------
+// Colour helpers -- everything neon in here is derived from the live palette
+// ---------------------------------------------------------------------------
+
+function clamp(n: number, lo: number, hi: number): number {
+  return Math.min(hi, Math.max(lo, n));
+}
+
+/**
+ * Re-alpha an already-resolved palette colour. Accepts #rgb/#rgba/#rrggbb/
+ * #rrggbbaa and rgb()/rgba(); anything else is passed through untouched so a
+ * caller handing us something exotic degrades to "no transparency" rather than
+ * to an invalid style.
+ */
+function rgba(color: string, alpha: number): string {
+  const a = Math.round(clamp(alpha, 0, 1) * 1000) / 1000;
+  const c = color.trim();
+
+  if (c.startsWith('#')) {
+    let h = c.slice(1);
+    if (h.length === 3 || h.length === 4) {
+      h = h
+        .split('')
+        .map((ch) => ch + ch)
+        .join('');
+    }
+    if (h.length === 6 || h.length === 8) {
+      const r = parseInt(h.slice(0, 2), 16);
+      const g = parseInt(h.slice(2, 4), 16);
+      const b = parseInt(h.slice(4, 6), 16);
+      if (!Number.isNaN(r) && !Number.isNaN(g) && !Number.isNaN(b)) {
+        return `rgba(${r}, ${g}, ${b}, ${a})`;
+      }
+    }
+    return c;
+  }
+
+  const m = /^rgba?\(([^)]*)\)$/i.exec(c);
+  if (m) {
+    const parts = (m[1] ?? '').split(',').map((s) => s.trim());
+    if (parts.length >= 3) return `rgba(${parts[0]}, ${parts[1]}, ${parts[2]}, ${a})`;
+  }
+  return c;
+}
+
+/**
+ * How angry the light should be, 0..1, read back off the resolved semantic
+ * colour. This deliberately does NOT change the hue -- it only decides how much
+ * light comes out of it, so a red stays red and simply burns brighter.
+ */
+function severityOf(color: string, t: Palette): number {
+  const c = color.toLowerCase();
+  if (c === t.red.toLowerCase()) return 1;
+  if (c === t.redDeep.toLowerCase()) return 0.85;
+  if (c === t.amber.toLowerCase()) return 0.6;
+  if (c === t.green.toLowerCase()) return 0.3;
+  if (c === t.accent.toLowerCase() || c === t.blue.toLowerCase()) return 0.35;
+  if (c === t.slate.toLowerCase()) return 0.12;
+  if (c === t.textFaint.toLowerCase() || c === t.textDim.toLowerCase()) return 0.1;
+  if (c === t.cardBorder.toLowerCase()) return 0.08;
+  return 0.4; // unknown but presumably meaningful: mid heat
+}
+
+/** A static bloom, as the one string style RN gives us. */
+function bloom(color: string, radius: number, alpha: number): string {
+  return `0 0 ${Math.round(radius)}px ${rgba(color, alpha)}`;
+}
+
+// ---------------------------------------------------------------------------
+// The shared breath clock
+// ---------------------------------------------------------------------------
+
+/**
+ * ONE clock per screen. `Screen` creates it from the machine's vitality and
+ * publishes it here; every card, bar and dot reads the same shared value, so N
+ * cards never mean N timers.
+ */
+const BreathCtx = React.createContext<SharedValue<number> | null>(null);
+
+/**
+ * The screen's breath, or a private resting value when a component is rendered
+ * outside a `Screen` (the Fleet tiles and the Console header are composed
+ * independently, and a card must never crash for want of a provider). The
+ * fallback shared value is always created -- hooks stay unconditional -- but it
+ * is never animated, so it costs nothing.
+ */
+function useBreathValue(): SharedValue<number> {
+  const ctx = useContext(BreathCtx);
+  const fallback = useSharedValue(BREATH_REST);
+  return ctx ?? fallback;
+}
+
+// ---------------------------------------------------------------------------
+// Screen: the reactor hum
+// ---------------------------------------------------------------------------
+
+/** Period of the background sheen. Slow enough to read as ambience, not motion. */
+const HUM_MS = 14000;
+
+function Screen({ children }: { children: React.ReactNode }) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const reduced = useReducedMotion();
+  const { v, alive } = useVitals();
+
+  // The one breath clock. Rate rises with exertion; a box that is not answering
+  // does not breathe at all.
+  const breath = useBreath(breathPeriod(v), alive);
+
+  const [size, setSize] = useState({ w: 0, h: 0 });
+  const hum = useSharedValue(0);
+
+  useEffect(() => {
+    if (reduced) {
+      // Reduced motion gets the ambience parked mid-sweep, never the movement.
+      hum.value = 0.5;
+      return;
+    }
+    hum.value = 0;
+    hum.value = withRepeat(
+      withTiming(1, { duration: HUM_MS, easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [reduced, hum]);
+
+  const humStyle = useAnimatedStyle(() => {
+    const span = size.w * 2.4;
+    return {
+      transform: [{ rotate: '18deg' }, { translateX: -size.w * 0.9 + hum.value * span }],
+    };
+  }, [size.w]);
+
+  const sheen = useMemo(
+    () => ({
+      position: 'absolute' as const,
+      top: -size.h * 0.5,
+      left: 0,
+      width: Math.max(1, size.w * 0.5),
+      height: Math.max(1, size.h * 2),
+      backgroundColor: rgba(t.accent, light ? 0.05 : 0.045),
+    }),
+    [size.w, size.h, t.accent, light],
+  );
+
+  return (
+    <BreathCtx.Provider value={breath}>
+      <View
+        style={styles.screen}
+        onLayout={(e) => {
+          const { width, height } = e.nativeEvent.layout;
+          setSize((p) => (p.w === width && p.h === height ? p : { w: width, h: height }));
+        }}>
+        {size.w > 0 && (
+          <View pointerEvents="none" style={styles.humClip}>
+            <Animated.View style={[sheen, humStyle]} />
+          </View>
+        )}
+        {children}
+      </View>
+    </BreathCtx.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card
+// ---------------------------------------------------------------------------
+
+function Card({
+  title,
+  index = 0,
+  tone = 'default',
+  accentColor,
+  onPress,
+  selected,
+  style,
+  children,
+}: CardProps) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const reduced = useReducedMotion();
+  const themed = useThemedStyles(makeStyles);
+  const { v, alive } = useVitals();
+  const breath = useBreathValue();
+
+  // Tone meanings are inherited verbatim from classic: live = green + rounder,
+  // down = deep red, selected = accent, alert = the unreachable banner.
+  const toneColor =
+    accentColor ??
+    (tone === 'live'
+      ? t.green
+      : tone === 'alert'
+        ? t.red
+        : tone === 'down'
+          ? t.redDeep
+          : selected
+            ? t.accent
+            : null);
+
+  const edgeColor = toneColor ?? t.cardBorder;
+  const glowColor = toneColor ?? t.accent;
+  const sev = severityOf(glowColor, t);
+  const radius = tone === 'live' ? 14 : 12;
+
+  // A plain card is barely lit; a toned/selected one commits. Exertion adds a
+  // little on top so a hot box is visibly hotter everywhere at once.
+  const peak = clamp(
+    (tone === 'default' && !selected ? 0.3 : 1) * (0.35 + 0.65 * sev) * (0.75 + 0.35 * v),
+    0,
+    1,
+  );
+  // A box that is not answering must not have a healthy pulse.
+  const dead = tone === 'down' || !alive;
+
+  const haloStyle = useAnimatedStyle(() => {
+    const b = dead ? BREATH_REST : breath.value;
+    return { opacity: peak * (dead ? 0.45 : 0.6 + 0.4 * b) };
+  }, [peak, dead]);
+
+  const edgeStyle = useAnimatedStyle(() => {
+    const b = dead ? BREATH_REST : breath.value;
+    return { opacity: dead ? 0.55 : 0.6 + 0.4 * b };
+  }, [dead]);
+
+  // Entrance. Cards probe-and-appear, so this fires exactly once per mount and
+  // is never re-triggered by a re-render (or by `index` shuffling underneath).
+  const enter = useSharedValue(0);
+  const started = useRef(false);
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    if (reduced) {
+      enter.value = 1;
+      return;
+    }
+    enter.value = withDelay(
+      Math.min(Math.max(0, index), 6) * 55,
+      withTiming(1, { duration: 260, easing: Easing.out(Easing.quad) }),
+    );
+  }, [enter, index, reduced]);
+
+  const enterStyle = useAnimatedStyle(() => ({
+    opacity: enter.value,
+    transform: [{ translateY: (1 - enter.value) * 8 }],
+  }));
+
+  const frameStyle = [
+    themed.card,
+    {
+      borderRadius: radius,
+      borderColor: light && toneColor != null ? toneColor : edgeColor,
+      // LIGHT MODE: "glow" becomes weight + a tinted lift, not a halo.
+      borderWidth: light && toneColor != null ? 1.5 : 1,
+      ...(light
+        ? {
+            backgroundColor: toneColor != null ? rgba(toneColor, 0.05) : t.card,
+            boxShadow: bloom(toneColor ?? t.slate, 6, 0.12 + 0.18 * sev),
+          }
+        : null),
+    },
+  ];
+
+  const body = (
+    <>
+      {/* Faked top-lit bevel: three hairlines at decreasing alpha. */}
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          themed.edge,
+          { top: 0, left: radius, right: radius, backgroundColor: rgba(glowColor, 0.65) },
+          edgeStyle,
+        ]}
+      />
+      <View
+        pointerEvents="none"
+        style={[
+          themed.edge,
+          { top: 1.5, left: radius + 4, right: radius + 4, backgroundColor: rgba(glowColor, 0.3) },
+        ]}
+      />
+      <View
+        pointerEvents="none"
+        style={[
+          themed.edge,
+          { top: 3, left: radius + 10, right: radius + 10, backgroundColor: rgba(glowColor, 0.14) },
+        ]}
+      />
+      {title != null && <Text style={themed.cardTitle}>{title}</Text>}
+      {children}
+    </>
+  );
+
+  return (
+    <Animated.View style={[themed.wrap, style, enterStyle]}>
+      {/* DARK MODE ONLY: the animated halo. It sits behind the opaque card, so
+          only the ring that spills past the edge is ever seen. */}
+      {!light && (
+        <Animated.View
+          pointerEvents="none"
+          style={[
+            themed.halo,
+            {
+              borderRadius: radius + 8,
+              backgroundColor: rgba(glowColor, 0.2),
+              boxShadow: bloom(glowColor, 16 + 20 * sev, 0.45),
+            },
+            haloStyle,
+          ]}
+        />
+      )}
+      {onPress == null ? (
+        <View style={frameStyle}>{body}</View>
+      ) : (
+        <Pressable
+          onPress={onPress}
+          style={({ pressed }) => [...frameStyle, pressed && themed.pressed]}>
+          {body}
+        </Pressable>
+      )}
+    </Animated.View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SectionTitle
+// ---------------------------------------------------------------------------
+
+function SectionTitle({ children }: { children: React.ReactNode }) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const themed = useThemedStyles(makeStyles);
+  return (
+    <Text
+      style={[
+        themed.sectionTitle,
+        {
+          color: light ? t.accent : rgba(t.accent, 0.8),
+          ...(light
+            ? null
+            : {
+                textShadowColor: rgba(t.accent, 0.45),
+                textShadowOffset: { width: 0, height: 0 },
+                textShadowRadius: 8,
+              }),
+        },
+      ]}>
+      {children}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// BigMetric: hot type
+// ---------------------------------------------------------------------------
+
+function BigMetric({ value, color }: MetricProps) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const themed = useThemedStyles(makeStyles);
+  const { v, alive } = useVitals();
+  const breath = useBreathValue();
+
+  const sev = severityOf(color, t);
+  const peak = clamp((0.4 + 0.6 * sev) * (0.75 + 0.35 * v), 0, 1);
+
+  const glowStyle = useAnimatedStyle(() => {
+    const b = alive ? breath.value : BREATH_REST;
+    return { opacity: peak * (alive ? 0.55 + 0.45 * b : 0.5) };
+  }, [peak, alive]);
+
+  return (
+    <View style={themed.metricWrap}>
+      {/* The bloom behind the digits. Dark: a real halo. Light: a tinted pill,
+          which is how "hot" has to read on white without turning to mud. */}
+      <Animated.View
+        pointerEvents="none"
+        style={[
+          themed.metricGlow,
+          {
+            backgroundColor: rgba(color, light ? 0.12 : 0.16),
+            ...(light ? null : { boxShadow: bloom(color, 14 + 18 * sev, 0.4) }),
+          },
+          glowStyle,
+        ]}
+      />
+      {/* Chromatic bleed. DARK ONLY -- on a white background an offset ghost
+          reads as a rendering bug, not as heat. */}
+      {!light && (
+        <Text
+          pointerEvents="none"
+          style={[themed.bigMetric, themed.metricGhost, { color: rgba(color, 0.35) }]}>
+          {value}
+        </Text>
+      )}
+      <Text
+        style={[
+          themed.bigMetric,
+          {
+            color,
+            ...(light
+              ? { fontWeight: '800' as const }
+              : {
+                  textShadowColor: rgba(color, 0.35 + 0.35 * sev),
+                  textShadowOffset: { width: 0, height: 0 },
+                  textShadowRadius: 10,
+                }),
+          },
+        ]}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bar
+// ---------------------------------------------------------------------------
+
+/** Width of the travelling highlight, in px. */
+const SWEEP_W = 46;
+
+function Bar({ pct, color, height = 10 }: BarProps) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const themed = useThemedStyles(makeStyles);
+  const reduced = useReducedMotion();
+  const { v, alive } = useVitals();
+
+  const p = clamp(pct, 0, 100);
+  const sev = severityOf(color, t);
+  const [w, setW] = useState(0);
+  const fillW = (w * p) / 100;
+
+  // The sweep only runs on a live box, and only when there is enough filled
+  // track for it to be a highlight rather than a flicker.
+  const on = alive && !reduced && fillW > SWEEP_W * 0.6;
+  const sweep = useSharedValue(0);
+
+  useEffect(() => {
+    if (!on) {
+      sweep.value = 0;
+      return;
+    }
+    sweep.value = 0;
+    sweep.value = withRepeat(
+      withTiming(1, { duration: Math.round(2400 - 900 * clamp(v, 0, 1)), easing: Easing.linear }),
+      -1,
+      false,
+    );
+  }, [on, v, sweep]);
+
+  const sweepStyle = useAnimatedStyle(() => {
+    const travel = fillW + SWEEP_W;
+    return {
+      opacity: on ? 1 : 0,
+      transform: [{ translateX: -SWEEP_W + sweep.value * travel }],
+    };
+  }, [fillW, on]);
+
+  return (
+    <View
+      style={themed.barWrap}
+      onLayout={(e) => {
+        const next = e.nativeEvent.layout.width;
+        setW((prev) => (prev === next ? prev : next));
+      }}>
+      {/* Dark: the filled portion throws light past the track edge. */}
+      {!light && fillW > 0 && (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            left: -2,
+            top: -3,
+            width: fillW + 4,
+            height: height + 6,
+            borderRadius: (height + 6) / 2,
+            backgroundColor: rgba(color, 0.16),
+            boxShadow: bloom(color, 8 + 14 * sev, 0.5),
+          }}
+        />
+      )}
+      <View
+        style={[
+          themed.barTrack,
+          {
+            height,
+            borderRadius: height / 2,
+            // Light: saturation instead of bloom -- a tinted track edge.
+            ...(light ? { borderWidth: 1, borderColor: rgba(color, 0.28) } : null),
+          },
+        ]}>
+        <View
+          style={{
+            width: `${p}%`,
+            height: '100%',
+            backgroundColor: color,
+            borderRadius: height / 2,
+            overflow: 'hidden',
+          }}>
+          <Animated.View
+            pointerEvents="none"
+            style={[
+              {
+                position: 'absolute',
+                top: 0,
+                bottom: 0,
+                width: SWEEP_W,
+                backgroundColor: rgba(t.text, light ? 0.22 : 0.3),
+              },
+              sweepStyle,
+            ]}
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Spark
+// ---------------------------------------------------------------------------
+
+/**
+ * Same contract as components/Sparkline (null samples are gaps, nothing renders
+ * under two real samples) but lit: older samples fade back, the newest and the
+ * tallest carry the bloom. Reimplemented rather than wrapped because the shared
+ * component takes no decoration props and a glow on its container would light
+ * the whole row uniformly, which loses the "most recent is hottest" read.
+ */
+function Spark({ values, color, height = 22, min, max }: SparkProps) {
+  const light = useResolvedScheme() === 'light';
+  const t = useTheme();
+  const themed = useThemedStyles(makeStyles);
+
+  const real = (values ?? []).filter((n): n is number => n != null);
+  if (!values || real.length < 2) return null;
+
+  const lo = min ?? Math.min(...real);
+  const hi = max ?? Math.max(...real);
+  const span = hi - lo;
+  const sev = severityOf(color, t);
+
+  // Which bars get the expensive treatment: the last real sample and the peak.
+  let lastReal = -1;
+  let tallest = -1;
+  let tallestV = -Infinity;
+  values.forEach((n, i) => {
+    if (n == null) return;
+    lastReal = i;
+    if (n > tallestV) {
+      tallestV = n;
+      tallest = i;
+    }
+  });
+
+  const n = values.length;
+
+  return (
+    <View style={[themed.sparkRow, { height }]} pointerEvents="none">
+      {values.map((val, i) => {
+        if (val == null) return <View key={i} style={themed.sparkBar} />;
+        const frac = span > 0 ? (val - lo) / span : 0.5;
+        const h = Math.max(3, Math.round(height * (0.12 + 0.88 * clamp(frac, 0, 1))));
+        // Recency ramp: the tail of the history is the bright end.
+        const recency = n > 1 ? i / (n - 1) : 1;
+        const hot = i === lastReal || i === tallest;
+        return (
+          <View
+            key={i}
+            style={[
+              themed.sparkBar,
+              {
+                height: h,
+                backgroundColor: color,
+                opacity: hot ? 1 : 0.3 + 0.45 * recency,
+                ...(hot && !light ? { boxShadow: bloom(color, 5 + 7 * sev, 0.75) } : null),
+              },
+            ]}
+          />
+        );
+      })}
+    </View>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Dot: the reactor core
+// ---------------------------------------------------------------------------
+
+function Dot({ color, size = 14, live = true }: DotProps) {
+  const t = useTheme();
+  const light = useResolvedScheme() === 'light';
+  const breath = useBreathValue();
+  const sev = severityOf(color, t);
+
+  const ringOuter = size * 1.75;
+  const ringInner = size * 1.3;
+
+  const ring1 = useAnimatedStyle(() => {
+    const b = live ? breath.value : BREATH_REST;
+    return { transform: [{ scale: 0.8 + 0.3 * b }], opacity: live ? 0.55 - 0.3 * b : 0.18 };
+  }, [live]);
+
+  const ring2 = useAnimatedStyle(() => {
+    // Phase-inverted so the two rings read as a pulse leaving the core.
+    const b = live ? 1 - breath.value : BREATH_REST;
+    return { transform: [{ scale: 0.85 + 0.25 * b }], opacity: live ? 0.4 - 0.22 * b : 0.14 };
+  }, [live]);
+
+  return (
+    <View style={[dotStyles.wrap, { width: size, height: size }]} pointerEvents="none">
+      <Animated.View
+        style={[
+          dotStyles.ring,
+          {
+            width: ringOuter,
+            height: ringOuter,
+            borderRadius: ringOuter / 2,
+            borderColor: rgba(color, light ? 0.5 : 0.7),
+          },
+          ring1,
+        ]}
+      />
+      <Animated.View
+        style={[
+          dotStyles.ring,
+          {
+            width: ringInner,
+            height: ringInner,
+            borderRadius: ringInner / 2,
+            borderColor: rgba(color, light ? 0.45 : 0.6),
+          },
+          ring2,
+        ]}
+      />
+      {/* Containment shell: keeps the dot's visual footprint the same size the
+          layout expects, with the bright core burning inside it. */}
+      <View
+        style={{
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor: rgba(color, light ? 0.3 : 0.28),
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}>
+        <View
+          style={{
+            width: size * 0.58,
+            height: size * 0.58,
+            borderRadius: size,
+            backgroundColor: color,
+            ...(light ? null : { boxShadow: bloom(color, 5 + 9 * sev, 0.85) }),
+          }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const dotStyles = StyleSheet.create({
+  wrap: { alignItems: 'center', justifyContent: 'center' },
+  ring: { position: 'absolute', borderWidth: 1 },
+});
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = StyleSheet.create({
+  screen: { flex: 1 },
+  humClip: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, overflow: 'hidden' },
+});
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { marginBottom: 10, position: 'relative' },
+    halo: { position: 'absolute', top: -8, left: -8, right: -8, bottom: -8 },
+    card: {
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 14,
+    },
+    pressed: { opacity: 0.7 },
+    edge: { position: 'absolute', height: StyleSheet.hairlineWidth },
+    cardTitle: {
+      color: t.textDim,
+      fontFamily: mono,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1.4,
+      marginBottom: 8,
+    },
+    sectionTitle: {
+      fontFamily: mono,
+      fontSize: 11,
+      letterSpacing: 1.6,
+      marginBottom: 10,
+    },
+    metricWrap: { alignSelf: 'flex-start', position: 'relative' },
+    metricGlow: {
+      position: 'absolute',
+      top: -6,
+      bottom: -6,
+      left: -10,
+      right: -10,
+      borderRadius: 12,
+    },
+    metricGhost: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      transform: [{ translateX: 1.5 }, { translateY: -1 }],
+    },
+    bigMetric: { fontSize: 28, fontWeight: '700', ...numeric },
+    barWrap: { position: 'relative' },
+    barTrack: { backgroundColor: t.inset, overflow: 'hidden' },
+    sparkRow: { flexDirection: 'row', alignItems: 'flex-end', gap: 2, marginTop: 8 },
+    sparkBar: { flex: 1, borderRadius: 1, backgroundColor: 'transparent' },
+  });
+
+export const reactorSkin: SkinKit = {
+  label: 'Reactor',
+  Screen,
+  Card,
+  SectionTitle,
+  BigMetric,
+  Bar,
+  Spark,
+  Dot,
+};

--- a/scripts/web-dev-skins.html
+++ b/scripts/web-dev-skins.html
@@ -1,0 +1,135 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Couchside — skin comparison</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root { color-scheme: dark; }
+  body {
+    margin: 0; padding: 28px 22px 60px;
+    background: #0b1220; color: #e5ecf8;
+    font: 15px/1.5 ui-monospace, Menlo, monospace;
+  }
+  h1 { font-size: 17px; letter-spacing: 2px; margin: 0 0 4px; }
+  p  { color: #8b97ad; margin: 0 0 22px; max-width: 640px; font-size: 13px; }
+  .grid { display: grid; gap: 14px; max-width: 640px; }
+  .row {
+    border: 1px solid #1e2942; border-radius: 12px;
+    background: #141c2e; padding: 14px 16px;
+  }
+  .name { font-weight: 700; font-size: 15px; margin-bottom: 3px; }
+  .desc { color: #8b97ad; font-size: 12px; margin-bottom: 11px; }
+  a {
+    display: inline-block; margin: 0 7px 7px 0; padding: 7px 12px;
+    border: 1px solid #2b3a5c; border-radius: 8px;
+    color: #60a5fa; text-decoration: none; font-size: 12px;
+  }
+  a:hover { background: #0e1526; }
+  a.alt { color: #8b97ad; }
+  .note { color: #5b6780; font-size: 11px; margin-top: 26px; max-width: 640px; }
+  code { color: #fbbf24; }
+  .health {
+    max-width: 640px; margin: 0 0 20px; padding: 9px 12px;
+    border-radius: 8px; font-size: 12px; border: 1px solid #1e2942; color: #8b97ad;
+  }
+  .health.ok   { border-color: #14532d; color: #34d399; }
+  .health.bad  { border-color: #7f1d1d; color: #f87171; }
+</style>
+
+<h1>COUCHSIDE — SKIN COMPARISON</h1>
+<div id="health" class="health">checking the mock agent…</div>
+<p>
+  This page pairs your browser with the mock agent, then hands off to the app.
+  Open a direction, then use the Console and Fleet tabs. Motion matters here —
+  the cards breathe, and that is the whole point — so give each one a few
+  seconds rather than judging the first frame.
+</p>
+
+<div class="grid" id="grid"></div>
+
+<p class="note">
+  <b>Reduced motion:</b> the “still” links force the same code path a
+  reduced-motion user gets — everything settled, no animation. Useful for
+  judging layout, useless for judging feel.<br><br>
+  <b>Not yet converted:</b> the Now&nbsp;Playing, Streaming&nbsp;To and Gaming
+  cards are separate components that don’t use the skin seam yet, so they still
+  look stock in every direction. They get converted once you pick one.
+</p>
+
+<script>
+  // Pair this browser with the running mock agent. Same origin, so the proxy
+  // forwards /api and no CORS is involved.
+  var PORT = location.port || '8099';
+  // The mock agent mints a fresh token per web-dev.sh run. This page is written
+  // with the token of the run that created it; ?token=... overrides it so a
+  // restarted harness doesn't mean editing this file.
+  var TOKEN = new URLSearchParams(location.search).get('token') || 'web-dev-11912';
+
+  localStorage.setItem('couchpilot.boxes.v1', JSON.stringify({
+    boxes: [{
+      id: 'web-dev', name: 'mock box', host: '127.0.0.1',
+      port: Number(PORT), token: TOKEN, padMode: 'trackpad'
+    }],
+    activeBoxId: 'web-dev'
+  }));
+
+  // Fail loudly rather than handing off to an app that will just say
+  // "No box configured" with no explanation.
+  (function () {
+    var el = document.getElementById('health');
+    fetch('/api/status', { headers: { Authorization: 'Bearer ' + TOKEN } })
+      .then(function (r) {
+        if (r.ok) {
+          el.className = 'health ok';
+          el.textContent = 'mock agent OK on port ' + PORT + ' — paired, token ' + TOKEN;
+        } else {
+          el.className = 'health bad';
+          el.textContent =
+            'mock agent answered ' + r.status + '. The token is probably stale (this page has ' +
+            TOKEN + '). Re-run scripts/web-dev.sh, then open this page with ?token=THE_NEW_TOKEN.';
+        }
+      })
+      .catch(function () {
+        el.className = 'health bad';
+        el.textContent =
+          'no mock agent on port ' + PORT + '. Start it with: scripts/web-dev.sh ' + PORT;
+      });
+  })();
+
+  var SKINS = [
+    ['hud',     'HUD / Terminal Deck',
+     'Corner brackets, title notches, scanlines, backdrop grid, reticle dots. Structure carries it — reads cyberpunk even with colour removed.'],
+    ['reactor', 'Reactor / Neon Core',
+     'Severity-driven glow, pulsing core dots, a highlight sweeping the bars, slow diagonal hum. The loudest one.'],
+    ['vitals',  'Vitals / Life Support',
+     'Quiet and biological. Breathing tied to real load, count-up numbers, easing bars. Looks almost like Classic frozen — you have to watch it.'],
+    ['classic', 'Classic (control)',
+     'Today’s shipped look, unchanged. Here so you can A/B against it.']
+  ];
+
+  function setTheme(mode) {
+    localStorage.setItem('couchside.theme.v1', JSON.stringify({ mode: mode, accent: 'blue' }));
+  }
+
+  var grid = document.getElementById('grid');
+  SKINS.forEach(function (s) {
+    var key = s[0], name = s[1], desc = s[2];
+    var el = document.createElement('div');
+    el.className = 'row';
+    el.innerHTML =
+      '<div class="name">' + name + '</div><div class="desc">' + desc + '</div>';
+
+    [['Console', '/?skin=' + key, 'dark'],
+     ['Fleet', '/fleet?skin=' + key, 'dark'],
+     ['Console · light', '/?skin=' + key, 'light'],
+     ['Console · still', '/?skin=' + key + '&motion=off', 'dark']]
+    .forEach(function (l, i) {
+      var a = document.createElement('a');
+      a.textContent = l[0];
+      if (i >= 2) a.className = 'alt';
+      a.href = l[1];
+      a.addEventListener('click', function () { setTheme(l[2]); });
+      el.appendChild(a);
+    });
+    grid.appendChild(el);
+  });
+</script>


### PR DESCRIPTION
Restyles Console and Fleet so the dashboard reads as a live machine rather than a static readout. Owner picked the **Reactor** direction after comparing three built variants side by side.

## The seam

`app/lib/skin/` defines a `SkinKit` (`Screen`, `Card`, `SectionTitle`, `BigMetric`, `Bar`, `Spark`, `Dot`). `index.tsx` and `fleet.tsx` compose those and never know which look is active, so directions could be built independently and swapped with `?skin=` in the web harness — no rebuild between comparisons.

**Classic is kept deliberately.** `?skin=classic` renders today's exact pre-redesign dashboard, verified pixel-identical to shipped 2.9.11. It makes "is this a regression?" answerable by live comparison instead of from memory — that is how the one suspected layout regression in this PR was cleared (GPU→OUTPUT spacing, delta 0).

`vitals.tsx` (motion-only, life-support) and `hud.tsx` (corner brackets, scanlines, typewriter titles) were built and compared, then dropped. Recoverable from this branch's history.

## Constraints held

- **Semantic colour is never substituted, only decorated.** Reactor's glow takes its colour *from* the already-resolved `tempColor`/`pctColor`/`batteryColor`, so a hot red stays red and burns harder. Battery stays inverted.
- **Motion rate, never colour, comes from vitality** (load + temp). A busy box breathes faster.
- **One breath clock per screen**, shared by context — N cards must not mean N oscillators. This runs on a phone while the box streams.
- **Reduced motion is a hard stop**, not a slowdown.
- **Light mode branches explicitly** — halos become tinted pills and border weight, because glow on `#f6f8fc` is mud. This was the variant's main risk and it was checked.
- Probe-and-appear cards mount/unmount mid-poll without re-firing entrances.

## Verification

Against the mock agent **and** the real box (10.1.1.60) through `web-dev-proxy.py`.

Interactions were **driven, not screenshotted** — Fleet tile taps and the Now Playing transport were exercised with real pointer events and asserted on side effects (`activeBoxId` changed; `media/spotify/play_pause` reached the agent). An early "TAP DEAD" reading turned out to be the wrong DOM element, caught by running the same dispatch against a known-good control.

## Two harness traps found

Both produce confidently wrong results and are now documented:

1. The preview browser tab is permanently `visibilityState: hidden`, so **rAF runs at 0 fps**. A probe that samples a reanimated shared value reports PASS while the DOM is frozen — measure the *painted* result. Cards entering from opacity 0 photograph blank; `?motion=off` forces the settled state.
2. RN Web maps `AppState` to document visibility, so **Fleet's fan-out polls nothing** until visibility is overridden.

`scripts/web-dev-skins.html` is a self-seeding comparison launcher (survives `expo export` wiping `dist/`, takes `?token=`, and fails loudly with the fix instead of a bare "No box configured").

## Not in this PR

`ScreenPreview`, the BOX UNREACHABLE banner and the "No box configured" empty card still use bespoke local styles rather than the kit.

`DEFAULT_SKIN` is `reactor`, so this changes the shipped look. No version bump here — next floors remain iOS ≥ 65 / vc ≥ 49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)