### PR TITLE
fix(app): interpolate the drag trail so it reads as a stroke

### DIFF
--- a/app/components/TouchIndicatorLayer.tsx
+++ b/app/components/TouchIndicatorLayer.tsx
@@ -51,13 +51,81 @@ const TAP_SIZE = 76;
 const TRAIL_SIZE = 26;
 const TAP_MS = 520;
 const TRAIL_MS = 320;
-/** Minimum gap between trail dots while a finger drags. Caps the React churn a
- *  fast scrub on the trackpad/swipe surface can cause to ~22 elements/sec. */
-const TRAIL_INTERVAL_MS = 45;
-/** Hard cap on live marks so a long drag can't grow the tree without bound. */
-const MAX_MARKS = 32;
+/**
+ * Trail dots are spaced by DISTANCE, not by time.
+ *
+ * The first shipped version throttled to one dot per 45ms. Measured off a
+ * device recording (2.9.17, iPhone, Track surface), that produced tight clumps
+ * of 3-4 dots spanning ~40-60px separated by 200-400px of nothing — specks, not
+ * a stroke, which fails the one job the feature has.
+ *
+ * Two things caused it and a time throttle can fix neither: 45ms of travel is
+ * hundreds of pixels during a real trackpad scrub, and iOS delivers touch-moves
+ * COALESCED in bursts, so events arrive clumped and then not at all. Lowering
+ * the interval cannot invent samples the OS never sent. Interpolating along the
+ * segment between the previous point and the new one does, and it is
+ * indifferent to how bursty the event stream is.
+ */
+const TRAIL_STEP_PX = 20;
+/**
+ * Cap dots emitted per event so one coalesced jump cannot spawn a whole stroke
+ * in a single frame — this runs on the trackpad path, which is latency-critical.
+ */
+const TRAIL_MAX_PER_EVENT = 6;
+/**
+ * Past this, treat the gap as a DISCONTINUITY (finger lifted and re-placed, or a
+ * dropped event) and drop a single dot instead of drawing a line the finger
+ * never travelled. A phantom stroke across the screen is worse than a gap.
+ */
+const TRAIL_JUMP_PX = 320;
+/** Hard cap on live marks so a long drag can't grow the tree without bound.
+ *  At 20px spacing this is ~960px of visible stroke. */
+const MAX_MARKS = 48;
 
 let nextMarkId = 0;
+
+type Pt = { x: number; y: number };
+
+/**
+ * Where to lay trail dots for one move event, given where the last one landed.
+ *
+ * Pure on purpose. The trail path cannot be exercised on web at all — RNW emits
+ * mouse events, not touch events — so the previous version's bug survived every
+ * check that was run before it shipped. Keeping the geometry in a pure function
+ * means the risky half is testable with synthetic input on any platform;
+ * `__touchTrailPoints` exposes it for exactly that.
+ *
+ * Returns the dots to draw and the point to carry forward. `next` is the LAST
+ * DOT LAID, not the event coordinate — carrying the event coordinate forward
+ * would silently swallow the leftover sub-step distance and let spacing drift.
+ */
+export function trailPoints(last: Pt | null, x: number, y: number): { points: Pt[]; next: Pt } {
+  if (!last) return { points: [{ x, y }], next: { x, y } };
+  const dx = x - last.x;
+  const dy = y - last.y;
+  const dist = Math.hypot(dx, dy);
+  if (dist < TRAIL_STEP_PX) return { points: [], next: last };
+  // Discontinuity: finger lifted and re-placed, or events were dropped. Draw
+  // where it IS rather than a line it never travelled.
+  if (dist > TRAIL_JUMP_PX) return { points: [{ x, y }], next: { x, y } };
+  const want = Math.floor(dist / TRAIL_STEP_PX);
+  const steps = Math.min(want, TRAIL_MAX_PER_EVENT);
+  const points: Pt[] = [];
+  for (let i = 1; i <= steps; i += 1) {
+    const t = (i * TRAIL_STEP_PX) / dist;
+    points.push({ x: last.x + dx * t, y: last.y + dy * t });
+  }
+  // When the per-event cap bites, resume from the FINGER, not from the last dot
+  // drawn. Resuming from the dot makes the shortfall accumulate: every event
+  // falls further behind until the gap trips the discontinuity guard and the
+  // trail visibly snaps. Accepting one gap keeps the stroke under the finger.
+  if (want > steps) return { points, next: { x, y } };
+  const done = (steps * TRAIL_STEP_PX) / dist;
+  return { points, next: { x: last.x + dx * done, y: last.y + dy * done } };
+}
+if (typeof globalThis !== 'undefined') {
+  (globalThis as Record<string, unknown>).__touchTrailPoints = trailPoints;
+}
 
 /**
  * Instrumentation for the drag-trail bug (see the note on onTouchMove below).
@@ -151,7 +219,10 @@ export function TapCapture({
   const t = useTheme();
   const scheme = useResolvedScheme();
   const [marks, setMarks] = useState<MarkSpec[]>([]);
-  const lastTrailAt = useRef(0);
+  /** Last point a trail dot was laid at, or null between gestures. Nulling it on
+   *  touch-down is what stops a new drag from drawing a line back to where the
+   *  previous one ended. */
+  const lastTrailPt = useRef<{ x: number; y: number } | null>(null);
 
   const add = useCallback((pageX: number, pageY: number, kind: MarkKind) => {
     // Guard NaN/undefined explicitly: a mark at NaN renders nothing and would
@@ -170,6 +241,7 @@ export function TapCapture({
   const onStartCapture = useCallback(
     (e: GestureResponderEvent) => {
       touchTrace.startCapture += 1;
+      lastTrailPt.current = null; // new gesture: never interpolate from the old one
       if (on) add(e.nativeEvent.pageX, e.nativeEvent.pageY, 'tap');
       return false; // observe only — the child still becomes the responder
     },
@@ -203,13 +275,19 @@ export function TapCapture({
     (e: GestureResponderEvent) => {
       touchTrace.touchMove += 1;
       if (!on || !trail) return;
-      const now = Date.now();
-      if (now - lastTrailAt.current < TRAIL_INTERVAL_MS) return;
-      lastTrailAt.current = now;
-      add(e.nativeEvent.pageX, e.nativeEvent.pageY, 'trail');
+      const { pageX, pageY } = e.nativeEvent;
+      if (!Number.isFinite(pageX) || !Number.isFinite(pageY)) return;
+
+      const { points, next } = trailPoints(lastTrailPt.current, pageX, pageY);
+      lastTrailPt.current = next;
+      for (const p of points) add(p.x, p.y, 'trail');
     },
     [on, trail, add],
   );
+
+  const onTouchEnd = useCallback(() => {
+    lastTrailPt.current = null;
+  }, []);
 
   const remove = useCallback((id: number) => {
     setMarks((prev) => prev.filter((m) => m.id !== id));
@@ -230,6 +308,8 @@ export function TapCapture({
       onStartShouldSetResponderCapture={onStartCapture}
       onMoveShouldSetResponderCapture={onMoveCapture}
       onTouchMove={onTouchMove}
+      onTouchEnd={onTouchEnd}
+      onTouchCancel={onTouchEnd}
     >
       {children}
       {marks.length > 0 ? (


### PR DESCRIPTION
Follow-up to #179, driven by device evidence from **2.9.17 / build 71**.

## The defect

The trail draws — the `onTouchMove` fix from #179 is confirmed working on a real iPhone. But it draws **tight clumps of 3–4 dots spanning ~40–60px, separated by 200–400px of nothing**. Specks, not a stroke, which fails the one job the feature has: making swipe and trackpad gestures readable on video.

Measured off the screen recording, not eyeballed. Two passes over the frames agreed on the shape: a strict threshold found ~40px clusters, a looser one merged those clusters and found 200–400px between them.

## Why a smaller interval wouldn't fix it

Two causes compound, and a time throttle addresses neither:

1. `TRAIL_INTERVAL_MS = 45` was sized for **React churn, not legibility**. 45ms of travel during a real trackpad scrub is hundreds of pixels; a 26px dot can't bridge it.
2. **iOS coalesces touch-moves into bursts.** Events arrive clumped, then not at all — which also explains why only 2–4 marks were ever alive where the design predicted ~7. **Lowering the interval cannot invent samples the OS never sent.**

## The fix — space by distance, not time

Interpolate along the segment between the previous point and the new one at a fixed **20px step**. Indifferent to how bursty the event stream is.

Details that carry weight:

- **`next` carries the last dot laid, not the event coordinate.** Carrying the event coordinate silently swallows leftover sub-step distance and lets spacing drift.
- **Except when the per-event cap bites** — then it resumes from the finger. Resuming from the last dot makes the shortfall *accumulate* until the gap trips the discontinuity guard and the trail visibly snaps.
- **Beyond 320px, treat as a discontinuity** (finger lifted and re-placed, or dropped events) and drop a single dot. A phantom stroke the finger never travelled is worse than a gap.
- Point is nulled on touch-down and touch-end/cancel, so a new gesture can't draw a line back to where the last one ended.
- `MAX_MARKS` 32 → 48 (~960px of stroke at 20px spacing; 32 would evict the tail of its own line).
- `TRAIL_MAX_PER_EVENT` caps dots per event — this runs on the trackpad path, and one coalesced jump must not spawn a stroke in a single frame.

## Testability — the actual root cause of #179 shipping broken

The trail **cannot be exercised on web at all** (RNW emits mouse events, not touch events). That's how the last bug survived every pre-ship check.

So the geometry is now a **pure exported function**. The risky half is testable with synthetic input on any platform.

Verified against the **real bundled function** in the harness — not a reimplementation — with controls whose answers were known in advance:

| Case | Expected | Result |
|---|---|---|
| 100px horizontal | exactly 5 dots at 20/40/60/80/100 | ✅ |
| 19px (< step) | 0 dots, `next` unmoved | ✅ |
| null previous point | 1 dot at the point | ✅ |
| 400px (> jump guard) | 1 dot, **no** phantom line | ✅ |
| 10 chained 50px events | 25 dots, uniform **20.00px**, zero drift | ✅ |
| 3-4-5 diagonal | spacing euclidean, not per-axis | ✅ |
| 8 sustained 200px capped events | lag flat at **0** | ✅ |

That last one is the regression test for the cap-resume decision — the pre-fix behaviour accumulated 80, 160, 240…

I confirmed the browser held the **new** bundle before trusting any of it, using a case whose answer the change flips (300px jump: `next.x` 120 → 300).

**Observe-never-steal re-checked:** a single press both incremented `marks` *and* switched the tab underneath it.

## NOT verified

- **Nothing here has run on a device.** On-screen legibility of the stroke, and whether 20px / 48 marks are the right numbers against a real 60Hz touch stream, need a build.
- This **increases mark volume** during a drag. The trackpad is the latency-critical path — watch for jank there specifically before calling it done.

No release cut: build 71 is in App Store review and shouldn't be disturbed. This is 2.9.18 material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
