### PR TITLE
fix(pad): swipe latched the d-pad and Steam repeated it forever

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
       - name: Unit tests (gamepad handoff)
         run: python3 tests/test_gamepad_handoff.py
 
+      # The d-pad is a LATCHED absolute axis (DPAD_MAP -> ABS_HAT0X/Y), not an
+      # edge-triggered key, and nothing re-zeroes it: no stuck-button watchdog,
+      # and the 12s idle reap never fires while the app pings every 5s. ONE
+      # missing release therefore pins the axis and Steam auto-repeats it
+      # forever -- the "swipe sticks and keeps going that direction" bug.
+      # _release_devices() destroyed a demoted pad without zeroing it, while
+      # carefully zeroing the mouse two lines below.
+      - name: Unit tests (dpad latch)
+        run: python3 tests/test_dpad_latch.py
+
       # Couch Mode ceremony: the staged desktop->TV switch. Its whole reason for
       # existing is to stop two lies (a fake-green "Ready" that didn't verify
       # Game Mode came up, and audio that silently "skipped" onto the wrong

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -9495,6 +9495,16 @@ def _release_devices(entry):
     can never be left held)."""
     dev = entry.get("device")
     if dev is not None:
+        # Zero the pad BEFORE destroying it, for the same reason the mouse is
+        # zeroed below — that reasoning just never got applied to the pad. The
+        # d-pad is a LATCHED absolute axis (DPAD_MAP -> ABS_HAT0X/Y), so a
+        # demote mid-swipe tears the device down with a direction still
+        # asserted. Unlike the keyboard, nothing here pairs press with release.
+        try:
+            dev.emit([(EV_ABS, ABS_HAT0X, 0), (EV_ABS, ABS_HAT0Y, 0)]
+                     + [(EV_KEY, code, 0) for code in BTN_CODES.values()])
+        except Exception:
+            pass
         try:
             dev.destroy()
         except Exception:

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -169,6 +169,8 @@ type DpadKey = 'du' | 'dd' | 'dl' | 'dr';
 
 type SwipeSurfaceProps = {
   onStep: (k: DpadKey) => void;
+  /** Gesture ended (lifted OR terminated) — release whatever is still held. */
+  onStepEnd: () => void;
   onSelect: () => void;
 };
 
@@ -177,9 +179,9 @@ type SwipeSurfaceProps = {
  * the dominant axis (a long swipe = several steps, like scrolling a menu);
  * a quick tap is A/select.
  */
-function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
-  const cb = useRef({ onStep, onSelect });
-  cb.current = { onStep, onSelect };
+function SwipeSurface({ onStep, onStepEnd, onSelect }: SwipeSurfaceProps) {
+  const cb = useRef({ onStep, onStepEnd, onSelect });
+  cb.current = { onStep, onStepEnd, onSelect };
   const track = useRef({ consumedX: 0, consumedY: 0, moved: false, t0: 0 });
   // Sensitivity read into a ref so the once-created responder sees live changes.
   // Higher sensitivity = smaller step = more steps per swipe.
@@ -198,6 +200,7 @@ function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
         const t = track.current;
         if (!t.moved && Math.hypot(g.dx, g.dy) > TAP_SLOP) t.moved = true;
         const step = SWIPE_STEP / sensRef.current;
+        let stepped = false;
         // Emit steps until the un-consumed travel is under one step on both axes.
         for (;;) {
           const availX = g.dx - t.consumedX;
@@ -205,6 +208,7 @@ function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
           const ax = Math.abs(availX);
           const ay = Math.abs(availY);
           if (ax < step && ay < step) break;
+          stepped = true;
           if (ax >= ay) {
             t.consumedX += Math.sign(availX) * step;
             cb.current.onStep(availX > 0 ? 'dr' : 'dl');
@@ -213,11 +217,30 @@ function SwipeSurface({ onStep, onSelect }: SwipeSurfaceProps) {
             cb.current.onStep(availY > 0 ? 'dd' : 'du');
           }
         }
+        // ONE haptic per move event, never one per step. This loop is unbounded
+        // — a fast swipe emits a burst — and on iOS each selectionAsync() hops
+        // to the main queue with a fresh feedback generator, so a per-step tick
+        // floods it. The trackpad surface already rate-limits this way
+        // (tpHapticAcc). Cheap, and it removes the best-motivated suspect for
+        // the JS stall that swallowed d-pad releases.
+        if (stepped) haptic();
       },
+      // Release AND terminate both end the gesture. Only Release fired before,
+      // so an iOS gesture stolen mid-swipe (screen-edge back, a parent
+      // responder) left the d-pad asserted with nothing to let it go — and the
+      // agent latches that axis until something explicitly zeroes it.
       onPanResponderRelease: () => {
         const t = track.current;
+        cb.current.onStepEnd();
         if (!t.moved && Date.now() - t.t0 < TAP_MS) cb.current.onSelect();
       },
+      onPanResponderTerminate: () => {
+        cb.current.onStepEnd();
+      },
+      // Keep the touch: both sibling surfaces already refuse termination
+      // (useTrackpad, the stick). Without this the surface can lose a gesture
+      // it is mid-way through emitting.
+      onPanResponderTerminationRequest: () => false,
     }),
   ).current;
 
@@ -849,13 +872,66 @@ function PadScreen() {
     [mode, setMode],
   );
 
-  // Swipe mode emits self-contained press+release pulses; releaseAll() on
-  // blur/close still covers a pulse interrupted mid-flight.
+  // Swipe mode drives the d-pad as an EXPLICIT hold, not a fire-and-forget
+  // pulse.
+  //
+  // Why this is a state machine and not `press; setTimeout(release, 50)`:
+  // the agent's d-pad is a LATCHED ABSOLUTE AXIS (ABS_HAT0X/Y), not an
+  // edge-triggered key — see DPAD_MAP in agent/couchsided.py. Nothing on either
+  // side ever re-zeroes it: there is no stuck-button watchdog, and the 12s idle
+  // reap cannot fire while the app is pinging every 5s. So exactly ONE missing
+  // `v:0` pins the axis and Steam auto-repeats it forever, which is the "swipe
+  // sticks and keeps going that direction" bug.
+  //
+  // The old emitter lost that release in two ways. (1) Steps are DISTANCE-gated
+  // but the release was TIME-gated at a fixed 50ms, so any finger faster than
+  // ~1 px/ms re-pressed before the release fired — the hat was already held
+  // continuously for the whole gesture, which is why the feature appeared to
+  // work at all. (2) Every outstanding release lived in a setTimeout, so a
+  // stalled JS thread simply never sent it. Measured on a real iPhone: the
+  // session was reaped after ~12s of silence, meaning the app missed two
+  // consecutive 5s pings — the same stall that swallowed the release.
+  //
+  // Now: assert once, re-arm while stepping, and ALWAYS release on gesture end
+  // (see SwipeSurface's onPanResponderRelease/Terminate). Switching axis
+  // releases the previous key first, because a stale axis is exactly what a
+  // perpendicular swipe cannot clear.
+  const dpadHeld = useRef<{ key: DpadKey | null; timer: ReturnType<typeof setTimeout> | null }>({
+    key: null,
+    timer: null,
+  });
+  const dpadRelease = useCallback(() => {
+    const h = dpadHeld.current;
+    if (h.timer) {
+      clearTimeout(h.timer);
+      h.timer = null;
+    }
+    if (h.key) {
+      client.sendButton(h.key, 0);
+      h.key = null;
+    }
+  }, [client]);
   const dpadStep = useCallback(
     (k: DpadKey) => {
-      haptic();
-      client.sendButton(k, 1);
-      setTimeout(() => client.sendButton(k, 0), 50);
+      const h = dpadHeld.current;
+      if (h.timer) clearTimeout(h.timer);
+      if (h.key !== k) {
+        // Release the old direction before asserting the new one, so a
+        // direction change can never leave the previous axis latched.
+        if (h.key) client.sendButton(h.key, 0);
+        client.sendButton(k, 1);
+        h.key = k;
+      }
+      // Safety net only: the authoritative release is the gesture-end handler.
+      // Kept so a terminated gesture that somehow skips both handlers still
+      // lets go, rather than latching for good.
+      h.timer = setTimeout(() => {
+        h.timer = null;
+        if (h.key) {
+          client.sendButton(h.key, 0);
+          h.key = null;
+        }
+      }, 250);
     },
     [client],
   );
@@ -1003,7 +1079,7 @@ function PadScreen() {
       ) : mode === 'swipe' ? (
         <>
           {/* Apple-TV-remote style: big swipe/tap surface + three big buttons */}
-          <SwipeSurface onStep={dpadStep} onSelect={selectTap} />
+          <SwipeSurface onStep={dpadStep} onStepEnd={dpadRelease} onSelect={selectTap} />
           <View style={styles.swipeBtnRow}>
             <PadButton
               label="‹ BACK"

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -20,6 +20,7 @@ import {
 
 import { AgentUpdateBanner } from '@/components/AgentUpdateBanner';
 import { Gated } from '@/components/Gated';
+import { InputTracePanel } from '@/components/InputTracePanel';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
 import { BoxScanPair } from '@/components/BoxScanPair';
@@ -1364,6 +1365,8 @@ function SetupBody() {
                 }}
               />
             </View>
+
+            <InputTracePanel />
           </>
         )}
 

--- a/app/components/InputTracePanel.tsx
+++ b/app/components/InputTracePanel.tsx
@@ -1,0 +1,136 @@
+/**
+ * Diagnostic: the last d-pad/button frames the app TRIED to send, and whether
+ * each one actually left the socket.
+ *
+ * Why this is user-facing UI and not a console log: the "swipe sticks and keeps
+ * going that direction" bug is INTERMITTENT, so it cannot be reproduced on
+ * demand, and a phone has nowhere to read a console. The agent's d-pad is a
+ * latched absolute axis — one lost `v:0` pins it until something zeroes it —
+ * and GamepadClient.sendRaw() has two paths that drop a frame with no error at
+ * all. Without a record, a stuck episode leaves no evidence whatsoever.
+ *
+ * After an episode: open this and screenshot it. See lib/gamepad.ts's
+ * InputTraceEntry docs for how to read it — in short, a trailing `v:1` means the
+ * release was never attempted (a stalled JS thread), while a trailing
+ * `v:0 sent` means it went out and died downstream.
+ */
+import React, { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { clearInputTrace, getInputTrace, type InputTraceEntry } from '@/lib/gamepad';
+import { hapticSelection } from '@/lib/haptics';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+const DPAD = new Set(['du', 'dd', 'dl', 'dr']);
+
+function line(e: InputTraceEntry, prev: InputTraceEntry | null): string {
+  const d = new Date(e.at);
+  const t =
+    String(d.getMinutes()).padStart(2, '0') +
+    ':' +
+    String(d.getSeconds()).padStart(2, '0') +
+    '.' +
+    String(d.getMilliseconds()).padStart(3, '0');
+  // The GAP is the diagnostic signal: a multi-second hole before a missing
+  // release is what a stalled JS thread looks like.
+  const gap = prev ? `+${String(e.at - prev.at).padStart(5)}ms` : '      —';
+  return `${t} ${gap}  ${e.k.padEnd(3)} ${e.v === 1 ? 'DOWN' : e.v === 0 ? 'up  ' : '?   '} ${e.how}`;
+}
+
+export function InputTracePanel() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [rows, setRows] = useState<InputTraceEntry[] | null>(null);
+
+  const refresh = useCallback(() => {
+    hapticSelection();
+    setRows(getInputTrace());
+  }, []);
+  const clear = useCallback(() => {
+    hapticSelection();
+    clearInputTrace();
+    setRows([]);
+  }, []);
+
+  // A d-pad key still DOWN at the end of the trace is the smoking gun.
+  const held = new Set<string>();
+  for (const e of rows ?? []) {
+    if (!DPAD.has(e.k)) continue;
+    if (e.v === 1) held.add(e.k);
+    else held.delete(e.k);
+  }
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.title}>PAD INPUT TRACE (DIAGNOSTIC)</Text>
+      <Text style={styles.hint}>
+        If a swipe sticks, come here and tap Capture, then screenshot this. It records the last
+        button frames the app tried to send and whether each one left the socket.
+      </Text>
+      <View style={styles.row}>
+        <Pressable onPress={refresh} style={[styles.btn, styles.btnPrimary]}>
+          <Text style={styles.btnPrimaryText}>CAPTURE</Text>
+        </Pressable>
+        <Pressable onPress={clear} style={[styles.btn, styles.btnGhost]}>
+          <Text style={styles.btnGhostText}>CLEAR</Text>
+        </Pressable>
+      </View>
+
+      {rows == null ? null : rows.length === 0 ? (
+        <Text style={styles.empty}>No frames recorded yet.</Text>
+      ) : (
+        <>
+          {held.size > 0 && (
+            <Text style={[styles.verdict, { color: t.red }]}>
+              STILL HELD: {Array.from(held).join(', ')} — a direction was never released. This is
+              the stuck state.
+            </Text>
+          )}
+          {held.size === 0 && (
+            <Text style={[styles.verdict, { color: t.green }]}>
+              Every direction was released. Nothing latched in this window.
+            </Text>
+          )}
+          <View style={styles.log}>
+            {rows.map((e, i) => (
+              <Text key={`${e.at}-${i}`} style={styles.logLine} numberOfLines={1}>
+                {line(e, i > 0 ? rows[i - 1] : null)}
+              </Text>
+            ))}
+          </View>
+        </>
+      )}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { gap: 8, marginTop: 22 },
+    title: { color: t.textDim, fontSize: 12, fontWeight: '700', letterSpacing: 1 },
+    hint: { color: t.textFaint, fontSize: 12, lineHeight: 17 },
+    row: { flexDirection: 'row', gap: 8 },
+    btn: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+      paddingVertical: 11,
+      minHeight: 44,
+    },
+    btnPrimary: { backgroundColor: t.blue },
+    btnPrimaryText: { color: t.bg, fontSize: 13, fontWeight: '800', letterSpacing: 0.5 },
+    btnGhost: { backgroundColor: t.inset, borderWidth: 1, borderColor: t.cardBorder },
+    btnGhostText: { color: t.textDim, fontSize: 13, fontWeight: '700', letterSpacing: 0.5 },
+    empty: { color: t.textFaint, fontSize: 12, fontStyle: 'italic' },
+    verdict: { fontSize: 12, fontWeight: '700', lineHeight: 17 },
+    log: {
+      backgroundColor: t.inset,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      borderRadius: 10,
+      padding: 10,
+      gap: 1,
+    },
+    logLine: { color: t.text, fontSize: 10, fontFamily: 'Menlo' },
+  });

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -117,6 +117,53 @@ export const BUTTON_KEYS: ButtonKey[] = [
  * ~30 bytes every 5s is free; the phone's radio is already up (screen on).
  */
 const PING_INTERVAL_MS = 5_000;
+
+// ---------- d-pad input trace (diagnostic) ---------------------------------
+/**
+ * Rolling record of every BUTTON frame this app tried to send, and whether it
+ * actually left the socket.
+ *
+ * Exists because the "swipe sticks and keeps going" bug is intermittent and
+ * therefore not reproducible on demand. The agent's d-pad is a LATCHED
+ * absolute axis, so ONE lost `v:0` pins it forever — and sendRaw() has two
+ * paths that drop a frame with no error at all (socket not OPEN, and a throw
+ * mid-send). Without this, a stuck episode leaves zero evidence.
+ *
+ * Reading a captured trace after an episode:
+ *   last entry is `v:1`            -> the release was never even ATTEMPTED,
+ *                                     i.e. the JS thread stalled and the timer
+ *                                     never ran. (Look for a time gap.)
+ *   last entry is `v:0 sent`       -> the client sent the release and it died
+ *                                     downstream (wire or agent).
+ *   last entry is `v:0 drop:...`   -> the release was attempted while the
+ *                                     socket was not OPEN, and vanished here.
+ *
+ * MODULE level on purpose: a GamepadClient is recreated on reconnect, so
+ * instance state would be wiped by the very disconnect worth investigating.
+ */
+export type InputTraceEntry = { at: number; k: string; v: number; how: string };
+const TRACE_MAX = 60;
+const inputTrace: InputTraceEntry[] = [];
+
+function wsStateName(ws: { readyState?: number } | null | undefined): string {
+  if (!ws) return 'none';
+  return ['connecting', 'open', 'closing', 'closed'][ws.readyState ?? 3] ?? 'unknown';
+}
+
+function traceButton(k: string | undefined, v: number | undefined, how: string): void {
+  if (!k) return;
+  inputTrace.push({ at: Date.now(), k, v: v ?? -1, how });
+  if (inputTrace.length > TRACE_MAX) inputTrace.shift();
+}
+
+/** Newest last. Copy, so callers can't mutate the buffer. */
+export function getInputTrace(): InputTraceEntry[] {
+  return inputTrace.slice();
+}
+
+export function clearInputTrace(): void {
+  inputTrace.length = 0;
+}
 /** Per-stick send throttle: ~50 Hz. */
 const STICK_INTERVAL_MS = 20;
 /**
@@ -807,14 +854,23 @@ export class GamepadClient {
 
   private sendRaw(obj: object): void {
     const ws = this.ws;
-    if (!ws || ws.readyState !== 1 /* OPEN */) return;
+    const f = obj as { t?: string; k?: string; v?: number };
+    if (!ws || ws.readyState !== 1 /* OPEN */) {
+      // SILENT DROP #1: the socket is not OPEN. A d-pad release lost here pins
+      // the agent's latched hat axis forever, with nothing anywhere recording
+      // that it happened. Trace it.
+      if (f.t === 'b') traceButton(f.k, f.v, 'drop:' + wsStateName(ws));
+      return;
+    }
     // Note real input (anything but our own keepalive ping) so the watchdog can
     // tighten its dead-socket deadline while the user is actively driving.
-    if ((obj as { t?: string }).t !== 'ping') this.lastInputAt = Date.now();
+    if (f.t !== 'ping') this.lastInputAt = Date.now();
     try {
       ws.send(JSON.stringify(obj));
+      if (f.t === 'b') traceButton(f.k, f.v, 'sent');
     } catch {
-      // socket died mid-send; onclose will handle it
+      // SILENT DROP #2: socket died mid-send; onclose will handle it.
+      if (f.t === 'b') traceButton(f.k, f.v, 'throw');
     }
   }
 

--- a/tests/test_dpad_latch.py
+++ b/tests/test_dpad_latch.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""The d-pad must never be left LATCHED when a session loses its pad.
+
+Run: python3 tests/test_dpad_latch.py
+
+Why this exists: the d-pad is not an edge-triggered key. DPAD_MAP maps each
+direction to an ABSOLUTE axis (ABS_HAT0X/ABS_HAT0Y) with a non-zero value, so
+"pressed" is a LATCHED state that persists until something writes 0. Nothing
+re-zeroes it on its own -- there is no stuck-button watchdog, and the 12s idle
+reap never fires while the app pings every 5s. Exactly one missing release
+therefore pins the axis and the consumer (Steam/SDL) auto-repeats it forever.
+That is the "swipe sticks and keeps going that direction" bug.
+
+_release_devices() demotes a session by destroying its pad. It carefully zeroes
+the MOUSE buttons two lines later and its docstring reasons about precisely
+this hazard for the mouse and the keyboard -- the pad case was simply never
+considered, so a demote mid-swipe tore the device down with a direction still
+asserted.
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(cond, name):
+    print(("  PASS  " if cond else "  FAIL  ") + name)
+    if not cond:
+        FAILURES.append(name)
+
+
+cs._wsend_json = lambda entry, obj: None
+cs._wsend_op = lambda entry, op, payload=b"": None
+
+
+class RecordingPad:
+    """Stands in for the virtual pad, remembering every event and the ORDER of
+    the destroy relative to them (zeroing after destroy would be useless)."""
+
+    def __init__(self):
+        self.events = []
+        self.destroyed = False
+        self.events_after_destroy = 0
+
+    def emit(self, events):
+        if self.destroyed:
+            self.events_after_destroy += len(events)
+        self.events.extend(events)
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def _hat_writes(pad):
+    return [(c, v) for (t, c, v) in pad.events
+            if t == cs.EV_ABS and c in (cs.ABS_HAT0X, cs.ABS_HAT0Y)]
+
+
+def test_demote_zeroes_the_hat():
+    print("a session demoted mid-swipe does not leave its d-pad latched")
+    pad = RecordingPad()
+    # Mid-swipe: the phone pressed 'du' and its release never arrived.
+    code, val = cs.DPAD_MAP["du"]
+    pad.emit([(cs.EV_ABS, code, val)])
+
+    entry = {"name": "phone", "device": pad, "mouse": None, "keyboard": None}
+    cs._release_devices(entry)
+
+    check(pad.destroyed, "the pad is still destroyed")
+    check(pad.events_after_destroy == 0, "and it was zeroed BEFORE the destroy")
+    check(entry["device"] is None, "the entry's device reference is cleared")
+
+    hats = _hat_writes(pad)
+    check(hats[0] == (cs.ABS_HAT0Y, val), "the swipe's latch was recorded")
+    check((cs.ABS_HAT0Y, 0) in hats, "the held axis was zeroed")
+    # BOTH axes, not just the one we know about: the demote path has no idea
+    # which direction was in flight.
+    check((cs.ABS_HAT0X, 0) in hats, "the other axis was zeroed too")
+    check(hats[-1][1] == 0, "the LAST hat write is a zero, so nothing stays latched")
+
+
+def test_demote_zeroes_buttons():
+    print("and face/shoulder buttons are released too")
+    pad = RecordingPad()
+    pad.emit([(cs.EV_KEY, cs.BTN_CODES["a"], 1)])
+    entry = {"name": "phone", "device": pad, "mouse": None, "keyboard": None}
+    cs._release_devices(entry)
+    zeroed = {c for (t, c, v) in pad.events if t == cs.EV_KEY and v == 0}
+    check(set(cs.BTN_CODES.values()) <= zeroed, "every declared button was zeroed")
+
+
+def test_missing_device_is_safe():
+    """CONTROL. A session with no pad must not explode -- and this also proves
+    the assertions above are not passing merely because the code no-ops."""
+    print("control: demoting a session that has no pad is a no-op, not a crash")
+    entry = {"name": "phone", "device": None, "mouse": None, "keyboard": None}
+    try:
+        cs._release_devices(entry)
+        check(True, "no exception")
+    except Exception as e:
+        check(False, "no exception (raised %r)" % (e,))
+
+
+if __name__ == "__main__":
+    test_demote_zeroes_the_hat()
+    test_demote_zeroes_buttons()
+    test_missing_device_is_safe()
+    print()
+    if FAILURES:
+        print("FAILED: %d" % len(FAILURES))
+        for f in FAILURES:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all dpad-latch tests passed")


### PR DESCRIPTION
Reported on iPhone: a swipe sticks and the selection keeps travelling that direction. The same session also showed **"connected" with inputs doing nothing**, and a **disconnect ~15s in**.

## What is proven

The d-pad is a **latched absolute axis**, not an edge-triggered key — `DPAD_MAP` writes `ABS_HAT0X`/`ABS_HAT0Y` with a non-zero value, and **nothing re-zeroes it**. There is no stuck-button watchdog, and the 12s idle reap cannot fire while the app pings every 5s.

So exactly **one** missing `v:0` pins the axis, and the consumer (Steam/SDL) auto-repeats it forever. The virtual pad never declares `EV_REP` — our side latches, Steam repeats.

The latch is also **axis-scoped**, which is why swiping the other way never clears it.

## What is NOT proven

Which trigger drops that release, and **why iOS and not Android**. A 77-agent investigation declined to name a winner rather than manufacture one. Two confounds in the original report remain unexcluded:

- **Both phones were connected.** A waiter's input frames are silently dropped (`couchsided.py`: *"Input frames only from the holder; a waiter's input is ignored"*) — which independently explains the "connected but nothing registers" observation. And a demoted holder's pad was destroyed with the hat still asserted.
- **`swipeSensitivity` is per-device and never synced** (`[0.6, 1, 1.6]`). At 1.6 the same finger speed produces a continuous hold where 0.6 produces discrete steps — identical code, different behaviour, no platform involved.

One new measurement did land: the session was reaped after ~12s of silence, meaning the app missed **at least two consecutive 5s pings**. That is a JS-thread stall, not a network blip — and the same stall would swallow a `setTimeout` release.

**The fixes below are correct regardless of which trigger it turns out to be.**

## Fixes

- **Emit a hold, not a fire-and-forget pulse.** Track the asserted key, re-arm while stepping, release the previous key on axis change, always release on gesture end. Steps were *distance*-gated while the release was *time*-gated at a fixed 50ms — so any finger faster than ~1px/ms already re-pressed before the release fired. The hat was held for the whole gesture, and the feature only ever worked because Steam repeats a held hat.
- **`SwipeSurface` had neither `onPanResponderTerminate` nor `onPanResponderTerminationRequest`**, so a gesture stolen mid-swipe (iOS screen-edge back, a parent responder) left the axis asserted with nothing to release it. Both sibling surfaces already refuse termination.
- **One haptic per move event**, not one per emitted step. The step loop is unbounded, and on iOS each `selectionAsync()` hops to the main queue with a fresh feedback generator. The trackpad surface already rate-limits exactly this way. Best-motivated suspect for the stall, and zero input-correctness risk either way.
- **`_release_devices()` now zeroes both hat axes and every button before destroying a demoted pad.** It already zeroes the mouse two lines later, and its docstring reasons about this exact hazard for the mouse and keyboard — the pad case was simply never considered.

## Verification

`tests/test_dpad_latch.py` pins the agent half, including that zeroing happens **before** the destroy (after would be useless). Against the pre-fix code it fails 4 assertions:

```
FAIL  the held axis was zeroed
FAIL  the other axis was zeroed too
FAIL  the LAST hat write is a zero, so nothing stays latched
FAIL  every declared button was zeroed
```

A control (demoting a session with no pad) stays green, so it is not passing by no-op. Full Python suite green; wired into CI.

**The app half is NOT verified.** The web harness has no WebSocket proxying and mouse is not touch, so the swipe surface cannot be exercised there. It needs a TestFlight build on the reporting device.

## Deliberately not done

An agent-side watchdog keyed on the d-pad. In Pad mode the on-screen arrows are genuine press/hold/release buttons, and holding ◀ to scroll a Steam list is a real gesture — a hat watchdog would cut it off mid-hold. The structural fix is a protocol pulse the agent releases itself, which would also cover the five other places this press+timed-release pattern is duplicated (including the Steam guide button, where a lost release leaves the menu key held). That needs an agent release plus a version gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)