### PR TITLE
feat(tv): drive a chosen TV, not whichever brand ranks highest

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -9265,6 +9265,30 @@ def mock_stream_host():
             "client": "macOS", "since": int(time.time()) - 725}
 
 
+def mock_tv():
+    """A box with TWO paired TVs, so the app's TV picker is reachable in the
+    web harness.
+
+    /api/tv had no mock branch, so under --mock it ran the real tv_info()
+    against the dev machine, found no backend and 404'd. That made the
+    multi-TV picker -- which only renders at 2+ backends -- impossible to
+    exercise anywhere except a box with two TVs physically paired, which is
+    exactly the state that is hardest to arrange and easiest to ship broken."""
+    return {
+        "available": True,
+        "backend": "webos",
+        "adapter": "LG webOS (10.7.0.205)",
+        "backends": ["webos", "androidtv"],
+        "tv_active": "webos",
+        "ops": ["power_on", "power_off", "volume_up", "volume_down", "mute"],
+        "box_volume": True, "tv_volume": True, "tv_power": True,
+        "source_box": False, "sources": [], "screen_toggle": False,
+        "keys": True, "source_key": False, "text": True,
+        "text_focus_push": True, "muted": False,
+        "box_volume_level": 70, "tv_volume_level": None,
+    }
+
+
 def mock_steamlink():
     """Stream hosts in EVERY liveness state at once.
 
@@ -10259,7 +10283,7 @@ class Handler(BaseHTTPRequestHandler):
             elif path == "/api/tv":
                 # Probe-and-appear: 404 when no TV backend so the app shows no
                 # TV strip; a body only when a backend is live.
-                info = tv_info()
+                info = mock_tv() if self.mock else tv_info()
                 if info is None:
                     self._send(404, {"error": "not found"}, started)
                 else:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -224,6 +224,12 @@ CONFIG_VIDAA = None  # optional {"host","name","mac"} Hisense VIDAA (MQTT) confi
 # optional {"host","name"} LG COMMERCIAL/signage panel (TCP 9761, no pairing).
 # Distinct from CONFIG_WEBOS: these panels do not speak consumer webOS at all.
 CONFIG_LGCOM = None
+# The brand the user explicitly chose to drive, or None to fall back to the
+# priority chain in _tv_hw_backend(). Without this a second paired TV was
+# UNREACHABLE: the chain returns exactly one backend, so pairing e.g. a Google
+# TV on a box that already had an LG reported success and then did nothing,
+# because webos outranks androidtv and kept winning silently.
+CONFIG_TV_ACTIVE = None
 # Guide-button hold -> Couch Mode. OFF BY DEFAULT: a false positive yanks the
 # user out of their desktop session mid-work. "uniq" optionally pins the trigger
 # to ONE pad, keyed on the evdev U: Uniq field (the pad's OWN MAC) because BT
@@ -572,7 +578,7 @@ def load_config(path):
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
     global CONFIG_ROKU, CONFIG_ANDROIDTV, CONFIG_VIDAA, ALLOW_APP_UPDATE
-    global CONFIG_LGCOM
+    global CONFIG_LGCOM, CONFIG_TV_ACTIVE
     global ALLOW_APP_LAUNCHERS, CONFIG_GUIDE
     CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
     try:
@@ -606,6 +612,8 @@ def load_config(path):
     CONFIG_ANDROIDTV = androidtv
     CONFIG_VIDAA = vidaa
     CONFIG_LGCOM = lgcom
+    active = raw.get("tv_active")
+    CONFIG_TV_ACTIVE = active if isinstance(active, str) and active else None
     CONFIG_GUIDE = guide
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
@@ -4850,6 +4858,7 @@ def _webos_save(host, client_key, mac=None):
                 pass
             raise
         CONFIG_WEBOS = cfg
+    set_tv_active("webos")
 
 
 # ---- shared helpers for the network TV backends ---------------------------
@@ -4874,6 +4883,20 @@ def _wol_send(mac):
         return _webos_result(start, True, "wol -> %s" % mac)
     except (ValueError, OSError) as e:
         return _webos_result(start, False, "wol failed: %s" % e)
+
+
+def set_tv_active(brand):
+    """Persist which paired TV the box should drive. None clears the choice and
+    restores the priority chain.
+
+    Called on every successful pair as well as from the picker: pairing a TV is
+    an unambiguous statement that you want to use it, and without this a second
+    paired TV stayed silently unreachable behind a higher-priority brand."""
+    global CONFIG_TV_ACTIVE
+    with CONFIG_LOCK:
+        _config_set_field("tv_active", brand)
+        CONFIG_TV_ACTIVE = brand
+    return brand
 
 
 def _config_set_field(field, value):
@@ -5090,6 +5113,7 @@ def _samsung_save(host, token, mac=None):
     with CONFIG_LOCK:
         _config_set_field("samsung", cfg)
         CONFIG_SAMSUNG = cfg
+    set_tv_active("samsung")
 
 
 # ---- Roku backend (ECP over plain HTTP) -----------------------------------
@@ -5222,6 +5246,7 @@ def _roku_save(host, name):
     with CONFIG_LOCK:
         _config_set_field("roku", cfg)
         CONFIG_ROKU = cfg
+    set_tv_active("roku")
 
 
 # ---- Android TV / Google TV backend (Remote v2, protobuf over TLS) --------
@@ -5498,6 +5523,7 @@ def _androidtv_save(host, cert_pem, key_pem, name=None, mac=None):
     with CONFIG_LOCK:
         _config_set_field("androidtv", cfg)
         CONFIG_ANDROIDTV = cfg
+    set_tv_active("androidtv")
 
 
 # -- persistent remote session (keepalive) --
@@ -5799,6 +5825,7 @@ def _vidaa_save(host, name=None, mac=None):
     with CONFIG_LOCK:
         _config_set_field("vidaa", cfg)
         CONFIG_VIDAA = cfg
+    set_tv_active("vidaa")
 
 
 # ---- LAN TV discovery (mDNS + SSDP sweep) ---------------------------------
@@ -6385,11 +6412,46 @@ def set_tv(mock):
     set_soft(mock)
 
 
+def _probe_ok(fn):
+    """True if an availability probe says yes. Probes touch config, sockets and
+    serial ports, so any of them can raise; a backend that errors is simply not
+    available. (set_caps has its own local `safe` for the same reason -- this is
+    the module-level equivalent, needed because _tv_hw_backend runs per request.)"""
+    try:
+        return bool(fn())
+    except Exception:
+        return False
+
+
+# brand -> availability probe, in the order the chain falls back through.
+def _tv_backend_probes():
+    return [("panel", panel_available), ("webos", webos_available),
+            ("samsung", samsung_available), ("androidtv", androidtv_available),
+            ("roku", roku_available), ("vidaa", vidaa_available),
+            ("lgcom", lgcom_available), ("cec", cec_available)]
+
+
+def tv_backends_available():
+    """Every controllable backend on this box, newest-choice first. The app
+    lists these so the user can pick WHICH paired TV to drive."""
+    return [name for name, probe in _tv_backend_probes() if _probe_ok(probe)]
+
+
 def _tv_hw_backend():
-    """The external TV backend for power (and TV volume, when chosen): the serial
+    """The external TV backend for power (and TV volume, when chosen).
+
+    An explicit user choice (config `tv_active`) wins, so a box with several
+    paired TVs drives the one the user picked. It is validated against live
+    availability every call rather than trusted: a chosen TV whose config was
+    removed must fall back instead of leaving the box with no working remote.
+
+    With no choice recorded, the historical priority chain applies: the serial
     panel first (it can power on from standby), then a paired webOS TV (explicit
-    config + a strict superset of CEC), then CEC. None when none exist. Kept
-    separate from box volume, which the soft backend handles."""
+    config + a strict superset of CEC), then CEC."""
+    if CONFIG_TV_ACTIVE:
+        for name, probe in _tv_backend_probes():
+            if name == CONFIG_TV_ACTIVE and _probe_ok(probe):
+                return name
     if panel_available():
         return "panel"
     if webos_available():
@@ -6418,6 +6480,10 @@ def tv_info():
     box_vol = soft_available()
     if hw is None and not box_vol:
         return None
+    # The roster the app's TV picker lists, plus what is actually driving now.
+    # `active` is the RESOLVED backend, not the stored preference: a chosen TV
+    # whose config vanished falls back, and the UI must show what is true.
+    backends = tv_backends_available()
     if hw == "panel":
         backend, adapter = "panel", "Newline RS-232 (%s @ %d)" % (
             PANEL["device"], PANEL["baud"])
@@ -6453,6 +6519,11 @@ def tv_info():
         "available": True,
         "backend": backend,
         "adapter": adapter,
+        # Every controllable backend on this box, and the user's stored choice.
+        # The app lists `backends` as a TV picker; older apps ignore both fields
+        # and keep seeing exactly the single `backend` they always did.
+        "backends": backends,
+        "tv_active": CONFIG_TV_ACTIVE,
         "ops": list(TV_OPS),
         "box_volume": box_vol,
         "tv_volume": hw is not None,
@@ -10705,6 +10776,41 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(200, {"ok": True, "backend": "lgcom", "host": host,
                                  "status": st}, started)
                 return
+            if path == "/api/tv/active":
+                # Pick WHICH paired TV drives the remote. The priority chain
+                # alone made a second paired TV unreachable, so this is the
+                # switch that makes multiple TVs actually usable.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    brand = req.get("backend")
+                    if brand is not None and not isinstance(brand, str):
+                        raise ValueError("backend must be a string or null")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "backend (string or null) required"},
+                               started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "tv_active": brand,
+                                     "backend": brand or "webos",
+                                     "backends": ["webos", "androidtv"]}, started)
+                    return
+                # Reject a brand this box cannot actually drive: silently
+                # storing an unusable choice is how the original bug felt.
+                avail = tv_backends_available()
+                if brand is not None and brand not in avail:
+                    self._send(400, {"error": "backend not available on this box",
+                                     "backends": avail}, started)
+                    return
+                try:
+                    set_tv_active(brand)
+                except Exception as e:
+                    self._send(500, {"error": "could not persist config: %s" % e},
+                               started)
+                    return
+                self._send(200, {"ok": True, "tv_active": CONFIG_TV_ACTIVE,
+                                 "backend": _tv_hw_backend(),
+                                 "backends": avail}, started)
+                return
             if path == "/api/tv/identify":
                 # What kind of device is at this address? Lets the app pick the
                 # pairing flow itself, and turn a wrong target into a sentence
@@ -10742,6 +10848,9 @@ class Handler(BaseHTTPRequestHandler):
                                          "reason": "webOS SSAP"}, started)
                     return
                 self._send(200, identify_tv(host), started)
+                self._send(200, {"ok": True, "tv_active": CONFIG_TV_ACTIVE,
+                                 "backend": _tv_hw_backend(),
+                                 "backends": avail}, started)
                 return
             if path == "/api/tv/webos/pair":
                 try:

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -66,6 +66,23 @@ function pairableBrand(b: TvIdentifyResult['brand']): Brand | null {
 }
 
 /**
+ * Display names for the TV-picker roster. It spans more than BRANDS: the box's
+ * non-pairable backends (RS-232 panel, HDMI-CEC) are choosable TVs too. An id
+ * a future agent adds falls through to the raw id rather than rendering blank.
+ */
+const BACKEND_LABELS: Record<string, string> = {
+  webos: 'LG',
+  samsung: 'Samsung',
+  roku: 'Roku',
+  androidtv: 'Google TV',
+  vidaa: 'Hisense',
+  panel: 'RS-232 panel',
+  cec: 'CEC',
+};
+
+const backendLabel = (id: string): string => BACKEND_LABELS[id] ?? id;
+
+/**
  * Pair a networked smart TV (LG webOS / Samsung Tizen / Roku / Android-Google TV)
  * to the box so the Pad tab's D-pad drives it. webOS/Samsung show an accept
  * prompt on the TV; Roku needs no pairing; Android/Google TV is two-step (a
@@ -94,6 +111,13 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
   // escape: identify can be wrong, and a TV in standby cannot be identified at
   // all, which would otherwise make an off TV impossible to set up.
   const [blocked, setBlocked] = useState<{ host: string; commercial: boolean } | null>(null);
+  const [switching, setSwitching] = useState(false);
+  // Discovery reports each TV's brand and pick() applies it, so for the common
+  // path the brand is already answered and the chip row is clutter. It collapses
+  // to a summary once something is known; `brandOpen` is the "Change" escape
+  // hatch, still needed for a TV that is off (unidentifiable) or a typed-in IP.
+  const [brandKnown, setBrandKnown] = useState(false);
+  const [brandOpen, setBrandOpen] = useState(false);
 
   const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
   const active =
@@ -101,6 +125,9 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       ? tvPoll.data
       : null;
   const meta = BRANDS.find((b) => b.id === brand)!;
+  // Absent on agents predating the picker, so `?? []` keeps those boxes on the
+  // exact pre-picker rendering: one backend, no roster, nothing to choose.
+  const backends = tvPoll.data?.backends ?? [];
 
   // Feedback for a SETTLED outcome fires here rather than at each of the ten
   // setMsg call sites, so no future branch can forget it. In-flight narration
@@ -134,6 +161,41 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     [tvPoll],
   );
 
+  // Point the remote at one of several paired TVs. Before this the box resolved
+  // a TV by a fixed priority chain, so a second pairing succeeded and then drove
+  // nothing at all -- this switch is what makes the extra TV reachable.
+  const chooseBackend = useCallback(
+    async (id: string) => {
+      if (switching) return;
+      setSwitching(true);
+      setMsg({ ok: true, text: `Switching to ${backendLabel(id)}…` });
+      try {
+        const r = await api.tvSetActive(settings, id);
+        // The reply's `backend` is what RESOLVED, not what was asked for: a
+        // chosen TV whose config vanished falls back, and reporting the request
+        // as fact is exactly the lie the original priority-chain bug told.
+        const now = r.backend ?? id;
+        setMsg(
+          now === id
+            ? { ok: true, done: true, text: `Remote now drives ${backendLabel(id)}.` }
+            : {
+                ok: false,
+                done: true,
+                text: `${backendLabel(id)} is not available — still driving ${backendLabel(now)}.`,
+              },
+        );
+      } catch (e: unknown) {
+        setMsg({ ok: false, done: true, text: pairErr(e, `Could not switch to ${backendLabel(id)}.`) });
+      } finally {
+        setSwitching(false);
+        // Re-read regardless of outcome: the picker highlights the RESOLVED
+        // backend, so a rejected choice must not leave the row looking switched.
+        tvPoll.refresh();
+      }
+    },
+    [settings, switching, tvPoll],
+  );
+
   // "Scan for TVs": the box sweeps the LAN (mDNS + SSDP) and returns pairable
   // TVs, so the user taps one instead of typing an IP. A 404 = agent too old.
   const scan = useCallback(async () => {
@@ -163,6 +225,8 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
   // Tap a discovered TV: prefill its brand + IP, then the normal pair flow runs.
   const pick = useCallback((tv: DiscoveredTv) => {
     setBrand(tv.brand);
+    setBrandKnown(true);
+    setBrandOpen(false);
     setHost(tv.host);
     setAwaitingCode(false);
     setCode('');
@@ -319,6 +383,38 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     }
   }, [code, mac, settings, connected]);
 
+  // Rendered in BOTH flow branches: a chip press is also the only way out of
+  // Android TV's step 2 (it clears awaitingCode), so hiding the selector during
+  // code entry would strand a user who picked the wrong brand.
+  const brandSelector =
+    brandKnown && !brandOpen ? (
+      <Pressable onPress={() => setBrandOpen(true)} style={styles.brandSummary}>
+        <Text style={styles.brandSummaryText}>TV type: {meta.label}</Text>
+        <Text style={styles.brandChange}>Change</Text>
+      </Pressable>
+    ) : (
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.segment}>
+        {BRANDS.map((b) => (
+          <Pressable
+            key={b.id}
+            onPress={() => {
+              setBrand(b.id);
+              setBrandKnown(true);
+              setBrandOpen(false);
+              setMsg(null);
+              setAwaitingCode(false);
+              setCode('');
+            }}
+            style={[styles.seg, brand === b.id && styles.segOn]}>
+            <Text style={[styles.segText, brand === b.id && styles.segTextOn]}>{b.label}</Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+    );
+
   return (
     <View style={styles.card}>
       <Text style={styles.title}>Smart TV remote</Text>
@@ -335,31 +431,40 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
         </View>
       ) : null}
 
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={styles.segment}>
-        {BRANDS.map((b) => (
-          <Pressable
-            key={b.id}
-            onPress={() => {
-              setBrand(b.id);
-              setMsg(null);
-              setAwaitingCode(false);
-              setCode('');
-              // `blocked` deliberately survives a brand change: switching brand
-              // is how the user forces a device identify rejected, so clearing
-              // it here would take away the "pair anyway" button at the exact
-              // moment they reached for it.
-            }}
-            style={[styles.seg, brand === b.id && styles.segOn]}>
-            <Text style={[styles.segText, brand === b.id && styles.segTextOn]}>{b.label}</Text>
-          </Pressable>
-        ))}
-      </ScrollView>
+      {/* Only worth a row when there is an actual choice. One backend (or an
+          agent too old to report the roster) renders nothing here — a picker
+          over a single TV is noise. Selection tracks the RESOLVED backend, so a
+          fallback shows as itself rather than as whatever was last tapped. */}
+      {backends.length > 1 ? (
+        <View style={styles.pickerBlock}>
+          <Text style={styles.pickerLabel}>Remote drives</Text>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.segment}>
+            {backends.map((b) => (
+              <Pressable
+                key={b}
+                onPress={() => chooseBackend(b)}
+                disabled={switching}
+                style={[
+                  styles.seg,
+                  tvPoll.data?.backend === b && styles.segOn,
+                  switching && styles.buttonBusy,
+                ]}>
+                <Text
+                  style={[styles.segText, tvPoll.data?.backend === b && styles.segTextOn]}>
+                  {backendLabel(b)}
+                </Text>
+              </Pressable>
+            ))}
+          </ScrollView>
+        </View>
+      ) : null}
 
       {awaitingCode ? (
         <>
+          {brandSelector}
           <TextInput
             value={code}
             onChangeText={(v) => setCode(v.replace(/[^0-9A-Fa-f]/g, '').slice(0, 6))}
@@ -428,6 +533,11 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
             editable={!busy}
             style={styles.input}
           />
+          {/* Demoted below Scan and the IP field: discovery already answers this
+              for any TV that is on, so leading with it asked the user a question
+              the app had. It stays reachable for a TV that is off (nothing to
+              identify) and for a hand-typed IP. */}
+          {brandSelector}
           {meta.needsMac ? (
             <TextInput
               value={mac}
@@ -535,6 +645,21 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 12,
   },
   activeText: { color: t.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
+  pickerBlock: { gap: 6 },
+  pickerLabel: { color: t.textDim, fontSize: 12, fontWeight: '700' },
+  brandSummary: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    backgroundColor: t.inset,
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    minHeight: 44,
+  },
+  brandSummaryText: { color: t.text, fontSize: 13, fontWeight: '600', flexShrink: 1 },
+  brandChange: { color: t.blue, fontSize: 13, fontWeight: '700' },
   segment: {
     flexDirection: 'row',
     backgroundColor: t.inset,

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -608,6 +608,22 @@ export type Tv = {
    * other backend, which keep the manual text button unchanged.
    */
   text_focus_push?: boolean;
+  /**
+   * Every backend this box can actually drive (agent >= 2.9.13), which the app
+   * lists as a TV picker. Older agents resolved exactly one backend by a fixed
+   * priority chain and sent no roster — that chain is why pairing a second TV
+   * reported success and then drove nothing. Kept as plain strings so a backend
+   * added agent-side later renders (by id) instead of being mistyped.
+   */
+  backends?: string[];
+  /**
+   * The user's stored choice, or null meaning "fall back to the priority
+   * chain" (agent >= 2.9.13). NOT the same as `backend`: the agent re-validates
+   * the choice against live availability every call, so a chosen TV whose
+   * config vanished falls back. `backend` is the one actually driving — show
+   * that one as the truth.
+   */
+  tv_active?: string | null;
   /** Current box OS volume 0-100 (agent >= 2.7.0), or null when unreadable. */
   box_volume_level?: number | null;
   /**
@@ -1299,6 +1315,26 @@ export const api = {
    */
   tv(settings: ConnSettings): Promise<Tv> {
     return request<Tv>(settings, '/api/tv');
+  },
+
+  /**
+   * Choose WHICH paired TV drives the remote (agent >= 2.9.13); `null` clears
+   * the choice and restores the priority chain. The agent rejects a backend the
+   * box cannot drive with a 400 ("backend not available on this box") rather
+   * than storing an unusable choice, so the ApiError message is worth showing.
+   * The reply's `backend` is the RESOLVED one and can differ from the requested
+   * `tv_active` — a chosen TV whose config vanished falls back.
+   */
+  tvSetActive(
+    settings: ConnSettings,
+    backend: string | null,
+  ): Promise<{ ok: boolean; tv_active?: string | null; backend?: TvBackend; backends?: string[] }> {
+    return request<{ ok: boolean; tv_active?: string | null; backend?: TvBackend; backends?: string[] }>(
+      settings, '/api/tv/active', {
+        method: 'POST',
+        timeoutMs: 12000,
+        body: { backend },
+      });
   },
 
   /**

--- a/tests/test_tv_identify.py
+++ b/tests/test_tv_identify.py
@@ -150,12 +150,27 @@ def test_nothing_there():
     check(r["brand"] is None and not r["supported"], "empty address is handled")
 
 
+def test_every_backend_is_offerable():
+    print("the roster and the chain agree")
+    # _tv_hw_backend() falls back through a chain, and _tv_backend_probes()
+    # supplies BOTH that chain and the roster the app's picker lists. A backend
+    # present in one and missing from the other can be added successfully and
+    # then be invisible and unreachable -- which is what happened to `lgcom`
+    # when two branches that touched different functions merged cleanly.
+    names = [n for n, _ in cs._tv_backend_probes()]
+    for expected in ("panel", "webos", "samsung", "androidtv", "roku", "vidaa",
+                     "lgcom", "cec"):
+        check(expected in names, "%s is offerable in the picker roster" % expected)
+    check(len(names) == len(set(names)), "no duplicate backends in the roster")
+
+
 if __name__ == "__main__":
     test_commercial_vs_consumer_lg()
     test_open_3001_alone_is_not_webos()
     test_commercial_wins_over_consumer_order()
     test_other_brands()
     test_nothing_there()
+    test_every_backend_is_offerable()
     print()
     if _fail:
         print("FAILED: %d" % len(_fail))


### PR DESCRIPTION
Pairing a second TV **reported success and then did nothing.**

`_tv_hw_backend()` was a fixed priority chain — `panel > webos > samsung > androidtv > roku > vidaa > cec` — returning exactly one backend. On a box with an LG already paired, pairing a Google TV changed nothing: webos outranked it and kept winning, silently. Config could hold several brands at once; only the top one was ever reachable.

Found while chasing a different report ("scan doesn't see my Google TV"), and fixing discovery makes this *easier* to hit, not harder.

## Agent

- Config gains **`tv_active`**. When set it wins — but it's validated against live availability on **every call**, so a chosen TV whose config vanished falls back to the chain instead of leaving the box with no working remote. Unset keeps the historical chain exactly: existing boxes unchanged, no migration.
- **Every successful pair now selects the TV it paired.** Pairing is an unambiguous statement that you want to use it, and this is what makes pairing a second TV actually take effect.
- **`POST /api/tv/active`** picks a TV (`null` clears). It **rejects** a brand the box can't drive rather than storing an unusable choice — silently accepting one is exactly what the original bug felt like.
- `GET /api/tv` gains `backends` and `tv_active`. `backend` still reports the **resolved** backend, so the UI shows what's true rather than what was requested.

## App

A **"Remote drives"** chip row, rendered only at 2+ backends (on a one-TV box it's noise). The highlighted chip follows the **resolved** backend from the poll, never the chip that was tapped, so a rejected or fallen-back choice can't leave the UI claiming a switch that didn't happen.

The **brand selector is demoted, not removed**. Discovery already sets the brand, so asking up front is a question the app can usually answer; it now collapses to a `TV type: LG` summary with a Change affordance. Kept because a TV that's *off* can't be identified and manual IP entry still needs it — and rendered in **both** flow branches, since a brand chip is the only escape from Android TV's 6-digit-code step.

## Verified by driving it, not reading it

Against a live box (LG 85" paired):

| | |
|---|---|
| select an unavailable brand | **400** + the real roster, nothing stored |
| select `webos` | 200, persists across re-read |
| clear | 200, falls back to the chain |
| re-pair | `tv_active` becomes `webos` automatically |

In the harness:

| | |
|---|---|
| picker renders | `Remote drives \| LG \| Google TV` |
| tapping Google TV | POSTs `/api/tv/active` — 0 calls → 1 |
| settled feedback | "Remote now drives Google TV." |

`mock_tv()` was added for that last part: `/api/tv` had no mock branch, so under `--mock` it ran the real `tv_info()` against the dev machine and 404'd — making the picker unreachable in the harness, since it needs 2+ backends. That's the state hardest to arrange on real hardware and easiest to ship broken. Same gap `mock_steamlink` closed for the offline-host UI.

`_probe_ok()` is module-level on purpose: `set_caps` has a local `safe` doing the same job, and reusing that name would have raised `NameError` at request time while `py_compile` stayed green. Caught by importing the module and calling the functions.

## Known limit

The choice is stored per **brand**, not per TV, so **two TVs of the same brand still collide** (two consumer LGs share one `webos` credential slot). A full roster means touching five credential write paths; this covers the reported case, where the devices are different brands. Worth doing if same-brand duplicates come up.

## Follow-ups

- **Brand auto-detect from an IP** — each brand has a distinctive fingerprint (webOS completes TLS on 3001; an LG *commercial* panel opens 9761 and accepts TCP on 3001 without ever handshaking). That turns `_ssl.c:1063` into "that's an LG commercial display, not a consumer webOS TV".
- **LG commercial backend** — proven working on a real panel over 9761: power/input/mute read *and* write, no pairing or TLS.