### PR TITLE
feat(app): touch animations — tap rings and drag trails, default off

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ app/asc-key.p8
 docs/memory/KNOWN_ISSUES.md
 docs/memory/DECISIONS.md
 docs/BUILD_LOG.md
+
+# One-off build/spec prompts dropped at the repo root. Public repo, and an
+# untracked file at the root is exactly how an unrelated copy change got swept
+# into a feature commit once already.
+*-build-prompt.md

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -659,6 +659,8 @@ function SetupBody() {
   const askToSwitchControl = usePref('askToSwitchControl');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
+  const showTaps = usePref('showTaps');
+  const traceDrags = usePref('traceDrags');
 
   const [restoring, setRestoring] = useState(false);
   const [buying, setBuying] = useState(false);
@@ -845,13 +847,15 @@ function SetupBody() {
           style={({ pressed }) => [styles.unlockRow, pressed && styles.pressed]}>
           <Ionicons name="lock-open-outline" size={18} color={t.blue} />
           <View style={styles.unlockRowBody}>
-            <Text style={styles.unlockRowTitle}>Unlock Couchside — {price ?? '$4.99'}</Text>
+            <Text style={styles.unlockRowTitle}>
+              Enjoying Couchside? Unlock for {price ?? '$4.99'}
+            </Text>
             <Text style={styles.unlockRowSub}>
               {entitlement.trialDaysLeft > 0
                 ? `Trial: ${entitlement.trialDaysLeft} day${
                     entitlement.trialDaysLeft === 1 ? '' : 's'
-                  } left · one-time purchase, no subscription`
-                : 'Trial ended · one-time purchase, no subscription'}
+                  } left · one-time purchase, no subscription · supports the work`
+                : 'Trial ended · one-time purchase, no subscription · supports the work'}
             </Text>
           </View>
           <Ionicons name="chevron-forward" size={18} color={t.textDim} />
@@ -1365,6 +1369,35 @@ function SetupBody() {
                 }}
               />
             </View>
+
+            {/* Named for WHAT IT DOES, not for one use case. Recording is the
+                motivating example, but these also make the swipe and trackpad
+                surfaces legible live -- neither gives any visual feedback on its
+                own -- and help on a support screen-share. Calling the card
+                "SCREEN RECORDING" would hide it from anyone looking for the
+                other two. */}
+            <View style={styles.card}>
+              <CardHeader icon="hand-left-outline" label="TOUCH ANIMATIONS" />
+              <TogglePref
+                label="Show taps"
+                sub="Draws a ring wherever you tap, so a screen recording shows what was pressed. iOS can't do this system-wide, so the app draws its own."
+                value={showTaps}
+                onValueChange={(v) => {
+                  void setPref('showTaps', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Trace drags"
+                sub="Leaves a trail of dots while a finger moves, which makes swipe and trackpad gestures readable on video. Needs Show taps."
+                value={traceDrags}
+                onValueChange={(v) => {
+                  void setPref('traceDrags', v);
+                  hapticSelection();
+                }}
+              />
+            </View>
+
 
             <InputTracePanel />
           </>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -847,15 +847,13 @@ function SetupBody() {
           style={({ pressed }) => [styles.unlockRow, pressed && styles.pressed]}>
           <Ionicons name="lock-open-outline" size={18} color={t.blue} />
           <View style={styles.unlockRowBody}>
-            <Text style={styles.unlockRowTitle}>
-              Enjoying Couchside? Unlock for {price ?? '$4.99'}
-            </Text>
+            <Text style={styles.unlockRowTitle}>Unlock Couchside — {price ?? '$4.99'}</Text>
             <Text style={styles.unlockRowSub}>
               {entitlement.trialDaysLeft > 0
                 ? `Trial: ${entitlement.trialDaysLeft} day${
                     entitlement.trialDaysLeft === 1 ? '' : 's'
-                  } left · one-time purchase, no subscription · supports the work`
-                : 'Trial ended · one-time purchase, no subscription · supports the work'}
+                  } left · one-time purchase, no subscription`
+                : 'Trial ended · one-time purchase, no subscription'}
             </Text>
           </View>
           <Ionicons name="chevron-forward" size={18} color={t.textDim} />

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -7,6 +7,7 @@ import { ReviewPrompt } from '@/components/ReviewPrompt';
 import { ReviewToast } from '@/components/ReviewToast';
 import { TrialEndsToast } from '@/components/TrialEndsToast';
 import { UnlockToast } from '@/components/UnlockToast';
+import { TapCapture } from '@/components/TouchIndicatorLayer';
 import { DeepLinkHandler } from '@/lib/DeepLink';
 import { EntitlementProvider } from '@/lib/EntitlementContext';
 import { SettingsProvider } from '@/lib/SettingsContext';
@@ -42,6 +43,13 @@ export default function RootLayout() {
         <ThemeProvider value={navTheme}>
           <StatusBar style={scheme === 'light' ? 'dark' : 'light'} />
           <DeepLinkHandler />
+          {/* Touch indicators wrap the whole tree because they read the responder
+              system in the CAPTURE phase -- an ancestor, not a sibling overlay.
+              Rendered unconditionally and gated internally on the pref: if the
+              wrapper came and went with the toggle, the navigator would remount
+              and drop the screen you were about to record. Observe-only; it must
+              never become the responder. */}
+          <TapCapture>
           <Stack>
             <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
           </Stack>
@@ -53,6 +61,7 @@ export default function RootLayout() {
           <ReviewPrompt />
           {/* The fallback invite ReviewPrompt falls back to when the OS sheet can't run. */}
           <ReviewToast />
+        </TapCapture>
         </ThemeProvider>
       </EntitlementProvider>
     </SettingsProvider>

--- a/app/components/TouchIndicatorLayer.tsx
+++ b/app/components/TouchIndicatorLayer.tsx
@@ -1,0 +1,264 @@
+/**
+ * Visible touch indicators: a ring wherever a finger lands, and optionally a
+ * trail of dots while it drags.
+ *
+ * iOS exposes NO public API for system-wide touch events. There is no equivalent
+ * of Android's "Show taps", and no screen recorder — built-in, third-party, or a
+ * ReplayKit broadcast extension — can draw where a finger landed in another app.
+ * The only process that knows where the user tapped is the app itself, so the
+ * app has to draw its own. That makes a recording of Couchside legible for the
+ * store listing, for support screen-shares, and for demo footage.
+ *
+ * OBSERVE, NEVER STEAL — this is load-bearing. `TapCapture` must be an ANCESTOR
+ * of what it draws over (it reads the responder system in the CAPTURE phase; it
+ * is not a sibling overlay), and every responder handler returns `false` so the
+ * touch still reaches whatever child would normally handle it. Get this wrong
+ * and every button in the app breaks. Worse, this app's gesture surfaces (the
+ * swipe d-pad, the trackpad, the mode-switch bar) all refuse to yield the
+ * responder, and a gesture stolen mid-swipe is exactly what leaves the agent's
+ * LATCHED d-pad axis asserted — see tests/test_dpad_latch.py for what that costs.
+ *
+ * The host View renders UNCONDITIONALLY, gated only internally on the pref. If
+ * the wrapper appeared and disappeared with the pref, the navigator would remount
+ * and the user would lose the screen they were about to record.
+ *
+ * MODAL CAVEAT: React Native <Modal> renders in its own native window ABOVE this
+ * host, so its touches never reach these handlers. Every sheet in the app records
+ * without indicators (CouchModeSheet, SleepTimerSheet, ScreensaverSheet,
+ * BoxSwitcher, RemotePowerBar, ScreenPreview, RemoteView's text sheet). TapCapture
+ * is exported so a sheet CAN wrap its own content, but the shipping sheets are
+ * deliberately not wrapped: that is seven production files touched for a
+ * recording aid, and the layout-regression risk is not worth it.
+ */
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import {
+  Animated,
+  Easing,
+  StyleSheet,
+  View,
+  type GestureResponderEvent,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+
+import { usePref } from '@/lib/prefs';
+import { useResolvedScheme, useTheme } from '@/lib/theme';
+
+type MarkKind = 'tap' | 'trail';
+type MarkSpec = { id: number; x: number; y: number; kind: MarkKind };
+
+const TAP_SIZE = 76;
+const TRAIL_SIZE = 26;
+const TAP_MS = 520;
+const TRAIL_MS = 320;
+/** Minimum gap between trail dots while a finger drags. Caps the React churn a
+ *  fast scrub on the trackpad/swipe surface can cause to ~22 elements/sec. */
+const TRAIL_INTERVAL_MS = 45;
+/** Hard cap on live marks so a long drag can't grow the tree without bound. */
+const MAX_MARKS = 32;
+
+let nextMarkId = 0;
+
+/**
+ * Instrumentation for the drag-trail bug (see the note on onTouchMove below).
+ * Counters only, no rendering cost. Readable from the web harness or a dev build
+ * as `globalThis.__touchTrace`, which is how the responder-vs-touch question was
+ * settled by measurement rather than by reading renderer source.
+ */
+export const touchTrace = {
+  startCapture: 0,
+  moveCapture: 0,
+  touchMove: 0,
+  marks: 0,
+  lastPageX: null as number | null,
+  lastPageY: null as number | null,
+};
+if (typeof globalThis !== 'undefined') {
+  (globalThis as Record<string, unknown>).__touchTrace = touchTrace;
+}
+
+/** One ripple. Self-animating, self-retiring: calls `onDone` to be unmounted. */
+function Mark({
+  mark,
+  ring,
+  fill,
+  onDone,
+}: {
+  mark: MarkSpec;
+  ring: string;
+  fill: string;
+  onDone: () => void;
+}) {
+  const p = useRef(new Animated.Value(0)).current;
+  // The removal callback is identity-unstable by design (it closes over the id);
+  // holding it in a ref keeps the animation effect from re-running on re-render.
+  const done = useRef(onDone);
+  done.current = onDone;
+
+  useEffect(() => {
+    Animated.timing(p, {
+      toValue: 1,
+      duration: mark.kind === 'tap' ? TAP_MS : TRAIL_MS,
+      easing: Easing.out(Easing.quad),
+      useNativeDriver: true,
+    }).start(() => done.current());
+  }, [p, mark.kind]);
+
+  const size = mark.kind === 'tap' ? TAP_SIZE : TRAIL_SIZE;
+  const scale = p.interpolate({
+    inputRange: [0, 1],
+    // A tap blooms outward; a trail dot just shrinks slightly as it fades, so a
+    // drag reads as a line of shrinking beads rather than a row of explosions.
+    outputRange: mark.kind === 'tap' ? [0.35, 1] : [1, 0.7],
+  });
+  const opacity = p.interpolate({
+    inputRange: [0, 0.15, 1],
+    outputRange: [0.55, 0.95, 0],
+  });
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[
+        styles.mark,
+        {
+          left: mark.x - size / 2,
+          top: mark.y - size / 2,
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          borderWidth: mark.kind === 'tap' ? 3 : 2,
+          borderColor: ring,
+          backgroundColor: fill,
+          opacity,
+          transform: [{ scale }],
+        },
+      ]}
+    />
+  );
+}
+
+/** Wrap a subtree to paint touch indicators over it while the prefs are on. */
+export function TapCapture({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: StyleProp<ViewStyle>;
+}) {
+  const on = usePref('showTaps');
+  const trail = usePref('traceDrags');
+  const t = useTheme();
+  const scheme = useResolvedScheme();
+  const [marks, setMarks] = useState<MarkSpec[]>([]);
+  const lastTrailAt = useRef(0);
+
+  const add = useCallback((pageX: number, pageY: number, kind: MarkKind) => {
+    // Guard NaN/undefined explicitly: a mark at NaN renders nothing and would
+    // look identical to "the handler never fired", which is exactly the
+    // ambiguity that made this bug hard to place.
+    if (!Number.isFinite(pageX) || !Number.isFinite(pageY)) return;
+    touchTrace.marks += 1;
+    touchTrace.lastPageX = pageX;
+    touchTrace.lastPageY = pageY;
+    setMarks((prev) => {
+      const next = prev.concat({ id: nextMarkId++, x: pageX, y: pageY, kind });
+      return next.length > MAX_MARKS ? next.slice(next.length - MAX_MARKS) : next;
+    });
+  }, []);
+
+  const onStartCapture = useCallback(
+    (e: GestureResponderEvent) => {
+      touchTrace.startCapture += 1;
+      if (on) add(e.nativeEvent.pageX, e.nativeEvent.pageY, 'tap');
+      return false; // observe only — the child still becomes the responder
+    },
+    [on, add],
+  );
+
+  // Kept for instrumentation and as the trail's fallback path. On device this
+  // fires far less than you would expect once a child owns the responder, which
+  // is why the trail does NOT depend on it — see onTouchMove.
+  const onMoveCapture = useCallback(() => {
+    touchTrace.moveCapture += 1;
+    return false;
+  }, []);
+
+  /**
+   * THE DRAG-TRAIL FIX.
+   *
+   * The prototype drove the trail from onMoveShouldSetResponderCapture. On a
+   * real iPhone that produced NOTHING while taps worked, because responder
+   * NEGOTIATION is not re-run for an ancestor once a child owns the gesture and
+   * refuses to give it up — and every surface worth tracing does exactly that
+   * (useTrackpad and the swipe pad both set
+   * onPanResponderTerminationRequest: () => false).
+   *
+   * onTouchMove is an ordinary BUBBLING touch event, dispatched independently of
+   * responder negotiation, so a child holding the responder does not suppress
+   * it. Taps stay on the capture handler, which is confirmed working; only the
+   * trail moves here, which is the minimal change.
+   */
+  const onTouchMove = useCallback(
+    (e: GestureResponderEvent) => {
+      touchTrace.touchMove += 1;
+      if (!on || !trail) return;
+      const now = Date.now();
+      if (now - lastTrailAt.current < TRAIL_INTERVAL_MS) return;
+      lastTrailAt.current = now;
+      add(e.nativeEvent.pageX, e.nativeEvent.pageY, 'trail');
+    },
+    [on, trail, add],
+  );
+
+  const remove = useCallback((id: number) => {
+    setMarks((prev) => prev.filter((m) => m.id !== id));
+  }, []);
+
+  // Turning the pref off mid-recording clears instantly rather than leaving the
+  // last ripple to finish its half-second fade.
+  useEffect(() => {
+    if (!on) setMarks([]);
+  }, [on]);
+
+  const fill = scheme === 'light' ? 'rgba(15,23,42,0.16)' : 'rgba(255,255,255,0.24)';
+
+  return (
+    <View
+      style={style ?? styles.host}
+      collapsable={false}
+      onStartShouldSetResponderCapture={onStartCapture}
+      onMoveShouldSetResponderCapture={onMoveCapture}
+      onTouchMove={onTouchMove}
+    >
+      {children}
+      {marks.length > 0 ? (
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          {marks.map((m) => (
+            <Mark
+              key={m.id}
+              mark={m}
+              ring={t.accent}
+              fill={fill}
+              onDone={() => remove(m.id)}
+            />
+          ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  host: { flex: 1 },
+  mark: {
+    position: 'absolute',
+    // Keeps a white-on-white / dark-on-dark ripple legible whatever screen it
+    // lands on, which matters more here than anywhere else in the app: the
+    // whole point of the ripple is to survive video compression.
+    shadowColor: '#000',
+    shadowOpacity: 0.35,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 1 },
+  },
+});

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -55,6 +55,18 @@ export type Prefs = {
       check is conservative and does call a live host offline, so the row stays
       visible and tappable unless you ask for it gone. Agent >= 2.9.32. */
   hideOfflineStreamHosts: boolean;
+  // ---- Touch indicators: making a screen recording of this app legible ----
+  /** Draw a ring wherever a finger lands. iOS exposes NO public API for
+      system-wide touch events -- no equivalent of Android's "Show taps", and no
+      screen recorder can draw touches from another app -- so the only process
+      that can show what was pressed is this one. Off by default; the whole
+      feature is inert until asked for. */
+  showTaps: boolean;
+  /** Also leave a trail of dots while a finger moves, which is what makes the
+      swipe remote and the trackpad readable on video. Requires showTaps. Off by
+      default: it emits a mark every 45ms, which is pure noise outside a
+      recording. */
+  traceDrags: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -76,6 +88,8 @@ export const DEFAULTS: Prefs = {
   // until the user opts in.
   volumeButtons: Platform.OS === 'android',
   hideOfflineStreamHosts: false,
+  showTaps: false,
+  traceDrags: false,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -154,6 +168,8 @@ function normalize(raw: unknown): Prefs {
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
     hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),
+    showTaps: bool(o.showTaps, DEFAULTS.showTaps),
+    traceDrags: bool(o.traceDrags, DEFAULTS.traceDrags),
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,19 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
-_(nothing currently mid-flight)_
+### Touch animations (tap rings + drag trails)
+- **priority:** P3 · **risk:** low · **affects:** app only · **depends_on:** none
+- Two Preferences toggles, both default OFF, drawing touch feedback over the whole UI so
+  screen recordings of Couchside are legible for the store listing, support screen-shares
+  and demos. iOS has no system-wide "Show taps" and no recorder can draw into another app,
+  so the app draws its own. Branch `feat/tap-indicators`. Pure JS, no new dependency.
+- **Not Complete because the drag trail is unverified.** "Show taps" is proven in the web
+  harness in both states with a coordinate control; "Trace drags" cannot be exercised on
+  web at all (`touchMove` measured 0 across 171 mouse-driven move events — RNW emits mouse
+  events, not touch events). Move to ✅ only after a device build shows the trail drawing.
+- The camera PiP from the `feat/demo-mode` prototype is explicitly **not** coming with it:
+  it needs `expo-camera`, the CI gate blocks that from `main`, and the shipping app carries
+  no mention of native camera use.
 
 ---
 

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -235,6 +235,33 @@ so a box switch clears stale data in the same render instead of painting the pre
 (`app/lib/api.ts:694-697`). Render-time consumers that mutate refs from `data` must check `dataKey`
 first — the reason is documented at `app/hooks/usePoll.ts:15-23`.
 
+### Overlays that watch touches: observe, never steal
+
+`TapCapture` (`app/components/TouchIndicatorLayer.tsx`) is the pattern for any layer that
+wants to see touches without consuming them. Three rules, all load-bearing:
+
+1. It is an **ancestor** of what it draws over, not a sibling overlay — it reads the
+   responder system in the **capture** phase.
+2. Every responder handler **returns `false`**. This app's gesture surfaces (`useTrackpad`,
+   the swipe d-pad, the mode-switch bar) all set `onPanResponderTerminationRequest: () =>
+   false` and will not yield; a gesture stolen mid-swipe is exactly what leaves the agent's
+   LATCHED d-pad axis asserted (`tests/test_dpad_latch.py`).
+3. The host `View` renders **unconditionally**, gated internally on its pref. A wrapper that
+   appears and disappears with a toggle remounts the whole navigator.
+
+**Responder handlers are not touch handlers, and the difference is a real bug.** Responder
+*negotiation* is not re-run for an ancestor once a child owns the gesture and refuses to
+give it up, so `onMoveShouldSetResponderCapture` fires far less than a reading of the
+renderer source suggests — it produced nothing on device while taps worked. For continuous
+tracking during a drag, use the raw bubbling `onTouchMove`, which is dispatched
+independently of negotiation. Note the web harness **cannot** tell these apart: RNW emits
+mouse events, so `onTouchMove` never fires there at all.
+
+Counter-based instrumentation (`globalThis.__touchTrace`) is kept in the component
+deliberately. It is what distinguishes "the handler never fired" from "it fired and rendered
+at `NaN`" — two failures that look identical on screen. `add()` also rejects non-finite
+coordinates explicitly for the same reason.
+
 ---
 
 ## 4. Git / PRs


### PR DESCRIPTION
Two Preferences toggles, both **default OFF**, that draw touch feedback over the whole UI so a screen recording of Couchside is legible — for the store listing, support screen-shares, and demo footage.

iOS exposes **no** system-wide touch API. There is no equivalent of Android's "Show taps", and no screen recorder — built-in, third-party, or a ReplayKit broadcast extension — can draw where a finger landed in another app. The only process that knows where the user tapped is the app itself, so the app draws its own.

Promoted from the `feat/demo-mode` prototype **without** its rear-camera PiP. That needs `expo-camera`, which `tests/test_no_camera_in_shipping_app.py` blocks from `main`, and the shipping app carries no mention of native camera use. `git diff origin/main -- app/package.json app/package-lock.json` is **0 lines** — no new dependency, pure JS.

## The bug this fixes

The prototype's **"Trace drags"** toggle was dead on a real iPhone while "Show taps" worked. It drove the trail from `onMoveShouldSetResponderCapture`.

Instrumented rather than guessed — a `globalThis.__touchTrace` counter object, incremented unconditionally *before* any pref check, which is what separates "the handler never fired" from "it fired and rendered at `NaN`". Those two failures look identical on screen. Working through the ranked hypotheses:

| # | Hypothesis | Verdict |
|---|---|---|
| 3 | Pref not reaching the component | **Ruled out** — persists to storage and reaches the handler |
| 1 | `pageX/pageY` absent on move, marks render at `NaN` | **Ruled out** — marks are created, coordinates finite and exact |
| 2 | Handler never fires once a child owns the gesture | **Confirmed** |

Responder *negotiation* is not re-run for an ancestor once a child owns the gesture and refuses to give it up — and every surface worth tracing does exactly that (`useTrackpad` and the swipe pad both set `onPanResponderTerminationRequest: () => false`).

The trail therefore moves to **`onTouchMove`**, an ordinary bubbling touch event dispatched independently of responder negotiation. Taps stay on the capture handler, which was already confirmed working — the minimal change. `add()` now also rejects non-finite coordinates explicitly, so hypotheses #1 and #2 can never look alike again.

## Observe, never steal

This is load-bearing. Every responder handler returns `false`, so the touch still reaches whatever child would normally handle it. A gesture stolen mid-swipe is exactly what leaves the agent's LATCHED d-pad axis asserted (see `tests/test_dpad_latch.py`). The host `View` renders **unconditionally**, gated only internally on the pref — a wrapper that appeared and disappeared with the toggle would remount the navigator and throw away the screen you were about to record.

## Naming

The card is **TOUCH ANIMATIONS** (`hand-left-outline`), not `SCREEN RECORDING`. It draws animations on touch and serves support and demos alike; "screen recording" names one use case and implies the app records something, which it does not.

## Verified how

Driven in the web harness against the mock agent, **pressing the controls, not just rendering them**.

- **Both states observed.** Prefs OFF: `{startCapture: 9, moveCapture: 171, touchMove: 0, marks: 0}` — nine presses, zero marks, provably inert. Prefs ON: one press took `marks` 7→8 and `startCapture` 7→8.
- **Persistence read back from storage**, not inferred from the switch UI: `couchside.prefs.v1` contains `"showTaps":true,"traceDrags":true`.
- **Control in the measurement.** The ripple's `pageX/pageY` compared against the browser's own `mousedown` `clientX/clientY` for the same press — both `281,316`, exact. The ring lands *on* the finger, not near it.
- All touch surfaces still work with the layer mounted.
- `npx tsc --noEmit` clean; `tests/test_no_camera_in_shipping_app.py` and the full Python suite pass.

## NOT verified

- **The drag trail itself.** This is measured, not assumed: across **171** mouse-driven `moveCapture` events, `touchMove` stayed at **0** — RNW dispatches mouse events, not touch events, so the new code path never executes on web. The fix is a reasoned one-line change to a bubbling event, but **it has not been observed working**. Do not call "Trace drags" fixed until a device build shows it.
- No device build produced, so no Hermes bundle inspected.
- Multi-touch, and whether the 45ms trail interval suits a real 60Hz touch stream, are untested.

The ROADMAP entry sits in **🔨 In Progress**, not Complete, for exactly this reason.

## Known gap — documented, not fixed

RN `<Modal>` renders in its own native window **above** the capture host, so `CouchModeSheet`, `SleepTimerSheet`, `ScreensaverSheet`, `BoxSwitcher`, `RemotePowerBar`, `ScreenPreview` and `RemoteView`'s text sheet all record without indicators. `TapCapture` is exported so a sheet *can* wrap its own content, but the shipping sheets are deliberately untouched — seven production files changed for a recording aid is not worth the layout-regression risk.

The `__touchTrace` counters are kept on purpose (counters only, no render cost) so the device verification of the trail needs no rebuild-to-instrument cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Correction — scope of this PR (added after it was opened)

When first pushed, `7e3c829` **also carried an unrelated copy change** to Setup's unlock row (`Unlock Couchside — $4.99` → `Enjoying Couchside? Unlock for $4.99`, plus a `· supports the work` suffix). It came from a parallel session, was sitting uncommitted in a shared working tree, and got swept in because `setup.tsx` was staged whole without its diff being read. The PR body above described a scope this branch did not have.

Worse, only *half* of that copy change was here — the matching Paywall blurb was in a separate uncommitted edit — so merging this branch as it stood would have shipped an unlock row and a paywall screen making two different arguments.

`f33bef3` restores the shipped strings verbatim. Both halves of the copy change now live in **#180**, reviewed on their own merits. Since `main` squash-merges, this branch lands feature-only.

**Verified after the split** (`git diff origin/main`):

- `app/components/Paywall.tsx` no longer appears at all
- `setup.tsx` is **+31 / −0** — the two `usePref` lines and the TOUCH ANIMATIONS card, nothing else
- grep for `supports the work` / `Enjoying Couchside` / `Paywall` across the whole net diff: **no matches**
- `npx tsc --noEmit` clean on this branch *and* on #180

`f33bef3` also gitignores `*-build-prompt.md`. This feature's one-off spec was sitting untracked and unignored at the root of a public repo — the same hazard that produced the sweep-in.
