### PR TITLE
fix(app): suspend no longer requires Ethernet

### DIFF
--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -634,27 +634,34 @@ export function RemotePowerBar() {
               {canSuspend && (
                 <View style={styles.suspendGroup}>
                   <Pressable
-                    disabled={wired === false}
                     onPress={() => {
                       setOpen(false);
                       onSuspend();
                     }}
-                    style={({ pressed }) => [
-                      styles.bigBtn,
-                      wired === false && styles.disabled,
-                      pressed && styles.pressed,
-                    ]}>
+                    style={({ pressed }) => [styles.bigBtn, pressed && styles.pressed]}>
                     <Ionicons name="moon" size={22} color={t.amber} />
-                    <Text style={[styles.bigLabel, { color: t.amber }]}>
-                      {wired === false ? 'Suspend (needs Ethernet)' : 'Suspend'}
-                    </Text>
+                    <Text style={[styles.bigLabel, { color: t.amber }]}>Suspend</Text>
                   </Pressable>
-                  {wired !== false && wolArmed === false && (
+                  {/* Suspending and WAKING are separate capabilities, and only
+                      the second one needs Ethernet. This button used to be
+                      DISABLED on WiFi and labelled "Suspend (needs Ethernet)",
+                      which took the feature away from the machine it matters
+                      most on: a Steam Deck is WiFi-only undocked, and its whole
+                      signature move is power-button suspend/resume -- no
+                      Wake-on-LAN involved. Suspending works fine over WiFi. Say
+                      how you'll wake it instead of blocking it. */}
+                  {wired === false ? (
+                    <Text style={styles.warnText}>
+                      Wake-on-LAN needs Ethernet, so the Wake button won&apos;t reach this
+                      box. Press its power button to wake it — it resumes where you left
+                      off.
+                    </Text>
+                  ) : wolArmed === false ? (
                     <Text style={styles.warnText}>
                       Wake-on-LAN is not armed on this box. It will sleep, but the
                       Wake button may not bring it back.
                     </Text>
-                  )}
+                  ) : null}
                 </View>
               )}
 


### PR DESCRIPTION
The Suspend button was **disabled** whenever `net.wired` was false, labelled *"Suspend (needs Ethernet)"*.

That conflates two different capabilities: **suspending** (always works) and **waking the box remotely** (needs Wake-on-LAN, which needs Ethernet). Only the second has the requirement.

## Measured on the real device

A Steam Deck OLED on WiFi, live — not a mock:

```
net.wired     : False      <- this disabled the button
net.wol_armed : None
caps.couchmode: True
agent         : 2.9.33  (taylor-steamdeck, 10.7.0.61)
```

A Deck is WiFi-only undocked, and **power-button suspend/resume is its signature behaviour** — you wake it by pressing the power button, no Wake-on-LAN involved. The app was greying out a button that would have worked perfectly.

## It also inverts our own rule

Dead buttons get hidden here because *"a dead button costs more trust than a missing one."* But this button was **not dead** — disabling a working control teaches the user the app is wrong about their box, which is worse.

## Now

Suspend is always offered, and the wording says how to wake it:

> Wake-on-LAN needs Ethernet, so the Wake button won’t reach this box. Press its power button to wake it — it resumes where you left off.

The existing `wol_armed` warning still applies on wired boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)