### PR TITLE
feat(stream): show which stream hosts are actually online

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,17 @@ jobs:
       - name: Unit tests (steam link / remote play)
         run: python3 tests/test_steamlink.py
 
+      # Stream-host liveness (the `online` field). remoteclients.vdf lists every
+      # host ever streamed from and says nothing about which are ON, so picking a
+      # game from a sleeping PC makes Steam offer a multi-GB install instead.
+      # Detection joins on the 64-bit Steam CLIENT ID (a box keeps it across a
+      # rename) and reads a STATE out of Steam's own remote-connections log --
+      # beacon recency alone was measured unusable (median gap 9s but p99 2725s).
+      # Fixtures are relative to now; a dated fixture plus an age cap is a time
+      # bomb, which this repo has already paid for once.
+      - name: Unit tests (stream host liveness)
+        run: python3 tests/test_stream_online.py
+
       # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
       # dir must not be read as a GPU), the reaper AppId matcher incl. the
       # [oom_reaper] reject, the empty-power_supply desktop case + the uniq (never

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -2965,6 +2965,145 @@ def _remoteclients_path():
     return p if os.path.isfile(p) else None
 
 
+# --- stream-host liveness ---------------------------------------------------
+#
+# remoteclients.vdf lists every host this box has EVER streamed from and says
+# nothing about which are on now. Picking a game from a host that is off makes
+# Steam fall back to "play locally" and offer a multi-GB INSTALL, which reads as
+# a Couchside bug when it is really "that PC is off".
+#
+# The signal is Steam's own logs/remote_connections.txt. Steam already receives
+# the LAN discovery beacons and writes them down with the client id, so the
+# agent never has to touch the network -- no probing, no port scan, no mDNS.
+#
+# MEASURED on two boxes (2026-07-20) before choosing the rule:
+#   * Beacon recency ALONE is not usable. Beacons are bursty: median gap 9s but
+#     p99 2725s, and 5.4% of gaps within an active stretch exceed 15 minutes.
+#     Any tight freshness window flickers a present host to "offline".
+#   * The lifecycle lines ("Client <id> (<host>) connected|disconnected") are a
+#     STATE, and that state matched every host whose truth was independently
+#     known: two live boxes read `connected` (1m, 6m), while the asleep Steam
+#     Deck from the original report read `disconnected` 12h, and a machine gone
+#     for a month read `disconnected` 28d.
+#   * IP-derived evidence was rejected: a beacon's address field is sometimes
+#     the client id rather than an IP, ARP reads FAILED for hosts that are live
+#     over a relay, and the "peer" holding a connection is frequently the
+#     ROUTER (the same trap already documented for stream-host detection).
+#
+# A host that loses power abruptly may never log `disconnected` -- the same
+# missing-stop-marker shape as streaming_log.txt. So `connected` is paired with
+# a staleness cap, and `last_seen` is always reported so the app can say "last
+# seen 12h ago" instead of asserting something it cannot know.
+_REMOTE_LOG_MAX_BYTES = 4 * 1024 * 1024   # tail cap: this log reaches MBs
+STREAM_HOST_STALE_S = 2 * 3600            # `connected` older than this = unknown
+_RX_REMOTE_LIFECYCLE = re.compile(
+    r"^\[(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)\].*?"
+    r"Client (\d+) \(([^)]*)\) (connected|disconnected)")
+_RX_REMOTE_BEACON = re.compile(
+    r"^\[(\d{4}-\d\d-\d\d \d\d:\d\d:\d\d)\].*?"
+    r"broadcast message from client (\d+) \(([^)]*)\)")
+
+
+def _remote_log_path():
+    root = _steam_root()
+    if root is None:
+        return None
+    p = os.path.join(root, "logs", "remote_connections.txt")
+    return p if os.path.isfile(p) else None
+
+
+def _remote_log_epoch(stamp):
+    """Unix seconds from a 'YYYY-MM-DD HH:MM:SS' log stamp, else None. Steam
+    writes local time, so this parses as local time (mktime), matching
+    _stream_line_epoch."""
+    try:
+        return int(time.mktime(time.strptime(stamp, "%Y-%m-%d %H:%M:%S")))
+    except (ValueError, OverflowError):
+        return None
+
+
+def remote_client_liveness():
+    """{client_id: {"state": "connected"|"disconnected"|None, "state_at": int,
+    "last_seen": int, "host": str}} from Steam's remote-connections log.
+
+    Reads only the TAIL: the log runs to megabytes and only the newest events
+    matter. Never raises -- a box with no log simply yields {}."""
+    path = _remote_log_path()
+    if path is None:
+        return {}
+    try:
+        size = os.path.getsize(path)
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            if size > _REMOTE_LOG_MAX_BYTES:
+                f.seek(size - _REMOTE_LOG_MAX_BYTES)
+                f.readline()             # discard the partial first line
+            lines = f.readlines()
+    except OSError:
+        return {}
+
+    out = {}
+
+    def touch(cid, host, when):
+        e = out.setdefault(cid, {"state": None, "state_at": 0, "last_seen": 0,
+                                 "host": host})
+        if when > e["last_seen"]:
+            e["last_seen"] = when
+        # Newest hostname wins: a box keeps its id across a rename.
+        if host and when >= e.get("_host_at", 0):
+            e["host"], e["_host_at"] = host, when
+        return e
+
+    for line in lines:
+        m = _RX_REMOTE_LIFECYCLE.match(line)
+        if m:
+            when = _remote_log_epoch(m.group(1))
+            if when is None:
+                continue
+            e = touch(m.group(2), m.group(3), when)
+            if when >= e["state_at"]:
+                e["state"], e["state_at"] = m.group(4), when
+            continue
+        m = _RX_REMOTE_BEACON.match(line)
+        if m:
+            when = _remote_log_epoch(m.group(1))
+            if when is not None:
+                touch(m.group(2), m.group(3), when)
+    for e in out.values():
+        e.pop("_host_at", None)
+    return out
+
+
+def stream_host_online(entry, now=None):
+    """(online: bool, reason: str) for one remote_client_liveness() entry.
+
+    `online` is deliberately conservative. Dimming a host that is actually up
+    costs the user one tap; calling a host up when it is not is what makes
+    Steam offer a multi-gigabyte install, so ambiguity resolves to offline."""
+    now = int(time.time()) if now is None else now
+    if not entry:
+        return False, "never seen on this network"
+    age = max(0, now - int(entry.get("last_seen") or 0))
+    if entry.get("state") == "connected":
+        if now - int(entry.get("state_at") or 0) <= STREAM_HOST_STALE_S:
+            return True, "connected"
+        return False, "no response in %s" % _short_ago(age)
+    if entry.get("state") == "disconnected":
+        return False, "offline (last seen %s ago)" % _short_ago(age)
+    return False, "last seen %s ago" % _short_ago(age)
+
+
+def _short_ago(seconds):
+    """Compact age for a user-facing reason string: 45s / 12m / 3h / 5d."""
+    s = max(0, int(seconds))
+    if s < 90:
+        return "%ds" % s
+    if s < 5400:
+        return "%dm" % (s // 60)
+    if s < 172800:
+        return "%dh" % (s // 3600)
+    return "%dd" % (s // 86400)
+
+
 def _vdf_line_val(line):
     """The VALUE of a `"key"  "value"` text-VDF line (the last quoted token), or
     None. Used for remoteclients.vdf, which has no nesting we care about."""
@@ -2977,16 +3116,29 @@ def _vdf_line_val(line):
 
 
 def _parse_remoteclients(text):
-    """[{host, last, apps:[appid_str,...]}] from a remoteclients.vdf blob. Text
-    line-scan (pure-stdlib agent, no VDF parser). Best-effort; [] on trouble."""
+    """[{host, cid, last, apps:[appid_str,...]}] from a remoteclients.vdf blob.
+    Text line-scan (pure-stdlib agent, no VDF parser). Best-effort; [] on trouble.
+
+    `cid` is the 64-bit Steam client id -- the map KEY each host block hangs
+    off, which earlier revisions read past. It matters because it is the same
+    id Steam writes in logs/remote_connections.txt, so host liveness can be
+    joined on an exact id instead of a hostname string (a box can be renamed
+    while keeping its id -- observed: bazzite -> lenovodesktop)."""
     hosts = []
     cur = None
     in_apps = False
+    pending_cid = None
     for raw in text.splitlines():
         s = raw.strip()
+        # A bare quoted run of digits at block level is a client id key.
+        if (not in_apps and len(s) > 2 and s[0] == '"' and s[-1] == '"'
+                and s[1:-1].isdigit()):
+            pending_cid = s[1:-1]
         if s.startswith('"hostname"'):
-            cur = {"host": _vdf_line_val(s) or "", "last": 0, "apps": []}
+            cur = {"host": _vdf_line_val(s) or "", "cid": pending_cid or "",
+                   "last": 0, "apps": []}
             hosts.append(cur)
+            pending_cid = None
             in_apps = False
         elif cur is not None and s.startswith('"lastupdated"'):
             try:
@@ -3022,9 +3174,9 @@ def discover_stream_games():
             for a in h["apps"]:
                 prev = best.get(a)
                 if prev is None or h["last"] > prev[0]:
-                    best[a] = (h["last"], h["host"])
+                    best[a] = (h["last"], h["host"], h.get("cid", ""))
         out = []
-        for a, (last, host) in best.items():
+        for a, (last, host, cid) in best.items():
             name = names.get(int(a), "")
             if _is_steam_tool(a, name):
                 continue
@@ -3034,6 +3186,7 @@ def discover_stream_games():
                 "kind": "stream",
                 "appid": int(a),
                 "host": host,
+                "cid": cid,
                 "last": last,
             })
         out.sort(key=lambda l: (l["label"].lower(), l["appid"]))
@@ -3064,12 +3217,23 @@ def steamlink_info():
     by_host = {}
     for g in games:
         by_host.setdefault(g["host"], {"host": g["host"], "last": g["last"],
-                                       "games": []})
+                                       "cid": g.get("cid", ""), "games": []})
         by_host[g["host"]]["games"].append(
             {"appid": g["appid"], "label": g["label"]})
     hosts = sorted(by_host.values(), key=lambda h: h["last"], reverse=True)
+
+    # Liveness, joined on the Steam client id (never the hostname -- a box can
+    # be renamed and keep its id). Read once for all hosts, not per host.
+    live = remote_client_liveness()
+    now = int(time.time())
     for h in hosts:
         h["games"].sort(key=lambda g: g["label"].lower())
+        entry = live.get(h.get("cid") or "")
+        online, reason = stream_host_online(entry, now)
+        h["online"] = online
+        h["reason"] = reason
+        h["last_seen"] = int(entry.get("last_seen") or 0) if entry else 0
+        h.pop("cid", None)               # internal join key, not app-facing
     return {"available": bool(games), "hosts": hosts}
 
 
@@ -8698,6 +8862,38 @@ def mock_stream_host():
             "client": "macOS", "since": int(time.time()) - 725}
 
 
+def mock_steamlink():
+    """Stream hosts in EVERY liveness state at once.
+
+    /api/steamlink previously had no mock branch, so under --mock it ran the
+    real detector against the dev machine's filesystem, found no Steam, and
+    404'd -- while set_caps(mock) advertised steamlink: True. The offline-host
+    UI was therefore impossible to exercise in the web harness, which is
+    exactly the surface it needed testing on.
+
+    Covers all four states the app must render: online, cleanly offline, a host
+    that stopped responding without ever disconnecting, and one never seen."""
+    now = int(time.time())
+    return {"available": True, "hosts": [
+        {"host": "emery-pc", "last": now - 900, "online": True,
+         "reason": "connected", "last_seen": now - 42,
+         "games": [{"appid": 3164500, "label": "Schedule I"},
+                   {"appid": 1174180, "label": "Red Dead Redemption 2"},
+                   {"appid": 271590, "label": "Grand Theft Auto V"}]},
+        {"host": "taylor-steamdeck", "last": now - 44536, "online": False,
+         "reason": "offline (last seen 12h ago)", "last_seen": now - 44536,
+         "games": [{"appid": 33230, "label": "Assassin's Creed II"},
+                   {"appid": 220, "label": "Half-Life 2"}]},
+        {"host": "steamdeck", "last": now - 7893, "online": False,
+         "reason": "no response in 2h", "last_seen": now - 7893,
+         "games": [{"appid": 1086940, "label": "Baldur's Gate 3"}]},
+        {"host": "DESKTOP-MAGJDDS", "last": now - 2420082, "online": False,
+         "reason": "never seen on this network", "last_seen": 0,
+         "games": [{"appid": 228980, "label": "Steamworks Common Redistributables"},
+                   {"appid": 3041230, "label": "Silksong"}]},
+    ]}
+
+
 # ---------------------------------------------------------------------------
 # Minimal RFC6455 WebSocket support (server side, no fragmentation)
 # ---------------------------------------------------------------------------
@@ -9765,7 +9961,7 @@ class Handler(BaseHTTPRequestHandler):
                 # appear: 404 when no host has ever been streamed from (nothing
                 # to offer) so the app hides the "Stream from PC" surface. Launch
                 # is the existing POST /api/launchers/stream:<appid>.
-                info = steamlink_info()
+                info = mock_steamlink() if self.mock else steamlink_info()
                 if info["available"]:
                     self._send(200, info, started)
                 else:

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -37,6 +37,7 @@ import {
   SteamLink,
 } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -266,6 +267,13 @@ function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
  * app to install. Probe-and-appear: the parent renders this only when the box
  * reports at least one host. Covers aren't shown (host-only games have no local
  * capsule), so it's a compact list rather than the cover grid below.
+ *
+ * Hosts the box reports as OFF are demoted, not removed: picking a game from an
+ * asleep PC makes Steam quietly fall back to "play locally" and offer a
+ * multi-GB install (measured: Assassin's Creed II, 6 GB, from a sleeping Deck),
+ * which reads as a Couchside bug rather than "that PC is off". The agent's
+ * check is deliberately conservative, so a dimmed host stays tappable — the
+ * user may well know better than we do.
  */
 function SteamLinkSection({
   data,
@@ -276,53 +284,91 @@ function SteamLinkSection({
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
-  // Expand the most-recently-seen host by default; the rest start collapsed.
-  const [expanded, setExpanded] = useState<Record<string, boolean>>(() =>
-    data.hosts.length ? { [data.hosts[0].host]: true } : {},
-  );
+  const hideOffline = usePref('hideOfflineStreamHosts');
+  // Expand the freshest host by default, preferring one that's actually up.
+  // `online` is absent on agents older than 2.9.32, and undefined !== false, so
+  // those fall through to hosts[0] — exactly the old behaviour.
+  const [expanded, setExpanded] = useState<Record<string, boolean>>(() => {
+    const first = data.hosts.find((h) => h.online !== false) ?? data.hosts[0];
+    return first ? { [first.host]: true } : {};
+  });
   if (data.hosts.length === 0) return null;
+  const hosts = hideOffline ? data.hosts.filter((h) => h.online !== false) : data.hosts;
   return (
     <View style={styles.dlCard}>
       <View style={styles.dlHeader}>
         <Ionicons name="tv-outline" size={14} color={t.blue} />
         <Text style={styles.dlHeaderText}>STREAM FROM PC</Text>
       </View>
-      <Text style={styles.slHint}>
-        Play a game from another Steam PC on your network. Make sure it&rsquo;s powered on and
-        running Steam.
-      </Text>
-      {data.hosts.map((h, i) => {
-        const open = !!expanded[h.host];
-        return (
-          <View key={h.host} style={i > 0 ? styles.dlHeaderGap : undefined}>
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setExpanded((e) => ({ ...e, [h.host]: !e[h.host] }));
-              }}
-              style={({ pressed }) => [styles.slHostHeader, pressed && styles.pressed]}>
-              <Ionicons name="desktop-outline" size={14} color={t.textDim} />
-              <Text style={styles.slHostName} numberOfLines={1}>
-                {h.host}
-              </Text>
-              <Text style={styles.slHostCount}>{h.games.length}</Text>
-              <Ionicons name={open ? 'chevron-up' : 'chevron-down'} size={14} color={t.textDim} />
-            </Pressable>
-            {open &&
-              h.games.map((g) => (
+      {hosts.length === 0 ? (
+        // Every host was filtered out by the pref. Say so — a card that just
+        // vanished looks like the feature broke.
+        <Text style={styles.slHint}>
+          {data.hosts.length} offline {data.hosts.length === 1 ? 'host is' : 'hosts are'} hidden by
+          your &ldquo;Hide offline stream hosts&rdquo; setting.
+        </Text>
+      ) : (
+        <>
+          <Text style={styles.slHint}>
+            Play a game from another Steam PC on your network. Make sure it&rsquo;s powered on and
+            running Steam.
+          </Text>
+          {hosts.map((h, i) => {
+            const open = !!expanded[h.host];
+            const off = h.online === false;
+            return (
+              <View key={h.host} style={i > 0 ? styles.dlHeaderGap : undefined}>
                 <Pressable
-                  key={g.appid}
-                  onPress={() => onStream(g.appid, g.label)}
-                  style={({ pressed }) => [styles.slGameRow, pressed && styles.pressed]}>
-                  <Ionicons name="play-circle" size={16} color={t.blue} />
-                  <Text style={styles.slGameName} numberOfLines={1}>
-                    {g.label}
+                  onPress={() => {
+                    hapticLight();
+                    setExpanded((e) => ({ ...e, [h.host]: !e[h.host] }));
+                  }}
+                  style={({ pressed }) => [styles.slHostHeader, pressed && styles.pressed]}>
+                  <Ionicons
+                    name="desktop-outline"
+                    size={14}
+                    color={off ? t.textFaint : t.textDim}
+                  />
+                  <View style={styles.slHostBody}>
+                    <Text style={[styles.slHostName, off && styles.slDimText]} numberOfLines={1}>
+                      {h.host}
+                    </Text>
+                    {off && h.reason ? (
+                      // The agent writes this already user-facing ("no response
+                      // in 66m") — never reword or prefix it here.
+                      <Text style={styles.slHostReason} numberOfLines={1}>
+                        {h.reason}
+                      </Text>
+                    ) : null}
+                  </View>
+                  <Text style={[styles.slHostCount, off && styles.slFaintText]}>
+                    {h.games.length}
                   </Text>
+                  <Ionicons
+                    name={open ? 'chevron-up' : 'chevron-down'}
+                    size={14}
+                    color={off ? t.textFaint : t.textDim}
+                  />
                 </Pressable>
-              ))}
-          </View>
-        );
-      })}
+                {open &&
+                  h.games.map((g) => (
+                    <Pressable
+                      key={g.appid}
+                      onPress={() => onStream(g.appid, g.label)}
+                      style={({ pressed }) => [styles.slGameRow, pressed && styles.pressed]}>
+                      <Ionicons name="play-circle" size={16} color={off ? t.textDim : t.blue} />
+                      <Text
+                        style={[styles.slGameName, off && styles.slDimText]}
+                        numberOfLines={1}>
+                        {g.label}
+                      </Text>
+                    </Pressable>
+                  ))}
+              </View>
+            );
+          })}
+        </>
+      )}
     </View>
   );
 }
@@ -798,8 +844,14 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   // Steam Remote Play "Stream from PC"
   slHint: { color: t.textFaint, fontSize: 12, lineHeight: 17, marginTop: -4 },
   slHostHeader: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 6 },
-  slHostName: { color: t.text, fontSize: 14, fontWeight: '700', fontFamily: mono, flex: 1 },
+  slHostBody: { flex: 1 },
+  slHostName: { color: t.text, fontSize: 14, fontWeight: '700', fontFamily: mono },
   slHostCount: { color: t.textDim, fontSize: 12, fontFamily: mono },
+  slHostReason: { color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 2 },
+  // Offline hosts are demoted a step, like QueuedRow — no opacity wrapper, so
+  // the row still reads as tappable (it is: the check is advisory only).
+  slDimText: { color: t.textDim },
+  slFaintText: { color: t.textFaint },
   slGameRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -656,6 +656,7 @@ function SetupBody() {
   const padHints = usePref('padHints');
   const askToSwitchControl = usePref('askToSwitchControl');
   const volumeButtons = usePref('volumeButtons');
+  const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -1340,6 +1341,21 @@ function SetupBody() {
                 value={volumeButtons}
                 onValueChange={(v) => {
                   void setPref('volumeButtons', v);
+                  hapticSelection();
+                }}
+              />
+            </View>
+
+            {/* The box's offline check is conservative and will sometimes call a
+                live PC offline, so dimming is the default and hiding is opt-in. */}
+            <View style={styles.card}>
+              <CardHeader icon="tv-outline" label="STREAM FROM PC" />
+              <TogglePref
+                label="Hide offline stream hosts"
+                sub="Offline PCs are dimmed with the reason shown, and stay tappable. Turn this on to drop them from the Launch tab's stream list entirely."
+                value={hideOfflineStreamHosts}
+                onValueChange={(v) => {
+                  void setPref('hideOfflineStreamHosts', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -333,6 +333,19 @@ export type StreamHost = {
   /** Unix seconds the box last saw this host (newest first in the list). */
   last: number;
   games: StreamGame[];
+  /**
+   * Whether the host looks reachable right now (agent >= 2.9.32). Absent on
+   * older agents — treat undefined as "unknown", NOT offline, so they render
+   * exactly as before. Deliberately conservative: ambiguity resolves to false,
+   * so a false here is advisory (dim + explain), never a reason to disable the
+   * row. Streaming from an off host is what makes Steam fall back to "play
+   * locally" and offer a multi-GB install, which reads as a Couchside bug.
+   */
+  online?: boolean;
+  /** Short, already user-facing explanation of `online` ("no response in 66m"). */
+  reason?: string;
+  /** Unix seconds Steam itself last saw the host; 0 when it never has. */
+  last_seen?: number;
 };
 export type SteamLink = { available: boolean; hosts: StreamHost[] };
 

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -50,6 +50,11 @@ export type Prefs = {
       volume HUD can't be suppressed and repurposing the buttons is App-Review
       risky (opt-in, experimental). */
   volumeButtons: boolean;
+  /** Drop hosts the box reports as offline from the Launch tab's "Stream from
+      PC" list entirely, rather than dimming them. Off by default: the online
+      check is conservative and does call a live host offline, so the row stays
+      visible and tappable unless you ask for it gone. Agent >= 2.9.32. */
+  hideOfflineStreamHosts: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -70,6 +75,7 @@ export const DEFAULTS: Prefs = {
   // Android intercepts the keycode cleanly (no HUD); iOS can't, so it stays off
   // until the user opts in.
   volumeButtons: Platform.OS === 'android',
+  hideOfflineStreamHosts: false,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -147,6 +153,7 @@ function normalize(raw: unknown): Prefs {
     padHints: bool(o.padHints, DEFAULTS.padHints),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
+    hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),
   };
 }
 

--- a/tests/test_stream_online.py
+++ b/tests/test_stream_online.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Tests for stream-host liveness (the `online` field on GET /api/steamlink).
+
+Run: python3 tests/test_stream_online.py
+
+WHY THIS EXISTS: remoteclients.vdf lists every host this box has EVER streamed
+from and says nothing about which are on now. Picking a game from a host that is
+off makes Steam fall back to "play locally" and offer a multi-GB INSTALL
+(observed: 6 GB, from an asleep Steam Deck), which reads as a Couchside bug when
+it is really "that PC is off".
+
+WHAT WAS MEASURED before choosing the rule (two live boxes, 2026-07-20):
+  * The join key is the 64-bit Steam CLIENT ID, not the hostname. It is the map
+    key in remoteclients.vdf and the id Steam writes in remote_connections.txt.
+    A box keeps its id across a rename -- one box in the sample appears as both
+    "bazzite" and "lenovodesktop" in the same log.
+  * Beacon recency ALONE is unusable: beacons are bursty, median gap 9s but p99
+    2725s, and 5.4% of gaps inside an active stretch exceed 15 minutes. Any
+    tight freshness window flickers a present host to "offline".
+  * The lifecycle lines are a STATE and matched every independently-known truth:
+    two live boxes read `connected`, the asleep Deck from the bug report read
+    `disconnected` 12h, a machine gone a month read `disconnected` 28d.
+  * A host that loses power abruptly may never log `disconnected` -- the same
+    missing-stop-marker shape as streaming_log.txt -- so `connected` is paired
+    with a staleness cap.
+
+FIXTURE TIMESTAMPS ARE RELATIVE TO NOW, NEVER LITERAL DATES. A dated fixture
+plus an age cap is a time bomb: it passes until wall-clock drifts past the
+threshold, then fails on every branch with no code change. That already cost a
+day's debugging on this repo (see tests/test_stream_host.py).
+
+Pure stdlib, no pytest -- same style as the other agent tests.
+"""
+import importlib.util
+import os
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+NOW = int(time.time())
+
+
+def stamp(ago):
+    return time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(NOW - ago))
+
+
+# Line shapes copied verbatim from a live box's remote_connections.txt.
+def beacon(ago, cid, host, addr=None):
+    return ("[%s] Received broadcast message from client %s (%s): %s:27036\n"
+            % (stamp(ago), cid, host, addr or ("10.0.0.5")))
+
+
+def life(ago, cid, host, what, extra=""):
+    if what == "connected":
+        return ("[%s] Client %s (%s) connected via direct connection\n"
+                % (stamp(ago), cid, host))
+    return ("[%s] Client %s (%s) disconnected: %s\n"
+            % (stamp(ago), cid, host, extra or "disconnect callback: I/O Operation Failed"))
+
+
+def with_log(text):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "remote_connections.txt")
+    with open(p, "w") as f:
+        f.write(text)
+    cs._remote_log_path = lambda: p
+    return p
+
+
+def test_lifecycle_state():
+    print("lifecycle state decides online")
+    o = cs._remote_log_path
+    try:
+        with_log(
+            beacon(400, "111", "live-box")
+            + life(300, "111", "live-box", "connected")
+            + life(3600, "222", "dead-box", "disconnected")
+            + beacon(3700, "222", "dead-box"))
+        live = cs.remote_client_liveness()
+        check(set(live) == {"111", "222"}, "both client ids parsed")
+
+        on, why = cs.stream_host_online(live["111"], NOW)
+        check(on is True, "a connected host reads online")
+        check(why == "connected", "reason names the state")
+
+        on, why = cs.stream_host_online(live["222"], NOW)
+        check(on is False, "a disconnected host reads offline")
+        check("last seen" in why, "reason carries a last-seen age")
+    finally:
+        cs._remote_log_path = o
+
+
+def test_beacon_recency_does_not_override():
+    print("a fresh beacon does NOT resurrect a disconnected host")
+    o = cs._remote_log_path
+    try:
+        # Disconnected 10 minutes ago, but still beaconing seconds ago. Steam
+        # keeps announcing itself; that is presence on the wire, not a usable
+        # host, and the whole point is to not promise a stream we cannot give.
+        with_log(life(600, "333", "flapper", "disconnected")
+                 + beacon(5, "333", "flapper"))
+        live = cs.remote_client_liveness()
+        on, _ = cs.stream_host_online(live["333"], NOW)
+        check(on is False, "beacon after a disconnect stays offline")
+        check(live["333"]["last_seen"] >= NOW - 10, "but last_seen tracks the beacon")
+    finally:
+        cs._remote_log_path = o
+
+
+def test_stale_connected_is_not_trusted():
+    print("a host that died without logging a disconnect")
+    o = cs._remote_log_path
+    try:
+        # Yanked power: the last thing ever written is `connected`. Without a
+        # staleness cap this host stays "online" forever and Steam offers the
+        # multi-GB install.
+        with_log(life(cs.STREAM_HOST_STALE_S + 600, "444", "yanked", "connected"))
+        live = cs.remote_client_liveness()
+        on, why = cs.stream_host_online(live["444"], NOW)
+        check(on is False, "stale `connected` is not trusted past the cap")
+        check("no response" in why, "reason says it stopped responding")
+
+        # Just inside the cap it is still trusted.
+        with_log(life(cs.STREAM_HOST_STALE_S - 600, "444", "yanked", "connected"))
+        live = cs.remote_client_liveness()
+        on, _ = cs.stream_host_online(live["444"], NOW)
+        check(on is True, "inside the cap it still counts as online")
+    finally:
+        cs._remote_log_path = o
+
+
+def test_rename_keeps_identity():
+    print("a renamed box keeps its client id")
+    o = cs._remote_log_path
+    try:
+        with_log(life(9000, "555", "old-name", "connected")
+                 + life(120, "555", "new-name", "connected"))
+        live = cs.remote_client_liveness()
+        check(list(live) == ["555"], "one identity, not two")
+        check(live["555"]["host"] == "new-name", "newest hostname wins")
+    finally:
+        cs._remote_log_path = o
+
+
+def test_unknown_and_missing():
+    print("hosts with no history, and no log at all")
+    o = cs._remote_log_path
+    try:
+        on, why = cs.stream_host_online(None, NOW)
+        check(on is False, "a host absent from the log is not called online")
+        check("never" in why, "reason says it was never seen")
+
+        cs._remote_log_path = lambda: None
+        check(cs.remote_client_liveness() == {}, "no log -> {}, no raise")
+    finally:
+        cs._remote_log_path = o
+
+
+def test_vdf_client_id_is_captured():
+    print("the vdf join key")
+    text = '''"RemoteClientCache"
+{
+\t"13928384185804371762"
+\t{
+\t\t"hostname"\t\t"MacBook-Pro-M2-4"
+\t\t"lastupdated"\t\t"1784558649"
+\t\t"apps"
+\t\t{
+\t\t\t"0"\t\t"220"
+\t\t}
+\t}
+}
+'''
+    hosts = cs._parse_remoteclients(text)
+    check(len(hosts) == 1, "one host parsed")
+    check(hosts[0]["cid"] == "13928384185804371762",
+          "client id captured from the block key (was previously discarded)")
+    check(hosts[0]["host"] == "MacBook-Pro-M2-4", "hostname still parsed")
+    check(hosts[0]["apps"] == ["220"], "apps still parsed")
+    # An appid inside "apps" is also a bare quoted number: it must not be
+    # mistaken for the next block's client id.
+    check(all(h["cid"] != "220" for h in hosts), "an appid is never read as a client id")
+
+
+def test_log_tail_only():
+    print("a multi-megabyte log is not read whole")
+    o = cs._remote_log_path
+    try:
+        filler = ("[%s] Received broadcast message from client 999 (noise): "
+                  "10.0.0.9:27036\n" % stamp(90000)) * 40000
+        with_log(filler + life(60, "777", "recent", "connected"))
+        live = cs.remote_client_liveness()
+        check("777" in live, "the newest events are still seen past the tail cap")
+        on, _ = cs.stream_host_online(live["777"], NOW)
+        check(on is True, "and still resolve correctly")
+    finally:
+        cs._remote_log_path = o
+
+
+if __name__ == "__main__":
+    test_lifecycle_state()
+    test_beacon_recency_does_not_override()
+    test_stale_connected_is_not_trusted()
+    test_rename_keeps_identity()
+    test_unknown_and_missing()
+    test_vdf_client_id_is_captured()
+    test_log_tail_only()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all stream-online tests passed")


### PR DESCRIPTION
Closes the "picking a game from an offline PC offers a 6 GB install" problem (task #16).

Offline hosts are **dimmed with the reason shown**, plus a Setup → Prefs toggle **"Hide offline stream hosts"** (default off) for people who want them gone.

## Detection is passive — the box sends nothing

The open question was how to detect online at all: `remoteclients.vdf` carries only a hostname and a WAN `ippublic` that is identical for every host.

The answer was already on disk. **Steam receives the LAN discovery beacons itself and writes them, with the client id, to `logs/remote_connections.txt`.** No probing, no port scan, no mDNS — the agent reads its own filesystem.

## What was measured before choosing the rule

Two live boxes, before writing the detector:

- **The join key is the 64-bit Steam client id, not the hostname.** It is the map key in `remoteclients.vdf` (which the parser previously read straight past) and the same id in the log. A box keeps its id across a rename — one machine appears as both `bazzite` and `lenovodesktop` in the same log.
- **Beacon recency alone is unusable.** Median gap 9s but **p99 2725s**, and 5.4% of gaps *inside an active stretch* exceed 15 minutes. Any tight freshness window flickers a present host to "offline".
- **The lifecycle lines are a state**, and that state matched every host whose truth was independently known:

| host | reads | independently known |
|---|---|---|
| MacBook-Pro-M2-4 | `connected` 1m | Steam running on it |
| lenovodesktop | `connected` 6m | SSH session open to it |
| taylor-steamdeck | `disconnected` 12h | the asleep Deck from the report |
| DESKTOP-MAGJDDS | `disconnected` 28d | gone for a month |

- **IP-derived evidence was tried and rejected.** A beacon's address field is sometimes the client id rather than an IP; ARP reads `FAILED` for hosts that are live over a relay; and the "peer" holding a connection is frequently the **router** — the same trap already documented for stream-host detection.

## Deliberately conservative

A host that loses power abruptly may never log `disconnected` — the same missing-stop-marker shape as `streaming_log.txt` — so `connected` is paired with a 2h staleness cap.

The asymmetry drives the design: dimming a host that is actually up costs one tap, while calling a host up when it is not is exactly what triggers the multi-gigabyte install. Ambiguity resolves to offline, and `last_seen` is always reported so the UI can say "last seen 12h ago" instead of asserting what it cannot know.

**Offline hosts stay tappable.** Detection will sometimes be wrong and the user may know better; the dimming is advisory, not a lock.

## Old agents

`online` / `reason` / `last_seen` are optional. Against an agent that predates them the app behaves exactly as today — verified by serving a payload with the fields stripped and confirming all hosts render undimmed and unfiltered **even with the pref ON**.

## Mock data

`/api/steamlink` had no `--mock` branch, so under `--mock` it ran the real detector against the dev machine, found no Steam, and 404'd — while `set_caps(mock)` advertised `steamlink: True`. This UI was therefore impossible to exercise in the web harness. The mock now covers all four states.

## Verified by driving it, not screenshotting

- an offline host still **expands on tap**
- a game under an offline host still fires `POST /api/launchers/stream:33230` — Assassin's Creed II, the exact case from the report
- the Prefs toggle **writes the pref** and removes offline hosts from the list
- with every host offline, the card explains *"4 offline hosts are hidden by your 'Hide offline stream hosts' setting"* rather than rendering blank

New CI step `Unit tests (stream host liveness)`. Fixtures are anchored to `time.time()`, never literal dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)