### PR TITLE
chore(app): reconcile build numbers to 66/50 (as built for 2.9.13)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "65",
+      "buildNumber": "66",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 49
+      "versionCode": 50
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
`autoIncrement` rewrote `app.json` during the build; repo said 65/49, shipped binaries were **iOS 66 / vc 50** (read back from the finished EAS builds, commit `94f4418`).

Both live: **Play production 2.9.13** (vc 50, `completed`, notes verified by read-back from Google) and **TestFlight build 66**.

Same as #145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)