### PR TITLE
fix(app): Fling to TV was dead on an undocked handheld

### DIFF
--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -95,7 +95,13 @@ export function CouchModeSheet({
   }, [job?.state, job?.session, onChanged]);
 
   const fling = useCallback(async () => {
-    if (busy || !output) return;
+    // NOT `|| !output`. The same gate lived here AND on the button's disabled
+    // prop; removing only the prop produced a button that looked pressable and
+    // silently did nothing, which is worse than a disabled one. An empty output
+    // is valid: the agent skips the pin step ("no external display selected")
+    // and switches anyway, which is the whole point on an undocked handheld
+    // where game_outputs is [] by design.
+    if (busy) return;
     setBusy(true);
     hapticLight();
     try {
@@ -186,13 +192,23 @@ export function CouchModeSheet({
                 </>
               )}
 
+              {/* NOT gated on `output`. game_outputs deliberately EXCLUDES
+                  internal displays, so an undocked handheld reports [] -- and
+                  since canPickOutput is also false there, no picker is shown
+                  either, leaving a permanently dead button. Measured on a Steam
+                  Deck OLED undocked: outputs [eDP-1 internal], game_outputs [],
+                  output_forcing false, caps.couchmode TRUE.
+
+                  The agent never required an output. couchmode_start("") is
+                  supported and simply skips the pin step ("no external display
+                  selected"), and couchmode_available() was relaxed to any
+                  connected display precisely so undocked handhelds could fling
+                  -- the app was just never updated to match. The output is a
+                  PREFERENCE for multi-display boxes, not a precondition. */}
               <Pressable
-                disabled={busy || !output}
+                disabled={busy}
                 onPress={fling}
-                style={({ pressed }) => [
-                  styles.startBtn,
-                  (pressed || busy || !output) && styles.pressed,
-                ]}>
+                style={({ pressed }) => [styles.startBtn, (pressed || busy) && styles.pressed]}>
                 <Ionicons name="tv-outline" size={18} color="#fff" />
                 <Text style={styles.startText}>{busy ? 'Switching…' : 'Fling to TV'}</Text>
               </Pressable>


### PR DESCRIPTION
Reported on a Steam Deck: Couch Mode returns to the desktop fine, but the button to go **back to Game Mode** "isn’t pressable."

It was **disabled**, so the app never sent anything — which is why the agent’s journal showed no `POST /api/couch-mode` at all. Absence of evidence *was* the evidence.

## Measured on the live Deck

`taylor-steamdeck`, agent 2.9.33, undocked:

```json
"outputs":        [{"name": "eDP-1", "internal": true}],
"game_outputs":   [],
"output_forcing": false,
"caps.couchmode": true
```

`game_outputs` deliberately **excludes internal displays** (`[o["name"] for o in outs if not o["internal"]]`), so an undocked handheld reports `[]`. The sheet gated on that — and `canPickOutput` is false there too, so there is no picker and no selectable output. Permanently dead button.

## The agent never required one

`couchmode_start("")` is supported and simply skips the pin step (*"no external display selected"*), and `couchmode_available()` was relaxed to any connected display **specifically so undocked handhelds could fling** — its own docstring says *"relaxing it is what lets the guide-button hold work undocked."*

The app was never updated to match. The output is a **preference** for multi-display boxes, not a precondition.

## The guard existed twice

On the button’s `disabled` prop **and** inside the `fling` handler:

```js
const fling = useCallback(async () => {
  if (busy || !output) return;   // ← second gate
```

Removing only the prop produced a button that *looked* pressable and silently did nothing — worse than a disabled one. That is not hypothetical: **the first version of this fix did exactly that, and it passed a screenshot.** Only pressing it and watching for the request caught it.

## Verified by pressing, not rendering

Against a mock reproducing the Deck’s exact payload (`game_outputs: []`, one internal display):

```
POST /api/couch-mode 200
```

Before the fix, the same press produced **no request at all**.

## Note

This unblocks the button. Whether the switch then *succeeds* on your Deck is a separate question — and #168 (agent 2.9.35) is what makes a failed switch report honestly instead of going green. Your Deck is on 2.9.33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)