### PR TITLE
copy(app): ask for the unlock instead of announcing it

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -845,13 +845,15 @@ function SetupBody() {
           style={({ pressed }) => [styles.unlockRow, pressed && styles.pressed]}>
           <Ionicons name="lock-open-outline" size={18} color={t.blue} />
           <View style={styles.unlockRowBody}>
-            <Text style={styles.unlockRowTitle}>Unlock Couchside — {price ?? '$4.99'}</Text>
+            <Text style={styles.unlockRowTitle}>
+              Enjoying Couchside? Unlock for {price ?? '$4.99'}
+            </Text>
             <Text style={styles.unlockRowSub}>
               {entitlement.trialDaysLeft > 0
                 ? `Trial: ${entitlement.trialDaysLeft} day${
                     entitlement.trialDaysLeft === 1 ? '' : 's'
-                  } left · one-time purchase, no subscription`
-                : 'Trial ended · one-time purchase, no subscription'}
+                  } left · one-time purchase, no subscription · supports the work`
+                : 'Trial ended · one-time purchase, no subscription · supports the work'}
             </Text>
           </View>
           <Ionicons name="chevron-forward" size={18} color={t.textDim} />

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -81,8 +81,8 @@ export default function Paywall() {
         <Text style={styles.appName}>Couchside</Text>
         <Text style={styles.title}>7-day trial ended</Text>
         <Text style={styles.blurb}>
-          Unlock Couchside forever with a one-time purchase. No subscription, no account, no
-          tracking.
+          If Couchside has earned a spot in your setup, one purchase unlocks it permanently and
+          supports the work. No subscription, no account, no tracking.
         </Text>
 
         <Pressable


### PR DESCRIPTION
Strings only. No pricing, entitlement, or IAP logic touched.

Split out of [#179](https://github.com/emerytech/couchside/pull/179) ("touch animations"), where it had been swept in by accident. Monetization wording should be reviewed as monetization wording, not ride along in a feature PR.

## What changes

Setup's unlock row:

> ~~Unlock Couchside — $4.99~~
> **Enjoying Couchside? Unlock for $4.99**

…and both trial branches of its subtitle gain `· supports the work`.

The Paywall blurb is rewritten to match:

> ~~Unlock Couchside forever with a one-time purchase. No subscription, no account, no tracking.~~
> **If Couchside has earned a spot in your setup, one purchase unlocks it permanently and supports the work.** No subscription, no account, no tracking.

The framing moves from stating a transaction to asking a question the user can answer, and names what the money does.

## Why both files in one PR

These are two halves of one change and they were **already drifting apart** — the unlock-row edit was sitting in one branch and the Paywall edit loose in the working tree. Merging them separately risks shipping an always-visible row and a trial-ended screen that argue different things. They land together or not at all.

## NOT verified

This is a **conversion claim and it is untested.** No A/B, no measurement, nothing observed. The honest case for it is that it reads better, not that it converts better.

Explicitly resist tuning this against the current store numbers: the app went live 2026-07-15, and six days of installs on a listing that new are partially-filled buckets, not a signal. Roughly 9–15 distinct people have downloaded it and approximately zero have got an agent onto a box — the funnel problem right now is almost certainly setup, not this sentence.

Merge it because the wording is better, or don't merge it. Don't merge it expecting a number to move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
