### PR TITLE
chore(release): 2.9.13 — agent 2.9.33, app 2.9.13

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.32"
+VERSION = "2.9.33"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.12",
+    "version": "2.9.13",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,6 @@
-New in 2.9.12
+New in 2.9.13
 
-• Console and Fleet got a redesign. Cards now glow with the reading they carry — a hot CPU burns amber, a cool one sits green — and the dashboard breathes faster when your box is working hard.
-• "Stream from PC" now shows which machines are actually on. Offline PCs are dimmed with the reason, so picking a game won't surprise you with a huge install instead of a stream. You can hide them entirely in Setup › Prefs.
-• Fixed the screen preview sticking on "capturing…".
+• Scan for TVs now actually finds them. It was missing TVs that don't answer the old way — including LG sets and Google TV.
+• Pairing tells you what a device is. Point it at something it can't pair with and it says so, instead of showing a cryptic error.
+• LG commercial and signage displays are now supported — power, input and mute, no pairing needed.
+• Paired more than one TV? Pick which one the remote drives, in Setup.


### PR DESCRIPTION
Version bump for 2.9.13.

- **Linux agent 2.9.32 → 2.9.33.** Required: `agent-version.txt` derives from it, so without the bump installed boxes are never prompted and the TV work reaches only new installs.
- **App 2.9.12 → 2.9.13.** Build numbers untouched — the production profile autoIncrements 65/49 → **66/50**, the required floor. Pre-bumping would overshoot.
- **Windows agent stays 0.3.7-win** — nothing here touches `agent/win`.
- Release notes **440 chars, measured before building**. Play's cap is 500 *characters*; last release I measured bytes first and had to trim after the build.

Ships: discovery fix (#147), identify (#150/#152), LG commercial backend (#151), multi-TV picker (#149).

🤖 Generated with [Claude Code](https://claude.com/claude-code)