### PR TITLE
fix(agent): stop forcing X11 on a Wayland-configured desktop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,16 @@ jobs:
       - name: Unit tests (couch ceremony)
         run: python3 tests/test_couch_ceremony.py
 
+      # The desktop switch must honour the box's CONFIGURED session. SteamOS
+      # ships both, and steamos-session-select maps the bare "plasma" arg to the
+      # X11 one -- so passing it silently downgraded a Wayland-configured box to
+      # X11 on every Couch Mode return. Measured on a real Deck: default was
+      # plasma.desktop (Wayland), session ended up x11. Degrading CLOSED is the
+      # load-bearing part: an unreadable or unlisted name must fall back to the
+      # X11 pair that shipped before, so a box we cannot read is unchanged.
+      - name: Unit tests (desktop session)
+        run: python3 tests/test_desktop_session.py
+
       # Two places the agent reported success it had not verified.
       # couchmode_start() returned ok because the switch SUBPROCESS exited 0 --
       # but steamos-session-select returns as soon as the switch is TRIGGERED, so

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.35"
+VERSION = "2.9.36"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -133,9 +133,15 @@ SESSION_ACTIONS = {
         "label": "Switch to Desktop",
         "description": "Leave Game Mode for the SteamOS desktop",
         "danger": "medium",
-        # "plasma" = one-time switch to the desktop (doesn't change the default
-        # login mode, so the box still boots into Game Mode). NB: session-select
-        # has no "desktop" arg: valid targets are plasma*/gamescope.
+        # One-time switch to the desktop: the default login mode is untouched,
+        # so the box still boots into Game Mode. NB: session-select has no
+        # "desktop" arg -- valid targets are plasma*/gamescope.
+        #
+        # The arg is REWRITTEN at injection time to match the box's configured
+        # default session (see _inject_session_actions). Bare "plasma" is
+        # SteamOS's legacy alias for the X11 session, so leaving it here would
+        # force X11 onto a Wayland-configured box. This value is the fallback
+        # for boxes whose default cannot be read.
         "cmd": ["steamos-session-select", "plasma"],
         "user_env": True,
         "detached": True,
@@ -703,9 +709,17 @@ def _inject_session_actions():
     global ACTIONS, ACTION_ORDER
     if not shutil.which("steamos-session-select"):
         return
+    # Point "Switch to Desktop" at the session this box is CONFIGURED for. The
+    # static spec says "plasma", which SteamOS maps to the X11 session -- on a
+    # Wayland-configured box that silently changes the user's desktop. Resolved
+    # once here, from a frozen allowlist, so the stored argv stays a fixed list.
+    _, select_arg = _default_desktop_session()
     for aid, spec in SESSION_ACTIONS.items():
         if aid not in ACTIONS:
-            ACTIONS[aid] = dict(spec)
+            spec = dict(spec)
+            if aid == "switch-desktop":
+                spec["cmd"] = ["steamos-session-select", select_arg]
+            ACTIONS[aid] = spec
             if aid not in ACTION_ORDER:
                 ACTION_ORDER.append(aid)
 
@@ -1897,17 +1911,58 @@ def _session_to_game():
     ])
 
 
-def _session_to_desktop():
-    """Transient switch back to the desktop session.
 
-    SteamOS: steamosctl with the X11 session (validated live). Bazzite: its
-    steamos-session-select 'plasma' runs a ONESHOT desktop session — the boot
-    default stays Game Mode, which is exactly couch-mode semantics (also
-    validated live)."""
+# SteamOS ships BOTH desktop sessions and steamos-session-select maps the bare
+# "plasma" arg to the X11 one:
+#     plasma)         steamosctl switch-to-desktop-mode plasmax11.desktop
+#     plasma-wayland) steamosctl switch-to-desktop-mode plasma.desktop
+# So passing "plasma" silently OVERRIDES a box configured for Wayland. Measured
+# on a real Deck (SteamOS 20260701.2): the configured default was
+# plasma.desktop (Wayland) and our switch landed it in an x11 session. The user
+# noticed their desktop had changed and had no idea we did it.
+#
+# FROZEN ALLOWLIST. The session name is read from the system, not a client, but
+# it still only ever SELECTS one of these known values -- never interpolated.
+# Anything unrecognised falls back to the previously-validated X11 path, so a
+# box we can't read stays exactly as it behaved before.
+_DESKTOP_SESSIONS = {
+    "plasma.desktop": "plasma-wayland",
+    "plasmax11.desktop": "plasma",
+}
+_DEFAULT_DESKTOP_FALLBACK = "plasmax11.desktop"
+
+
+def _default_desktop_session():
+    """The desktop session this box is CONFIGURED to use, as a
+    (session_file, session_select_arg) pair from the frozen table above.
+
+    Degrades closed: any read failure, or a name not on the allowlist, returns
+    the X11 pair that shipped before -- never a guess, never a raw value."""
+    try:
+        r = subprocess.run(["steamosctl", "get-default-desktop-session"],
+                           capture_output=True, text=True, timeout=5)
+        name = (r.stdout or "").strip()
+    except Exception:
+        name = ""
+    if name not in _DESKTOP_SESSIONS:
+        name = _DEFAULT_DESKTOP_FALLBACK
+    return name, _DESKTOP_SESSIONS[name]
+
+
+def _session_to_desktop():
+    """Transient switch back to the desktop session, honouring the box's OWN
+    configured default rather than forcing one.
+
+    This used to hardcode plasmax11.desktop. That silently downgraded a
+    Wayland-configured box to X11 every time Couch Mode came back to the
+    desktop (see _default_desktop_session). It stays a ONESHOT switch either
+    way: the boot default is untouched, so the box still returns to Game Mode,
+    which is exactly couch-mode semantics."""
+    session, select_arg = _default_desktop_session()
     return _couch_run_first([
-        ["steamosctl", "switch-to-desktop-mode", "plasmax11.desktop"],
+        ["steamosctl", "switch-to-desktop-mode", session],
         ["steamosctl", "switch-to-desktop-mode"],
-        ["steamos-session-select", "plasma"],
+        ["steamos-session-select", select_arg],
     ])
 
 

--- a/tests/test_desktop_session.py
+++ b/tests/test_desktop_session.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""The desktop switch must honour the box's CONFIGURED session, not force one.
+
+Run: python3 tests/test_desktop_session.py
+
+SteamOS ships both desktop sessions, and steamos-session-select maps the bare
+"plasma" arg to the X11 one:
+
+    plasma)         steamosctl switch-to-desktop-mode plasmax11.desktop
+    plasma-wayland) steamosctl switch-to-desktop-mode plasma.desktop
+
+We passed "plasma" (and hardcoded plasmax11.desktop in _session_to_desktop), so
+every Couch Mode return and every "Switch to Desktop" silently downgraded a
+Wayland-configured box to X11. Measured on a real Steam Deck, SteamOS
+20260701.2:
+
+    steamosctl get-default-desktop-session -> plasma.desktop   (Wayland)
+    loginctl show-session ... -p Type       -> x11             (what we forced)
+
+The user noticed their desktop had changed and had no idea we had done it.
+
+DEGRADE CLOSED is the load-bearing property here: any read failure, or a session
+name not on the frozen allowlist, must fall back to the X11 pair that shipped
+before -- a box we cannot read must behave exactly as it did.
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+class _Run:
+    def __init__(self, stdout="", raise_=False):
+        self.stdout, self.raise_ = stdout, raise_
+
+    def __call__(self, *a, **k):
+        if self.raise_:
+            raise OSError("steamosctl missing")
+        class R:
+            pass
+        r = R()
+        r.stdout = self.stdout
+        r.returncode = 0
+        return r
+
+
+def _with_default(stdout="", raise_=False):
+    orig = cs.subprocess.run
+    cs.subprocess.run = _Run(stdout, raise_)
+    try:
+        return cs._default_desktop_session()
+    finally:
+        cs.subprocess.run = orig
+
+
+def test_wayland_box_is_left_on_wayland():
+    print("a Wayland-configured box gets the Wayland session")
+    session, arg = _with_default("plasma.desktop\n")
+    check(session == "plasma.desktop", "session file is plasma.desktop")
+    check(arg == "plasma-wayland",
+          "select arg is plasma-wayland, NOT the bare 'plasma' that means X11")
+
+
+def test_x11_box_stays_x11():
+    """CONTROL. An X11-configured box must be unaffected -- this fix is about
+    not overriding the user, in either direction."""
+    print("control: an X11-configured box still gets X11")
+    session, arg = _with_default("plasmax11.desktop\n")
+    check(session == "plasmax11.desktop", "session file is plasmax11.desktop")
+    check(arg == "plasma", "select arg is the bare 'plasma' (X11)")
+
+
+def test_unreadable_degrades_closed():
+    print("an unreadable or unknown default degrades to the shipped X11 pair")
+    for label, kw in (("command raises", {"raise_": True}),
+                      ("empty output", {"stdout": ""}),
+                      ("unknown name", {"stdout": "something-else.desktop\n"}),
+                      ("junk", {"stdout": "; rm -rf /\n"})):
+        session, arg = _with_default(**kw)
+        check(session == "plasmax11.desktop" and arg == "plasma",
+              "%s -> falls back to the previously shipped X11 pair" % label)
+
+
+def test_never_passes_an_unvetted_name():
+    """The session name comes from the system, not a client -- but it still must
+    only ever SELECT a known value, never be interpolated through."""
+    print("a hostile default name is never passed through")
+    session, arg = _with_default("$(reboot).desktop\n")
+    check(session in cs._DESKTOP_SESSIONS, "returned name is on the allowlist")
+    check(arg in set(cs._DESKTOP_SESSIONS.values()), "returned arg is on the allowlist")
+
+
+def test_injected_action_uses_the_resolved_arg():
+    print("the injected Switch to Desktop action carries the resolved arg")
+    orig_which, orig_run = cs.shutil.which, cs.subprocess.run
+    cs.shutil.which = lambda *a, **k: "/usr/bin/steamos-session-select"
+    cs.subprocess.run = _Run("plasma.desktop\n")
+    cs.ACTIONS, cs.ACTION_ORDER = {}, []
+    try:
+        cs._inject_session_actions()
+    finally:
+        cs.shutil.which, cs.subprocess.run = orig_which, orig_run
+    cmd = (cs.ACTIONS.get("switch-desktop") or {}).get("cmd")
+    check(cmd == ["steamos-session-select", "plasma-wayland"],
+          "action cmd targets Wayland on a Wayland box (got %r)" % (cmd,))
+    check(cs.ACTIONS["switch-desktop"]["cmd"] is not
+          cs.SESSION_ACTIONS["switch-desktop"]["cmd"],
+          "and the static SESSION_ACTIONS spec was not mutated")
+
+
+if __name__ == "__main__":
+    test_wayland_box_is_left_on_wayland()
+    test_x11_box_stays_x11()
+    test_unreadable_degrades_closed()
+    test_never_passes_an_unvetted_name()
+    test_injected_action_uses_the_resolved_arg()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all desktop-session tests passed")


### PR DESCRIPTION
A user asked why their Steam Deck was running X11 when they had never changed desktop environments.

**They hadn’t. We did it.**

## Cause

SteamOS ships **both** desktop sessions, and `steamos-session-select` maps the bare `plasma` arg to the X11 one:

```
plasma)         steamosctl switch-to-desktop-mode plasmax11.desktop
plasma-wayland) steamosctl switch-to-desktop-mode plasma.desktop
```

`_session_to_desktop()` additionally hardcoded `plasmax11.desktop`, and the injected "Switch to Desktop" action passed bare `plasma`. So every Couch Mode return and every desktop switch silently downgraded the session.

Measured on a real Deck, SteamOS `20260701.2`:

```
steamosctl get-default-desktop-session -> plasma.desktop   (Wayland — the configured default)
loginctl show-session ... -p Type       -> x11             (what we forced)
```

## Fix

Both paths now read the box’s **configured** default and honour it. Verified on that same Deck:

```
steamosctl says default = plasma.desktop
resolver picks         -> plasma.desktop | plasma-wayland

OLD would run: steamosctl switch-to-desktop-mode plasmax11.desktop   (X11)
NEW will run : steamosctl switch-to-desktop-mode plasma.desktop
```

## Degrades closed

The load-bearing property. The name is read from the system rather than a client, but it still only ever **selects** a value from a frozen two-entry table — never interpolated. Any read failure, empty output, or unlisted name falls back to the X11 pair that shipped before, so a box whose default cannot be read behaves exactly as it did.

Tested with a raising command, empty output, an unknown name, and a shell-injection-shaped name. An X11-configured box is asserted to **still get X11** — this is about not overriding the user, in either direction.

## Not claimed

**This is not asserted to fix the trackpad-in-desktop-mode report that led here.** Xorg’s own log shows it attaching our virtual mouse correctly:

```
(II) event17 - Couchside Virtual Mouse: device is a pointer
(II) XINPUT: Adding extended input device "Couchside Virtual Mouse" (type: MOUSE, id 17)
```

So the pointer being ignored is a separate, still-open bug. The session override is a real defect found on the way — worth fixing on its own merits.

Agent `2.9.35` → `2.9.36`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)