### PR TITLE
fix(screen): re-detect the capture backend instead of freezing it at boot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,17 @@ jobs:
       - name: Unit tests (stream host)
         run: python3 tests/test_stream_host.py
 
+      # Screen capture backend selection. couchside.service and the Steam
+      # session race at boot: measured on a real box, the agent came up 34
+      # seconds BEFORE the gamescope socket existed, cached "desktop/spectacle"
+      # for its whole uptime, and fired a KDE screenshot tool at a gamescope
+      # session -- every frame 503 until someone restarted the service. These
+      # drive the socket set CHANGING after startup, which is the only shape
+      # that catches it; a test that merely checks a correct startup passes
+      # against the bug.
+      - name: Unit tests (screen capture)
+        run: python3 tests/test_screen_capture.py
+
       # Injected actions: buttons the agent offers only when the box can really
       # perform them ("a dead button costs more trust than a missing one"), so
       # every gate is asserted in BOTH directions. Covers the Bluetooth pairing

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6440,34 +6440,61 @@ def _screen_downscaler():
 
 
 def set_screen(mock):
-    """Detect a capture path at startup: gamescopectl when a gamescope socket
-    exists, else spectacle for a KDE desktop. Requires a downscaler for real
-    frames (a raw 4K PNG is too big to stream)."""
+    """Cache the STATIC half of the capture capability at startup: the
+    downscaler and which capture binaries exist. Requires a downscaler for real
+    frames (a raw 4K PNG is too big to stream).
+
+    The session-dependent half (which compositor is up, hence which backend can
+    actually grab a frame) is deliberately NOT decided here -- see
+    _screen_live(). Binaries do not come and go at runtime; compositors do."""
     global _SCREEN
     if mock:
         _SCREEN = {"session": "mock", "backends": ["mock"], "dscale": None}
         return
     dbuild, _ = _screen_downscaler()
     if dbuild is None:
-        _SCREEN = None
+        _SCREEN = None                  # no downscaler: this box can never capture
         return
+    if not (shutil.which("gamescopectl") or shutil.which("spectacle")):
+        _SCREEN = None                  # no capture tool at all
+        return
+    _SCREEN = {"dscale": dbuild,
+               "has_gamescopectl": bool(shutil.which("gamescopectl")),
+               "has_spectacle": bool(shutil.which("spectacle"))}
+
+
+def _screen_live():
+    """Resolve the CURRENT session and usable backends, or None if nothing can
+    capture right now. Cheap (one listdir); callers are rate-limited anyway.
+
+    WHY THIS IS RE-EVALUATED PER CALL AND NOT CACHED AT STARTUP: couchside.service
+    and the Steam session race at boot. Measured on a real box -- agent up at
+    09:34:26, gamescope-0 socket created at 09:35 -- the agent decided "desktop /
+    spectacle", then spent the whole uptime firing a KDE screenshot tool at a
+    gamescope session. spectacle wrote no file, so every /api/screen/frame
+    returned 503 "capture failed" until the service happened to be restarted.
+    It presented as "screen capture works sometimes", because whether it works
+    depended purely on which of the two won the boot race."""
+    if _SCREEN is None or _SCREEN.get("dscale") is None:
+        return _SCREEN                  # None, or the mock dict, unchanged
     gs = [s for s in _wayland_display_sockets() if s.startswith("gamescope-")]
     backends = []
-    if shutil.which("gamescopectl") and gs:
+    # gamescopectl only works against a live gamescope socket; order matters,
+    # the session's own grabber goes first.
+    if _SCREEN["has_gamescopectl"] and gs:
         backends.append("gamescopectl")
-    if shutil.which("spectacle"):
+    if _SCREEN["has_spectacle"]:
         backends.append("spectacle")
     if not backends:
-        _SCREEN = None
-        return
-    _SCREEN = {"session": "gamescope" if gs else "desktop", "backends": backends,
-               "dscale": dbuild, "gs_socket": gs[0] if gs else None}
+        return None
+    return {"session": "gamescope" if gs else "desktop", "backends": backends,
+            "dscale": _SCREEN["dscale"], "gs_socket": gs[0] if gs else None}
 
 
-def _screen_env():
+def _screen_env(live=None):
     env = _user_env()
-    if _SCREEN and _SCREEN.get("gs_socket"):
-        env["WAYLAND_DISPLAY"] = _SCREEN["gs_socket"]
+    if live and live.get("gs_socket"):
+        env["WAYLAND_DISPLAY"] = live["gs_socket"]
     else:
         socks = _wayland_display_sockets()
         if len(socks) == 1:
@@ -6532,7 +6559,8 @@ def _grab_spectacle(env, outdir):
 def real_screen_frame():
     """Capture one frame -> (jpeg_bytes, "image/jpeg") or None. Single-flight +
     500 ms cache so any number of pollers cause at most ~2 captures/sec."""
-    if _SCREEN is None:
+    live = _screen_live()
+    if live is None:
         return None
     now = time.monotonic()
     if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
@@ -6547,7 +6575,7 @@ def real_screen_frame():
         now = time.monotonic()
         if _SCREEN_CACHE["data"] is not None and now - _SCREEN_CACHE["ts"] < SCREEN_MIN_INTERVAL_S:
             return (_SCREEN_CACHE["data"], _SCREEN_CACHE["mime"])
-        env = _screen_env()
+        env = _screen_env(live)
         outdir = os.path.join(XDG_RUNTIME_DIR, "couchside-screen")
         try:
             os.makedirs(outdir, mode=0o700, exist_ok=True)
@@ -6557,7 +6585,7 @@ def real_screen_frame():
         jpg = os.path.join(outdir, "frame.jpg")
         try:
             grabbed = None
-            for backend in _SCREEN["backends"]:
+            for backend in live["backends"]:
                 if backend == "gamescopectl":
                     grabbed = _grab_gamescopectl(env, outdir)
                 elif backend == "spectacle":
@@ -6568,7 +6596,7 @@ def real_screen_frame():
                 return None
             data = None
             try:
-                subprocess.run(_SCREEN["dscale"](grabbed, jpg), env=env,
+                subprocess.run(live["dscale"](grabbed, jpg), env=env,
                                timeout=SCREEN_CAPTURE_TIMEOUT_S,
                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
                 with open(jpg, "rb") as f:
@@ -6592,11 +6620,15 @@ def real_screen_frame():
 
 
 def screen_info():
-    """{available, session, backends, formats} or None when no capture path."""
-    if _SCREEN is None:
+    """{available, session, backends, formats} or None when no capture path.
+
+    Reports the LIVE session, so the card reflects what would actually be
+    grabbed right now rather than whatever was true when the agent booted."""
+    live = _screen_live()
+    if live is None:
         return None
-    return {"available": True, "session": _SCREEN["session"],
-            "backends": _SCREEN["backends"], "formats": ["image/jpeg"]}
+    return {"available": True, "session": live["session"],
+            "backends": live["backends"], "formats": ["image/jpeg"]}
 
 
 def _encode_png(w, h, rows):
@@ -11105,8 +11137,11 @@ def main():
     print("tv: %s" % ("%s (%s)" % (info["backend"], info["adapter"])
                       if info else "unavailable"), flush=True)
     print("mpris: %s" % ("available" if BUSCTL else "unavailable"), flush=True)
-    print("screen: %s" % (("%s (%s)" % (_SCREEN["session"], ",".join(_SCREEN["backends"])))
-                          if _SCREEN else "unavailable"), flush=True)
+    # Report the LIVE view: the startup dict now holds only static capability,
+    # and the banner should say what would actually be captured right now.
+    _scr = _screen_live()
+    print("screen: %s" % (("%s (%s)" % (_scr["session"], ",".join(_scr["backends"])))
+                          if _scr else "unavailable"), flush=True)
     print("caps: %s" % (",".join(sorted(k for k, v in CAPS.items() if v)) or "none"),
           flush=True)
     try:

--- a/tests/test_screen_capture.py
+++ b/tests/test_screen_capture.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Tests for screen-capture backend selection (GET /api/screen, /api/screen/frame).
+
+Run: python3 tests/test_screen_capture.py
+
+THE BUG THIS LOCKS DOWN, measured on a real box (lenovodesktop, agent 2.9.31):
+
+  couchside.service came up at 09:34:26. The gamescope compositor socket
+  (gamescope-0) appeared at 09:35 -- one minute LATER. set_screen() ran once at
+  startup, saw no gamescope socket, and cached {session: desktop, backends:
+  [spectacle]}. Nothing ever re-evaluated it, so for the rest of the agent's
+  uptime every capture fired `spectacle` (a KDE desktop tool) at a gamescope
+  session. spectacle wrote no file, so /api/screen/frame returned
+  503 "capture failed" forever and the app's SCREEN card sat on "capturing...".
+
+  Verified by hand on the box: spectacle -> no file; gamescopectl -> a 357KB
+  PNG. Restarting the service (with gamescope already up) flipped
+  /api/screen to {session: gamescope, backends: [gamescopectl, spectacle]} and
+  /api/screen/frame to 200 image/jpeg.
+
+  It presented as "screen capture works sometimes" because whether it worked
+  depended entirely on which of the agent and the Steam session won the boot
+  race. That is why the fix is re-evaluation per call, and why these tests
+  drive the socket set CHANGING after startup rather than only checking a
+  correct startup.
+
+Pure stdlib, no pytest -- same style as the other agent tests.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def _install(sockets, tools=("gamescopectl", "spectacle"), downscaler=True):
+    """Point the agent at a fake compositor socket set + tool set, then run the
+    real startup detection. Returns a restore callable."""
+    o_socks, o_which, o_dscale = (cs._wayland_display_sockets, cs.shutil.which,
+                                  cs._screen_downscaler)
+    box = {"sockets": list(sockets)}
+
+    cs._wayland_display_sockets = lambda: list(box["sockets"])
+    cs.shutil.which = lambda n: ("/usr/bin/" + n) if n in tools else None
+    if downscaler:
+        cs._screen_downscaler = lambda: ((lambda src, dst: ["true", src, dst]), "fake")
+    else:
+        cs._screen_downscaler = lambda: (None, None)
+    cs.set_screen(False)
+
+    def restore():
+        cs._wayland_display_sockets, cs.shutil.which = o_socks, o_which
+        cs._screen_downscaler = o_dscale
+    return box, restore
+
+
+def test_session_appearing_after_startup():
+    print("compositor that starts AFTER the agent (the boot race)")
+    box, restore = _install([])          # agent boots first: no compositor yet
+    try:
+        live = cs._screen_live()
+        check(live is not None, "desktop-only start still offers a backend")
+        check(live["session"] == "desktop", "no gamescope socket -> desktop")
+        check(live["backends"] == ["spectacle"], "desktop start selects spectacle")
+
+        # Game Mode comes up a minute later. THIS is what used to be missed.
+        box["sockets"] = ["gamescope-0"]
+        live = cs._screen_live()
+        check(live["session"] == "gamescope",
+              "session re-detected as gamescope without a restart")
+        check(live["backends"][0] == "gamescopectl",
+              "gamescopectl preferred once its socket exists (the regression)")
+        check(live["gs_socket"] == "gamescope-0",
+              "WAYLAND_DISPLAY target follows the live socket")
+    finally:
+        restore()
+
+
+def test_session_disappearing():
+    print("compositor that goes away (Game Mode -> desktop)")
+    box, restore = _install(["gamescope-0"])
+    try:
+        check(cs._screen_live()["backends"][0] == "gamescopectl",
+              "starts on gamescopectl")
+        box["sockets"] = []
+        live = cs._screen_live()
+        check(live["session"] == "desktop", "falls back to desktop")
+        check("gamescopectl" not in live["backends"],
+              "gamescopectl dropped with its socket (never grabs a dead socket)")
+        check(live["gs_socket"] is None, "stale socket path cleared")
+    finally:
+        restore()
+
+
+def test_env_targets_live_socket():
+    print("capture env follows the live socket")
+    box, restore = _install([])
+    try:
+        box["sockets"] = ["gamescope-1"]
+        env = cs._screen_env(cs._screen_live())
+        check(env.get("WAYLAND_DISPLAY") == "gamescope-1",
+              "WAYLAND_DISPLAY points at the current compositor")
+    finally:
+        restore()
+
+
+def test_probe_and_appear_preserved():
+    print("probe-and-appear: a box that cannot capture stays hidden")
+    # No downscaler at all -> the card must never appear, however many
+    # compositors show up later.
+    box, restore = _install(["gamescope-0"], downscaler=False)
+    try:
+        check(cs._SCREEN is None, "no downscaler -> no capability at startup")
+        check(cs._screen_live() is None, "and none later either")
+        check(cs.screen_info() is None, "/api/screen 404s (card hidden)")
+    finally:
+        restore()
+
+    # Tools present, downscaler present, but no compositor AND no desktop tool:
+    # nothing can grab right now, so the card hides until something can.
+    box, restore = _install([], tools=("gamescopectl",))
+    try:
+        check(cs._screen_live() is None,
+              "gamescopectl installed but no socket -> nothing to capture")
+        check(cs.screen_info() is None, "card hidden while unusable")
+        box["sockets"] = ["gamescope-0"]
+        check(cs.screen_info() is not None,
+              "card appears once the compositor is up (no restart needed)")
+    finally:
+        restore()
+
+
+def test_no_tools():
+    print("degrades safely")
+    box, restore = _install(["gamescope-0"], tools=())
+    try:
+        check(cs._SCREEN is None, "no capture tool -> no capability")
+        check(cs._screen_live() is None, "no raise, just unavailable")
+    finally:
+        restore()
+
+
+if __name__ == "__main__":
+    test_session_appearing_after_startup()
+    test_session_disappearing()
+    test_env_targets_live_socket()
+    test_probe_and_appear_preserved()
+    test_no_tools()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all screen-capture tests passed")


### PR DESCRIPTION
Screen capture silently stops working on a box whose agent starts before its Steam session does. Reported from the field, reproduced, root-caused, and fixed.

## Root cause

`set_screen()` decided the session and backend **once, at startup**.

Measured on `lenovodesktop` (agent 2.9.31):

| event | time |
|---|---|
| `couchside.service` up | 09:34:26 |
| `gamescope-0` socket created | 09:35 |

The agent had already cached `{session: desktop, backends: [spectacle]}` and never re-evaluated it. For the rest of its uptime it fired **spectacle — a KDE desktop tool — at a gamescope session**. spectacle writes no file, so `real_screen_frame()` returned `None` and `/api/screen/frame` answered `503 {"error": "capture failed"}` indefinitely. The app's SCREEN card sat on "capturing…".

It presented as *"capture works sometimes"* because whether it worked depended entirely on which of the agent and the Steam session won the boot race.

## Confirmed on the box, both directions

| test | result |
|---|---|
| `spectacle -b -n -o …` (what the agent was using) | **no file** |
| `gamescopectl screenshot …` (what it should use) | **357,149-byte PNG** |

Restarting the service with gamescope already up flipped `/api/screen` from `{session: desktop, backends: [spectacle]}` to `{session: gamescope, backends: [gamescopectl, spectacle]}`, and `/api/screen/frame` from 503 to `200 image/jpeg`.

## The fix

`set_screen()` now caches only what is genuinely static — the downscaler and which capture binaries exist. Binaries do not come and go at runtime; compositors do.

`_screen_live()` resolves the current compositor and usable backends **per call**. Cost is one `listdir`, and callers are already rate-limited to ~2 captures/sec by the existing 500ms frame cache. `screen_info()` and the startup banner report the live view, so `/api/screen` describes what would actually be grabbed right now.

**Probe-and-appear is preserved in both directions.** A box with no downscaler or no capture tool still reports nothing and the card stays hidden. A box whose compositor appears later now *gains* the card without a restart, instead of being stuck hidden until someone notices.

## Verification

- **New tests drive the socket set changing after startup** — the only shape that catches this. A test that merely checks a correct startup passes against the bug.
- **Control run:** reverted to startup-frozen detection and re-ran — the new tests fail. So they genuinely bite.
- **End to end on the real box:** patched agent on spare port 8788 returned a 57KB JPEG (the running Donut County session). Test agent cleaned up, port freed.
- Existing `test_stream_host`, `test_gaming_card`, `test_steamlink` still pass.

Wired into CI as `Unit tests (screen capture)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)