### PR TITLE
feat(tv): identify the device before pairing, so a wrong target explains itself

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -10718,9 +10718,28 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "host (string) required"}, started)
                     return
                 if self.mock:
-                    self._send(200, {"brand": "webos", "label": "LG webOS",
-                                     "supported": True, "reason": "webOS SSAP"},
-                               started)
+                    # Vary by address so the harness can drive BOTH outcomes.
+                    # A mock that only ever returns "supported" leaves the
+                    # unsupported path -- the whole reason identify exists --
+                    # untestable outside real hardware.
+                    if host.endswith(".178"):
+                        self._send(200, {
+                            "brand": "lg_commercial",
+                            "label": "LG commercial display", "supported": False,
+                            "reason": "This is an LG commercial/signage display, "
+                                      "not a consumer webOS TV. It does not "
+                                      "support webOS pairing."}, started)
+                    elif host.endswith(".199"):
+                        self._send(200, {
+                            "brand": None, "label": "", "supported": False,
+                            "reason": "Nothing answered at that address. Check "
+                                      "the IP, and make sure the TV is powered "
+                                      "on -- a TV in standby cannot be "
+                                      "identified."}, started)
+                    else:
+                        self._send(200, {"brand": "webos", "label": "LG webOS",
+                                         "supported": True,
+                                         "reason": "webOS SSAP"}, started)
                     return
                 self._send(200, identify_tv(host), started)
                 return

--- a/app/components/SmartTvSetup.tsx
+++ b/app/components/SmartTvSetup.tsx
@@ -11,7 +11,16 @@ import {
 } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
-import { api, ApiError, ConnSettings, DiscoveredTv, hostKey, Tv, TvPairResult } from '@/lib/api';
+import {
+  api,
+  ApiError,
+  ConnSettings,
+  DiscoveredTv,
+  hostKey,
+  Tv,
+  TvIdentifyResult,
+  TvPairResult,
+} from '@/lib/api';
 import { hapticError, hapticSuccess } from '@/lib/haptics';
 import { normalizeMac } from '@/lib/settings';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -44,7 +53,17 @@ const BRANDS: { id: Brand; label: string; needsMac: boolean; verb: string }[] = 
   { id: 'vidaa', label: 'Hisense', needsMac: true, verb: 'Add' },
 ];
 
-const NETWORK_BACKENDS = ['webos', 'samsung', 'roku', 'androidtv', 'vidaa'];
+const NETWORK_BACKENDS = ['webos', 'samsung', 'roku', 'androidtv', 'vidaa', 'lgcom'];
+
+/**
+ * identify's `brand` names devices we cannot pair too ("lg_commercial", null),
+ * so it is not assignable to Brand. Anything outside BRANDS falls back to the
+ * user's selection rather than pairing with a backend this build has no flow
+ * for.
+ */
+function pairableBrand(b: TvIdentifyResult['brand']): Brand | null {
+  return BRANDS.some((x) => x.id === b) ? (b as Brand) : null;
+}
 
 /**
  * Pair a networked smart TV (LG webOS / Samsung Tizen / Roku / Android-Google TV)
@@ -69,6 +88,12 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
   const [msg, setMsg] = useState<{ ok: boolean; text: string; done?: boolean } | null>(null);
   const [scanning, setScanning] = useState(false);
   const [found, setFound] = useState<DiscoveredTv[] | null>(null);
+  // Set when identify settled on "do not pair with this". `commercial` splits
+  // the one blocked device we CAN still drive (an LG signage panel, over plain
+  // TCP 9761) from the ones we cannot. Either way the user keeps a force-pair
+  // escape: identify can be wrong, and a TV in standby cannot be identified at
+  // all, which would otherwise make an off TV impossible to set up.
+  const [blocked, setBlocked] = useState<{ host: string; commercial: boolean } | null>(null);
 
   const tvPoll = usePoll<Tv>(() => api.tv(settings), 15000, true, hostKey(settings));
   const active =
@@ -87,14 +112,18 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     else hapticError();
   }, [msg]);
 
+  // `label` is passed in rather than read off `meta`: identify can switch the
+  // brand in the same tick it pairs, and this closure would still be holding
+  // the label the user had selected before.
   const connected = useCallback(
-    (r: TvPairResult) => {
-      setMsg({ ok: true, done: true, text: r.name ? `Connected: ${r.name}` : `Connected to ${meta.label}.` });
+    (r: TvPairResult, label: string) => {
+      setMsg({ ok: true, done: true, text: r.name ? `Connected: ${r.name}` : `Connected to ${label}.` });
       setHost('');
       setMac('');
       setCode('');
       setAwaitingCode(false);
       setFound(null);
+      setBlocked(null);
       // Pull the TV state NOW instead of waiting out the 15s poll. That poll
       // drives the persistent "Connected: <adapter>" row at the top of the
       // card, which is the durable confirmation -- the transient message
@@ -102,7 +131,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       // seconds is why a successful pairing read as no feedback at all.
       tvPoll.refresh();
     },
-    [meta, tvPoll],
+    [tvPoll],
   );
 
   // "Scan for TVs": the box sweeps the LAN (mDNS + SSDP) and returns pairable
@@ -137,19 +166,18 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     setHost(tv.host);
     setAwaitingCode(false);
     setCode('');
+    setBlocked(null);
     setMsg({ ok: true, text: `${tv.name} — tap ${BRANDS.find((b) => b.id === tv.brand)?.verb ?? 'Pair'} below.` });
   }, []);
 
-  const submit = useCallback(async () => {
-    const h = host.trim();
-    if (!h) {
-      setMsg({ ok: false, done: true, text: 'Enter the TV’s IP address.' });
-      return;
-    }
-    setBusy(true);
-    const m = meta.needsMac && mac.trim() ? normalizeMac(mac.trim()) ?? undefined : undefined;
-    try {
-      if (brand === 'androidtv') {
+  // The pairing itself, with the brand passed in: identify may have chosen a
+  // different one than the selector shows, and setBrand does not land in time
+  // for this call. Assumes busy/error handling from its caller.
+  const runPair = useCallback(
+    async (b: Brand, h: string) => {
+      const bm = BRANDS.find((x) => x.id === b)!;
+      const m = bm.needsMac && mac.trim() ? normalizeMac(mac.trim()) ?? undefined : undefined;
+      if (b === 'androidtv') {
         // Step 1: open the pairing socket -> TV shows a 6-digit code.
         setMsg({ ok: true, text: 'Opening pairing on the TV…' });
         const r = await api.tvAndroidtvPairStart(settings, h);
@@ -164,23 +192,112 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
       setMsg({
         ok: true,
         text:
-          brand === 'roku' || brand === 'vidaa'
+          b === 'roku' || b === 'vidaa'
             ? 'Contacting the TV…'
             : 'Waiting for you to accept on the TV…',
       });
       let r: TvPairResult;
-      if (brand === 'webos') r = await api.tvPairWebos(settings, h, m);
-      else if (brand === 'samsung') r = await api.tvPairSamsung(settings, h, m);
-      else if (brand === 'vidaa') r = await api.tvAddVidaa(settings, h, m);
+      if (b === 'webos') r = await api.tvPairWebos(settings, h, m);
+      else if (b === 'samsung') r = await api.tvPairSamsung(settings, h, m);
+      else if (b === 'vidaa') r = await api.tvAddVidaa(settings, h, m);
       else r = await api.tvAddRoku(settings, h);
-      if (r.ok) connected(r);
+      if (r.ok) connected(r, bm.label);
       else setMsg({ ok: false, done: true, text: r.error ?? 'Could not connect to the TV.' });
+    },
+    [mac, settings, connected],
+  );
+
+  /**
+   * Identify first, then act. A user who picked an LG signage panel out of our
+   * OWN scan used to get `HTTP 502: pairing failed: _ssl.c:1063: The handshake
+   * operation timed out` — nothing in that names the actual problem, and there
+   * was no way forward. Asking the box what is at the address turns that into
+   * an explanation plus, for the signage case, a path that works.
+   */
+  const submit = useCallback(async () => {
+    const h = host.trim();
+    if (!h) {
+      setMsg({ ok: false, done: true, text: 'Enter the TV’s IP address.' });
+      return;
+    }
+    setBusy(true);
+    setBlocked(null);
+    try {
+      let id: TvIdentifyResult | null = null;
+      try {
+        setMsg({ ok: true, text: 'Identifying…' });
+        id = await api.tvIdentify(settings, h);
+      } catch (e: unknown) {
+        // Most boxes in the field predate identify and 404 this route. That
+        // MUST degrade to exactly the old behaviour (pair with the selected
+        // brand) -- refusing to pair because a probe is missing would break
+        // setup on every un-updated box. Any other error is a real failure and
+        // rethrows into the handler below.
+        if (!(e instanceof ApiError && e.kind === 'http' && e.status === 404)) throw e;
+      }
+
+      if (id && id.brand === 'lg_commercial') {
+        // Do NOT attempt webOS here: this is the exact device whose port 3001
+        // accepts a connection and then never completes TLS.
+        setBlocked({ host: h, commercial: true });
+        setMsg({ ok: false, done: true, text: id.reason });
+        return;
+      }
+      if (id && !id.supported) {
+        // Settled failure. Falling through would only re-produce the raw socket
+        // error identify exists to replace.
+        setBlocked({ host: h, commercial: false });
+        setMsg({ ok: false, done: true, text: id.reason });
+        return;
+      }
+
+      // The user should not have to have picked the right brand.
+      const chosen = (id && pairableBrand(id.brand)) || brand;
+      if (chosen !== brand) setBrand(chosen);
+      await runPair(chosen, h);
     } catch (e: unknown) {
       setMsg({ ok: false, done: true, text: pairErr(e, 'Could not reach the box or TV. Check the IP and try again.') });
     } finally {
       setBusy(false);
     }
-  }, [brand, host, mac, meta, settings, connected]);
+  }, [brand, host, settings, runPair]);
+
+  // The escape hatch: pair with the brand the user selected, skipping identify
+  // entirely. Reachable after identify blocked the address -- it can be wrong,
+  // and a TV that is OFF cannot be identified at all, so "nothing answered"
+  // must not be the end of the road.
+  const pairAnyway = useCallback(async () => {
+    const h = host.trim();
+    if (!h) return;
+    setBusy(true);
+    setBlocked(null);
+    try {
+      await runPair(brand, h);
+    } catch (e: unknown) {
+      setMsg({ ok: false, done: true, text: pairErr(e, 'Could not reach the box or TV. Check the IP and try again.') });
+    } finally {
+      setBusy(false);
+    }
+  }, [brand, host, runPair]);
+
+  // Record an LG commercial/signage panel. No pairing and no accept prompt --
+  // its 9761 control port is unauthenticated -- so this is a one-tap path out
+  // of what used to be a dead end.
+  const addCommercial = useCallback(async () => {
+    const h = blocked?.host ?? host.trim();
+    if (!h) return;
+    setBusy(true);
+    setMsg({ ok: true, text: 'Contacting the display…' });
+    try {
+      const r = await api.tvAddLgCommercial(settings, h);
+      if (r.ok) connected(r, 'LG commercial display');
+      else setMsg({ ok: false, done: true, text: r.error ?? 'Could not connect to the display.' });
+    } catch (e: unknown) {
+      setMsg({ ok: false, done: true, text: pairErr(e, 'Could not reach the box or display. Check the IP and try again.') });
+    } finally {
+      setBusy(false);
+    }
+  }, [blocked, host, settings, connected]);
 
   const finishAndroidtv = useCallback(async () => {
     const c = code.trim();
@@ -193,7 +310,7 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
     try {
       const m = mac.trim() ? normalizeMac(mac.trim()) ?? undefined : undefined;
       const r = await api.tvAndroidtvPairFinish(settings, c, m);
-      if (r.ok) connected(r);
+      if (r.ok) connected(r, 'Google TV');
       else setMsg({ ok: false, done: true, text: r.error ?? 'Pairing failed — check the code and retry.' });
     } catch (e: unknown) {
       setMsg({ ok: false, done: true, text: pairErr(e, 'Could not reach the box. Try again.') });
@@ -230,6 +347,10 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
               setMsg(null);
               setAwaitingCode(false);
               setCode('');
+              // `blocked` deliberately survives a brand change: switching brand
+              // is how the user forces a device identify rejected, so clearing
+              // it here would take away the "pair anyway" button at the exact
+              // moment they reached for it.
             }}
             style={[styles.seg, brand === b.id && styles.segOn]}>
             <Text style={[styles.segText, brand === b.id && styles.segTextOn]}>{b.label}</Text>
@@ -294,7 +415,11 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
           ) : null}
           <TextInput
             value={host}
-            onChangeText={setHost}
+            onChangeText={(v) => {
+              setHost(v);
+              // The block belongs to the address that was identified.
+              setBlocked(null);
+            }}
             placeholder="TV IP address (e.g. 192.168.1.50)"
             placeholderTextColor={t.textFaint}
             autoCapitalize="none"
@@ -327,6 +452,24 @@ export function SmartTvSetup({ settings }: { settings: ConnSettings }) {
               </Text>
             )}
           </Pressable>
+          {blocked?.commercial ? (
+            <Pressable
+              onPress={addCommercial}
+              disabled={busy}
+              style={[styles.button, busy && styles.buttonBusy]}>
+              <Text style={styles.buttonText}>Add as LG commercial display</Text>
+            </Pressable>
+          ) : null}
+          {blocked ? (
+            <Pressable
+              onPress={pairAnyway}
+              disabled={busy}
+              style={[styles.altBtn, busy && styles.buttonBusy]}>
+              <Text style={styles.altBtnText}>
+                {meta.verb} as {meta.label} anyway
+              </Text>
+            </Pressable>
+          ) : null}
         </>
       )}
 
@@ -436,6 +579,17 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderColor: t.cardBorder,
   },
   scanBtnText: { color: t.blue, fontSize: 14, fontWeight: '700' },
+  altBtn: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+    paddingVertical: 11,
+    minHeight: 44,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  altBtnText: { color: t.textDim, fontSize: 14, fontWeight: '600' },
   foundList: { gap: 6 },
   foundRow: {
     flexDirection: 'row',

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -483,7 +483,10 @@ export type TvBackend =
   | 'samsung'
   | 'roku'
   | 'androidtv'
-  | 'vidaa';
+  | 'vidaa'
+  // LG's signage line over plain TCP 9761 (no pairing, no TLS). Distinct from
+  // "webos": these panels do not speak consumer webOS at all.
+  | 'lgcom';
 
 /**
  * A TV the box found on the LAN (GET /api/tv/discover, agent >= 2.9.12). `brand`
@@ -493,6 +496,21 @@ export type DiscoveredTv = {
   brand: 'webos' | 'samsung' | 'roku' | 'androidtv';
   name: string;
   host: string;
+};
+
+/**
+ * What the box found at one address (POST /api/tv/identify, agent >= 2.9.32).
+ * `brand` widens past the pairable backends because the point is to name the
+ * devices we do NOT support: an LG commercial/signage panel opens the same
+ * port 3001 as a consumer webOS TV and then never completes TLS, which is how
+ * "pair" on one produced a raw `_ssl.c: handshake operation timed out`.
+ * `reason` is already user-facing prose — render it verbatim.
+ */
+export type TvIdentifyResult = {
+  brand: 'webos' | 'samsung' | 'roku' | 'androidtv' | 'vidaa' | 'lg_commercial' | null;
+  label: string;
+  supported: boolean;
+  reason: string;
 };
 
 /**
@@ -1451,6 +1469,40 @@ export const api = {
   tvDiscover(settings: ConnSettings): Promise<{ tvs: DiscoveredTv[] }> {
     return request<{ tvs: DiscoveredTv[] }>(settings, '/api/tv/discover', {
       timeoutMs: 8000,
+    });
+  },
+
+  /**
+   * Ask the box what kind of device is at `host` (agent >= 2.9.32), so the app
+   * can pick the pairing flow instead of making the user guess — and so a wrong
+   * target lands as a sentence rather than a raw socket error. The box makes
+   * several sequential TCP connects to that one address, each with its own
+   * timeout, so this needs far more than the 4 s default. A 404 means the agent
+   * predates identify: callers MUST fall back to pairing with the selected
+   * brand, since most boxes in the field are older.
+   */
+  tvIdentify(settings: ConnSettings, host: string): Promise<TvIdentifyResult> {
+    return request<TvIdentifyResult>(settings, '/api/tv/identify', {
+      method: 'POST',
+      timeoutMs: 15000,
+      body: { host },
+    });
+  },
+
+  /**
+   * Register an LG commercial/signage panel by host (agent >= 2.9.32). Its 9761
+   * control port is unauthenticated, so there is no pairing and no on-TV accept
+   * prompt — the agent just confirms something answers there before persisting.
+   */
+  tvAddLgCommercial(
+    settings: ConnSettings,
+    host: string,
+    name?: string,
+  ): Promise<TvPairResult> {
+    return request<TvPairResult>(settings, '/api/tv/lgcommercial/add', {
+      method: 'POST',
+      timeoutMs: 12000,
+      body: name ? { host, name } : { host },
     });
   },
 


### PR DESCRIPTION
Closes the loop on the reported failure. Stacked on [#151](https://github.com/emerytech/couchside/pull/151) → [#150](https://github.com/emerytech/couchside/pull/150) — **merge those first, in that order.**

A user picked a TV from our own scan, tapped Pair, and got:

> Could not reach the box or TV. Check the IP and try again. — box says: HTTP 502: pairing failed: `_ssl.c:1063: The handshake operation timed out`

The address was an LG **commercial** signage panel. The agent can now identify what's actually there; this makes the app use it.

## Identify first, then act

| result | behaviour |
|---|---|
| `supported` | adopt the **detected** brand and pair with that — the user doesn't have to have picked right |
| `lg_commercial` | don't attempt webOS pairing at all. Show the reason, offer **"Add as LG commercial display"** — a working path, no pairing or TLS |
| anything else | show the reason as a settled failure, instead of falling through to a raw socket error |

`reason` renders **verbatim** — the agent already writes it as prose, and re-wording here would be two places to keep honest.

## Escape hatches, because identification isn't certainty

- **A TV that is OFF cannot be identified at all.** A rejected address still offers "Pair as {brand} anyway", skipping identify. It deliberately **survives a brand change** — switching brand is exactly how you force a rejected device, so clearing the button there would remove it at the moment you reached for it.
- **Older agents 404** on `/api/tv/identify` → falls back to today's behaviour, pairing with the selected brand. Most boxes in the field are old, so this is the path that matters. Only 404 means "too old"; a 500 still surfaces as an error rather than silently pairing blind.

## Mock covers the unhappy paths

`--mock` identify varies by address: `.178` commercial, `.199` nothing-there, else webOS. A mock that only ever returns "supported" leaves the unsupported paths — the entire reason identify exists — untestable outside real hardware. That's how the multi-TV picker nearly shipped unexercised.

## Verified by driving the real UI

Re-checked independently of the agent that wrote it:

| | |
|---|---|
| `10.0.0.178` | explanation shown, both affordances offered, and **zero** `webos/pair` attempts — the doomed request is never sent |
| add button | POSTs `/api/tv/lgcommercial/add` → **"Connected to LG commercial display."** |
| identify 404 (old agent, impersonated by intercepting fetch) | `webos/pair` still fires → "Connected to LG." |

`tsc` clean, verified with an injected control.

## Note

`npx expo lint` scaffolded eslint into the repo mid-work (devDeps, a `lint` script, `app/eslint.config.js`). It was fully reverted and I confirmed independently: `package.json`/lock untouched, no config file, no eslint reference. Only residue is unused packages in `app/node_modules`, cleared by any `npm ci`.