### PR TITLE
chore(app): 2.9.17

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.16",
+    "version": "2.9.17",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",


### PR DESCRIPTION
Marketing version bump only: `2.9.16` → `2.9.17`.

`buildNumber` (70) and `versionCode` (52) deliberately untouched — `autoIncrement` is on for the production profile and derives 71 / 53 at build time. Pre-bumping is how these drifted before.

## Contents

- #179 — touch animations (tap rings + drag trails), both prefs default OFF
- #180 — unlock copy pass

## Release context

- Play production is **2.9.16 / vc52 LIVE**
- App Store live is **2.9.9**; **2.9.16 (build 70) is queued `WAITING_FOR_REVIEW`** and will be pulled so 2.9.17 can carry everything in one submission. Queue slot being forfeited is ~3h old, and this queue has already been reset three times in two days.
- Agent needs no release: published **2.9.36** / **0.3.8-win** already match local.

## Still unverified

**"Trace drags" has never been observed working on a device.** Default OFF, so nothing regresses, but shipping it is not evidence it works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)