### PR TITLE
chore: project constitution + memory system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,21 @@ app/play-service-account.json
 *service-account*.json
 app/asc-key.p8
 *.p8
+
+# --- AI build-method working files (local only) -------------------------------
+# This repo is PUBLIC. The constitution and the technical memory files
+# (ARCHITECTURE / CONVENTIONS / DEPENDENCIES) ARE tracked: they help anyone
+# reading a source-available project, and ARCHITECTURE.md carries file:line refs
+# that drift, so it needs version history.
+#
+# These three stay local to the maintainer's machine:
+#   docs/memory/KNOWN_ISSUES.md  a numbered registry of where this is soft. The
+#                                agent runs as the user's desktop account and can
+#                                reboot their machine; publishing a weakness map
+#                                for a LAN-exposed daemon is not a good trade.
+#   docs/memory/DECISIONS.md     internal rationale, candid about what was wrong.
+#   docs/BUILD_LOG.md            per-session journal, same.
+# CLAUDE.md section 2 marks them LOCAL so a fresh clone knows they exist.
+docs/memory/KNOWN_ISSUES.md
+docs/memory/DECISIONS.md
+docs/BUILD_LOG.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,205 @@
+# Couchside — Claude Instructions
+
+> **This file governs how you work, not what you build.**
+> Read it fully at the start of every session before touching any code.
+
+Couchside turns a phone into the dashboard, remote console, and game controller for a
+living-room Linux box (SteamOS / Bazzite / Steam Deck / any systemd machine). A native
+iOS + Android app talks to a dependency-free Python service on the box. LAN-only,
+token-authed, no cloud, no accounts, no analytics.
+
+---
+
+## ⛔ CRITICAL CONSTRAINT — READ BEFORE ANYTHING ELSE
+
+**The agent executes only what is on an explicit allowlist. Nothing a client sends ever
+becomes a command, a path, or a shell string.**
+
+The agent runs as the user's desktop account on their gaming machine. It can launch
+programs, switch sessions, reboot, and power off. It sits on a home LAN behind one bearer
+token. If a client can steer it to run something arbitrary, an attacker on that LAN owns
+the box — and the blast radius is somebody's personal computer, not a sandbox. There is no
+cloud tier to revoke, no account to lock: a shipped hole stays open until the user updates
+the agent themselves.
+
+**Treat every violation as a zero-tolerance bug.** If you are ever unsure whether code
+respects this, STOP and ask before writing or executing it.
+
+---
+
+## 1. Startup Sequence (run at the start of EVERY session)
+
+1. **Read all memory files** in `docs/memory/`. Create missing ones with sensible defaults.
+2. **Read `docs/ROADMAP.md`** — planned, in progress, done.
+3. **Read `docs/BUILD_LOG.md`** — what was last worked on, where things were left.
+4. **Scan the source area** you're about to touch — read existing files before creating new ones.
+5. **Identify the allowlist pattern** already used in that area (launcher ids, action ids,
+   menu ids, TV ops — each has one).
+6. **State your plan** in one short paragraph before writing code: what, which files, how it
+   fits existing patterns, how the allowlist constraint is maintained. Wait for confirmation
+   if anything is architecturally ambiguous.
+
+Note: `app/CLAUDE.md` carries an app-specific instruction (read the versioned Expo SDK 57
+docs before writing app code). It is not superseded by this file.
+
+## 2. Memory Files
+
+| Path | Contents |
+|------|----------|
+| `docs/memory/ARCHITECTURE.md` | Stack, directory layout, key patterns, integrations |
+| `docs/memory/CONVENTIONS.md` | Coding conventions, naming, test + PR + release rules |
+| `docs/memory/DEPENDENCIES.md` | Every meaningful dependency, version, why |
+| `docs/memory/DECISIONS.md` | **LOCAL — gitignored.** Append-only log of significant decisions |
+| `docs/memory/KNOWN_ISSUES.md` | **LOCAL — gitignored.** Numbered KI-### registry: bugs, limitations, debt |
+
+**Three files are deliberately untracked** (`docs/memory/KNOWN_ISSUES.md`,
+`docs/memory/DECISIONS.md`, `docs/BUILD_LOG.md`). This repo is public, and a numbered
+registry of where a LAN-exposed daemon is soft is not something to publish — the agent runs
+as the user's desktop account and can reboot their machine. They exist on the maintainer's
+machine and are read at the start of every session. **If you are in a fresh clone they will
+be absent: create them rather than assuming there is no history**, and do not "helpfully"
+commit them.
+
+Update the relevant file any time you add a dependency, establish a pattern, make a decision,
+or find an issue. **Never let these go stale.**
+
+## 3. Allowlist Rules — never violate
+
+1. **A client-supplied identifier is looked up, never interpolated.** Ids index a frozen
+   set or dict defined in the agent source (`_STEAM_MENU_IDS`, `ACTIONS`, `LAUNCHERS`,
+   the TV op tables). An id that is not present is a 404 — never a pass-through.
+2. **`subprocess` is called with an argv LIST. Never `shell=True`, never a formatted
+   command string.** The binary and its arguments are chosen by the agent; user input
+   only ever selects *which allowlisted entry* runs.
+3. **Never widen an allowlist to a pattern.** No globs, no prefix matches, no "anything
+   under this namespace". Adding a capability means adding an explicit entry.
+4. **Every route that changes state requires the bearer token.** `/api/ping` is the only
+   deliberate pre-auth endpoint. `/pair` is loopback-only AND checks the Host header
+   (anti-DNS-rebinding) because it renders the token.
+5. **Paths derived from client input are contained.** Resolve, then verify the result is
+   still inside the intended root before opening it.
+6. **Reject rather than sanitise.** If input is not exactly a known-good value, return an
+   error. Do not attempt to clean it up.
+7. **Degrade closed.** When a probe fails or `/proc` is unreadable, return "unavailable",
+   never "allowed".
+8. **If you find existing code violating these rules**, do not replicate it. Add a KI-###
+   entry with `Impact: high` and flag it immediately.
+
+## 4. Hard Constraints — Never Violate
+
+- **The gamepad / trackpad input path is safety-critical.** It is the most stateful,
+  most concurrent code in the project and the source of most escaped bugs: half-dead
+  sockets, promote/demote races, leaked uinput devices. Changes here require tests for
+  the lifecycle (create → hold → hand off → reap), not just the happy path.
+  **The agent's own virtual pad must never be matched as a real device** — that filter is
+  load-bearing; if it ever matched, connecting a phone would tear down the user's desktop.
+- **Reachability is protected.** `/api/ping`, `/api/status` and the auth gate are smoke-tested
+  in CI on every push. Do not weaken those gates. The product's promise is that it works when
+  the TV is black — being unreachable is a total failure.
+- **The agent stays pure Python 3 stdlib, single file.** No third-party imports, ever.
+  It installs onto machines we do not control.
+- **Never change existing API response shapes.** Add fields; never rename or remove. Old
+  app versions in the wild must keep working against new agents (verify with the harness).
+- **A capability key requires all five edit sites** (agent CAPS dict + mock tuple; app
+  BoxCaps + normalizeCaps + capsEqual). Missing the app two is a silent bug: the cap never
+  persists and the app re-probes forever.
+- **No credentials in source.** The release signing key lives offline and never touches CI.
+- **Do not add CORS to the agent.** It is LAN-only and token-authed by design; dev browsers
+  go through `scripts/web-dev-proxy.py` instead.
+
+## 5. Stack and Key File Locations
+
+| Layer | Choice |
+|---|---|
+| App | Expo SDK 57, React Native 0.86, TypeScript, expo-router |
+| Agent | Python 3, standard library only, single file, systemd user service |
+| Transport | HTTP + RFC6455 WebSocket (hand-rolled), bearer token, LAN only |
+| Tests | Pure-stdlib Python, no pytest; one CI step per file |
+| CI/Release | GitHub Actions; EAS builds; Ed25519-signed agent assets |
+
+```
+agent/couchsided.py      the whole Linux agent (~11k lines)
+agent/win/               Windows agent variant
+app/                     Expo app (app/(tabs)/ screens, components/, lib/)
+tests/test_*.py          agent tests, each its own CI step
+scripts/                 release, signing, store submission, web-dev harness
+docs/memory/             the files listed in §2
+```
+
+See `docs/memory/ARCHITECTURE.md` for the canonical patterns (probe-and-appear, caps,
+injected actions) with real snippets. New code matches those exactly.
+
+## 6. Testing Requirements
+
+| Area | Required |
+|------|----------|
+| New agent endpoint | Happy path + auth failure + unknown-input rejection |
+| Anything taking a client id | A test proving a non-allowlisted id is refused and nothing runs |
+| Gamepad / input path change | Device lifecycle test (create → hold → hand off → reap) |
+| New capability key | A test asserting all five edit sites are wired |
+| Parsing `/proc` or sysfs | Fixtures copied VERBATIM from real hardware |
+| App UI change | Driven in the web harness — **press the control, don't just render it** |
+| Anything only observable on the TV | Screen-capture proof via `/api/screen/frame` |
+
+**A render is not a test.** A tap shipped broken to TestFlight because the harness was used
+to look at a screen and never to press anything.
+
+## 7. Living Build Documents
+
+`docs/ROADMAP.md`: sections ✅ Completed / 🔨 In Progress / 📋 Planned / 💡 Backlog.
+Entries carry priority, risk, affects, depends_on, description, notes. Move items; never
+delete. Only mark Complete after the constraint checklist passed.
+
+`docs/BUILD_LOG.md`: append-only. After every session:
+
+    ## YYYY-MM-DD — Session title
+    **What was done:** bullets
+    **Files created/modified:** path — why
+    **Allowlist verification:** endpoints/ids added + how each is constrained
+    **Verified how:** what was actually exercised, and what was NOT
+    **Left off at:** one sentence
+    **Known issues / follow-ups:** bullets
+
+## 8. Before Writing Any Code — Checklist
+
+- [ ] Read memory files, BUILD_LOG, ROADMAP
+- [ ] Scanned existing files in the area
+- [ ] Identified the allowlist pattern for this area
+- [ ] Every new route/handler follows the §3 rules
+- [ ] Not introducing a pattern without noting it in CONVENTIONS.md
+- [ ] Not adding a dependency without DEPENDENCIES.md
+- [ ] Not creating a new file where extending an existing one is cleaner
+
+## 9. After Completing Work
+
+1. Append to BUILD_LOG including the verification sections.
+2. Update ROADMAP.
+3. Update memory files (dependency → DEPENDENCIES, pattern → CONVENTIONS, decision →
+   DECISIONS, issue → KNOWN_ISSUES).
+4. State what was completed, what's next, and any open edge cases.
+
+## 10. Roadmap Intake
+
+When the user says "add X to the roadmap" / "capture this feature": dedupe against ROADMAP +
+KNOWN_ISSUES first; add a structured 📋 Planned entry; specs with 3+ phases go to
+`docs/memory/project_<slug>.md`, never into this file.
+
+## 11. Evidence Rules — how claims get made here
+
+This project's expensive bugs have almost all been *confident wrong claims*, not bad code.
+These are not style preferences; they are the house standard for what counts as knowing.
+
+1. **Test the thing; don't grep for it.** Absence of a string is not absence of a feature.
+   Grepping Steam's bundle "proved" a working deep link did not exist. Firing the URL took
+   ten seconds.
+2. **Observe both states.** A detector is unverified until you have seen it fire AND not
+   fire. Shipping on one half produced a card that advertised a dead session for 27 minutes.
+3. **Put a control in every measurement** — an input whose answer you already know. Two
+   automated sweeps produced confident, entirely wrong tables before one had controls.
+4. **Verify the tool did what it claims.** `autoIncrement` silently rewrites `app.json`
+   mid-build; the release-notes script published a stale changelog and exited 0. Read the
+   artifact, not the exit code.
+5. **Don't generalise from one observation — in either direction.** One install dialog was
+   read as "streaming is broken"; streaming was fine, the host was asleep.
+6. **Write down what you did NOT verify.** PR bodies say so explicitly. If you catch
+   yourself writing "should work", stop and go verify it instead.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,94 @@
+# Couchside Roadmap
+
+Living plan. Move items between sections; **never delete**. Only mark Complete after the
+§8 checklist in `CLAUDE.md` passed and the work is verified (not merely written).
+
+Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `depends_on` · notes.
+
+---
+
+## 🔨 In Progress
+
+_(nothing currently mid-flight)_
+
+---
+
+## 📋 Planned
+
+### In-app Bluetooth pairing
+- **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
+- Agent drives `bluetoothctl`; app renders discovered devices and pairs on tap. Removes the
+  TV round-trip and works on non-Steam boxes.
+- **Research done:** one-shot `bluetoothctl pair` does NOT work — `--agent` registration is
+  async and loses the race ("No agent is registered"); the same command over stdin succeeds.
+  So it needs a **persistent stdin-fed session**, not a one-shot. Scan output carries
+  hard-coded ANSI even when piped; bare `devices` mixes scan leftovers with real pairings
+  (use `devices Paired`); Battery Percentage only appears on a *connected* device.
+- **Value is narrower than it looks:** the shipped Bluetooth button already reaches Steam's
+  own pairing UI, which handles agents and PINs correctly.
+
+### Find the missing Steam settings slugs
+- **priority:** P3 · **risk:** none · **affects:** agent only
+- Notifications, In Game and Remote Play are visible in Steam's sidebar but their slugs are
+  unknown; ~25 guesses measured absent. Any find ships agent-side with no app release.
+
+---
+
+## 💡 Backlog
+
+- **Cloud iOS build to clear 2.9.10's `INVALID_BINARY`** — the App Store record is still
+  editable; local builds are TestFlight-only on this beta-macOS Mac. Moot if a later version
+  supersedes it. **priority:** P2 · costs EAS overage.
+- **Windows agent CI** — `couchsided-win.py` is only syntax-checked; no real `windows-latest`
+  build/import gate. See KI registry.
+- **AMD / NVIDIA hardware coverage** — the amdgpu GPU block and NVIDIA boxes are unverified;
+  no such box has been reachable.
+- **Owner-side:** Legion Go Decky crash-loop + right-stick drift.
+
+---
+
+## ✅ Completed
+
+### 2026-07-20 — Release 2.9.12 (app 2.9.12 / agent 2.9.32)
+Play vc49 / iOS build 65. Carries the redesign, host-online, the screen-capture
+re-detect (#142) and the fixture time-bomb fix (#141).
+
+### 2026-07-20 — Cyberpunk Console + Fleet, via a swappable skin seam (#140)
+Owner picked **Reactor** from three directions built and compared live. Landed as a
+seam (`app/lib/skin/`) rather than a restyle: `kit.ts` defines the surface screens
+compose against, `motion.ts` owns ONE breath clock per screen (N cards must not mean N
+oscillators) and drives motion RATE from vitality but **never colour**. `classic.tsx`
+is retained as a live A/B control — `?skin=classic` is the real shipped 2.9.11
+dashboard, which is what makes "is this a regression?" answerable in seconds. Don't
+delete it. `vitals.tsx` and `hud.tsx` were built, compared and deleted; recover from
+git history if revisited.
+**Known gap:** `ScreenPreview`, the BOX UNREACHABLE banner and the "No box configured"
+empty card still use bespoke local styles rather than the kit.
+
+### 2026-07-20 — Stream hosts show whether they are actually online (#143)
+Offline hosts dim with a reason; Setup › Prefs can hide them entirely. Detection reads
+**Steam's own remote-connection log** for when each client was last seen — no hostname
+resolution, no port probing, no network sweep. That sidesteps the dead end this was
+stuck on (`remoteclients.vdf` has only a hostname and a WAN `ippublic` identical across
+hosts). `stream_host_online()` is deliberately conservative: ambiguity resolves to
+**offline**, because a false "online" is exactly what makes Steam offer a multi-gigabyte
+install instead of a stream.
+
+### 2026-07-19 — Steam settings shortcuts (app 2.9.11 / agent 2.9.31)
+19 hardware-verified deep links behind `/api/steam/menus`, surfaced as an Actions sub-tab.
+Shipped Play production vc48 + TestFlight 64.
+
+### 2026-07-19 — Steam Controller detection (agent 2.9.28)
+`max(len(real), phantoms − our_pads)`. Proven on device.
+
+### 2026-07-19 — Stream-host dirty-end recovery (agent 2.9.29)
+Data-port cross-check; sessions clear in a poll instead of 12 hours.
+
+### 2026-07-19 — "Pair a controller" action (agent 2.9.30)
+Screen-capture verified end to end through the agent's own runner.
+
+### 2026-07-19 — Web target + dev harness
+`scripts/web-dev.sh` renders the real app UI against mock or the real box.
+
+_(Earlier releases 2.8.x–2.9.10 predate this roadmap; see `docs/BUILD_LOG.md` and the
+release tags.)_

--- a/docs/memory/ARCHITECTURE.md
+++ b/docs/memory/ARCHITECTURE.md
@@ -1,0 +1,402 @@
+# Couchside — Architecture
+
+Living-room box control from a phone. **LAN-only, bearer-token authed, no cloud, no account.**
+The only outbound internet call in the whole system is the box's own GitHub update check
+(`agent/couchsided.py:1004-1013`) — the phone app never leaves your network.
+
+---
+
+## 1. Components and how they talk
+
+| Component | Language / runtime | Lives in | Role |
+|---|---|---|---|
+| Phone app | Expo / React Native / TypeScript (expo-router) | `app/` | The remote. Talks HTTP + one WebSocket to a box. |
+| Linux agent | Python 3, **pure stdlib**, single file | `agent/couchsided.py` (11,121 lines) | The daemon on the SteamOS/Bazzite/Linux box. |
+| Windows agent | Python 3 stdlib + `ctypes` Win32 | `agent/win/couchsided-win.py` | Same API contract v1 on a Windows HTPC. |
+| Decky plugin | Python backend + React (Decky Loader) | `couchside-decky/` | Installs/manages the agent from Game Mode, no terminal. |
+| Installers | bash / PowerShell | `install.sh`, `install.ps1` | Signed release assets; write unit, sudoers, udev, token. |
+
+### Wire protocol
+
+- **HTTP**, port **8787** (`DEFAULT_PORT`, `agent/couchsided.py:50`; app mirror `app/lib/settings.ts:86`).
+  Server is `ThreadingHTTPServer` with `protocol_version = "HTTP/1.1"`, per-connection
+  `timeout = 30`, and a hard `MAX_BODY_BYTES = 8 MiB` enforced *before* any body read
+  (`agent/couchsided.py:9355-9369`).
+- **WebSocket**, same port, single route `/ws/gamepad` — hand-rolled framing, no library
+  (`WS_GUID` at `agent/couchsided.py:8673`, upgrade at `:10662-10695`). App side:
+  `ws://<host>:<port>/ws/gamepad?token=…` (`app/lib/gamepad.ts:577`).
+
+### Auth model
+
+One shared bearer token per box, stored at `/etc/couchside/token`, loaded at startup and
+re-readable so a regenerated token needs no restart (`_current_token`, `:9412-9424`).
+
+```python
+def _authorized(self):
+    auth = self.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        return False
+    supplied = auth[len("Bearer "):].strip()
+    return hmac.compare_digest(supplied, self.token)
+```
+`agent/couchsided.py:9494-9499`
+
+Rules that fall out of that:
+- Every `/api/*` route is gated (`do_GET:9571`, `do_POST:9889`). Auth happens **before** the
+  body is read on POST, then the size cap, then the read — an unauthenticated client can't
+  make the agent allocate.
+- The WS token rides `?token=` and is checked **before** the 101 handshake (`:10669-10673`).
+  Query strings are redacted from the access log (`_log:9445-9451`) because journald output
+  is itself served back over `/api/journal`.
+- **No CORS headers, deliberately** — `ACAO:*` would let a malicious browser tab read
+  responses (`_send:9463-9465`).
+- Unauthenticated routes are exactly four: `/api/ping`, `/pair`, `/api/pair/start`,
+  `/api/pair/finish` (plus `/api/pair/status`).
+
+### Discovery and pairing
+
+1. **Discovery.** Two probes run in parallel and merge by IP (`app/lib/boxDiscovery.ts:1-16`):
+   an HTTP sweep of the phone's /24 hitting unauth `GET /api/ping`, and a UDP broadcast of
+   `COUCHSIDE_DISCOVER?` (`agent/couchsided.py:9257`). The HTTP sweep is the reliable path —
+   **iOS blocks UDP on the local network**, so UDP is a fast-path bonus only.
+   `/api/ping` returns `{ok, app, version, ip, host}` where `ip` is
+   `self.connection.getsockname()[0]` — the LAN address the phone actually reached, cached by
+   the app as a fallback for when mDNS `.local` dies (SteamOS Game Mode Wi-Fi power-save).
+   `/api/status` refreshes the same value every poll (`:9575-9588`).
+2. **PIN pairing** (app-initiated, no token yet). `POST /api/pair/start` mints a 6-digit PIN and
+   opens the loopback `/pair` page **on the box's own screen**; `POST /api/pair/finish` trades
+   the correct PIN for the token. TTL 120s, 5 attempts, 3s start debounce, one live session
+   (`:9129-9200`, routes at `:9860-9886`).
+3. **QR pairing** (box-initiated). `GET /pair` renders the token as a QR. Two independent gates,
+   both required: peer IP must be loopback **and** the `Host:` header must name loopback
+   (anti-DNS-rebinding — a page in the box's own browser can rebind a domain to 127.0.0.1, but
+   its `Host` header still says `attacker.tld`). See `_is_loopback:9382` and
+   `_host_header_is_local:9394`.
+   The QR encodes `https://couchside.tv/pair#host=…&port=…&token=…&ip=…` — HTTPS because Android
+   camera apps won't open custom schemes, and the params ride the **URL fragment** so the token
+   never reaches a server (`build_pair_url:9107-9126`).
+
+---
+
+## 2. Directory layout
+
+```
+agent/
+  couchsided.py            The entire Linux agent. Single file, pure stdlib, ~11k lines.
+  couchside.service        systemd unit TEMPLATE; install.sh substitutes __USER__/__UID__/__EXEC__.
+  couchside-screensaver.sh Aerial screensaver runner launched via a Steam shortcut.
+  qr.py                    Terminal/HTML QR renderer for the pairing link (stdlib, no qrcode dep).
+  win/couchsided-win.py    Windows agent — same API contract, ViGEmBus + SendInput + sc/wevtutil.
+  win/couchside-tray.pyw   Windows tray widget; win/build.ps1 packages it.
+  steam-grid/              Branded Steam capsule art for the screensaver shortcut.
+
+app/
+  app/(tabs)/              expo-router screens: index (Console), pad, launch, actions, fleet, setup.
+  app/(tabs)/_layout.tsx   Tab gating from caps + first-run redirect to Setup.
+  lib/api.ts               The whole HTTP client + every response type (BoxCaps, probeGated, capsEqual).
+  lib/gamepad.ts           WebSocket client: pad/trackpad/keyboard frames, handoff, reconnect.
+  lib/settings.ts          Persisted fleet/box model; normalizeCaps lives here.
+  lib/SettingsContext.tsx  React context over settings.ts.
+  lib/entitlement.ts       IAP unlock state; purchase.ts drives the store.
+  lib/boxDiscovery.ts      HTTP /24 sweep + UDP probe, merged.
+  hooks/useCapsSync.ts     Always-mounted 30s caps healer (see §3).
+  hooks/usePoll.ts         Generic poll-with-resetKey hook every card uses.
+  components/              One file per surface: RemoteView, RemotePowerBar, GamingCard, etc.
+
+tests/                     Pure-stdlib python tests, no pytest. Each locks a field-proven trap:
+  test_guide_hold.py       Guide-hold must not fire on a tap or match the agent's OWN pad.
+  test_gamepad_handoff.py  Re-promotion must REUSE its virtual pad (orphan-pad regression).
+  test_couch_ceremony.py   Staged desktop->TV switch; no fake-green "Ready", no wrong audio sink.
+  test_steamlink.py        remoteclients.vdf + binary appinfo.vdf v29 parsing, launch allowlist.
+  test_gaming_card.py      sysfs/proc fixtures: card* glob trap, reaper AppId matcher.
+  test_stream_host.py      /proc/net fixtures; ESTABLISHED :27036 peer is the ROUTER, not a session.
+  test_actions_inject.py   Injected-action gating.
+  test_steam_menus.py      The frozen Steam settings-panel allowlist.
+
+scripts/
+  release-agent.sh         Publish agent assets (agent-version.txt / -win.txt) onto a release.
+  sign-release.sh          Ed25519 detached signatures the installers verify.
+  asc-submit.py            App Store Connect submission.
+  play-release-notes.py    Play Console release notes upload.
+  ws-latency-test.py       Cold-path latency harness for /ws/gamepad.
+  web-dev.sh / web-dev-proxy.py  Local web dev against a real box.
+
+.github/workflows/
+  ci.yml                   compile job (py_compile all three entrypoints incl. the Windows agent,
+                           cross-platform because py_compile is syntax-only) + smoke job (boot
+                           --mock on a spare port, hit a real authed endpoint) + every tests/ file.
+  notify-decky.yml         Pings the couchside-decky repo when the agent ships.
+```
+
+---
+
+## 3. The architectural patterns that actually matter
+
+### 3a. Probe-and-appear
+
+Optional features are discovered, never assumed. The app fires a probe; **a 404 means the
+surface doesn't exist and the UI hides it** — it is never an error.
+
+```ts
+async function probeOrNull<T>(p: Promise<T>): Promise<T | null> {
+  try { return await p; }
+  catch (e: unknown) {
+    if (e instanceof ApiError && e.kind === 'http' && e.status === 404) return null;
+    throw e;
+  }
+}
+```
+`app/lib/api.ts:654-661`
+
+This is what makes an old agent and a new app compose without a version matrix: ship a route,
+the surface appears; don't, and it stays hidden.
+
+### 3b. The caps system (probe-and-appear, folded into the poll)
+
+N features meant N probe round-trips on every connect. `caps` is a boolean summary that rides
+the status poll the app already makes, so the right UI paints on the **first frame**
+(rationale block at `agent/couchsided.py:931-947`). It is a **hint, not authority** — a live op
+still confirms, and `probeGated` falls back to probing whenever caps is unknown:
+
+```ts
+function probeGated<T>(cap: boolean | undefined, probe: () => Promise<T | null>) {
+  if (cap === false) return Promise.resolve(null);
+  return probe();
+}
+```
+`app/lib/api.ts:671-677` — only an **explicit false** skips the request. `undefined` (older
+agent, or a key that predates this box's version) still probes, so behavior against agents
+< 2.8.2 is unchanged.
+
+Two details worth knowing:
+- `CAPS` is a **boot-time snapshot** (presence of a Steam install, a session bus, a controller
+  node is static per boot), *except* `desktop`, which is session-volatile and recomputed per
+  request: `"caps": dict(CAPS, desktop=desktop_available())` (`agent/couchsided.py:1419-1423`).
+- In `--mock` every capability reads `True`, so the whole app is exercisable on a dev laptop
+  with no hardware.
+- `hooks/useCapsSync.ts` is an always-mounted 30s safety net. Without it, a stale persisted
+  `false` (cached before a box *became* capable) stuck forever for a user who lived on the Pad
+  tab — observed in the field.
+
+### 3c. Adding a capability key — FIVE sites, all mandatory
+
+Miss any one and the cap silently never persists, so the app re-probes on every launch. This
+has been shipped-and-fixed five separate times (`screensaver`, `couchmode`/`desktop`,
+`steamlink`, `gaming`, `streamhost`, `steammenus` — the comments in `normalizeCaps` are a
+scar log).
+
+| # | File | Site |
+|---|---|---|
+| 1 | `agent/couchsided.py:980-994` | the real `CAPS` dict — `"newcap": safe(newcap_available)` |
+| 2 | `agent/couchsided.py:975-978` | the **mock all-true tuple** — add the string or `--mock` lies |
+| 3 | `app/lib/api.ts:79-137` | the `BoxCaps` type — declare it **optional** (`newcap?: boolean`) |
+| 4 | `app/lib/settings.ts:200-241` | `normalizeCaps` — `const newcap = bool('newcap')` **and** put it in the returned object |
+| 5 | `app/lib/api.ts:715-733` | `capsEqual` — add `a.newcap === b.newcap` |
+
+Sites 4 and 5 are the trap. `normalizeCaps` hard-requires the six **original** keys as booleans
+(`gamepad, steam, media, tv, screen, power_schedule`) and drops the whole blob if any is
+missing — a partial payload is not half-trusted. Every key added *after* those six must be
+optional, so `undefined` stays "unknown, probe" and never degrades to `false`.
+
+Current keys: `gamepad`, `steam`, `media`, `tv`, `screen`, `power_schedule`, `screensaver`,
+`couchmode`, `desktop`, `steamlink`, `gaming`, `streamhost`, `steammenus`.
+
+Caps also gate whole tabs — `hidePad = caps?.gamepad === false`,
+`hideLaunch = caps?.steam === false` (`app/app/(tabs)/_layout.tsx:28-30`), which is how a
+headless "server box" loses its gaming tabs. Note the `=== false`: **never hide a tab on a guess.**
+
+### 3d. Single-file, pure-stdlib agent
+
+Immutable/atomic distros (SteamOS, Bazzite/ostree) have no usable `pip`, so the agent imports
+nothing outside the stdlib — no `psutil`, no `requests`, no `vdf` parser. Consequences visible
+throughout:
+
+- Metrics come from `/proc` directly: `/proc/uptime` (`:749`), `/proc/meminfo` (`:886-898`),
+  `/proc/net/route` for the default interface (`:768-780`), `/sys/class/net/<if>/address` for
+  the MAC.
+- HTTP is `urllib.request` (`_http_text:1017-1024`), JSON is `json`, hashing is `hashlib`/`hmac`.
+- uinput is driven by **hand-assembled ioctl numbers** — the kernel's `_IOC` macros
+  reimplemented in Python (`:6887-6926`), with a runtime assert that
+  `struct uinput_user_dev` packs to exactly 1116 bytes (`:6937-6940`).
+- WebSocket framing is hand-rolled (`ws_recv_frame`, `_wsend_op`, `_wsend_json` at `:8789-8810`).
+- Steam's VDF is line-scanned rather than parsed:
+  ```python
+  # Steam's VDF has no stdlib parser and the agent ships pure-stdlib (no pip on
+  # immutable distros), so rather than vendor a parser we line-scan for the one
+  # thing needed here: `"path"   "<value>"`.
+  ```
+  `_parse_vdf_paths`, `agent/couchsided.py:2609-2627`. The binary `appinfo.vdf` gets a bespoke
+  v28/v29 reader (`:2839-2934`) locked by a synthetic fixture in `tests/test_steamlink.py`.
+- CI enforces the constraint cheaply: `py_compile` on all three entrypoints plus a `--mock`
+  boot-and-authed-request smoke test, no dependencies to install (`.github/workflows/ci.yml`).
+
+### 3e. Injected Actions — gated on the box *actually* being able to do it
+
+Actions are config-driven (`/etc/couchside/config.json`), but four are **injected at load time
+only when the box can really perform them**, because *a dead button costs more trust than a
+missing one*. All four are idempotent, run after `load_config`, and yield to a config-defined
+action of the same id (`main:11076-11079`).
+
+| Action | Gate | Site |
+|---|---|---|
+| Switch to Desktop / Return to Game Mode | `shutil.which("steamos-session-select")` | `:611-623` |
+| Suspend | sudoers NOPASSWD grant for `systemctl suspend` | `:677-690` |
+| Restart Decky | unit file **and** NOPASSWD grant for `systemctl restart plugin_loader` | `:698-716` |
+| Pair Controller | a Steam install (the action is a `steam://` URL) | `:718-733` |
+
+The sudo probe is the load-bearing part, and its docstring is the best bug story in the repo
+(`_nopasswd_last_match`, `:626-653`): `sudo -n -l <cmd>` exit-code probing returns 0 for *any*
+allowing rule including password-requiring `(ALL) ALL`, and "any NOPASSWD line names the
+command" is wrong because **sudoers is last-match-wins and sudoers.d loads in lexical order** —
+a box's `wheel` file sorted after `couchside` and silently shadowed every grant for three days.
+Hence the real evaluator walks rules in order tracking the last match, and the installers now
+write `zz-couchside` so it sorts last. Any failure returns `False`: a missing grant must **hide**
+the action.
+
+### 3f. TTL-memo caches
+
+Every expensive read is memoized behind a monotonic-clock TTL so the app's polls stay cheap.
+
+| Cache | TTL | Why | Site |
+|---|---|---|---|
+| `_NET_CACHE` | 30s | avoid shelling to `ethtool` per status poll | `:761-763`, `:836-840` |
+| `_GAMING_CACHE` | 2s | ~5s card poll must not re-scan sysfs/proc | `:8004-8006`, `:8300-8310` |
+| `_STEAM_LIB_CACHE` | 30s | re-reading `libraryfolders.vdf` + realpath per request | `:2665-2680` |
+| `_update_cache` | 6h | GitHub contacted at most a few times a day | `:1013-1045` |
+| `_APPINFO_CACHE` | mtime+size keyed | the multi-MB `appinfo.vdf` blob | `:2822-2830`, `:2936-2952` |
+
+Chatty *logging* gets the same treatment: `/api/screen/frame` successes are sampled to one per
+15s so a 1–2 fps preview can't scroll real diagnostics out of the journal (`:9436-9440`).
+
+### 3g. The launcher allowlist
+
+`POST /api/launchers/<id>` never executes a caller-supplied argv. `_launcher_argv`
+(`agent/couchsided.py:3243-3283`) resolves an id only if it corresponds to a launcher that
+actually exists right now:
+
+- `steam:<appid>` → digits only, **and** `_steam_game_installed(appid)` must find that specific
+  `appmanifest_<appid>.acf`.
+- `stream:<appid>` → digits only, **and** the appid must appear in `_streamable_appids()`, the
+  set harvested from `remoteclients.vdf` (a host game is by definition *not* installed locally,
+  so the on-disk check can't apply).
+- `custom:<slug>` → must match a stored launcher; the argv comes from config, never the request.
+
+Anything else returns `None` → 404 "unknown launcher". Launch itself is
+`subprocess.Popen(argv, shell=False, start_new_session=True)` into a discovered graphical
+session env (`real_launch:3306-3320`). Two related kill switches default **off**:
+`ALLOW_APP_UPDATE` and `ALLOW_APP_LAUNCHERS` (`:238`, `:248`) — app-side launcher *creation*
+would let any bearer-token holder run an arbitrary command.
+
+### 3h. Session and handoff state (`/ws/gamepad`)
+
+Multi-phone control is explicit. Module state: `GAMEPAD_LOCK`, `GAMEPAD_HOLDER` (the one entry
+owning the virtual devices), `GAMEPAD_SESSIONS` (holder + waiters) at `:8776-8778`. Each entry
+carries its own `slock` so sends are serialized per socket.
+
+On connect, `?handoff=ask` decides the role (`_gamepad_session:10702-10745`):
+no holder → **hold**; `ask` → **wait**, and the holder gets a `control_request` prompt;
+anything else (including pre-2.9.2 clients) → **takeover**, demoting the holder with a
+`{"t":"released","by":…}` frame. Waiters receive `waiting`; only the holder ever receives
+`hello`, so **`hello` IS the "you have control now" signal** (`_make_holder:8849-8892`).
+
+Two hard-won details:
+- Waiters **pre-create** their mouse/keyboard while the human decides, because the uinput
+  enumeration settle burns real time — first input after a pass measured 524ms with
+  create-at-grant vs ~7ms with create-at-wait (`:10743-10756`).
+- `_make_holder` **reuses** an existing pad on re-promotion. The old always-create path orphaned
+  a pad per Pass/take-back cycle with its fd open; three phantom "Microsoft X-Box 360 pad"
+  devices were found on one box after an afternoon, and the enumeration churn corrupted that
+  box's Steam desktop controller config. Locked by `tests/test_gamepad_handoff.py`.
+- `GAMEPAD_IDLE_TIMEOUT_S = 12.0` (`:8786`): the app pings every ~5s, so 12s of silence means
+  app→box is dead. A box→app heartbeat *cannot* detect this — it flows regardless and would mask
+  a dead outbound.
+
+---
+
+### 3i. The skin seam (`app/lib/skin/`) — added #140
+
+Console and Fleet render through a **swappable look**, not fixed styles. Screens compose
+a `SkinKit` and never know which skin is active.
+
+```
+app/lib/skin/
+  kit.ts       the SkinKit surface (Screen, Card, SectionTitle, BigMetric, Bar, Spark,
+               Dot) + VitalsContext. This is the contract screens code against.
+  motion.ts    useBreath, useReducedMotion, vitality(), breathPeriod().
+  classic.tsx  the pre-redesign look, RETAINED as a live A/B control.
+  reactor.tsx  the shipped look.
+  index.tsx    registry, DEFAULT_SKIN, web-only ?skin= dev override.
+```
+
+Four rules a skin must obey — each exists because breaking it produced a real defect:
+
+1. **ONE breath clock per screen**, shared via `VitalsContext`. N cards must not mean N
+   oscillators.
+2. **Semantic colour is sacred.** Callers pass the already-resolved
+   `tempColor`/`pctColor`/`batteryColor` (battery is INVERTED — low is bad). A skin
+   *decorates* with that colour and never substitutes its own. Vitality drives motion
+   **rate**, never hue.
+3. **Light mode branches explicitly** — halos in dark, tinted pills + border weight in
+   light. Glow on a near-white background is mud.
+4. **Reduced motion is a hard stop, not a slowdown**, and probe-and-appear cards
+   mount/unmount mid-poll, so entrance animations must not re-fire.
+
+`classic.tsx` is not dead code: `?skin=classic` renders the genuinely shipped 2.9.11
+dashboard, which is what makes "is this a regression?" answerable in ten seconds rather
+than from memory. **Do not delete it.**
+
+**Verifying a skin is harder than it looks** — the browser pane reports
+`visibilityState: hidden` permanently, so `requestAnimationFrame` runs at 0 fps while
+Reanimated shared values keep advancing when read from JS. A probe that samples `.value`
+reports PASS against a frozen DOM. Measure the *painted* result
+(`getComputedStyle(el).opacity` over time). See CONVENTIONS §"Verifying app UI".
+
+## 4. External integrations
+
+**Steam.** Root discovery + library enumeration via line-scanned `libraryfolders.vdf`
+(`:2597-2660`); installed games from `appmanifest_*.acf` as an **allowlist** (`:3118`);
+non-Steam shortcuts registered through `shortcuts.vdf` + `steam://addnonsteamgame`
+(`:1216-1255`), which is how the aerial screensaver gets a launchable, branded Steam entry with
+custom capsule art from `agent/steam-grid/`. Everything user-facing is a `steam://` deep link
+fired as the desktop user through the already-running client — `steam://rungameid/<id>` to
+launch or stream, `steam://open/settings/bluetooth` for controller pairing.
+**Remote Play** works in both directions and they are distinct caps: `steamlink` is the CLIENT
+direction ("Stream from PC", parsed from `config/remoteclients.vdf`, `:2809-3050`), `streamhost`
+is this box **serving** a session, detected log-driven and cross-checked against `/proc/net`
+ports 27036/27031 (`:8371-8470`) — an ESTABLISHED peer on 27036 is the router, not a session.
+Cover art is served from the box's own cache over the LAN, never a CDN.
+
+**TV / CEC.** Three backends, in preference order (`:3492-3510`): `panel` — RS-232 to a
+commercial display (e.g. Newline TruTouch), config-driven via `CONFIG_PANEL`; `cec` — HDMI-CEC
+through the kernel framework (`cec-ctl`) or libcec (`cec-client`); `soft` — the box's own volume
+via uinput media keys, the fallback when neither can drive the TV. CEC availability is
+re-evaluated **cheaply per request** (`cec_current:3594`), because a TV powered on after the
+agent booted must not stay hidden — only the ~6s libcec adapter probe is frozen at startup
+(`set_cec:3575-3591`). `_usable_cec_dev` (`:3535-3549`) skips `/dev/cecN` whose DRM connector
+reads `disconnected`, so the TV strip never appears over a dead bus. CEC has no discrete "off" —
+`power_off` maps to standby. Smart TVs add hand-rolled backends: LG WebOS over its own WS
+protocol (`:4215-4310`), Android TV / Samsung / Roku / VIDAA discovered by a stdlib mDNS query
+implementation (`_mdns_discover:5689-5720`).
+
+**MPRIS media.** Now-playing and transport over the user session bus via `busctl --user
+--json=short` — no `dbus-python`, no `playerctl` dependency (`:6056-6160`). `mpris_available`
+requires both `busctl` and a live session bus (`:6079-6082`). Album art is resolved from the
+player's own advertised cache path and inlined by the app as a base64 `data:` URI, so nothing
+sensitive lands in Fresco's disk cache (`app/lib/api.ts:749-790`).
+
+**uinput virtual devices.** Four pure-stdlib device classes, each a legacy-uinput handshake of
+`UI_SET_EVBIT` / `UI_SET_KEYBIT` / `UI_SET_ABSBIT` → write `uinput_user_dev` → `UI_DEV_CREATE`:
+`UInputGamepad` (a virtual Xbox 360 pad, `:6927-6980`), `UInputMouse` (`:7088`),
+`UInputKeyboard` (`:7145`), and `UInputMediaKeys` for soft volume (`:3945-3951` — needs
+`/dev/uinput`, never sudo). Access comes from `SupplementaryGroups=input` in the systemd unit
+plus the installer's udev rule — deliberately **not** an active login seat, since headless boxes
+have none (`agent/couchside.service:15-18`). There is a mandatory settle window after
+`UI_DEV_CREATE`: the compositor enumerates a new device asynchronously and events sent before
+that lands are dropped (`:7065-7073`). Windows swaps the whole layer for ViGEmBus via
+`ViGEmClient.dll` + `SendInput`, which is why that agent must run as a **logon-triggered
+scheduled task in the interactive session**, never a session-0 service
+(`agent/win/couchsided-win.py:27-32`).
+
+**Screen preview.** Backend picked at startup (`set_screen:6442-6464`): gamescope/Game Mode does
+*not* implement wlr-screencopy so `grim` fails there; KDE desktop sessions use `spectacle -b -n`.
+Downscaling shells out to ImageMagick then ffmpeg, keeping the agent off PIL (`:6427-6438`).

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -1,0 +1,307 @@
+# Conventions
+
+Inferred from the code as it stands (agent 2.9.31 / app 2.9.11). These are the conventions this
+repo *already follows* — read this before adding code so new work matches, and update it when a
+convention genuinely changes rather than letting the doc drift.
+
+---
+
+## 1. Python agent (`agent/couchsided.py`)
+
+### Pure stdlib, single file
+
+The agent is one ~11k-line file with **zero third-party dependencies** — the import block is all
+stdlib (`agent/couchsided.py:14-35`). This is load-bearing: the agent is fetched as a raw signed
+`.py` onto SteamOS/Bazzite (immutable-ish, no pip) and run by systemd. Do not add a dependency, and
+do not split the file without solving the single-file install path first.
+
+Platform-optional imports degrade instead of failing at import time:
+
+```python
+try:
+    import fcntl  # POSIX only; uinput needs it (Linux), absent on Windows
+except ImportError:  # pragma: no cover
+    fcntl = None
+```
+(`agent/couchsided.py:36-39`)
+
+`VERSION` is a module constant bumped per release (`agent/couchsided.py:47`).
+
+### Docstrings explain WHY, and record hardware measurements
+
+Docstrings here are unusually long by design. They do not restate the signature — they record the
+trap the code exists to avoid, the alternative that was rejected, and **the measurement taken on
+real hardware**. Examples:
+
+- `_stream_data_bound()` (`agent/couchsided.py:8489-8510`) names the wild failure ("a card still
+  claiming a live macOS stream 27 minutes after the client disconnected"), states
+  *"Measured on hardware in BOTH states, which is the bar this detector failed to clear the first
+  time around"*, and records the rejected alternative (log mtime staleness, 41s of silence measured
+  *during* a live stream).
+- `_gpu_sensors()` (`agent/couchsided.py:8032-8043`) documents the `card*` glob trap — a
+  `cardN-DP-1` connector dir also matches and carries a `device` symlink — and names
+  `re.fullmatch(r"card\d+")` as the fix.
+- Inline measurements are cited with the box they came from:
+  `# ... would misdiagnose a stall (measured on the TT-7516UB)` (`:3918`),
+  `# measured 508ms first-frame stall -> ~7ms` (`:7074`),
+  `# Both measured on a live box, 2026-07-19.` (`:8179`).
+
+If you cannot measure it, say so in the docstring rather than guessing. `:8537` states the standard
+outright: *"Hence measured, never guessed."*
+
+### Errors degrade; probes never raise
+
+Read-only probes return an empty value instead of throwing, and say so in the docstring. The phrase
+**"Never raises"** appears ~30 times and is a contract, not a comment. The return convention is:
+
+| Shape | Absent/failed value | Example |
+|---|---|---|
+| dict payload block | `{}` | `_gpu_sensors` (`:8032`) |
+| list of things | `[]` | `_proc_net_rows` yields nothing (`:8459`) |
+| single value | `None` | `_read_int` (`:8013`), `_steam_root` (`:2598`) |
+| boolean capability | `False` | `gaming_available` (`:8023`), `_stream_listening` (`:8481`) |
+
+Catch narrowly where the failure is known (`except (OSError, ValueError)` in `_read_int`,
+`:8013-8019`); use bare `except Exception` only at a "this must never take the agent down" boundary
+(`gaming_available`, `:8023-8029`).
+
+**Probe-and-appear, per field.** A payload omits a key entirely rather than shipping a blank or a
+wrong-but-populated block — `_gaming_payload` (`:8300`) drops `gpu`/`game`/`controllers` when
+absent, and the test asserts the omission (`tests/test_gaming_card.py:325-330`). The rule stated at
+`:8537`: a dead button costs more trust than a missing one. Never substitute a plausible number for
+a real one (an Intel box gets *no* GPU block, never a CPU temp mislabelled as GPU).
+
+### Naming
+
+- `_leading_underscore` for module-private helpers — the vast majority of the file.
+- Public (no underscore) only for things the HTTP layer or caps block calls: `gaming_available()`,
+  `couch_ceremony_start()`.
+- `_UPPER_SNAKE` module constants for tunables, caches, and locks, grouped just above their section:
+  `_GAMING_TTL` / `_GAMING_CACHE` / `_GAMING_LOCK` (`:8004-8006`), `_STEAM_LIB_TTL` (`:2666`).
+- **Filesystem roots are module constants specifically so tests can repoint them at fixtures**, and
+  the comment says so:
+
+```python
+# Sysfs roots, as module constants so tests can point them at fixtures (the same
+# pattern as _PROC_INPUT_DEVICES for the pad list).
+_DRM_DIR = "/sys/class/drm"
+_POWER_SUPPLY_DIR = "/sys/class/power_supply"
+```
+(`agent/couchsided.py:8008-8010`; `_PROC_INPUT_DEVICES` at `:7600`)
+
+New code that reads a path under `/sys`, `/proc`, or a cache dir **must** route through a
+module-level constant, or it cannot be tested without root and real hardware.
+
+---
+
+## 2. Tests (`tests/test_*.py`)
+
+### Pure stdlib, no pytest
+
+Every test file is a standalone script run as `python3 tests/test_x.py`. No pytest, no test runner,
+no `conftest.py`. Each loads the agent by path via `importlib.util.spec_from_file_location`
+(`tests/test_gaming_card.py:20-24`) — the agent is not an installed module. Files whose subject uses
+threads also register it under its name first (`sys.modules["couchsided"] = cs`,
+`tests/test_couch_ceremony.py:28`).
+
+Tests **drive the real agent functions** against fixtures via the module-constant roots; they never
+reimplement the logic under test (`tests/test_gaming_card.py:5-9`).
+
+### The `check()` / PASS / FAIL harness
+
+Two variants are in use. Both accumulate failures in a module-level list, print a per-function
+header, and exit non-zero at the end. Match the file you are editing:
+
+- **`check(cond, label)`** with ANSI `PASS`/`FAIL` constants and a `_fail` list —
+  `tests/test_gaming_card.py:26-34`. Used by `test_gaming_card`, `test_steamlink`,
+  `test_stream_host`, `test_steam_menus`, `test_actions_inject`.
+- **`check(name, got, want)`** printing plain `"  PASS"` / `"  FAIL  (got %r, want %r)"` into a
+  `FAILURES` list — `tests/test_couch_ceremony.py:32-39`. Used by `test_couch_ceremony`,
+  `test_guide_hold`, `test_gamepad_handoff`.
+
+Labels are sentences describing the *behaviour*, not the assertion:
+`"[oom_reaper] rejected"`, `"no gpu key when GPU absent (no blank block)"`. Gates are asserted in
+**both directions** — the capability present *and* absent (`.github/workflows/ci.yml:84-86`).
+
+### Fixtures are copied verbatim from real hardware
+
+Fixture blocks are pasted byte-for-byte off a live box, dated, and annotated with what makes them
+tricky — never hand-written to be convenient:
+
+- `# Every block below is verbatim off a live Bazzite box (2026-07-19).`
+  (`tests/test_gaming_card.py:133`)
+- `VERBATIM from a live box, including a genuine macOS Remote Play session it`
+  (`tests/test_stream_host.py:7`)
+- Where a fixture is synthetic, it says so and justifies it (`_phantom()`,
+  `tests/test_gaming_card.py:143-145`: *"real bits, so `_declares_key` does actual work here rather
+  than being fixture theatre"*).
+
+If a value was confirmed by screen-capturing a real box, record that in the file
+(`tests/test_steam_menus.py:8,40`).
+
+### Every test function is registered in `__main__` by hand
+
+There is **no auto-discovery**. A new `def test_*` that is not added to the runner silently never
+runs. Both spellings exist:
+
+```python
+if __name__ == "__main__":
+    test_appid_from_cmdline()
+    test_gpu_sensors()
+    ...
+```
+(`tests/test_gaming_card.py:320-328`)
+
+```python
+if __name__ == "__main__":
+    for fn in (test_happy, test_no_tv_backend, ...):
+        fn()
+```
+(`tests/test_couch_ceremony.py:161-163`)
+
+### Every test file is its own named CI step, with a WHY comment
+
+`.github/workflows/ci.yml` runs each file as a separate, human-named step preceded by a comment
+explaining **what breaks in the real world if this gate is removed** — not what the file tests.
+This is the strongest convention in the repo; a new test file without one is incomplete:
+
+```yaml
+# The guide-hold trigger fires a SESSION SWITCH, which tears down the
+# user's desktop and any unsaved work. Its two dangerous failure modes —
+# firing on a tap, and matching the agent's OWN emulated pad ...
+- name: Unit tests (guide-hold trigger)
+  run: python3 tests/test_guide_hold.py
+```
+(`.github/workflows/ci.yml:36-43`; see also `:45-50`, `:66-72`, `:74-82`, `:93-101`)
+
+CI is two jobs: `compile` (`py_compile` on all three entrypoints, then the unit tests) and `smoke`
+(boots the agent `--mock` on a spare port and proves auth: `/api/ping` 200, `/api/status` 401
+without a token, 200 with one) — `.github/workflows/ci.yml:103-186`.
+
+---
+
+## 3. TypeScript app (`app/`)
+
+### Probe-and-appear
+
+The app never shows a control a box cannot back. Optional features resolve `null` and the UI hides,
+via the documented house pattern `probeOrNull` — **exactly 404**, so a transient 500 still throws
+and a briefly-unhealthy agent does not read as "feature vanished" (`app/lib/api.ts:645-661`).
+`probeGated` skips the request entirely when `Status.caps` says the feature is absent, while still
+probing against pre-2.8.2 agents that report no caps (`app/lib/api.ts:663-676`). Call sites are
+commented as such (`app/app/(tabs)/index.tsx:170,176,241`).
+
+Caps are a **hint, not authority** — a live op still confirms (`app/lib/api.ts:69-76`).
+
+### `request()` stringifies the body — callers pass plain objects
+
+`request()` (`app/lib/api.ts:925`) sets `Content-Type` and calls `JSON.stringify` itself
+(`app/lib/api.ts:837, 1019`). Callers pass a plain object: `body: { mac }`, `body: { level, target }`.
+Passing `body: JSON.stringify(...)` double-encodes and the agent correctly rejects it with
+`HTTP 400: body must be a JSON object` — this shipped once (fixed in #137) and is the single
+easiest mistake to make in this file.
+
+`request()` also owns the cached-IP fallback: GETs race host + last-known IP, non-idempotent
+POST/DELETE probe first and then send **exactly once, never retried**, because React Native cannot
+distinguish "never connected" from "delivered then lost" and a retried POST could reboot the box
+twice (`app/lib/api.ts:935-967`).
+
+### Typed payloads
+
+Every agent response has an exported type with per-field doc comments recording the agent version
+that introduced it and what `null` means (`Ping`, `NetInfo`, `BoxCaps` — `app/lib/api.ts:17-80`).
+Add the type alongside the method; do not return `any` or an inline shape.
+
+### Theming: read colors through the hooks
+
+Components read colors via `useTheme()` (`app/lib/theme.ts:277`) or `useThemedStyles(makeStyles)`
+for `StyleSheet` styles (`app/lib/theme.ts:286-299`), so they react to system scheme, the user's
+Light/Dark/System override, and the accent. New or touched components must not hardcode palette
+colors.
+
+Two honest caveats: `export const theme = dark` is a **deliberate backward-compat bridge** for the
+many components not yet converted, so the sweep can proceed incrementally without breaking anything
+(`app/lib/theme.ts:11-13, 86`) — it is not license to write new code against it. And a handful of
+literal hexes legitimately survive because they are not theme-relative: ink on a bright accent
+button (`#0b1220`, `app/components/Paywall.tsx:157`) and the physically black-on-white QR code
+(`app/components/QrView.tsx:58,72`).
+
+### Hooks
+
+`usePoll(fn, intervalMs, enabled, resetKey)` (`app/hooks/usePoll.ts`) is the standard data path:
+fires immediately, ~2s retry while a box is unreachable, refetch on AppState `active`, paused while
+unfocused, never setState after unmount. Pass `hostKey(settings)` as `resetKey` for any per-box poll
+so a box switch clears stale data in the same render instead of painting the previous box's data
+(`app/lib/api.ts:694-697`). Render-time consumers that mutate refs from `data` must check `dataKey`
+first — the reason is documented at `app/hooks/usePoll.ts:15-23`.
+
+---
+
+## 4. Git / PRs
+
+- **`main` is branch-protected** (verified: PR required, force-push disabled). No direct pushes.
+- **PR + squash only.** Every commit on `main` carries its PR number (`… (#139)`).
+- **Conventional-commit prefixes**, with a scope: `feat(gaming):`, `fix(streamhost):`,
+  `chore(app):`, `copy(ios):`, `docs:`. Agent-side changes name the agent version in the subject —
+  `feat(steam): expose Steam's settings panels as deep links (agent 2.9.31)`.
+- **Trailer on every commit:** `Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>`.
+- **Commit bodies and PR bodies state what was and was NOT verified**, and how a bug escaped. See
+  #137: *"Rendering a control is not exercising it."* Bodies routinely include a **Verification**
+  section separating mock-harness from real-box testing, and a **Release impact** section naming
+  which builds are dead. Write the honest negative — an unverified path must be called out as
+  unverified, because the next PR's author relies on it.
+- **Never delete the base branch of a stacked PR** — it retargets or closes the dependent PR.
+
+---
+
+## 5. Releases
+
+- **Explicit version bumps**, never automatic: agent `VERSION` (`agent/couchsided.py:47`) and app
+  `version` in `app/app.json:6`. `app/package.json` version is inert (`1.0.0`) — ignore it.
+- Build numbers come from EAS autoincrement and are **reconciled back into the repo from the
+  artifacts, not the log**, in a `chore(app): reconcile build numbers …` commit (#138, #136, #128).
+- **Tag every release** at the shipped commit (`v2.9.11`, `v2.9.10`, …); app-only releases have used
+  a `-app` suffix when needed (`v2.9.4-app`).
+- **Agent assets are signed.** After tagging, run `scripts/release-agent.sh <tag>` **locally** to
+  upload `couchsided.py`, `couchside.service`, `qr.py`, `couchside-screensaver.sh`, `SHA256SUMS`,
+  and `SHA256SUMS.sig`, signed with the offline Ed25519 key whose public half is embedded in
+  `install.sh`. `scripts/sign-release.sh <tag>` does the same for the Decky plugin repo.
+- **The signing key never touches CI** — that is the whole point: a compromised repo, CI, or account
+  cannot forge a release (`scripts/release-agent.sh:11-12`, `scripts/sign-release.sh:8-10`).
+- `release-agent.sh` clobbers assets on an existing tag, so re-run it after every agent bump that
+  ships under the same app-version tag.
+
+---
+
+## Verifying app UI (the harness, and how it lies)
+
+`scripts/web-dev.sh` renders the real app in a browser against a `--mock` agent;
+`scripts/web-dev-proxy.py <dist> <port> <box-host:port>` points the same bundle at a real
+box. Use it instead of a TestFlight cycle for anything presentational.
+
+**Press the control. Do not merely render it.** A Steam chip tap shipped broken to
+TestFlight because the harness was used to photograph a screen and never to click
+anything — while the PR text itself said the tap was unverified.
+
+Three measured traps, each of which produces confident garbage:
+
+1. **The browser pane is permanently `visibilityState: hidden`.** `requestAnimationFrame`
+   runs at **0 fps**, so every rAF-driven animation is frozen — but Reanimated shared
+   values still advance when read from JS, so a probe sampling `.value` reports PASS
+   against a dead DOM. Measure the painted result (`getComputedStyle`), never the shared
+   value. Cards entering from opacity 0 photograph blank.
+2. **RN Web maps `AppState` to document visibility**, so anything gated on
+   `AppState === 'active'` never runs (the Fleet fan-out polls zero boxes). Fix
+   harness-side, no app change:
+   `Object.defineProperty(document,'visibilityState',{get:()=>'visible'})` then dispatch
+   `visibilitychange`.
+3. **`localStorage` is per-origin AND per-browser.** Reseed after changing port; seeding
+   from one browser does not seed another.
+
+RN Web `Pressable`s expose no a11y role, so `read_page`/`find` cannot reach them — drive
+taps by dispatching pointerdown/mousedown/pointerup/mouseup/click on the Pressable
+ancestor.
+
+**What the harness cannot cover — verify on a device:** Pad/trackpad and gamepad (no WS
+proxying; mouse != touch), iOS Local Network permission, the no-UDP behaviour, app
+backgrounding, safe-area insets, and the purchase flow (`expo-iap` is a no-op on web).

--- a/docs/memory/DEPENDENCIES.md
+++ b/docs/memory/DEPENDENCIES.md
@@ -1,0 +1,276 @@
+# DEPENDENCIES
+
+Every meaningful dependency, its version, and why it is there. Two halves of the
+product with two opposite dependency philosophies: the **app** leans on the Expo
+ecosystem, the **agent** has none at all.
+
+Source of truth: `app/package.json`, `app/app.json` (plugins),
+`agent/couchsided.py`, `scripts/`. Update this file any time a dependency is
+added or removed (see the checklist in `CLAUDE.md`).
+
+---
+
+## 1. The app — `app/package.json`
+
+Expo SDK 57 / React Native 0.86 / React 19.2.3. Managed workflow with a
+prebuilt `ios/` directory checked in.
+
+### Core runtime
+
+| Package | Version | Why |
+|---|---|---|
+| `expo` | `~57.0.1` | The SDK itself. Everything below pins to its 57.x train. |
+| `react` / `react-dom` | `19.2.3` | React 19. `react-dom` is only reachable on the web target. |
+| `react-native` | `0.86.0` | The runtime. New Architecture era. |
+
+### Navigation / router
+
+| Package | Version | Why |
+|---|---|---|
+| `expo-router` | `~57.0.2` | File-based routing and the entry point (`"main": "expo-router/entry"`). Registered as a plugin in `app.json`. Provides `Stack`/`ThemeProvider` in `app/_layout.tsx`, the imperative `router` and `useFocusEffect` in `app/(tabs)/fleet.tsx`, `useLocalSearchParams`/`useRouter` in `setup.tsx`, and the re-exported `ErrorBoundary`. `experiments.typedRoutes` is on, so routes are typechecked. |
+| `react-native-screens` | `4.25.2` | Never imported directly — required peer of `expo-router`'s native stack; backs each screen with a real native view controller. |
+| `react-native-safe-area-context` | `~5.7.0` | `useSafeAreaInsets` throughout the UI (`pad.tsx`, `BoxSwitcher`, `RemotePowerBar`, `Paywall`, `UnlockToast`, `ReviewToast`, and more). Load-bearing for the trackpad tab, where the touch surface must avoid the home indicator. |
+
+### UI / presentation
+
+| Package | Version | Why |
+|---|---|---|
+| `@expo/vector-icons` | `^15.0.2` | Ionicons only. Tab-bar glyphs (`app/(tabs)/_layout.tsx`) and inline icons across `actions.tsx`, `pad.tsx`, `launch.tsx`, `BoxSwitcher`, `SmartTvSetup`. |
+| `expo-status-bar` | `~57.0.0` | Root `_layout.tsx` syncs native status-bar chrome to the active theme (`lib/theme.ts` defers to it rather than styling the bar itself). |
+| `expo-splash-screen` | `~57.0.1` | Config plugin only, no imports. Supplies the splash image and `#0b1220` background at build time. |
+| `react-native-reanimated` | `4.5.0` | Imported for side effects only — a bare `import 'react-native-reanimated'` in `app/_layout.tsx` to install the runtime. No animations authored against its API yet. |
+| `react-native-worklets` | `0.10.0` | Never imported directly — mandatory peer of Reanimated 4, which moved the worklet runtime into its own package. Removing it breaks Reanimated. |
+
+### Native capability
+
+These are the reason the product exists — each one maps to a feature that
+cannot be done in JS alone.
+
+| Package | Version | Why |
+|---|---|---|
+| `expo-secure-store` | `~57.0.0` | The persistence layer for everything sensitive and not: box tokens and box list (`lib/settings.ts`), user prefs (`lib/prefs.ts`), haptics toggle (`lib/haptics.ts`), theme choice (`lib/theme.ts`), keep-awake toggle (`lib/keepAwake.ts`). `settings.ts` wraps it with a `localStorage` fallback so the web target still runs. Registered as an `app.json` plugin. |
+| `expo-network` | `~57.0.1` | Reads the phone's own IPv4 address in `lib/boxDiscovery.ts` so the LAN sweep knows which `/24` to scan. |
+| `react-native-udp` | `^4.1.7` | UDP datagrams for Wake-on-LAN magic packets (`lib/wol.ts`) and the fast broadcast discovery probe (`lib/boxDiscovery.ts`). **Deliberately optional**: both call sites `require()` it inside a `try/catch` so a build predating the dependency degrades instead of crashing. Discovery's reliable path is the HTTP `/api/ping` sweep — iOS blocks UDP on the local network even after the permission is granted, so the UDP probe is an Android fast-path only. `boxDiscovery.ts` also has to accept either `udp.default` or the module itself, because the package does both `module.exports` and `export default`. |
+| `buffer` | `^6.0.3` | Node's `Buffer` shim, not present in the RN runtime. Needed to build the raw WoL magic packet byte-for-byte (`lib/wol.ts`) and to frame discovery datagrams (`lib/boxDiscovery.ts`). |
+| `expo-haptics` | `~57.0.0` | Tactile feedback on trackpad taps and button presses, wrapped in `lib/haptics.ts` behind a user-toggleable pref. |
+| `react-native-volume-manager` | `^2.0.8` | `hooks/useVolumeButtons.ts` — binds the phone's physical volume rocker to the box's volume, so the phone behaves like a real remote. |
+| `expo-screen-orientation` | `~57.0.0` | `hooks/useLockOrientation.ts` — pins orientation per screen (the gamepad/trackpad surfaces need a fixed frame). |
+| `expo-linking` | `~57.0.1` | Deep links for pairing (`lib/DeepLink.tsx`) and outbound URL opening in `setup.tsx`. Note: `DeepLink.tsx` deliberately avoids `Linking.parse` and hand-parses instead — a documented behavior problem in expo-linking 57. |
+| `expo-constants` | `~57.0.2` | App metadata in `setup.tsx`. Used *alongside* `expo-application`, not instead of it (see the warning below). |
+| `expo-application` | `~57.0.2` | The correct source of the native build number in `setup.tsx`. There is an explicit comment there: `Constants.nativeBuildVersion` does **not** exist in SDK 57 but still typechecks via an index signature — this package is the fix. |
+| `qrcode` | `^1.5.4` | Pairing QR generation. Only `QRCode.create()` is used, for its raw bit matrix — `components/QrView.tsx` draws that matrix as merged rows of `View`s, because `toDataURL`/`toString` need a browser canvas or Node `zlib`, neither of which exists in RN (this previously rendered a blank modal on-device). |
+
+### In-app purchase
+
+| Package | Version | Why |
+|---|---|---|
+| `expo-iap` | `^4.3.6` | Direct StoreKit / Google Play Billing for the `couchpilot_unlock` entitlement. Registered as an `app.json` plugin. `lib/purchase.ts` is a deliberately no-throw wrapper that `require()`s it lazily and types only a minimal structural view of the v4 Open IAP surface — so web and any build without the native module return null instead of crashing. Given the prior App Review 2.1(b) rejection, the fail-closed behavior here is intentional. |
+| `expo-store-review` | `~57.0.0` | Native rating prompt in `components/ReviewPrompt.tsx`. Lazily `require()`d, never a top-level import, for the same native-module-absent reason. |
+
+### Web target
+
+| Package | Version | Why |
+|---|---|---|
+| `react-native-web` | `~0.21.0` | `app.json` sets `web.bundler: metro`, `web.output: static`. Not imported by hand; Metro aliases `react-native` to it. There is a committed `dist/` web build and a `scripts/web-dev.sh` harness, so this path is live. |
+| `@expo/metro-runtime` | `~57.0.6` | Metro's web runtime (Fast Refresh, error overlay). Required by the web target, never imported directly. |
+
+### Dev / build
+
+| Package | Version | Why |
+|---|---|---|
+| `typescript` | `~6.0.3` | Typechecking. Note the caveat below about what `tsc` does and does not prove. |
+| `@types/react` | `~19.2.2` | React 19 types. |
+| `@types/qrcode` | `^1.5.6` | Types for `qrcode`, which ships none. |
+| `expo-build-properties` | `~57.0.2` | Config plugin, no imports. Its single job here is `android.usesCleartextTraffic: true` — the agent is plain HTTP on the LAN by design, and Android would otherwise block it. |
+
+---
+
+## 2. The agent — zero third-party dependencies
+
+`agent/couchsided.py` is ~11,100 lines in **one file** with **no imports outside
+the Python 3 standard library**. Same for `agent/qr.py`, `agent/win/couchsided-win.py`,
+`couchside-decky/main.py`, `cec-bridge/couchside-cec-bridge.py`, and every file
+in `tests/`.
+
+`CLAUDE.md` states the rule directly: *"The agent stays pure Python 3 stdlib,
+single file. No third-party imports, ever."* Treat a violation as a bug, not a
+tradeoff.
+
+### Why the constraint exists
+
+The agent installs onto **immutable-rootfs distros** — SteamOS and Bazzite —
+where the root filesystem is read-only and there is no usable `pip` story. There
+is no virtualenv to activate in a systemd unit, no package manager to invoke, no
+build toolchain to compile a native wheel against. What *is* guaranteed is that
+`python3` is preinstalled on both. So the install path reduces to: copy one file
+into `~/.local/opt`, write a systemd unit, start it. `install.sh` verifies the
+download with nothing more than `python3 -m py_compile`.
+
+The agent confines its writes to `~/.local/opt`, `/etc`, and
+`/etc/systemd/system` — the three places writable on both distros.
+
+### What the constraint forces
+
+Every convenience library the agent cannot use has a hand-rolled replacement:
+
+- **No `psutil`.** System metrics are read by parsing kernel interfaces
+  directly: `/proc/uptime`, `/proc/meminfo`, `/proc/net/route` (to find the
+  default-route interface), `/proc/net/tcp{,6}` and `/proc/net/udp{,6}`,
+  `/proc/bus/input/devices` (gamepad enumeration), and `/proc/*/cmdline`
+  (scanning for the Steam reaper wrapper to identify the running AppId).
+  Hardware state comes from sysfs by hand: `/sys/class/hwmon/hwmon*/name` and
+  `/sys/class/thermal/thermal_zone*/temp` for temperature, `/sys/class/net/<if>/`
+  for MAC and wireless detection, `/sys/class/drm/` for display and connector
+  status, `/sys/class/power_supply/` for battery.
+- **No `websockets` / `websocket-client`.** RFC 6455 is implemented twice, by
+  hand. A **server** side (`ws_try_parse` / `ws_recv_frame` / `ws_send`, no
+  fragmentation support) for the phone's control socket, and a separate
+  **client** side over TLS for LG WebOS TV control, which speaks the same
+  framing with a different message schema — explicitly reused rather than
+  pulling in a library.
+- **No `vdf` parser.** Steam's VDF format has no stdlib parser, so
+  `_parse_vdf_paths` extracts library paths from `libraryfolders.vdf` by string
+  scanning. The same applies to `shortcuts.vdf` (screensaver registration),
+  `remoteclients.vdf` (Steam Link hosts), and the multi-megabyte `appinfo.vdf`
+  name cache, which is read incrementally rather than parsed whole.
+- **No `evdev` / `pynput`.** Virtual input devices are created against the
+  legacy uinput API using `fcntl.ioctl` plus `struct` packing. This is fragile
+  enough that the code does a runtime size check rather than an `assert`
+  (`struct.calcsize(_UINPUT_USER_DEV) != 1116`), specifically because `python3 -O`
+  strips asserts.
+- **No `pyserial`.** RS-232 control of the Newline panel opens the line raw at
+  8N1 through `termios`.
+- **No `requests`.** Outbound HTTP is `urllib.request` / `urllib.error`.
+- **No `paho-mqtt`, no CEC bindings, no cloud SDKs.** Anything else is
+  `subprocess` against a system binary that is already present.
+- **No `pytest`.** `tests/*.py` are plain scripts run as `python3 tests/foo.py`,
+  one CI step per file. They load the agent via `importlib.util.spec_from_file_location`
+  and drive the *real* functions against temp-directory fixtures, repointing
+  module constants like `_DRM_DIR`, `_POWER_SUPPLY_DIR`, and `_PROC_INPUT_DEVICES`
+  rather than reimplementing logic.
+
+### Stdlib modules it leans on hardest
+
+Top-level imports in `couchsided.py`:
+
+`argparse`, `base64`, `calendar`, `glob`, `hashlib`, `hmac`, `json`, `os`,
+`random`, `re`, `select`, `shutil`, `socket`, `ssl`, `struct`, `subprocess`,
+`sys`, `tempfile`, `termios`, `threading`, `time`, `urllib.error`,
+`urllib.request`, `zlib`, plus `http.server` (`BaseHTTPRequestHandler`,
+`ThreadingHTTPServer`) and `urllib.parse`.
+
+Conditional / local imports: `fcntl` (POSIX only — uinput needs it, absent on
+Windows), `math`, and a deferred `urllib.request`.
+
+The heavy hitters, by role:
+
+- `http.server` + `threading` — the entire API surface. `ThreadingHTTPServer`
+  is the web framework.
+- `socket` + `select` + `struct` — WebSocket framing, discovery datagrams,
+  RS-232 and TV control.
+- `subprocess` — the universal escape hatch, standing in for every library
+  that would otherwise be a pip install.
+- `glob` + `os` + `re` — the `/proc` and sysfs parsing layer.
+- `hmac` + `hashlib` + `base64` — token auth and the WebSocket handshake accept key.
+- `fcntl` + `struct` — uinput ioctls.
+
+### Windows agent
+
+`agent/win/couchsided-win.py` holds the same line. Instead of `pywin32` or
+`pynput` it uses **`ctypes`** to call Win32 directly (`SendInput`, WTS session
+queries), plus `winreg` for registry access. Its only non-stdlib-shaped import
+is `qr` — the sibling `agent/qr.py`, in-repo.
+
+### Python version floor
+
+**Python 3.8+.** The binding constraint is a single walrus operator at
+`couchsided.py:6003`; f-strings appear ~39 times (3.6+). There is no `match`
+statement, no PEP 585 builtin generics (`list[...]`/`dict[...]`), no
+`dataclasses`, and no `str | None` unions — the code is written in a
+conservative dialect and formats mostly with `%`. Nothing declares the floor
+explicitly (no `python_requires`, no `sys.version` guard); it is inferred from
+syntax. Both target distros ship well past 3.8, so this has not been tested at
+the boundary.
+
+---
+
+## 3. Build and release tooling
+
+Not runtime dependencies, but required to ship.
+
+| Tool | Where | Why |
+|---|---|---|
+| `eas-cli` (`>= 12.0.0`) | `app/eas.json` | Builds and submits both platforms. Profiles: `development`, `preview`, `beta` (sets `EXPO_PUBLIC_BETA_UNLOCK=1`), `production`. `appVersionSource: local` — versions come from `app.json`, not EAS. Cloud builds are the default; the self-hosted Mac (`eas build --local`) is a quota fallback only. |
+| `openssl` (Ed25519) | `scripts/sign-release.sh`, `scripts/release-agent.sh` | Signs `SHA256SUMS` for every release so `install.sh` can verify what it downloads. Needs one-shot Ed25519 signing (`-rawin`) — macOS system LibreSSL 3.3+ works, otherwise Homebrew `openssl@3`; both scripts probe `PATH` first and fall back to `brew --prefix openssl@3`. |
+| `gh` (GitHub CLI) | `scripts/release-agent.sh` | Creates the release and uploads assets (`--clobber`). Fails fast if unauthenticated. Note: `main` is branch-protected, so releases go through PRs. |
+| `scripts/asc-submit.py` | — | App Store Connect API. Mints an ES256 JWT from the `.p8` key and drives submission. |
+| `scripts/play-release-notes.py` | — | Google Play Developer API. Service-account RS256 JWT, pushes release notes. |
+| `python3` | `install.sh`, `scripts/*` | The installer shells into `python3` heredocs for config generation, VDF parsing, LAN-IP detection, and version comparison. |
+
+**One documented exception to the stdlib rule:** `scripts/asc-submit.py` and
+`scripts/play-release-notes.py` both import the third-party **`cryptography`**
+package (for ES256 / RS256 JWT signing). This is fine and deliberate — these run
+on a developer's Mac or a CI runner, never on a user's box. The stdlib
+constraint applies to shipped agent code, not to release tooling. Worth keeping
+the boundary explicit so it does not erode.
+
+---
+
+## 4. Flags
+
+### Unused — safe to remove
+
+Three packages appear **only** in `app/package.json`, with zero references
+anywhere in `app/`, `components/`, `hooks/`, `lib/`, or `app.json`:
+
+- **`expo-font` `~57.0.0`** — no `useFonts`, no custom font assets loaded.
+- **`expo-symbols` `~57.0.0`** — no `SymbolView`. Icon work goes through
+  `@expo/vector-icons` instead.
+- **`expo-web-browser` `~57.0.0`** — no `WebBrowser.openBrowserAsync`.
+  Outbound links go through `expo-linking` in `setup.tsx`.
+
+All three are Expo defaults from `create-expo-app` that were never wired up.
+Dropping them trims the native build. Verify against the pending "set up a box"
+deep-link work first — if that ends up wanting an in-app browser tab,
+`expo-web-browser` is the package it would use.
+
+Not unused, despite having no direct imports — **do not remove**:
+`react-native-screens` (expo-router peer), `react-native-worklets` (Reanimated 4
+peer), `@expo/metro-runtime` and `react-native-web` (web target),
+`expo-splash-screen` and `expo-build-properties` (config plugins).
+
+### Worth a look
+
+- **`react-native-reanimated` `4.5.0` earns its keep only by side effect.** The
+  sole reference is a bare `import 'react-native-reanimated'` in `_layout.tsx`.
+  Together with its `react-native-worklets` peer that is two native packages
+  carrying no authored animation. If nothing downstream (a navigator, a gesture
+  surface) actually requires it, both could go; if something does, a comment at
+  the import site would prevent a future removal attempt.
+- **`usesCleartextTraffic: true` on Android is a real, accepted exposure.** It
+  disables TLS enforcement app-wide, not just for the agent. It is correct under
+  the LAN-only threat model documented in the security audit, and TLS pinning
+  was deferred for needing a native module. Worth revisiting if the app ever
+  talks to anything off-LAN.
+- **`expo-iap` is a `^` range on a fast-moving v4 package.** `lib/purchase.ts`
+  types only a minimal structural view of the API surface, which limits the
+  blast radius, but a minor bump could still shift runtime behavior on a revenue
+  path. Consider pinning exactly, given the App Review history.
+- **`qrcode` is a Node-oriented package used against the grain.** Only
+  `QRCode.create()` works in RN; the render helpers need canvas or `zlib`. This
+  already caused a blank-QR bug on-device. It works and is well commented, but
+  it is one upstream refactor away from breaking again.
+- **TypeScript does not protect you here.** `setup.tsx` documents a live case:
+  `Constants.nativeBuildVersion` does not exist in SDK 57 but typechecks anyway
+  because of an index signature on the module type. `tsc` passing is not
+  evidence that an Expo API exists — grep the installed `.d.ts`.
+
+### Checked and clean
+
+`app/asc-key.p8` (App Store Connect private key) and
+`secrets/play-service-account.json` (Play service account) are both present on
+disk, both correctly gitignored (`app/.gitignore:44`, `.gitignore:13`), and
+neither is tracked by git. Confirmed via `git ls-files`. The Ed25519 release
+signing keys live outside the repo entirely (`~/couchside-release.key` and the
+rollover backup) — losing both means losing the ability to ship updates, so the
+offline backup is not optional.


### PR DESCRIPTION
Retrofits the BlueBird governance method onto this repo. **No behaviour changes** — this changes how future sessions start and what they must prove.

## The constitution

`CLAUDE.md` governs how to work, not what to build.

> **PRIME DIRECTIVE:** the agent executes only what is on an explicit allowlist. Nothing a client sends becomes a command, a path, or a shell string.

Chosen because the agent runs as the user's desktop account on their personal machine and can launch programs, reboot and power off. There's no cloud tier to revoke and no account to lock — a shipped hole stays open until the user updates the agent themselves. §3 turns it into 8 mechanical rules checkable against a diff.

**Safety-critical path: the gamepad/trackpad input loop**, not reachability. Reachability is the louder promise, but it's a plain authed GET already covered by the CI smoke gate — designating it adds ceremony without catching anything. The input loop is where bugs actually escape: half-dead sockets, promote/demote races, leaked uinput devices.

## What is tracked, and what deliberately isn't

This repo is **public**, so the split matters:

| tracked | local-only (gitignored) |
|---|---|
| `CLAUDE.md`, `ARCHITECTURE`, `CONVENTIONS`, `DEPENDENCIES`, `ROADMAP` | `KNOWN_ISSUES.md`, `DECISIONS.md`, `BUILD_LOG.md` |

`KNOWN_ISSUES` is a numbered registry of where a LAN-exposed daemon is soft, for a service running as the user's desktop account — not something to publish. `CLAUDE.md` §2 marks all three LOCAL so a fresh clone knows they exist, is told to create rather than assume no history, and is told not to "helpfully" commit them.

The technical files stay tracked: they help anyone reading a source-available project, and `ARCHITECTURE.md` carries `file:line` refs that drift, so it needs version history.

## Derived, not templated

`ARCHITECTURE`, `CONVENTIONS` and `DEPENDENCIES` came from reading this codebase — real file:line refs, real patterns, real dependency rationale. The sweep surfaced two inconsistencies now settled rather than left to drift (two incompatible test `check()` signatures; three app deps with zero imports), and found **zero** TODO/FIXME/HACK markers in tracked source.

Rebased onto current `main`, so it documents what actually shipped: the **skin seam** from #140 (including why `classic.tsx` must not be deleted, and the one-clock/semantic-colour rules), and the host-online detection from #143 — which solved via Steam's own connection log the exact problem I'd left open as "needs a network probe".

## §11 is not in the standard template

It records the evidence rules this project learned expensively: test the thing rather than grepping for it; observe both states before believing a detector; put a control in every measurement; verify the tool did what it claims; don't generalise from one observation in either direction; write down what you did *not* verify.

Every one has a scar behind it — including a fixture time bomb I wrote that turned CI red 12 hours later (fixed in #141) and a tap that shipped broken because the harness was used to render, not to press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)