### PR TITLE
feat(app): pairing a box lands on the swipe Remote

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -39,6 +39,7 @@ import {
   useHapticsEnabled,
 } from '@/lib/haptics';
 import { setKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
+import { navigateAfterPair } from '@/lib/postPair';
 import { setPref, usePref } from '@/lib/prefs';
 import { buy, getProduct, restore } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
@@ -774,7 +775,7 @@ function SetupBody() {
   const save = useCallback(async () => {
     const conn = draftConn();
     if (!conn.host) return;
-    await addBox({
+    const added = await addBox({
       host: conn.host,
       port: conn.port,
       token: conn.token,
@@ -791,6 +792,9 @@ function SetupBody() {
     hapticSuccess();
     setSaved(true);
     setTimeout(() => setSaved(false), 2000);
+    // Straight to the remote — see lib/postPair.ts. The "Saved" flag above is
+    // still set so the confirmation is there if the user comes back to Setup.
+    navigateAfterPair(added);
   }, [addBox, draftConn, name]);
 
   // QR / deep-link pairing is handled entirely by the root <DeepLinkHandler/>

--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -14,6 +14,7 @@ import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 
 import { pairFinish, pairStart } from '@/lib/api';
 import { FoundBox, scanAvailable, scanForBoxes, selfIp } from '@/lib/boxDiscovery';
 import { hapticSelection } from '@/lib/haptics';
+import { navigateAfterPair } from '@/lib/postPair';
 import { useBoxes } from '@/lib/SettingsContext';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -88,10 +89,17 @@ export function BoxScanPair() {
     try {
       const r = await pairFinish(box.ip, box.port, code);
       if (r.ok && r.token) {
-        await addBox({ host: box.host, port: r.port ?? box.port, token: r.token, lastIp: box.ip });
+        const added = await addBox({
+          host: box.host,
+          port: r.port ?? box.port,
+          token: r.token,
+          lastIp: box.ip,
+        });
         setPhase({ k: 'idle' });
         setPin('');
         setMsg({ ok: true, text: `Paired ${box.name}.` });
+        // Straight to the remote — see lib/postPair.ts.
+        navigateAfterPair(added);
       } else {
         setPhase({ k: 'pin', box });
         setMsg({ ok: false, text: r.error ?? 'Pairing failed — check the PIN and retry.' });

--- a/app/lib/DeepLink.tsx
+++ b/app/lib/DeepLink.tsx
@@ -1,7 +1,7 @@
 import * as Linking from 'expo-linking';
-import { useRouter } from 'expo-router';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { navigateAfterPair } from './postPair';
 import { DEFAULT_PORT } from './settings';
 import { useBoxes } from './SettingsContext';
 
@@ -55,8 +55,11 @@ function parseQuery(url: string): Record<string, string> {
  * tab is focused never mounts Setup's effect, and `couchside://setup` parses
  * `setup` as the URL host (not a route), so the params don't always reach the
  * screen. Here we read `queryParams` straight off the URL, add/update the box
- * (addBox dedupes by host+port), and jump to Setup with `?paired=1` so it can
- * flash its confirmation banner.
+ * (addBox dedupes by host+port), and jump to the Pad -- the swipe Remote -- so a
+ * QR scan lands on the thing the user paired the box to use. See lib/postPair.ts.
+ *
+ * (This used to claim it jumped to Setup with `?paired=1` to flash a confirmation
+ * banner. Setup has no `paired` param and never did; the comment was drift.)
  *
  * Uses Linking.addEventListener (fires on EVERY inbound URL, even an identical
  * re-scan) plus getInitialURL for the cold-start launch URL. A link that lands
@@ -65,7 +68,6 @@ function parseQuery(url: string): Record<string, string> {
  */
 export function DeepLinkHandler() {
   const { addBox, ready } = useBoxes();
-  const router = useRouter();
 
   const readyRef = useRef(ready);
   readyRef.current = ready;
@@ -91,10 +93,14 @@ export function DeepLinkHandler() {
         Number.isFinite(portRaw) && portRaw > 0 && portRaw <= 65535 ? portRaw : DEFAULT_PORT;
       const ip = q.ip || undefined;
 
-      void addBox({ host, port, token, lastIp: ip });
-      router.navigate('/setup');
+      // Navigate only once the box is actually stored and active, so the Pad
+      // opens against the box that was just paired rather than the previous one.
+      void addBox({ host, port, token, lastIp: ip }).then(navigateAfterPair, () => {
+        // addBox failed (storage write) — stay put rather than opening a remote
+        // for a box that was never saved.
+      });
     },
-    [addBox, router],
+    [addBox],
   );
 
   useEffect(() => {

--- a/app/lib/postPair.ts
+++ b/app/lib/postPair.ts
@@ -1,0 +1,35 @@
+/**
+ * Where the app goes once a box is paired.
+ *
+ * Pairing is the last step of setup, not a destination — the user paired a box
+ * because they want to drive it. So every pairing path lands on the Pad (the
+ * swipe Remote), which is already the app's declared default screen
+ * (`unstable_settings.initialRouteName = 'pad'` in app/(tabs)/_layout.tsx).
+ * First run deliberately detours to Setup so a box exists before the remote
+ * opens; this closes that detour instead of stranding the user on Setup.
+ *
+ * There are three pairing entry points (LAN scan + PIN, the manual host/token
+ * form, and the QR deep link) and they must agree, hence one helper rather than
+ * three copies of the rule.
+ *
+ * Server boxes: a headless box reports caps.gamepad === false and the tab layout
+ * BOUNCES off /pad to Console. Routing such a box to the Pad would still land
+ * correctly, but only after a visible Pad->Console flash, so we skip straight to
+ * Console when we already know. Only `=== false` counts: caps are undefined for
+ * a box being paired for the first time (they arrive with the first /api/status),
+ * and the layout's own rule is "never hide a tab on a guess" — an unknown box
+ * gets the Pad.
+ */
+import { router } from 'expo-router';
+
+import type { Box } from './settings';
+
+export function navigateAfterPair(box: Box | undefined) {
+  // replace, not navigate: pairing is a completed step, so leaving it on the
+  // back stack would let Back return to a half-filled add form.
+  if (box?.caps?.gamepad === false) {
+    router.replace('/(tabs)');
+    return;
+  }
+  router.replace('/(tabs)/pad');
+}


### PR DESCRIPTION
Pairing is the last step of setup, not a destination — you pair a box because you want to drive it.

The app already declares the Pad (the swipe Remote) as its default screen (`unstable_settings.initialRouteName = "pad"`), and first run deliberately detours to Setup so a box exists before the remote opens. Nothing ever closed that detour, so a freshly paired box left the user sitting on Setup. Now every pairing path finishes on the Pad.

## Change

All three entry points agree, via one helper (`app/lib/postPair.ts`) rather than three copies of the rule:

- LAN scan + PIN (`BoxScanPair`)
- the manual host/token form (Setup)
- the QR deep link (`DeepLink`)

`addBox` always makes the added/deduped box active, so the Pad opens against the box that was just paired. The deep link now navigates only *after* `addBox` resolves — for that reason — and stays put if the store write fails.

**Drive-by:** the deep-link doc comment claimed it jumped to Setup with `?paired=1` to flash a confirmation banner. Setup has no `paired` param and never did — the comment was drift. Corrected rather than left to mislead the next reader.

## Verified

In `scripts/web-dev.sh` against a `--mock` agent, driving the real form: filled host/port/token, clicked ADD BOX, observed

```
/setup  ->  /pad
```

with the box stored active and `padMode: "swipe"`, and the Pad rendering in SWIPE mode ("swipe to move · tap to select").

A control ran first: empty fleet redirects to `/setup`, and `location.pathname` tracks the route — so a "PASS" here could actually have failed. Worth noting an early attempt at this looked like it worked but had silently typed into nothing; the filled-form screenshot below is the check that caught it.

## NOT verified

The `caps.gamepad === false` shortcut for headless boxes. The mock agent reports every cap true, and an unreachable box has its caps *cleared*, so the branch never held in the harness — two different setups failed to produce it.

It is a cosmetic flash-avoidance path using the same predicate as the tab layout’s `hidePad`. The layout’s existing bounce is what actually guarantees the destination, and that **was** observed working: flipping caps to `gamepad:false` moved the app off `/pad` to Console on its own. So the worst case here is a brief Pad→Console flash, not a wrong destination.

## Not covered by the web harness

Per the harness’ own header: real touch input, WebSocket gamepad traffic, and safe-area/keyboard behaviour. This change is routing only, which the harness does cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)