### PR TITLE
chore(release): 2.9.14 — app-only

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.13",
+    "version": "2.9.14",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,6 +1,4 @@
-New in 2.9.13
+New in 2.9.14
 
-• Scan for TVs now actually finds them. It was missing TVs that don't answer the old way — including LG sets and Google TV.
-• Pairing tells you what a device is. Point it at something it can't pair with and it says so, instead of showing a cryptic error.
-• LG commercial and signage displays are now supported — power, input and mute, no pairing needed.
-• Paired more than one TV? Pick which one the remote drives, in Setup.
+• TV navigation is snappier. D-pad presses take a more direct path to the box, so controlling a TV feels closer to instant.
+• Sending text to a TV now tells you when there's nowhere for it to go. If no text field is focused on the TV, the app says so instead of silently doing nothing — and points you at the search box that makes it work.


### PR DESCRIPTION
App 2.9.13 → 2.9.14.

- **Agent is byte-identical to v2.9.13** (`git diff v2.9.13..main -- agent/` is empty), so the Linux agent VERSION stays **2.9.33** and no box is re-prompted — nothing new to install.
- Build numbers untouched — autoIncrement → **67/51** at build time, the floor.
- **`release-agent.sh` still runs on the tag** even though the agent is unchanged: install.sh / `couchside update` fetch from `releases/latest/download`, so the newest release must carry valid signed assets or they 404. Re-signs the same 2.9.33 agent.
- **Decky not re-cut** — it bundles the agent, which is unchanged.
- Release notes 355 chars, measured before building.

Ships: TV nav responsiveness (#156), text-into-unfocused-TV feedback (#155).

🤖 Generated with [Claude Code](https://claude.com/claude-code)