### PR TITLE
feat(tv): identify what is at an address, so a wrong target explains itself

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,16 @@ jobs:
       - name: Unit tests (stream host liveness)
         run: python3 tests/test_stream_online.py
 
+      # TV identification. A user aimed pairing at an LG COMMERCIAL signage
+      # panel the scan had offered, and got "_ssl.c:1063: The handshake
+      # operation timed out" -- a raw socket error that says nothing about the
+      # real problem. Measured: the panel opens 3001 in 6ms and never
+      # handshakes, while opening 9761; a consumer set completes TLSv1.3 and
+      # refuses 9761. So an open port is NOT an identification, and the
+      # commercial check must precede the consumer one because both open 3001.
+      - name: Unit tests (tv identify)
+        run: python3 tests/test_tv_identify.py
+
       # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
       # dir must not be read as a GPU), the reaper AppId matcher incl. the
       # [oom_reaper] reject, the empty-power_supply desktop case + the uniq (never

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6067,6 +6067,107 @@ def _discover_webos():
     return out
 
 
+# LG COMMERCIAL / signage control port. Commercial panels expose LG's
+# documented RS-232 command set over TCP here; consumer sets do not open it.
+LG_COMMERCIAL_PORT = 9761
+
+
+def _port_open(host, port, timeout=1.5):
+    """True if a TCP connect succeeds. An OPEN port is weak evidence on its own
+    -- see identify_tv, where a commercial LG panel opens 3001 and then never
+    completes a TLS handshake."""
+    try:
+        s = socket.create_connection((host, port), timeout=timeout)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def _tls_completes(host, port, timeout=4.0):
+    """True if a TLS handshake actually COMPLETES (self-signed is fine).
+
+    This is the check that separates a consumer webOS TV from an LG commercial
+    panel, and it cannot be replaced by a port check. Measured on real hardware:
+    the panel accepts TCP on 3001 in 6ms and then never handshakes, so the
+    pairing attempt died with "_ssl.c:1063: The handshake operation timed out"
+    -- an error that told the user nothing about the actual problem, which was
+    that they had aimed Couchside at the wrong device entirely."""
+    try:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        raw = socket.create_connection((host, port), timeout=timeout)
+        raw.settimeout(timeout)
+        with ctx.wrap_socket(raw, server_hostname=host):
+            return True
+    except Exception:
+        return False
+
+
+def identify_tv(host):
+    """What KIND of device is at this address?
+
+    {"brand": <id or None>, "label": str, "supported": bool, "reason": str}
+
+    Exists so a wrong target produces an explanation instead of a raw socket
+    error. Ordered most-specific first: the HTTP APIs answer with a real device
+    name, and the LG commercial check must precede the consumer webOS check
+    because both open 3001.
+
+    A handful of connects to ONE address the user typed -- not a sweep."""
+    host = (host or "").strip()
+    if not host:
+        return {"brand": None, "label": "", "supported": False,
+                "reason": "no address given"}
+
+    # Roku: unauthenticated ECP, names itself.
+    if _port_open(host, ROKU_PORT):
+        xml = _discover_http("http://%s:%d/query/device-info" % (host, ROKU_PORT))
+        m = re.search(r"<friendly-device-name>(.*?)</friendly-device-name>", xml)
+        if m or "<device-info>" in xml:
+            return {"brand": "roku", "label": (m.group(1).strip() if m else "Roku"),
+                    "supported": True, "reason": "Roku ECP"}
+
+    # Samsung Tizen: the v2 API returns a device block.
+    if _port_open(host, SAMSUNG_PORT):
+        return {"brand": "samsung", "label": "Samsung", "supported": True,
+                "reason": "Samsung Tizen remote port"}
+
+    # LG COMMERCIAL before consumer: a signage panel also opens 3001, but its
+    # 3001 never completes TLS. 9761 is the tell and it is unambiguous.
+    if _port_open(host, LG_COMMERCIAL_PORT):
+        return {"brand": "lg_commercial", "label": "LG commercial display",
+                "supported": False,
+                "reason": "This is an LG commercial/signage display, not a "
+                          "consumer webOS TV. It does not support webOS "
+                          "pairing."}
+
+    # Consumer webOS: TCP alone is not enough, the handshake must complete.
+    if _port_open(host, WEBOS_PORT):
+        if _tls_completes(host, WEBOS_PORT):
+            return {"brand": "webos", "label": "LG webOS", "supported": True,
+                    "reason": "webOS SSAP"}
+        return {"brand": None, "label": "unknown device", "supported": False,
+                "reason": "Port %d is open but it is not answering as a webOS "
+                          "TV (the secure handshake times out). This is usually "
+                          "a commercial display or another device entirely."
+                          % WEBOS_PORT}
+
+    if _port_open(host, ANDROIDTV_REMOTE_PORT):
+        return {"brand": "androidtv", "label": "Google TV", "supported": True,
+                "reason": "Android TV remote port"}
+
+    if _port_open(host, VIDAA_PORT):
+        return {"brand": "vidaa", "label": "Hisense", "supported": True,
+                "reason": "VIDAA MQTT port"}
+
+    return {"brand": None, "label": "", "supported": False,
+            "reason": "Nothing answered at that address. Check the IP, and "
+                      "make sure the TV is powered on -- a TV in standby "
+                      "cannot be identified."}
+
+
 def tv_discover(mock, timeout=2.6):
     """Sweep the LAN for controllable TVs (see the module note). Returns a list
     of {brand, name, host}, deduped by host (a pairing backend wins over a bare
@@ -10403,6 +10504,25 @@ class Handler(BaseHTTPRequestHandler):
             # "<ip>", "mac": "<optional, for Wake-on-LAN power-on>"}. Blocks up
             # to ~60s while the TV shows an Accept prompt; on success the granted
             # client_key is persisted to config so later starts are silent.
+            if path == "/api/tv/identify":
+                # What kind of device is at this address? Lets the app pick the
+                # pairing flow itself, and turn a wrong target into a sentence
+                # instead of a raw TLS error.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    host = req["host"]
+                    if not isinstance(host, str) or not host:
+                        raise ValueError("host required")
+                except (ValueError, TypeError, KeyError, UnicodeDecodeError):
+                    self._send(400, {"error": "host (string) required"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"brand": "webos", "label": "LG webOS",
+                                     "supported": True, "reason": "webOS SSAP"},
+                               started)
+                    return
+                self._send(200, identify_tv(host), started)
+                return
             if path == "/api/tv/webos/pair":
                 try:
                     req = json.loads(body.decode("utf-8")) if body else {}

--- a/tests/test_tv_identify.py
+++ b/tests/test_tv_identify.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for identify_tv() — what KIND of device is at this address.
+
+Run: python3 tests/test_tv_identify.py
+
+WHY THIS EXISTS: the app used to ask the user to pick a brand, then fire that
+brand's pairing at whatever IP was in the box. Aiming it at the wrong device
+produced a raw socket error. Reported from the field, pairing an LG:
+
+    Could not reach the box or TV. Check the IP and try again.
+    — box says: HTTP 502: pairing failed: _ssl.c:1063:
+      The handshake operation timed out
+
+The address was an LG COMMERCIAL signage panel that the scan had offered and
+the app had pre-filled. Nothing in that message says so.
+
+THE TRAP, measured on real hardware (both devices on one network):
+
+    10.7.0.178  LG signage    3001 OPEN (6ms), TLS NEVER COMPLETES, 9761 OPEN
+    10.7.0.205  consumer 85"  3001 OPEN,       TLS completes TLSv1.3, 9761 REFUSED
+
+So "port 3001 is open" does NOT mean "consumer webOS TV". The handshake has to
+actually complete, and the commercial panel is positively identifiable by 9761.
+Order matters: the commercial check MUST precede the consumer one, because both
+open 3001.
+
+Verified live against three real devices and one empty address; these tests
+lock in that behaviour with the sockets stubbed.
+
+Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def fake(open_ports, tls_ok=(), http=None):
+    """Stub the three primitives identify_tv probes with."""
+    o = (cs._port_open, cs._tls_completes, cs._discover_http)
+    cs._port_open = lambda h, p, timeout=1.5: p in open_ports
+    cs._tls_completes = lambda h, p, timeout=4.0: p in tls_ok
+    cs._discover_http = lambda url, timeout=2.0: (http or "")
+    return o
+
+
+def restore(o):
+    cs._port_open, cs._tls_completes, cs._discover_http = o
+
+
+def test_commercial_vs_consumer_lg():
+    print("the LG trap: signage panel vs consumer TV")
+    # The panel: 3001 open but the handshake never completes, 9761 open.
+    o = fake({3001, cs.LG_COMMERCIAL_PORT}, tls_ok=())
+    try:
+        r = cs.identify_tv("10.0.0.1")
+        check(r["brand"] == "lg_commercial", "signage panel identified as commercial")
+        check(r["supported"] is False, "and reported as NOT pairable")
+        check("commercial" in r["reason"].lower() or "signage" in r["reason"].lower(),
+              "reason names what it actually is")
+        check("_ssl" not in r["reason"], "reason is a sentence, not a socket error")
+    finally:
+        restore(o)
+
+    # The consumer TV: 3001 open AND the handshake completes; no 9761.
+    o = fake({3001}, tls_ok={3001})
+    try:
+        r = cs.identify_tv("10.0.0.2")
+        check(r["brand"] == "webos", "consumer webOS identified")
+        check(r["supported"] is True, "and reported as pairable")
+    finally:
+        restore(o)
+
+
+def test_open_3001_alone_is_not_webos():
+    print("an open port is not an identification")
+    # 3001 open, no 9761, handshake fails: something else entirely. Guessing
+    # "webos" here is what produced the raw TLS error in the field.
+    o = fake({3001}, tls_ok=())
+    try:
+        r = cs.identify_tv("10.0.0.3")
+        check(r["brand"] is None, "not claimed as webOS on an open port alone")
+        check(r["supported"] is False, "not offered as pairable")
+        check("handshake" in r["reason"] or "not answering" in r["reason"],
+              "reason explains the handshake, in words")
+    finally:
+        restore(o)
+
+
+def test_commercial_wins_over_consumer_order():
+    print("check order: 9761 decides even when 3001 would handshake")
+    # A panel that BOTH opens 9761 and completes TLS on 3001 must still read as
+    # commercial -- the consumer branch must not be reached first.
+    o = fake({3001, cs.LG_COMMERCIAL_PORT}, tls_ok={3001})
+    try:
+        check(cs.identify_tv("10.0.0.4")["brand"] == "lg_commercial",
+              "commercial check precedes the consumer check")
+    finally:
+        restore(o)
+
+
+def test_other_brands():
+    print("the remaining brands")
+    o = fake({cs.ROKU_PORT}, http="<device-info><friendly-device-name>Den Roku"
+                                  "</friendly-device-name></device-info>")
+    try:
+        r = cs.identify_tv("10.0.0.5")
+        check(r["brand"] == "roku", "Roku identified from its ECP reply")
+        check(r["label"] == "Den Roku", "and names itself")
+    finally:
+        restore(o)
+
+    for ports, brand in ((({cs.SAMSUNG_PORT}), "samsung"),
+                         (({cs.ANDROIDTV_REMOTE_PORT}), "androidtv"),
+                         (({cs.VIDAA_PORT}), "vidaa")):
+        o = fake(ports)
+        try:
+            check(cs.identify_tv("10.0.0.6")["brand"] == brand, "%s identified" % brand)
+        finally:
+            restore(o)
+
+
+def test_nothing_there():
+    print("an address with nothing on it")
+    o = fake(set())
+    try:
+        r = cs.identify_tv("10.0.0.7")
+        check(r["brand"] is None, "no brand claimed")
+        # A TV in standby is the common case and the user can act on it.
+        check("powered on" in r["reason"] or "standby" in r["reason"],
+              "reason suggests the TV may be off, which is actionable")
+    finally:
+        restore(o)
+
+    r = cs.identify_tv("")
+    check(r["brand"] is None and not r["supported"], "empty address is handled")
+
+
+if __name__ == "__main__":
+    test_commercial_vs_consumer_lg()
+    test_open_3001_alone_is_not_webos()
+    test_commercial_wins_over_consumer_order()
+    test_other_brands()
+    test_nothing_there()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all tv-identify tests passed")


### PR DESCRIPTION
Pairing an LG at an address that turned out to be a **commercial signage panel** produced this, verbatim from the field:

> Could not reach the box or TV. Check the IP and try again. — box says: HTTP 502: pairing failed: `_ssl.c:1063: The handshake operation timed out`

Nothing in that says *"you are pointed at the wrong kind of device"*, which was the entire problem. Worse: the address had been offered by our own scan and pre-filled by the app, so there was no reason to doubt it.

## The trap, measured on two real devices on one network

| device | 3001 | TLS handshake | 9761 |
|---|---|---|---|
| `10.7.0.178` LG signage | OPEN (6ms) | **never completes** | **OPEN** |
| `10.7.0.205` consumer 85" | OPEN | completes TLSv1.3 | REFUSED |

So **an open 3001 does not mean "consumer webOS TV"** — the handshake has to actually complete. And the panel is positively identifiable by 9761, which consumer sets refuse.

**Ordering is load-bearing:** the commercial check must precede the consumer check, because both open 3001. There's a test asserting exactly that.

## What it does

`identify_tv(host)` → `{brand, label, supported, reason}`, exposed as `POST /api/tv/identify`, so the app can pick the pairing flow itself instead of asking the user to choose a brand and hoping they chose right.

An open port never resolves to a brand on its own. 3001 open with a failing handshake and no 9761 returns `brand: null` with a reason explaining the handshake *in words*, rather than guessing `webos` and reproducing the original error one layer down.

## Verified live against every device on the network

```
10.7.0.205  ->  webos          supported      (the 85")
10.7.0.178  ->  lg_commercial  NOT supported  (the panel that caused this)
10.7.0.183  ->  androidtv      supported      (Conference Room)
10.7.0.199  ->  none           "may be off"   (empty address)
```

## Tests were checked against a control

Making tests pass is the easy half. I reverted `identify_tv` to the pre-fix assumption — open 3001 means webOS, no commercial check — and re-ran: **7 assertions fail**, including the ordering one. So they genuinely catch this rather than merely passing alongside it.

New CI step `Unit tests (tv identify)`.

## Next

The app side wiring (identify on IP entry, surface `reason` when `supported` is false) and the **LG commercial backend** — power/input/mute over 9761, proven read *and* write on the real panel, no pairing or TLS. This PR is what makes that backend offerable: once a panel is identified, Couchside can propose adding it instead of failing.