### PR TITLE
chore(app): record build 70 as shipped

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "69",
+      "buildNumber": "70",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Build 69 was **rejected by App Store review as `INVALID_BINARY`** — the second occurrence (2.9.10 was the first). Both were **local** builds on the runner, which runs macOS 27.0 build `26A5368g`, a beta seed.

Build 70 is the **cloud rebuild of the same commit**. The metadata isolates the one variable that changed:

```
build 69 (rejected)   BuildMachineOSBuild = 26A5368g   <- beta seed
build 70              BuildMachineOSBuild = 25F84      <- release macOS
both                  DTXcode 2660, DTSDKName iphoneos26.5
```

Same toolchain, different build host.

## The trap

**TestFlight processing and App Store review are different gates.** Build 69 reached `processingState: VALID`, installed, and ran on a real iPhone — then review rejected it. A `VALID` build is not evidence it will clear review, and "TestFlight took it" is exactly the reasoning that led me to call this risk *low* before submitting. It is not low; from that host it is certain.

**Rule:** anything bound for the App Store gets a cloud build. Local builds remain fine for TestFlight-only work and save EAS quota.

## Verified from Apple

- version 2.9.16 → `WAITING_FOR_REVIEW`, build **70** attached
- TestFlight public link serves only build 70

🤖 Generated with [Claude Code](https://claude.com/claude-code)