### PR TITLE
chore(app): reconcile build numbers to 65/49 (as built for 2.9.12)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "64",
+      "buildNumber": "65",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 48
+      "versionCode": 49
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
`autoIncrement` rewrote `app.json` during the production build, so the repo said 64/48 while the shipped binaries were **iOS 65 / vc 49**.

Numbers read back out of the finished EAS builds rather than assumed:

| | value | commit |
|---|---|---|
| iOS build number | 65 | `6d51b5b` |
| Android versionCode | 49 | `6d51b5b` |

Both are live: **Play production 2.9.12** (vc 49, status `completed`, release notes verified by reading them back from Google) and **TestFlight build 65**.

Same reconciliation as #136 / #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)