### PR TITLE
chore(app): 2.9.15 — swipe stick fix, pair-to-remote, input trace

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.14",
+    "version": "2.9.15",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "66",
+      "buildNumber": "67",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 50
+      "versionCode": 51
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,4 +1,5 @@
-New in 2.9.14
+New in 2.9.15
 
-• TV navigation is snappier. D-pad presses take a more direct path to the box, so controlling a TV feels closer to instant.
-• Sending text to a TV now tells you when there's nowhere for it to go. If no text field is focused on the TV, the app says so instead of silently doing nothing — and points you at the search box that makes it work.
+• Fixed a swipe that could stick and keep scrolling one direction. The remote now releases the d-pad explicitly whenever your finger leaves the screen, including when another gesture interrupts it.
+• Pairing a box takes you straight to the remote instead of leaving you on Setup.
+• New pad input trace under Setup › Prefs. If a swipe ever sticks, tap Capture and screenshot it — it records whether each release reached your box.


### PR DESCRIPTION
Version bump + release notes for the TestFlight build.

## The reconcile matters this time

`appVersionSource` is **`local`**, so `autoIncrement` counts from `app.json` — not from EAS. The repo said **66/50** because 2.9.14’s reconcile PR was never merged, but EAS confirms 2.9.14 actually shipped as **iOS 67 / vc 51**.

Left at 66, the build would have produced **67 again** and Apple would have rejected the duplicate — about 20 minutes after the fact. So app.json is reconciled to 67/51 here, and `autoIncrement` takes it to **68/52** during the build. Deliberately not pre-bumped to 68.

Numbers read from `eas build:list`, not from memory or the repo.

## Play notes

Measured **before** building: the first draft was 515 characters against a **500-character** cap (527 bytes — the cap is characters, and conflating those has cost a build here before). Trimmed to fit.

## Ships

- #161 — swipe latched the d-pad and Steam repeated it forever, plus the input trace diagnostic
- #159 — pairing a box lands on the swipe Remote
- #158 — config saves followed the CWD, not the config
- #160 — Decky detected by the loader; installer stops faking panel success

🤖 Generated with [Claude Code](https://claude.com/claude-code)