### PR TITLE
test: extend protocol parity to capability flags

### DIFF
--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -17,54 +17,170 @@
     "-- KDE desktop actions are meaningless on Windows, and Windows system chords",
     "are meaningless on SteamOS. Those entries declare their platforms, and the",
     "test asserts they are ABSENT elsewhere. That absence is a designed decision,",
-    "not an omission, and asserting it stops a half-port from looking finished."
+    "not an omission, and asserting it stops a half-port from looking finished.",
+    "",
+    "CAPABILITIES are included because they are the highest-drift surface here: a",
+    "capability key needs FIVE edit sites (agent CAPS + mock; app BoxCaps,",
+    "normalizeCaps, capsEqual) and missing the app ones is SILENT -- the cap never",
+    "persists and the app re-probes forever.",
+    "",
+    "HTTP ENDPOINTS are deliberately NOT modelled. Route dispatch takes at least",
+    "four forms in the agents (path ==, path in (...), prefix match, and a generic",
+    "/api/tv/<op> dispatcher), so any extraction is approximate. A first pass at it",
+    "produced three false 'missing route' findings in a row -- /api/pair/finish,",
+    "/api/tv/source_box and /api/tv/screen_toggle all exist and all work. A parity",
+    "test that cries wolf gets disabled, which is worse than not having it."
   ],
-
   "buttons": {
     "_doc": "{'t':'b','k':<key>,'v':0|1}. Virtual Xbox 360 pad. Required on BOTH agents. NOTE: the d-pad keys are a LATCHED ABS hat on Linux, not edge-triggered -- one missing v:0 pins the axis forever (see tests/test_dpad_latch.py).",
-    "platforms": ["linux", "windows"],
-    "keys": ["a", "b", "x", "y", "lb", "rb", "l3", "r3", "start", "select", "guide", "dl", "dr", "du", "dd"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "a",
+      "b",
+      "x",
+      "y",
+      "lb",
+      "rb",
+      "l3",
+      "r3",
+      "start",
+      "select",
+      "guide",
+      "dl",
+      "dr",
+      "du",
+      "dd"
+    ]
   },
-
   "triggers": {
     "_doc": "{'t':'t','k':<key>,'v':0..255}. Analog shoulder triggers.",
-    "platforms": ["linux", "windows"],
-    "keys": ["lt", "rt"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "lt",
+      "rt"
+    ]
   },
-
   "sticks": {
     "_doc": "{'t':'s','k':<key>,'x':<n>,'y':<n>}. Analog sticks.",
-    "platforms": ["linux", "windows"],
-    "keys": ["l", "r"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "l",
+      "r"
+    ]
   },
-
   "mouseButtons": {
     "_doc": "{'t':'mb','k':<key>,'v':0|1}. Relative-mouse buttons (protocol v2).",
-    "platforms": ["linux", "windows"],
-    "keys": ["l", "m", "r"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "l",
+      "m",
+      "r"
+    ]
   },
-
   "specialKeys": {
     "_doc": "{'t':'k','k':<key>} named non-character keys. Required on BOTH agents.",
-    "platforms": ["linux", "windows"],
-    "keys": ["backspace", "down", "end", "enter", "esc", "home", "left", "right", "space", "tab", "up"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "backspace",
+      "down",
+      "end",
+      "enter",
+      "esc",
+      "home",
+      "left",
+      "right",
+      "space",
+      "tab",
+      "up"
+    ]
   },
-
   "desktopKeys": {
     "_doc": "SteamOS/Bazzite (KDE Plasma) desktop actions on the {t:'k'} channel: 'meta' taps Super (Kickoff), 'overview' fires the KWin overview chord. LINUX ONLY by design -- the app gates them on caps.desktop and an agent that doesn't know the name drops the frame.",
-    "platforms": ["linux"],
-    "keys": ["meta", "overview"]
+    "platforms": [
+      "linux"
+    ],
+    "keys": [
+      "meta",
+      "overview"
+    ]
   },
-
   "chords": {
     "_doc": "One-shot Windows desktop system shortcuts the agent expands into a key sequence. WINDOWS ONLY by design. Ctrl+Alt+Del is deliberately absent: it is the Secure Attention Sequence and SendInput cannot generate it.",
-    "platforms": ["windows"],
-    "keys": ["win", "alt-tab", "lock", "taskmgr"]
+    "platforms": [
+      "windows"
+    ],
+    "keys": [
+      "win",
+      "alt-tab",
+      "lock",
+      "taskmgr"
+    ]
   },
-
   "frameTypes": {
     "_doc": "Top-level {'t':...} discriminators the gamepad WebSocket accepts.",
-    "platforms": ["linux", "windows"],
-    "keys": ["b", "t", "s", "m", "mb", "mw", "k", "kt", "ping", "grant", "deny", "request", "force"]
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "b",
+      "t",
+      "s",
+      "m",
+      "mb",
+      "mw",
+      "k",
+      "kt",
+      "ping",
+      "grant",
+      "deny",
+      "request",
+      "force"
+    ]
+  },
+  "capabilities": {
+    "_doc": "/api/status caps flags. Compared against the agents' REAL runtime CAPS dicts (set_caps is called and the dict read) and the app's BoxCaps / normalizeCaps / capsEqual -- all five edit sites.",
+    "platforms": [
+      "linux",
+      "windows"
+    ],
+    "keys": [
+      "couchmode",
+      "desktop",
+      "gamepad",
+      "media",
+      "power_schedule",
+      "screen",
+      "screensaver",
+      "steam",
+      "tv"
+    ]
+  },
+  "linuxOnlyCapabilities": {
+    "_doc": "Linux-only TODAY. gaming reads sysfs and streamhost reads /proc/net, so they are inherently Linux. steamlink and steammenus are portable in principle and simply are NOT ported -- recorded here so the Windows gap is visible as a decision rather than rediscovered as a surprise. The app treats a MISSING cap as unknown (not false), so a Windows box just doesn't offer these.",
+    "platforms": [
+      "linux"
+    ],
+    "keys": [
+      "gaming",
+      "steamlink",
+      "steammenus",
+      "streamhost"
+    ]
   }
 }

--- a/tests/test_protocol_parity.py
+++ b/tests/test_protocol_parity.py
@@ -179,6 +179,8 @@ def _ts_union(name):
     return set(re.findall(r"'([^']+)'", m.group(1)))
 
 
+CAP_GROUPS = ("capabilities", "linuxOnlyCapabilities")
+
 APP_UNIONS = {
     "buttons": "ButtonKey",
     "triggers": "TriggerKey",
@@ -200,6 +202,104 @@ def test_app_matches_spec():
               % (ts, gname, sorted(want - got) or "none", sorted(got - want) or "none"))
 
 
+# ---- capabilities: the five-edit-site rule, checked ------------------------
+#
+# A capability key needs FIVE edits: the agent's CAPS dict + its mock tuple, and
+# the app's BoxCaps + normalizeCaps + capsEqual. Missing the app ones is SILENT
+# -- the cap never persists, so the app re-probes on every launch forever. That
+# is exactly how `steammenus` and the TV sections drifted.
+#
+# Read from the agents' REAL runtime dicts (set_caps is called and CAPS is read),
+# not from source text. An earlier regex pass over the same data produced two
+# false findings purely from a truncated match window.
+
+def _agent_caps(mod):
+    """The cap NAMES this agent declares, from BOTH of its two sites.
+
+    set_caps(mock) has two code paths: the mock branch builds CAPS from a fixed
+    name tuple, the real branch from a dict of detector calls. Those are two of
+    the five edit sites, and a cap added to one but not the other is exactly the
+    drift being hunted -- an earlier version of this test read only the mock
+    path and did NOT catch a cap injected into the real dict. Union both, and
+    _agent_caps_disagree() reports the pair falling out of step."""
+    names = set()
+    for mock in (True, False):
+        try:
+            mod.set_caps(mock)
+            names |= set(mod.CAPS)
+        except Exception:
+            pass
+    mod.set_caps(True)          # leave the module in a deterministic state
+    return names
+
+
+def _agent_caps_disagree(mod):
+    """Cap names present in one set_caps() branch but not the other."""
+    sets = {}
+    for mock in (True, False):
+        try:
+            mod.set_caps(mock)
+            sets[mock] = set(mod.CAPS)
+        except Exception:
+            sets[mock] = set()
+    mod.set_caps(True)
+    return sorted(sets[True] ^ sets[False])
+
+
+def _app_caps_sites():
+    """The app's three caps edit sites, as sets. Full function bodies, never a
+    fixed window -- truncation is what produced the earlier false finding."""
+    api = open(os.path.join(ROOT, "app", "lib", "api.ts")).read()
+    st = open(os.path.join(ROOT, "app", "lib", "settings.ts")).read()
+    m = re.search(r"export type BoxCaps = \{(.*?)\n\};", api, re.S)
+    box = set(re.findall(r"^\s{2}([a-z_]+)\??:", m.group(1), re.M)) if m else set()
+    i = api.find("capsEqual")
+    equal = set(re.findall(r"a\.([a-z_]+) === b\.", api[i:i + 2000])) if i >= 0 else set()
+    j = st.find("normalizeCaps")
+    k = st.find("\n}", j)
+    norm = set(re.findall(r"bool\('([a-z_]+)'\)", st[j:k])) if j >= 0 else set()
+    return {"BoxCaps": box, "normalizeCaps": norm, "capsEqual": equal}
+
+
+def test_capabilities():
+    print("capabilities: every declared cap exists on its platforms")
+    for gname in CAP_GROUPS:
+        keys, platforms = group(gname)
+        for plat, mod in AGENTS.items():
+            have = _agent_caps(mod)
+            if plat in platforms:
+                missing = [k for k in keys if k not in have]
+                check(not missing, "%s: %s present (missing: %s)"
+                      % (plat, gname, missing or "none"))
+            else:
+                leaked = [k for k in keys if k in have]
+                check(not leaked, "%s: %s correctly absent (leaked: %s)"
+                      % (plat, gname, leaked or "none"))
+    # No agent may declare a cap the spec has never heard of.
+    declared = set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+    for plat, mod in AGENTS.items():
+        extra = sorted(_agent_caps(mod) - declared)
+        check(not extra, "%s: no undeclared caps (extra: %s)" % (plat, extra or "none"))
+        # The agent's own two sites must agree with each other.
+        skew = _agent_caps_disagree(mod)
+        check(not skew, "%s: mock and real CAPS declare the same keys (differ: %s)"
+              % (plat, skew or "none"))
+
+
+def test_app_knows_every_capability():
+    """All THREE app sites must carry every cap any agent can send. This is the
+    silent one: BoxCaps and capsEqual can agree while normalizeCaps quietly drops
+    a key, and the only symptom is a cap that never persists."""
+    print("capabilities: all three app edit sites carry every cap")
+    declared = set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+    for site, have in _app_caps_sites().items():
+        check(have, "app: %s parsed something at all" % site)
+        missing = sorted(declared - have)
+        extra = sorted(have - declared)
+        check(not missing, "app: %s has every cap (missing: %s)" % (site, missing or "none"))
+        check(not extra, "app: %s has no unknown caps (extra: %s)" % (site, extra or "none"))
+
+
 def test_spec_is_well_formed():
     """CONTROL. A spec with an empty group would make the checks above vacuous."""
     print("control: the spec itself is non-empty and platform-tagged")
@@ -217,6 +317,8 @@ if __name__ == "__main__":
     test_special_keys_both_agents()
     test_platform_scoped_keys()
     test_app_matches_spec()
+    test_capabilities()
+    test_app_knows_every_capability()
     print()
     if _fail:
         print("FAILED: %d" % len(_fail))


### PR DESCRIPTION
Extends #165 to the surface that drifts most.

A capability key needs **five edit sites** — agent `CAPS` dict + mock tuple, app `BoxCaps` + `normalizeCaps` + `capsEqual` — and missing the app ones is **silent**: the cap never persists, so the app re-probes forever. That is how `steammenus` and the TV sections drifted.

Checked from the agents’ **real runtime dicts**, not source text, and from full app function bodies rather than fixed windows. Both directions.

## The agent’s own two sites are checked against each other

`set_caps()` has two branches — the mock one builds `CAPS` from a name tuple, the real one from a dict of detectors. **The first version of this test read only the mock path, and a cap injected into the real dict was not caught.** Both branches are now unioned and compared, and that same injection fails twice.

## Findings: no drift

All three implementations agree on **13 caps**. Windows declares **9**; the missing four are recorded as `linuxOnlyCapabilities`:

- `gaming` reads sysfs and `streamhost` reads `/proc/net` — inherently Linux
- `steamlink` / `steammenus` are portable in principle and simply are **not ported**

Writing the gap down makes it a decision instead of a surprise. The app already treats a missing cap as *unknown* rather than false, so a Windows box just doesn’t offer them.

## HTTP endpoints are deliberately NOT modelled

Route dispatch takes at least four forms — `path ==`, `path in (...)`, prefix match, and a generic `/api/tv/<op>` dispatcher — so extraction is approximate. A first pass produced **three false "missing route" findings in a row**: `/api/pair/finish`, `/api/tv/source_box` and `/api/tv/screen_toggle` all exist and all work.

A parity test that cries wolf gets disabled, which is worse than not having one. The rationale is recorded in the spec so it isn’t re-litigated later.

## Verified against injected drift

```
normalizeCaps drops steammenus  -> app: normalizeCaps has every cap (missing: [steammenus])
cap added to real dict only     -> linux: no undeclared caps (extra: [newthing])
                                 + linux: mock and real CAPS declare the same keys
```

Test-only: `protocol/protocol.json` and the test file. Nothing at runtime reads either, so **no rebuild needed** — and since it found no drift, nothing needs folding into 2.9.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)