### PR TITLE
fix(app): give the power sheet's text styles a color

### DIFF
--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -909,7 +909,17 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderRadius: 10,
     backgroundColor: t.inset,
   },
-  bigLabel: { fontSize: 15, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
+  // color is REQUIRED here, not optional polish. A Text style with no color
+  // falls back to the platform default (black), which is invisible on this
+  // sheet — that shipped as the "black text even in dark mode" report. Call
+  // sites that want a semantic colour still override inline.
+  bigLabel: {
+    color: t.text,
+    fontSize: 15,
+    fontWeight: '800',
+    fontFamily: mono,
+    letterSpacing: 0.5,
+  },
   suspendGroup: { gap: 6 },
   warnText: {
     color: t.amber,
@@ -929,7 +939,15 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderRadius: 10,
     backgroundColor: t.inset,
   },
-  tvBtnText: { fontSize: 14, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
+  // Every call site currently passes a colour inline, so this was not visibly
+  // broken — but the same black-on-black trap is one new usage away.
+  tvBtnText: {
+    color: t.text,
+    fontSize: 14,
+    fontWeight: '800',
+    fontFamily: mono,
+    letterSpacing: 0.5,
+  },
   volRow: { flexDirection: 'row', gap: 8 },
   volBtn: {
     flex: 1,
@@ -950,7 +968,14 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderRadius: 10,
     backgroundColor: t.inset,
   },
-  sourceBtnText: { fontSize: 14, fontWeight: '800', fontFamily: mono, letterSpacing: 0.5 },
+  // Same reasoning as tvBtnText: covered today, one usage away from invisible.
+  sourceBtnText: {
+    color: t.text,
+    fontSize: 14,
+    fontWeight: '800',
+    fontFamily: mono,
+    letterSpacing: 0.5,
+  },
   sourceSection: { gap: 6 },
   sourceHdr: {
     color: t.textFaint,

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -226,6 +226,23 @@ literal hexes legitimately survive because they are not theme-relative: ink on a
 button (`#0b1220`, `app/components/Paywall.tsx:157`) and the physically black-on-white QR code
 (`app/components/QrView.tsx:58,72`).
 
+### Every text style declares a `color`
+
+A `Text` style that omits `color` renders **black** on native — React Native has no CSS
+inheritance. On a dark sheet that is invisible, and it is not hypothetical: it shipped in
+2.9.17 as "black text even in dark mode", where `bigLabel` in `RemotePowerBar` had no colour
+and only the call sites that happened to pass one inline (`t.green`, `t.amber`) were legible.
+Screensaver and Sleep timer were not.
+
+Put `color: t.text` in the style itself and let call sites override inline for semantic
+colour. "Every current usage passes a colour inline" is not safety — it is one new usage away
+from invisible text.
+
+**The web harness cannot be trusted to catch this.** On web, colour resolves through the CSS
+cascade; on native it does not. Verify contrast in the harness by measuring
+`getComputedStyle().color` against the resolved background, and note that a style with no
+colour resolves to `rgb(0, 0, 0)` there too — that is the control.
+
 ### Hooks
 
 `usePoll(fn, intervalMs, enabled, resetKey)` (`app/hooks/usePoll.ts`) is the standard data path:


### PR DESCRIPTION
Field report: **"black text here even in dark mode"** — Screensaver and Sleep timer render black-on-black in the power sheet.

## Cause

`bigLabel` declared no `color`. **React Native has no CSS inheritance**, so a `Text` style without one renders **black** on native.

The rows that looked fine were the ones whose call sites happened to pass a colour inline — Wake box gets `t.green`, Suspend gets `t.amber`. Screensaver and Sleep timer pass nothing, so they took the platform default and vanished into the sheet. That's exactly the pattern in the report: Suspend legible, the two below it not.

`tvBtnText` and `sourceBtnText` had the same hole. Every current call site passes a colour inline so neither was visibly broken — but that isn't safety, it's one new usage away from the same bug. All three now declare `color: t.text`; inline overrides still win.

## Swept for others

One other candidate, `SmartTvSetup`'s `msgDone`, is a **false positive**: it's applied *after* an inline `{ color }` in the style array and declares no colour of its own, so it can't clobber it. RemotePowerBar was the only real instance.

## Verified

In the harness, dark mode, measuring `getComputedStyle().color` against the resolved background rather than eyeballing — and **both states observed on the same node**:

| | colour | contrast |
|---|---|---|
| style with **no** colour (the bug) | `rgb(0,0,0)` | **1.06** |
| with the fix | `rgb(229,236,248)` | **15.33** |

Controls prove the semantic inline colours still win and weren't clobbered: Suspend amber **10.9**, TV On green **9.47**. All seven rows clear WCAG AA.

## The part worth keeping

**The web harness would not have caught this on its own.** Web resolves colour through the CSS cascade; native does not. The bug only exists on device. My first attempt to prove this was itself wrong — clearing the inline style still left RNW's generated class applying the colour — so the check had to force `color: unset` on a clone to see what a style with no colour actually resolves to.

Recorded in `CONVENTIONS.md`: every text style declares a colour, and the harness measurement needs the no-colour control to be meaningful.

## Not verified

Not seen on a device. The fix is a style-level default with measured contrast, so the risk is low, but the original bug was device-only and the confirmation should be too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
