### PR TITLE
chore(app): record build 69 as shipped

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 52
+      "versionCode": 51
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "68",
+      "buildNumber": "70",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 51
+      "versionCode": 52
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "70",
+      "buildNumber": "69",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Verified against App Store Connect rather than the filename or `app.json`:

```
build 69 | VALID | 2026-07-21T06:58:46
```

The working tree said **70**. That is phantom — `autoIncrement` rewrites `app.json` on every invocation, whether or not the build completes, so an extra run left the file one ahead of reality.

Both local IPAs confirm only two builds exist:

```
build-1784608075481.ipa   v2.9.15 build 68
build-1784641094258.ipa   v2.9.16 build 69
```

and Apple has no 70. Recording **69** means the next build is 70 instead of skipping it.

`versionCode` left at 51 — no Android artifact was produced this round, so 52 is still unclaimed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)