### PR TITLE
fix(agent): config saves followed the CWD, not the config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
       - name: Unit tests (config load)
         run: python3 tests/test_config_load.py
 
+      # Config SAVES must land beside the config, not in the process CWD. The
+      # temp-file dir came from `dirname(CONFIG_PATH) or "."`, and mkstemp
+      # returns an ABSOLUTE path -- so "." followed the CWD, which for a systemd
+      # service is "/". A relative --config therefore wrote to the root
+      # filesystem; on SteamOS that is read-only, and pairing a TV on a Steam
+      # Deck died with "[Errno 30] Read-only file system:
+      # '/.couchside-config-il0oed3c'". Reproducing it needs no read-only mount:
+      # the defect is following the CWD at all. Covers BOTH agents -- Windows
+      # shipped the identical block, where the stray CWD is System32.
+      - name: Unit tests (config write)
+        run: python3 tests/test_config_write.py
+
       # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
       # dir must not be read as a GPU), the reaper AppId matcher incl. the
       # [oom_reaper] reject, the empty-power_supply desktop case + the uniq (never

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.33"
+VERSION = "2.9.34"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -580,7 +580,11 @@ def load_config(path):
     global CONFIG_ROKU, CONFIG_ANDROIDTV, CONFIG_VIDAA, ALLOW_APP_UPDATE
     global CONFIG_LGCOM, CONFIG_TV_ACTIVE
     global ALLOW_APP_LAUNCHERS, CONFIG_GUIDE
-    CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
+    # ABSOLUTE on purpose: every rewrite derives the temp-file directory from
+    # os.path.dirname(CONFIG_PATH), and a relative path has no directory part.
+    # That fell through to the process CWD, which under systemd is "/" — see
+    # _write_config_atomic for the read-only-root failure that caused.
+    CONFIG_PATH = os.path.abspath(path)  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path) as f:
             raw = json.load(f)
@@ -638,6 +642,57 @@ def check_config_writable():
               "launcher changes will fail to save. chown the config dir to the "
               "agent's user." % (directory, os.getuid()), file=sys.stderr,
               flush=True)
+
+
+def _write_config_atomic(raw):
+    """Persist <raw> to CONFIG_PATH via temp file + os.replace. THE writer.
+
+    Every config save funnels here — launchers, TV pairings, _config_set_field.
+    It used to be three copy-pasted blocks that each carried the same trap:
+
+        directory = os.path.dirname(CONFIG_PATH) or "."
+
+    `or "."` looks like a harmless fallback. It is not: tempfile.mkstemp returns
+    an ABSOLUTE path, so "." resolves against the process CWD, and a systemd
+    service's CWD is "/". A CONFIG_PATH with no directory part therefore tried to
+    write the temp file to the ROOT filesystem. On SteamOS root is read-only, so
+    pairing a TV on a Steam Deck failed with
+
+        [Errno 30] Read-only file system: '/.couchside-config-il0oed3c'
+
+    — an errno on a temp name that named neither the config nor the real problem,
+    and that no user could act on. load_config now abspath's CONFIG_PATH so the
+    directory is always real; the check below turns the remaining case (a dir
+    that genuinely isn't writable — root-owned config under a non-root agent, or
+    a read-only mount) into a message that says what to fix.
+
+    Raises ConfigError (a ValueError) on an unwritable dir. Deliberate: the
+    pairing routes catch Exception and render it as a 500, and the launcher route
+    catches ConfigError, so no caller is left with an unhandled traceback. MUST
+    be called with CONFIG_LOCK held by the callers that mutate shared state."""
+    directory = os.path.dirname(CONFIG_PATH) or "."
+    # W_OK to create the temp file, X_OK to os.replace into the dir. Checked here
+    # and not only at startup because a remount or chown can land mid-run.
+    if not os.access(directory, os.W_OK | os.X_OK):
+        raise ConfigError(
+            "config dir %s is not writable by uid %d, so %s cannot be saved "
+            "(read-only filesystem, or the dir is owned by another user). "
+            "Reinstall or chown the config dir to the agent's user."
+            % (directory, os.getuid(), CONFIG_PATH))
+    fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(raw, f, indent=2)
+            f.write("\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, CONFIG_PATH)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def _inject_session_actions():
@@ -3613,21 +3668,7 @@ def _write_config_launchers_locked(new_launchers):
         {"id": l["id"], "label": l["label"], "cmd": list(l["cmd"])}
         for l in new_launchers
     ]
-    directory = os.path.dirname(CONFIG_PATH) or "."
-    fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(raw, f, indent=2)
-            f.write("\n")
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, CONFIG_PATH)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    _write_config_atomic(raw)
     # Only mutate the in-memory list once the write succeeded.
     global LAUNCHERS
     LAUNCHERS = new_launchers
@@ -4842,21 +4883,7 @@ def _webos_save(host, client_key, mac=None):
         if not isinstance(raw, dict):
             raw = {"units": [{"name": n, "scope": s} for n, s in WATCHLIST]}
         raw["webos"] = cfg
-        directory = os.path.dirname(CONFIG_PATH) or "."
-        fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(raw, f, indent=2)
-                f.write("\n")
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, CONFIG_PATH)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        _write_config_atomic(raw)
         CONFIG_WEBOS = cfg
     set_tv_active("webos")
 
@@ -4911,21 +4938,7 @@ def _config_set_field(field, value):
     if not isinstance(raw, dict):
         raw = {"units": [{"name": n, "scope": s} for n, s in WATCHLIST]}
     raw[field] = value
-    directory = os.path.dirname(CONFIG_PATH) or "."
-    fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            json.dump(raw, f, indent=2)
-            f.write("\n")
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp, CONFIG_PATH)
-    except Exception:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
+    _write_config_atomic(raw)
 
 
 # ---- Samsung backend (Tizen Smart TVs, WS remote over the stdlib WebSocket) -

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.3.7-win"
+VERSION = "0.3.8-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -427,7 +427,11 @@ def load_config(path):
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_CEC_BRIDGE, ALLOW_APP_UPDATE
     global CONFIG_ROKU, ALLOW_APP_LAUNCHERS
-    CONFIG_PATH = path  # remembered so launcher POST/DELETE can rewrite it
+    # ABSOLUTE on purpose: every rewrite derives the temp-file directory from
+    # os.path.dirname(CONFIG_PATH), and a relative path has no directory part.
+    # That fell through to the process CWD -- for a service, System32. See
+    # _write_config_atomic.
+    CONFIG_PATH = os.path.abspath(path)  # remembered so launcher POST/DELETE can rewrite it
     try:
         with open(path, encoding="utf-8-sig") as f:
             raw = json.load(f)
@@ -1673,43 +1677,46 @@ def _write_config_launchers(new_launchers):
             {"id": l["id"], "label": l["label"], "cmd": list(l["cmd"])}
             for l in new_launchers
         ]
-        directory = os.path.dirname(CONFIG_PATH) or "."
-        # Create the config dir if it's missing: on Windows the agent may run
-        # with a literal --token and no pre-existing %ProgramData%\Couchside,
-        # and the first launcher POST would otherwise 500 on a FileNotFoundError.
-        os.makedirs(directory, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                json.dump(raw, f, indent=2)
-                f.write("\n")
-                f.flush()
-                os.fsync(f.fileno())
-            os.replace(tmp, CONFIG_PATH)
-        except Exception:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            raise
+        _write_config_atomic(raw)
         global LAUNCHERS
         LAUNCHERS = new_launchers
 
 
-def _config_set_field(field, value):
-    """Read config.json, set one top-level field, and write it back atomically
-    (temp file + os.replace). The CALLER must hold CONFIG_LOCK. Raises on I/O
-    failure. Used to persist a Roku add without disturbing other config."""
-    try:
-        with open(CONFIG_PATH, "r", encoding="utf-8-sig") as f:
-            raw = json.load(f)
-    except (OSError, ValueError):
-        raw = None
-    if not isinstance(raw, dict):
-        raw = {}
-    raw[field] = value
+def _write_config_atomic(raw):
+    """Persist <raw> to CONFIG_PATH via temp file + os.replace. THE writer.
+
+    Every config save funnels here. It used to be copy-pasted blocks that each
+    carried the same trap:
+
+        directory = os.path.dirname(CONFIG_PATH) or "."
+
+    `or "."` looks harmless. It is not: tempfile.mkstemp returns an ABSOLUTE
+    path, so "." resolves against the process CWD -- for a service, System32. A
+    CONFIG_PATH with no directory part therefore wrote its temp file there
+    instead of beside the config. The Linux agent shipped the same defect and it
+    bit a real user: pairing a TV on a Steam Deck (CWD "/", read-only root)
+    failed with "[Errno 30] Read-only file system: '/.couchside-config-il0oed3c'"
+    -- an errno naming a temp file nobody had heard of. load_config now abspath's
+    CONFIG_PATH; the check below turns a genuinely unwritable dir into a message
+    that says what to fix.
+
+    Raises ConfigError (a ValueError) on an unwritable dir, which the pairing and
+    launcher routes already handle -- so no caller gets an unhandled traceback."""
     directory = os.path.dirname(CONFIG_PATH) or "."
-    os.makedirs(directory, exist_ok=True)
+    # Create the config dir if it's missing: on Windows the agent may run with a
+    # literal --token and no pre-existing %ProgramData%\Couchside, and the first
+    # launcher POST would otherwise 500 on a FileNotFoundError.
+    try:
+        os.makedirs(directory, exist_ok=True)
+    except OSError as e:
+        raise ConfigError("cannot create config dir %s (%s), so %s cannot be "
+                          "saved" % (directory, e, CONFIG_PATH))
+    if not os.access(directory, os.W_OK | os.X_OK):
+        raise ConfigError(
+            "config dir %s is not writable, so %s cannot be saved (read-only "
+            "location, or owned by another user). Reinstall, or grant the "
+            "agent's account write access to that directory."
+            % (directory, CONFIG_PATH))
     fd, tmp = tempfile.mkstemp(prefix=".couchside-config-", dir=directory)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -1724,6 +1731,21 @@ def _config_set_field(field, value):
         except OSError:
             pass
         raise
+
+
+def _config_set_field(field, value):
+    """Read config.json, set one top-level field, and write it back atomically
+    (temp file + os.replace). The CALLER must hold CONFIG_LOCK. Raises on I/O
+    failure. Used to persist a Roku add without disturbing other config."""
+    try:
+        with open(CONFIG_PATH, "r", encoding="utf-8-sig") as f:
+            raw = json.load(f)
+    except (OSError, ValueError):
+        raw = None
+    if not isinstance(raw, dict):
+        raw = {}
+    raw[field] = value
+    _write_config_atomic(raw)
 
 
 def add_launcher(label, cmd):

--- a/tests/test_config_write.py
+++ b/tests/test_config_write.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests that config saves land NEXT TO the config, not in the process CWD.
+
+Run: python3 tests/test_config_write.py
+
+Regression guard for the Steam Deck pairing bug. Pairing a Google TV on a Deck
+returned:
+
+    HTTP 500: could not persist config:
+    [Errno 30] Read-only file system: '/.couchside-config-il0oed3c'
+
+The atomic save built its temp file with
+
+    directory = os.path.dirname(CONFIG_PATH) or "."
+
+and tempfile.mkstemp returns an ABSOLUTE path, so `"."` resolved against the
+process CWD -- which for a systemd service is "/". A CONFIG_PATH with no
+directory part therefore wrote to the ROOT filesystem, which on SteamOS is
+read-only. The errno named a temp file the user had never seen and gave them
+nothing to act on.
+
+Reproducing it does NOT need a read-only root: the defect is that the write
+follows the CWD instead of the config. So the test chdir's somewhere else and
+asserts nothing is created there. Pre-fix that directory receives the file;
+post-fix it stays empty.
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load(name, relpath):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(HERE, "..", relpath))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# BOTH agents, because both shipped the same defect. couchsided-win.py's Win32
+# bits are lazy ctypes, so it imports and runs here on Linux CI.
+AGENTS = [("linux", _load("couchsided", "agent/couchsided.py")),
+          ("windows", _load("couchsided_win", "agent/win/couchsided-win.py"))]
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+_agent = ""
+
+
+def check(cond, label):
+    label = "[%s] %s" % (_agent, label)
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+MINIMAL = {"units": [{"name": "couchside", "scope": "user"}], "actions": {}}
+
+
+def _seed(directory, name="config.json"):
+    path = os.path.join(directory, name)
+    with open(path, "w") as f:
+        json.dump(MINIMAL, f)
+    return path
+
+
+def _save(cm, field, value):
+    with cm.CONFIG_LOCK:
+        cm._config_set_field(field, value)
+
+
+def test_relative_path_does_not_follow_cwd(cm):
+    """The bug itself: a bare config name + a different CWD."""
+    print("a relative --config writes beside the config, not into the CWD")
+    home = tempfile.mkdtemp(prefix="cfg-home-")
+    elsewhere = tempfile.mkdtemp(prefix="cfg-cwd-")  # stands in for "/"
+    prev = os.getcwd()
+    try:
+        _seed(home)
+        os.chdir(home)
+        cm.load_config("config.json")  # bare name -- no directory part
+        check(os.path.isabs(cm.CONFIG_PATH), "CONFIG_PATH resolved to absolute")
+        check(os.path.dirname(cm.CONFIG_PATH) == os.path.realpath(home),
+              "and points at the config's real directory")
+
+        os.chdir(elsewhere)  # systemd would have us at "/"
+        _save(cm, "tv_active", "webos")
+
+        strays = os.listdir(elsewhere)
+        check(strays == [], "nothing written into the CWD (was: %r)" % strays)
+        with open(os.path.join(home, "config.json")) as f:
+            check(json.load(f).get("tv_active") == "webos",
+                  "the real config actually received the save")
+    finally:
+        os.chdir(prev)
+        shutil.rmtree(home, ignore_errors=True)
+        shutil.rmtree(elsewhere, ignore_errors=True)
+
+
+def test_unwritable_dir_is_actionable(cm):
+    """A read-only/foreign-owned config dir must explain itself."""
+    print("an unwritable config dir raises something a user can act on")
+    if os.getuid() == 0:
+        print("  SKIP  running as root -- W_OK is not enforced")
+        return
+    directory = tempfile.mkdtemp(prefix="cfg-ro-")
+    try:
+        path = _seed(directory)
+        cm.load_config(path)
+        os.chmod(directory, stat.S_IRUSR | stat.S_IXUSR)  # r-x, no write
+        raised = None
+        try:
+            _save(cm, "tv_active", "webos")
+        except Exception as e:
+            raised = e
+        check(isinstance(raised, cm.ConfigError),
+              "raises ConfigError (handled by both the pairing and launcher routes)")
+        msg = str(raised or "")
+        check(directory in msg, "message names the offending directory")
+        check(path in msg, "message names the config it could not save")
+        check("Errno" not in msg,
+              "message is a sentence, not a bare errno on a temp file")
+    finally:
+        os.chmod(directory, stat.S_IRWXU)
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+def test_writable_dir_still_saves(cm):
+    """CONTROL. A plain writable config must round-trip.
+
+    Without this, an implementation that raised unconditionally would pass every
+    other test in this file."""
+    print("control: a normal writable config saves and round-trips")
+    directory = tempfile.mkdtemp(prefix="cfg-ok-")
+    try:
+        path = _seed(directory)
+        cm.load_config(path)
+        _save(cm, "tv_active", "samsung")
+        with open(path) as f:
+            saved = json.load(f)
+        check(saved.get("tv_active") == "samsung", "field persisted")
+        check(saved.get("units") == MINIMAL["units"],
+              "and the rest of the config survived the rewrite")
+        leftovers = [n for n in os.listdir(directory)
+                     if n.startswith(".couchside-config-")]
+        check(leftovers == [], "no temp file left behind (was: %r)" % leftovers)
+    finally:
+        shutil.rmtree(directory, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    for _agent, _mod in AGENTS:
+        print("=== %s agent ===" % _agent)
+        test_relative_path_does_not_follow_cwd(_mod)
+        test_unwritable_dir_is_actionable(_mod)
+        test_writable_dir_still_saves(_mod)
+        print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all config-write tests passed")


### PR DESCRIPTION
Pairing a Google TV on a Steam Deck failed with:

```
HTTP 500: could not persist config:
[Errno 30] Read-only file system: /.couchside-config-il0oed3c
```

## Cause

The atomic config save picked its temp-file directory with:

```python
directory = os.path.dirname(CONFIG_PATH) or "."
```

`or "."` reads as a harmless fallback. It is not — `tempfile.mkstemp` returns an **absolute** path, so `"."` resolves against the process CWD, and a systemd service’s CWD is `/`. A `CONFIG_PATH` with no directory part therefore wrote its temp file to the **root filesystem**, which on SteamOS is read-only.

The resulting error named a temp file the user had never seen and gave them nothing to act on.

## Fix

- `load_config()` abspath’s `CONFIG_PATH`, so the temp directory is always a real one.
- The three copy-pasted write blocks (launchers, webOS pairing, `_config_set_field`) collapse into a single `_write_config_atomic()` — one writer, one place for this to be right.
- A genuinely unwritable dir (read-only mount, foreign-owned config) now raises `ConfigError` naming **the directory and the config** rather than an errno on a temp path. `ConfigError` is deliberate: the pairing routes catch `Exception` and the launcher route catches `ConfigError`, so no caller is left with an unhandled traceback.

Both agents shipped the identical block — on Windows the stray CWD is `System32`. Fixed in both; the test runs against both.

## Verification

The regression test needs no read-only mount: the defect is *following the CWD at all*, so it chdir’s elsewhere and asserts nothing lands there.

Proven to actually catch the bug — reverted the fix in each agent and confirmed the test fails, in both:

```
FAIL [linux]   nothing written into the CWD (was: [config.json])
FAIL [windows] nothing written into the CWD (was: [config.json])
```

The writable-config control stays green throughout, so an implementation that simply raised unconditionally could not pass. Full agent suite green (13 files).

## Not covered here

This does not retroactively fix the user’s Deck: it runs agent 2.9.12 and needs updating to pick this up. The current Decky plugin already moved config to an absolute `/var/lib/couchside`, which independently avoids the trap.

Agent versions bumped: `2.9.34` / `0.3.8-win`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)