### PR TITLE
chore(app): 2.9.16 — Steam shortcuts tab, header layout, verified success

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.15",
+    "version": "2.9.16",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,5 @@
-New in 2.9.15
+New in 2.9.16
 
-• Fixed a swipe that could stick and keep scrolling one direction. The remote now releases the d-pad explicitly whenever your finger leaves the screen, including when another gesture interrupts it.
-• Pairing a box takes you straight to the remote instead of leaving you on Setup.
-• New pad input trace under Setup › Prefs. If a swipe ever sticks, tap Capture and screenshot it — it records whether each release reached your box.
+• Steam settings are one swipe past the remote. Jump to Controller, Display, Audio, Storage and more without leaving the Pad. Shown only in Game Mode, where those shortcuts work.
+• Connection status now has its own row, so it reads in full instead of being cut off, and the mode tabs spread evenly.
+• Couch Mode no longer reports success when Game Mode didn't come up, and the screen preview no longer shows a black frame as if it were real.


### PR DESCRIPTION
Version bump + release notes for the 2.9.16 build.

## Version discipline

`buildNumber`/`versionCode` are left at what 2.9.15 **shipped** (68/51, already reconciled by #163). `appVersionSource` is `local`, so `autoIncrement` counts from this file and will produce **69/52** during the build.

Never pre-bump — doing so double-increments and Apple rejects the duplicate that follows.

## Play notes

Measured **before** building: **457 characters** against the 500-**character** cap. The first two drafts came in at 516 and 515. This cap has cost a build here before, and it is characters, not bytes.

## Ships

| PR | |
|---|---|
| #164 | Steam settings shortcuts as a Pad mode, one swipe past the Remote |
| #166 | Status pill and mode tabs on their own full-width rows |
| #167 | That Steam tab gated to Game Mode, where the deep links actually work |
| #168 | Agent 2.9.35 — Couch Mode verifies gamescope presented; screen preview rejects an all-black readback |
| #165 / #169 | Protocol parity spec + test (CI only, not shipped) |

Agent goes out at **2.9.35**, so `scripts/release-agent.sh` needs re-running for this tag — it clobbers assets on the existing app-version tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)