### PR TITLE
fix(agent): stop reporting success the agent never verified

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Unit tests (couch ceremony)
         run: python3 tests/test_couch_ceremony.py
 
+      # Two places the agent reported success it had not verified.
+      # couchmode_start() returned ok because the switch SUBPROCESS exited 0 --
+      # but steamos-session-select returns as soon as the switch is TRIGGERED, so
+      # a compositor that never came up produced a green result on a black TV, on
+      # both the HTTP and guide-hold paths. And real_screen_frame() served
+      # whatever came back: _png_complete only proves an IEND chunk exists, and
+      # an all-black readback is a well-formed PNG. The inconclusive case is
+      # asserted too -- a frame that CANNOT be measured must still be served, or
+      # every box without magick/ffmpeg would lose its preview.
+      - name: Unit tests (verified success)
+        run: python3 tests/test_verified_success.py
+
       # Steam Remote Play discovery: parse remoteclients.vdf (streamable host
       # games) + the v29 appinfo.vdf name cache (a synthetic fixture locks the
       # binary parser), the most-recent-host de-dupe, the tool filter, and the

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.34"
+VERSION = "2.9.35"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1973,8 +1973,30 @@ def couchmode_start(output, hdr=False):
     # (3) Enter Game Mode (the one step that must succeed).
     sw = _session_to_game()
     steps["session"] = sw
-    return {"ok": sw["ok"], "output": output, "hdr": bool(hdr),
-            "session": "gamescope" if sw["ok"] else _couchmode_session(),
+    # (4) READBACK. steamos-session-select returns as soon as the switch is
+    # TRIGGERED, so sw["ok"] only means "the subprocess exited 0" -- it does not
+    # mean Game Mode came up. A compositor that fails to initialise on this GPU
+    # (proprietary NVIDIA, a bad output) previously reported success onto a black
+    # TV. Both live callers were affected: couchmode_enter (HTTP) and
+    # couchmode_try_enter (the guide-hold controller trigger).
+    #
+    # Reuses _couch_verify_gamescope() -- the staged ceremony already solved this
+    # exact problem for its own path, and a second private poller would be two
+    # implementations of one rule. NOTE this makes the call block up to
+    # SESSION_VERIFY_TIMEOUT_S; both callers already hold COUCH_LOCK for the
+    # whole switch, and blocking there is what stops a re-trigger mid-switch.
+    presented = False
+    if sw["ok"]:
+        presented = _couch_verify_gamescope()
+        steps["gamescope_up"] = {
+            "ok": presented, "exit_code": 0 if presented else 1, "stdout": "",
+            "stderr": "" if presented else
+            "switch reported success but Game Mode did not appear within %gs"
+            % SESSION_VERIFY_TIMEOUT_S}
+    return {"ok": bool(sw["ok"] and presented), "output": output,
+            "hdr": bool(hdr),
+            # Report the session we actually observed, never the one we hoped for.
+            "session": "gamescope" if presented else _couchmode_session(),
             "steps": steps}
 
 
@@ -7000,6 +7022,13 @@ SCREEN_WIDTH = 960                # downscale target width
 SCREEN_LOCK = threading.Lock()    # single-flight: never stack captures
 _SCREEN = None                    # capability dict or None; set by set_screen
 _SCREEN_CACHE = {"ts": 0.0, "data": None, "mime": None}  # 500 ms frame cache
+# Grayscale 0-255. Below this a frame is ~uniform (an all-black compositor
+# readback) and is rejected as a failed capture rather than served. _png_complete
+# only proves the PNG has an IEND chunk -- a perfectly well-formed all-black
+# frame passes it, and the app then shows a black preview that looks identical
+# to a working one.
+SCREEN_MIN_STDDEV = 2.0
+_screen_black_logged_at = 0.0     # rate-limit the ~uniform-frame log line
 
 
 def _screen_downscaler():
@@ -7136,6 +7165,67 @@ def _grab_spectacle(env, outdir):
     return png if _png_complete(png) else None
 
 
+def _grayscale_stddev(raw):
+    """Population std-dev of an 8-bit grayscale byte buffer (0-255), or None when
+    empty. Pure stdlib -- this agent ships with no third-party dependency and
+    must stay installable on an immutable SteamOS/Bazzite rootfs."""
+    n = len(raw)
+    if n == 0:
+        return None
+    mean = sum(raw) / n
+    return (sum((b - mean) ** 2 for b in raw) / n) ** 0.5
+
+
+def _frame_variance(src, env):
+    """Std-dev (0-255 grayscale) of a 32x32 sample of `src` (a PNG), using
+    whatever image tool this box has -- the same family _screen_downscaler picks
+    from, so it adds no new dependency.
+
+    Returns None when it CANNOT be measured (no tool, tool error). Callers MUST
+    treat None as "inconclusive" and never as black: a measurement gap must not
+    be able to suppress a real frame. 32x32 is plenty to separate a black
+    readback from a real desktop, and it is one short-lived subprocess on a path
+    that already runs a downscale per capture (and is capped at ~2/sec by the
+    500ms cache)."""
+    if shutil.which("magick"):
+        argv = ["magick", src, "-resize", "32x32!", "-colorspace", "Gray",
+                "-depth", "8", "GRAY:-"]
+    elif shutil.which("convert"):
+        argv = ["convert", src, "-resize", "32x32!", "-colorspace", "Gray",
+                "-depth", "8", "GRAY:-"]
+    elif shutil.which("ffmpeg"):
+        argv = ["ffmpeg", "-y", "-loglevel", "error", "-i", src, "-vf",
+                "scale=32:32,format=gray", "-f", "rawvideo", "-"]
+    else:
+        return None
+    try:
+        r = subprocess.run(argv, env=env, timeout=SCREEN_CAPTURE_TIMEOUT_S,
+                           stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except Exception:
+        return None
+    if r.returncode != 0 or not r.stdout:
+        return None
+    return _grayscale_stddev(r.stdout)
+
+
+def _reject_uniform_frame(grabbed, env):
+    """True when this capture is ~uniform (black) and must not be served.
+
+    Rejecting makes the route 503, so the app keeps the SCREEN card and retries,
+    instead of rendering a black image that is indistinguishable from a working
+    preview of a dark scene."""
+    sd = _frame_variance(grabbed, env)
+    if sd is None or sd >= SCREEN_MIN_STDDEV:
+        return False
+    global _screen_black_logged_at
+    now = time.monotonic()
+    if now - _screen_black_logged_at > 15:
+        _screen_black_logged_at = now
+        print("[screen] rejecting ~uniform frame (stddev %.2f < %.1f)"
+              % (sd, SCREEN_MIN_STDDEV), flush=True)
+    return True
+
+
 def real_screen_frame():
     """Capture one frame -> (jpeg_bytes, "image/jpeg") or None. Single-flight +
     500 ms cache so any number of pollers cause at most ~2 captures/sec."""
@@ -7173,6 +7263,11 @@ def real_screen_frame():
                 if grabbed:
                     break
             if not grabbed:
+                return None
+            # Checked BEFORE the downscale so a rejected frame costs nothing
+            # further. _png_complete() above only proves the file has an IEND
+            # chunk; an all-black readback is a perfectly well-formed PNG.
+            if _reject_uniform_frame(grabbed, env):
                 return None
             data = None
             try:

--- a/tests/test_verified_success.py
+++ b/tests/test_verified_success.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Two places the agent used to report success it had not verified.
+
+Run: python3 tests/test_verified_success.py
+
+(1) couchmode_start() returned ok purely because the switch SUBPROCESS exited 0.
+    steamos-session-select returns as soon as the switch is TRIGGERED, so a
+    compositor that never comes up -- the proprietary NVIDIA driver, a bad
+    output -- produced a green result on a black TV. Both live callers were
+    affected: couchmode_enter (HTTP) and couchmode_try_enter (the guide-hold
+    controller trigger). The staged ceremony already solved this for its own
+    path; couchmode_start is a SECOND path that did not.
+
+(2) real_screen_frame() served whatever the compositor handed back. _png_complete
+    only proves the file has an IEND chunk, and an all-black readback is a
+    perfectly well-formed PNG -- so the app rendered a black preview that looks
+    exactly like a working one.
+
+The inconclusive case in (2) matters as much as the positive one: when no image
+tool exists to measure with, the frame MUST still be served. A measurement gap
+that silently suppressed every frame would be a worse bug than the one being
+fixed.
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+# ---- (1) couch mode: the switch exiting 0 is not Game Mode being up ---------
+
+def _run_couchmode(switch_ok, gamescope_up):
+    """Drive the REAL couchmode_start with only its environment stubbed."""
+    cs._session_to_game = lambda: {"ok": switch_ok, "exit_code": 0 if switch_ok else 1,
+                                   "stdout": "", "stderr": ""}
+    cs._couchmode_session = lambda: ("gamescope" if gamescope_up else "desktop")
+    cs._couch_verify_gamescope = lambda: gamescope_up
+    cs.tv_send = lambda *a, **k: None
+    cs._couch_run = lambda *a, **k: {"ok": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    cs._hdmi_sink = lambda: None
+    cs._set_preferred_output = lambda o: {"skipped": True, "reason": "test"}
+    return cs.couchmode_start("", False)
+
+
+def test_switch_ok_but_gamescope_never_appears():
+    print("the bug: switch exits 0, Game Mode never comes up")
+    j = _run_couchmode(switch_ok=True, gamescope_up=False)
+    check(j["ok"] is False, "NOT reported ok (this used to be a fake green)")
+    check(j["session"] == "desktop", "reports the session actually observed")
+    step = j["steps"].get("gamescope_up") or {}
+    check(step.get("ok") is False, "the readback step is recorded as failed")
+    check("did not appear" in (step.get("stderr") or ""),
+          "and it explains itself rather than failing bare")
+
+
+def test_switch_ok_and_gamescope_up():
+    """CONTROL. Without this, always returning ok=False would pass the test
+    above -- and would break Couch Mode for every user."""
+    print("control: a switch that really works still succeeds")
+    j = _run_couchmode(switch_ok=True, gamescope_up=True)
+    check(j["ok"] is True, "reported ok")
+    check(j["session"] == "gamescope", "session is gamescope")
+    check((j["steps"].get("gamescope_up") or {}).get("ok") is True,
+          "readback step passed")
+
+
+def test_switch_tool_itself_failed():
+    print("the switch command fails outright")
+    j = _run_couchmode(switch_ok=False, gamescope_up=False)
+    check(j["ok"] is False, "not ok")
+    check("gamescope_up" not in j["steps"],
+          "no readback step -- nothing to verify when the switch never ran")
+
+
+# ---- (2) screen preview: an all-black PNG is a well-formed PNG --------------
+
+def test_uniform_frame_rejected():
+    print("a ~uniform (black) capture is rejected, not served")
+    cs._frame_variance = lambda src, env: 0.0
+    check(cs._reject_uniform_frame("/tmp/x.png", {}) is True, "black frame rejected")
+    cs._frame_variance = lambda src, env: cs.SCREEN_MIN_STDDEV - 0.01
+    check(cs._reject_uniform_frame("/tmp/x.png", {}) is True, "just under threshold rejected")
+
+
+def test_real_frame_served():
+    """CONTROL. A rejector that rejected everything would pass the test above and
+    kill the preview entirely."""
+    print("control: a real frame is served")
+    cs._frame_variance = lambda src, env: 42.0
+    check(cs._reject_uniform_frame("/tmp/x.png", {}) is False, "busy frame served")
+    cs._frame_variance = lambda src, env: cs.SCREEN_MIN_STDDEV
+    check(cs._reject_uniform_frame("/tmp/x.png", {}) is False,
+          "exactly at threshold is served (reject is strictly below)")
+
+
+def test_unmeasurable_frame_is_served():
+    """The most important one. No image tool -> no measurement -> the frame MUST
+    still be served. Treating "couldn't measure" as "black" would blank the
+    preview on every box without magick/convert/ffmpeg."""
+    print("a frame that CANNOT be measured is served, never rejected")
+    cs._frame_variance = lambda src, env: None
+    check(cs._reject_uniform_frame("/tmp/x.png", {}) is False,
+          "inconclusive != black")
+
+
+def test_stddev_math():
+    print("the std-dev helper itself")
+    check(cs._grayscale_stddev(b"") is None, "empty buffer -> None, not 0.0")
+    check(cs._grayscale_stddev(bytes([7] * 64)) == 0.0, "uniform buffer -> 0.0")
+    sd = cs._grayscale_stddev(bytes([0, 255] * 32))
+    check(sd is not None and abs(sd - 127.5) < 0.01, "half black/half white -> 127.5")
+
+
+if __name__ == "__main__":
+    test_switch_ok_but_gamescope_never_appears()
+    test_switch_ok_and_gamescope_up()
+    test_switch_tool_itself_failed()
+    test_uniform_frame_rejected()
+    test_real_frame_served()
+    test_unmeasurable_frame_is_served()
+    test_stddev_math()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all verified-success tests passed")


### PR DESCRIPTION
Reimplements the substance of #57 on current main. **Supersedes #57 — do not merge that one.**

That PR was opened against `2.9.5`; main is `2.9.34` with **41 commits to `couchsided.py`** since. Merging it would have been a conflict-resolution exercise on a file that moved underneath it. The bugs it found are still real, so they are fixed here fresh.

## 1. Couch Mode reported a switch it never confirmed

`couchmode_start()` returned ok purely because the switch subprocess exited 0. `steamos-session-select` returns as soon as the switch is **triggered**, not when gamescope presents — so a compositor that fails to come up (proprietary NVIDIA, a bad output) reported a green result onto a black TV.

Both live callers were affected: `couchmode_enter` (HTTP) and `couchmode_try_enter` (**the guide-hold controller trigger**).

**This is not the ceremony bug.** I initially suspected #57 was superseded, because main’s CI has a couch-ceremony test explicitly about "a fake-green Ready that didn’t verify Game Mode came up." It isn’t — that covers the staged *ceremony* worker, which does verify. `couchmode_start` is a **second path** that never got it.

Rather than add a private poller (#57’s approach, which would leave two implementations of one rule), this reuses `_couch_verify_gamescope()`. It makes the call block up to `SESSION_VERIFY_TIMEOUT_S`; both callers already hold `COUCH_LOCK` across the whole switch, and blocking there is exactly what prevents a re-trigger mid-switch.

## 2. An all-black preview is a well-formed PNG

`real_screen_frame()` served whatever the compositor returned. `_png_complete()` only proves the file has an `IEND` chunk — an all-black readback passes it — so the app rendered a black preview indistinguishable from a working one.

Now a 32×32 grayscale sample is measured and a near-uniform frame is rejected, making the route 503 so the app keeps the card and retries. Measured *before* the downscale, and using the same image tools `_screen_downscaler` already picks from — no new dependency, which this agent cannot take (pure stdlib, must install on an immutable rootfs).

**"Couldn’t measure" is not "black".** `_frame_variance` returns `None` when no image tool exists, and the caller serves the frame. Treating that as black would blank the preview on every box without magick/convert/ffmpeg — a worse bug than the one being fixed — so it is asserted directly.

## Verified against the pre-fix behaviour of both

Not just that the fixed code passes:

```
restoring the old fake-green return  -> 5 failures, led by
    "NOT reported ok (this used to be a fake green)"
flipping the inconclusive branch     -> "inconclusive != black" fails
```

Controls in both halves stop a vacuous pass: a switch that really works must still succeed (or Couch Mode breaks for everyone), and a real frame must still be served (or the preview dies).

Agent `2.9.34` → `2.9.35`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)