### PR TITLE
fix(install): detect Decky by the loader, and stop faking panel success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,14 @@ jobs:
       # shipped the identical block, where the stray CWD is System32.
       - name: Unit tests (config write)
         run: python3 tests/test_config_write.py
+      # Decky detection. install.sh gated co-existence on `[ -d ~/homebrew/plugins ]`,
+      # but Decky's OWN uninstaller removes the unit and services/PluginLoader and
+      # LEAVES that directory behind -- so a box that had uninstalled Decky still
+      # tested as having it, left couchside.service DORMANT, and handed the agent
+      # to a plugin that could never load. Net result: no running agent. The test
+      # extracts the real function from install.sh so it fails on drift.
+      - name: Unit tests (decky detection)
+        run: bash tests/test_decky_detect.sh
 
       # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
       # dir must not be read as a GPU), the reaper AppId matcher incl. the

--- a/install.sh
+++ b/install.sh
@@ -133,6 +133,19 @@ UNIT_DST="/etc/systemd/system/couchside.service"
 # installed here when Decky is present, and removed from here on --uninstall.
 DECKY_PLUGINS="${HOME}/homebrew/plugins"
 DECKY_PLUGIN_DIR="${DECKY_PLUGINS}/Couchside"
+# What actually proves Decky Loader is INSTALLED. Its own uninstaller removes
+# the unit and homebrew/services/PluginLoader but LEAVES homebrew/plugins behind
+# (see decky-loader dist/uninstall.sh), so `[ -d "$DECKY_PLUGINS" ]` reports a
+# box that has uninstalled Decky as still having it. That is not cosmetic: the
+# co-existence branch then leaves couchside.service DORMANT and hands the agent
+# to a plugin that can never load, so the box ends up with no running agent at
+# all. The agent gates the same decision on the unit file for this reason.
+DECKY_UNIT="/etc/systemd/system/plugin_loader.service"
+DECKY_LOADER="${HOME}/homebrew/services/PluginLoader"
+
+decky_installed() {
+    [ -f "$DECKY_UNIT" ] || [ -e "$DECKY_LOADER" ]
+}
 
 # Pairing-QR launcher: a script that opens http://localhost:PORT/pair full-screen
 # on the box's own display, plus a .desktop entry to add it to Steam (Game Mode).
@@ -864,7 +877,7 @@ sudo systemctl daemon-reload
 # so the two installs don't fight over the file + port; the plugin block below
 # (or the plugin itself) activates it. Without Decky, this service is the sole
 # supervisor and is enabled + started normally.
-if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
+if [ "$NO_DECKY" -eq 0 ] && decky_installed; then
     DECKY_OWNS_AGENT=1
     sudo systemctl disable --now couchside.service 2>/dev/null || true
     note "Decky Loader detected → standalone couchside.service left DORMANT (the Couchside plugin manages the agent)."
@@ -1502,7 +1515,7 @@ fi
 # the install: the whole thing runs inside an `if` condition (set -e is
 # suspended there) and any failure just prints a note and moves on. --no-decky
 # skips it entirely.
-if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
+if [ "$NO_DECKY" -eq 0 ] && decky_installed; then
     say "Decky Loader detected: installing the Couchside Game Mode panel"
     decky_tmp="$(mktemp -d)"
     # Decky's plugin dir is root-owned (same as a store install), so place the
@@ -1556,6 +1569,11 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
         }
         return 0
     }
+    # The gate above is now "Decky is installed" (unit / loader binary), which no
+    # longer implies the plugins DIR exists — it did back when the gate was
+    # `[ -d "$DECKY_PLUGINS" ]`. tar -C would fail on a Decky install that has
+    # never had a plugin. Root-owned to match a store install.
+    sudo mkdir -p "$DECKY_PLUGINS"
     if decky_verify_ok \
         && sudo rm -rf "$DECKY_PLUGIN_DIR" \
         && sudo tar -xzf "${decky_tmp}/Couchside.tar.gz" -C "$DECKY_PLUGINS"; then
@@ -1565,7 +1583,23 @@ if [ "$NO_DECKY" -eq 0 ] && [ -d "$DECKY_PLUGINS" ]; then
         # from the menu). Store installs are root-owned; match that.
         sudo chown -R root:root "$DECKY_PLUGIN_DIR" 2>/dev/null || true
         sudo systemctl restart plugin_loader.service 2>/dev/null || true
-        note "panel installed. Open the Decky menu in Game Mode to see it."
+        # VERIFY, don't assume. The restart status used to be discarded
+        # (`|| true`) and the success note printed unconditionally, so a box
+        # whose loader would not start was still told the panel was ready and
+        # to "open the Decky menu" — advice that could never work. That is
+        # exactly the state a user hit. Poll briefly: `systemctl restart`
+        # returns once the job is done, but a loader that starts and then dies
+        # should be reported as down, not up.
+        _decky_up=0
+        for _ in 1 2 3; do
+            if systemctl is-active --quiet plugin_loader.service; then _decky_up=1; break; fi
+            sleep 1
+        done
+        if [ "$_decky_up" -eq 1 ]; then
+            note "panel installed. Open the Decky menu in Game Mode to see it."
+        else
+            note "panel files installed, but plugin_loader.service is NOT running — the panel will not appear until it is. Recover with: sudo systemctl restart plugin_loader   (diagnose with: systemctl status plugin_loader)"
+        fi
     else
         note "couldn't install the panel (skipping); the agent still works."
     fi

--- a/tests/test_decky_detect.sh
+++ b/tests/test_decky_detect.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Tests install.sh's decky_installed() gate.
+#
+# Run: bash tests/test_decky_detect.sh
+#
+# Why this exists: the gate used to be `[ -d "$DECKY_PLUGINS" ]`, i.e.
+# ~/homebrew/plugins. Decky Loader's OWN uninstaller removes the systemd unit and
+# homebrew/services/PluginLoader but LEAVES homebrew/plugins behind. So a box that
+# had uninstalled Decky still tested as "Decky present", took the co-existence
+# branch, left couchside.service DORMANT, and handed the agent to a plugin that
+# could never load -- ending with no running agent at all.
+#
+# The function is extracted from install.sh rather than copied, so this test
+# fails if the real implementation drifts.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SH="$HERE/../install.sh"
+
+# Pull the real function out of install.sh (definition through its closing brace).
+FN="$(sed -n '/^decky_installed() {/,/^}/p' "$INSTALL_SH")"
+if [ -z "$FN" ]; then
+    echo "FAIL: decky_installed() not found in install.sh -- did it get renamed?"
+    exit 1
+fi
+eval "$FN"
+
+PASS=$'  \033[32mPASS\033[0m'
+FAIL=$'  \033[31mFAIL\033[0m'
+fails=0
+
+check() { # check <expected 0|1> <label>
+    local want="$1" label="$2" got
+    if decky_installed; then got=0; else got=1; fi
+    if [ "$got" -eq "$want" ]; then
+        echo "$PASS  $label"
+    else
+        echo "$FAIL  $label (wanted $want, got $got)"
+        fails=$((fails + 1))
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- the regression: Decky uninstalled, plugins dir left behind ---------------
+echo "Decky uninstalled but ~/homebrew/plugins litter remains"
+DECKY_PLUGINS="$TMP/home/homebrew/plugins"
+DECKY_UNIT="$TMP/no-such-unit.service"
+DECKY_LOADER="$TMP/home/homebrew/services/PluginLoader"
+mkdir -p "$TMP/home/homebrew/plugins/Couchside"   # the litter the old gate saw
+check 1 "not detected (the old -d gate said yes here, and broke the box)"
+
+# --- Decky genuinely installed, via the loader binary ------------------------
+echo "Decky installed (homebrew/services/PluginLoader present)"
+mkdir -p "$(dirname "$DECKY_LOADER")"
+touch "$DECKY_LOADER"
+check 0 "detected via the loader binary"
+
+# --- Decky genuinely installed, via the systemd unit only --------------------
+echo "Decky installed (unit file only, no loader binary)"
+rm -rf "$TMP/home/homebrew/services"
+touch "$TMP/plugin_loader.service"
+DECKY_UNIT="$TMP/plugin_loader.service"
+check 0 "detected via the systemd unit"
+
+# --- nothing at all -----------------------------------------------------------
+echo "no Decky anywhere"
+DECKY_UNIT="$TMP/absent.service"
+DECKY_LOADER="$TMP/absent-loader"
+check 1 "not detected"
+
+# --- CONTROL -----------------------------------------------------------------
+# Without this, an implementation hardcoded to `return 1` would pass every
+# not-detected case above.
+echo "control: a fresh Decky install with NO plugins dir must still be detected"
+rm -rf "$TMP/home/homebrew/plugins"
+DECKY_LOADER="$TMP/home/homebrew/services/PluginLoader"
+mkdir -p "$(dirname "$DECKY_LOADER")"
+touch "$DECKY_LOADER"
+check 0 "detected with no plugins dir (install.sh must mkdir -p before extracting)"
+
+echo
+if [ "$fails" -ne 0 ]; then
+    echo "FAILED: $fails"
+    exit 1
+fi
+echo "all decky-detect tests passed"


### PR DESCRIPTION
Both found while diagnosing a Steam Deck with no Decky entry in its QAM. They compound: the box decides Decky owns the agent, hands the service over, then reports success.

## 1. Detection was looking at litter

The co-existence gate was `[ -d "$DECKY_PLUGINS" ]` — `~/homebrew/plugins`. Decky’s **own uninstaller** removes the systemd unit and `services/PluginLoader` but **leaves `homebrew/plugins` behind**.

So a box that had uninstalled Decky still tested as having it →  took the dormancy branch → `systemctl disable --now couchside.service` → handed the agent to a plugin that can never load. Net result: **no running agent at all.**

Now gated on the unit file or the loader binary — which is what the agent already does for this same decision.

**Consequence I had to handle:** the old gate incidentally guaranteed the plugins *directory* existed, and `tar -xzf ... -C "$DECKY_PLUGINS"` relied on that. "Decky is installed" no longer implies it (a Decky install that never had a plugin), so the extract path now `mkdir -p`s it. Without that, this fix would have traded one bug for another — the control test below is what forces it.

## 2. The installer printed a success it had not checked

```sh
sudo systemctl restart plugin_loader.service 2>/dev/null || true
note "panel installed. Open the Decky menu in Game Mode to see it."
```

Status discarded, success printed unconditionally. On a box whose loader will not start, that message is false — **and it is exactly the message a user in that state saw.** Now polls `systemctl is-active` and reports which actually happened, with the recovery command when it is down. Polling rather than a single check so a loader that starts and immediately dies is reported down, not up.

## Verification

`tests/test_decky_detect.sh` **extracts** `decky_installed()` from install.sh with `sed` rather than copying it, so the test fails if the real implementation drifts.

Run against the **pre-fix** gate, it fails 3 cases including the motivating one:

```
FAIL  not detected (the old -d gate said yes here, and broke the box) (wanted 1, got 0)
FAIL  detected with no plugins dir (install.sh must mkdir -p before extracting) (wanted 0, got 1)
FAILED: 3
```

Two cases still pass under the old gate, so the suite is not uniformly failing. `bash -n install.sh` clean. Wired into CI.

## Not fixed here

The other findings from the same investigation — the `Restart=always` rationale that is wrong in four places, the destructive plugin extraction with no rollback, the unit healers that test for the `--config` flag rather than its value — are left for separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)