### PR TITLE
chore(app): record build 71 / versionCode 53 as shipped (2.9.17)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "70",
+      "buildNumber": "71",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 52
+      "versionCode": 53
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,6 +1,4 @@
-New in 2.9.16
+New in 2.9.17
 
-• Couch Mode now works on a handheld with no TV attached — the Fling button was dead whenever no external display was connected.
-• Suspend no longer requires Ethernet. It was greyed out on Wi-Fi, including on Steam Deck; wake it with its power button.
-• Steam settings are one swipe past the remote, in Game Mode.
-• Connection status now reads in full, and the mode tabs spread evenly.
+• Touch animations. Preferences can now draw a ring wherever you tap, and a trail of dots while a finger moves, so a screen recording or a support screen-share shows what was actually pressed. Both are off by default.
+• Clearer wording on the unlock screen.


### PR DESCRIPTION
Bookkeeping after the 2.9.17 release chain.

| | |
|---|---|
| iOS | build **71** — `WAITING_FOR_REVIEW` |
| Android | vc **53** — **LIVE** on Play production |
| Agent | 2.9.36 / 0.3.8-win — unchanged, already published |

Numbers came from EAS `autoIncrement` and were **read back out of the stores**, not taken from the build output: ASC reports build 71 `VALID` and attached to the 2.9.17 record; Play reports vc53 live as 2.9.17.

Also replaces `whatsnew-en-US.txt`, which still contained 2.9.16's text. Published notes were read back from Google (272/500 chars, en-US) rather than trusted to the writer's exit code.

## Not verified

**"Trace drags" has still never been observed on a device.** It is default-OFF and now live on Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)