### PR TITLE
chore(app): record build 68 as shipped

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "67",
+      "buildNumber": "68",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Commits the `autoIncrement` rewrite from the 2.9.15 local build.

`appVersionSource` is **`local`**, so `app.json` *is* the source of truth for build numbers. Left uncommitted, the repo says **67** while TestFlight holds **68**, and the next build emits 68 again — which Apple rejects as a duplicate.

**This is not hypothetical.** 2.9.14 reconcile was never merged, so the repo claimed 66 while 67 was live. That drift is what nearly collided on the first 2.9.15 attempt, and it cost real time to unpick.

Verified against App Store Connect rather than inferred:

```
build 68 | VALID | 2026-07-20T21:31:09-07:00
```

Worth noting for the record: build 68 was produced on the macOS 27.0 beta-seed host and Apple accepted it — `DTXcode 2660` / `DTSDKName iphoneos26.5` are release values, which is what validation keys on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)