### PR TITLE
chore(app): record versionCode 52 as shipped

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 51
+      "versionCode": 52
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
2.9.16 is live on Play production as **versionCode 52** (track `production`, status `completed`, 100% rollout). `autoIncrement` wrote the `51 → 52` bump into `app/app.json` during the local build; this commits it so the shipped versionCode has a record in git.

No code change — one line in `app/app.json`.

### Context

Android had drifted three releases behind: Play production was serving 2.9.13 / vc50 while the repo was at 2.9.16. The 2.9.14 cloud build (vc51) finished on EAS but was never submitted, so vc51 stays unpublished and Android went vc50 → vc52.

Built locally on the Mac (`eas build --local`) rather than in the cloud — EAS is in overage this billing period, and a local build costs no quota while still auto-signing with the EAS-managed upload keystore.

### Verified

Every number read out of the `.aab`, not out of `app.json`:

| check | result |
|---|---|
| versionName | 2.9.16 |
| versionCode | 52 |
| package | com.ets3d.rescueremote |
| signer SHA1 | `7D:00:14:29:03:0C:9D:C7:CC:A8:76:51:5B:D0:CD:20:D6:7E:DB:76` (upload key) |
| gradle | `Build successful`, 891.7s |

Play state read back from the Android Publisher API **after** the upload, rather than trusting the CLI exit code — production track returns `name='2.9.16' status=completed versionCodes=['52']` with the en-US notes attached. Release notes were checked for staleness before upload (411/500 chars, header `New in 2.9.16`, bullets match #170/#171/#172).

The shipped bundle is code-equivalent to the `v2.9.16` tag: the only commits merged during the build window were #175 (`app/app.json` iOS buildNumber, irrelevant to an Android bundle) and #174 (agent + CI + tests, no app code).

### NOT verified

The app was not installed from Play and launched on a device. Nothing exercised vc52 on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)