### PR TITLE
fix(agent): restore the audio device Couch Mode moved, never guess one (2.9.37)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Unit tests (couch ceremony)
         run: python3 tests/test_couch_ceremony.py
 
+      # Leaving Couch Mode used to GUESS its way back, picking whichever sink had
+      # "speaker"/"analog"/"pci" in its name and making that the system default.
+      # That is a substitution, not a restore, and it cost a user their audio.
+      # These pin the rule: put audio back exactly where it was, or leave it
+      # alone -- never pick a device the user did not choose.
+      - name: Unit tests (audio sink restore)
+        run: python3 tests/test_audio_sink_restore.py
+
       # The desktop switch must honour the box's CONFIGURED session. SteamOS
       # ships both, and steamos-session-select maps the bare "plasma" arg to the
       # X11 one -- so passing it silently downgraded a Wayland-configured box to

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.36"
+VERSION = "2.9.37"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1872,14 +1872,70 @@ def _tv_audio_sink():
     return None
 
 
-def _internal_audio_sink():
-    """Node name of the built-in speaker/analog sink (for restoring on return)."""
-    for s in _pactl_sinks():
-        low = s["name"].lower()
-        if not s["hdmi"] and ("speaker" in low or "analog" in low
-                              or "pci" in low):
-            return s["name"]
-    return None
+def _current_default_sink():
+    """The node name pactl currently reports as the default sink, or None when
+    pactl is missing/errors. Read BEFORE any set-default-sink so the user's own
+    choice can be put back verbatim."""
+    if not shutil.which("pactl"):
+        return None
+    r = _couch_run(["pactl", "get-default-sink"], timeout=8)
+    if not r["ok"]:
+        return None
+    name = (r["stdout"] or "").strip()
+    return name or None
+
+
+# The default sink as it was BEFORE Couchside moved audio to the TV, so leaving
+# Couch Mode restores exactly what the user had.
+#
+# This used to be guessed on the way back out: _internal_audio_sink() matched a
+# sink whose name contained "speaker"/"analog"/"pci" and made that the default.
+# That is not a restore, it is a substitution, and it cost a user their audio --
+# reported from the field as the box's default device being changed out from
+# under them, with sound gone from the TV until they fixed it by hand. Anyone
+# whose default was a USB DAC, a Bluetooth speaker or any virtual sink got the
+# same treatment.
+#
+# In memory rather than on disk deliberately: this is ephemeral state belonging
+# to one Couch Mode session, and config.json is the user's file, not a scratch
+# pad. The cost is that an agent restart mid-session forgets it -- in which case
+# the restore SKIPS instead of guessing. Doing nothing is always recoverable;
+# moving a user's audio somewhere they did not choose is what caused this bug.
+_PRIOR_DEFAULT_SINK = None
+_PRIOR_SINK_LOCK = threading.Lock()
+
+
+def _remember_default_sink():
+    """Record the current default sink before Couchside changes it. First writer
+    wins: entering Couch Mode twice must not overwrite the ORIGINAL value with
+    the TV sink we ourselves set."""
+    global _PRIOR_DEFAULT_SINK
+    with _PRIOR_SINK_LOCK:
+        if _PRIOR_DEFAULT_SINK is not None:
+            return
+        _PRIOR_DEFAULT_SINK = _current_default_sink()
+
+
+def _restore_default_sink():
+    """Put the default sink back to what it was before Couch Mode.
+
+    Degrades closed, three ways. Nothing remembered (agent restarted, or the box
+    never entered Couch Mode through us) -> skipped. The remembered sink no
+    longer exists -> skipped, because a stale name would either fail or, worse,
+    match something else. Already the default -> skipped as a no-op."""
+    global _PRIOR_DEFAULT_SINK
+    with _PRIOR_SINK_LOCK:
+        want = _PRIOR_DEFAULT_SINK
+        _PRIOR_DEFAULT_SINK = None
+    if not want:
+        return {"skipped": True,
+                "reason": "no prior audio device recorded; leaving audio alone"}
+    if want not in [s["name"] for s in _pactl_sinks()]:
+        return {"skipped": True,
+                "reason": "the previous audio device is gone; leaving audio alone"}
+    if _current_default_sink() == want:
+        return {"skipped": True, "reason": "already the default"}
+    return _couch_run(["pactl", "set-default-sink", want])
 
 
 def _couch_run_first(cmds):
@@ -2019,10 +2075,13 @@ def couchmode_start(output, hdr=False):
     steps["tv_power_on"] = pwr if pwr is not None else {"skipped": True}
     src = tv_send("source_box", False)
     steps["tv_input"] = src if src is not None else {"skipped": True}
-    # (1) Route audio to the TV.
+    # (1) Route audio to the TV, remembering where it was so exit can undo it.
     sink = _tv_audio_sink()
-    steps["audio"] = (_couch_run(["pactl", "set-default-sink", sink])
-                      if sink else {"skipped": True})
+    if sink:
+        _remember_default_sink()
+        steps["audio"] = _couch_run(["pactl", "set-default-sink", sink])
+    else:
+        steps["audio"] = {"skipped": True}
     # (2) Honor the display picker where the platform allows it.
     steps["output"] = _set_preferred_output(output)
     # (3) Enter Game Mode (the one step that must succeed).
@@ -2056,13 +2115,13 @@ def couchmode_start(output, hdr=False):
 
 
 def desktop_mode():
-    """Return from Game Mode to the Plasma desktop and route audio back to the
-    built-in speaker."""
+    """Return from Game Mode to the Plasma desktop and put the audio device back
+    to whatever it was before Couch Mode moved it.
+
+    Restores, never substitutes: if we did not record a prior device, audio is
+    left exactly where it is. See _restore_default_sink."""
     sw = _session_to_desktop()
-    steps = {"session": sw}
-    sink = _internal_audio_sink()
-    steps["audio"] = (_couch_run(["pactl", "set-default-sink", sink])
-                      if sink else {"skipped": True})
+    steps = {"session": sw, "audio": _restore_default_sink()}
     return {"ok": sw["ok"],
             "session": "desktop" if sw["ok"] else _couchmode_session(),
             "steps": steps}
@@ -2190,6 +2249,7 @@ def _couch_do_audio(has_external):
         return {"state": "failed",
                 "reason": "the TV's HDMI audio sink never appeared — "
                           "sound may still be on the box"}
+    _remember_default_sink()  # capture BEFORE the change, so exit can undo it
     r = _couch_run(["pactl", "set-default-sink", sink])
     if r["ok"]:
         return {"state": "ok"}

--- a/tests/test_audio_sink_restore.py
+++ b/tests/test_audio_sink_restore.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for restoring the audio device Couch Mode moved.
+
+Run: python3 tests/test_audio_sink_restore.py
+
+Leaving Couch Mode used to GUESS its way back: it picked whichever sink had
+"speaker"/"analog"/"pci" in its name and made that the system default. That is a
+substitution, not a restore, and it cost a user their audio -- reported from the
+field as the box's default device being changed out from under them, with sound
+gone from the TV until they put it back by hand. Anyone whose default was a USB
+DAC, a Bluetooth speaker or a virtual sink got the same treatment.
+
+The rule these tests pin down: Couchside puts audio back exactly where it found
+it, or it leaves audio alone. It never picks a device the user did not choose.
+
+The last test is the regression proper -- a box with a tempting "speaker" sink
+sitting right there, and nothing recorded, must run NO pactl command at all.
+
+Pure stdlib, no pytest -- same style as the other agent tests.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _stub(*, sinks, default, ran):
+    """Stub pactl. `ran` collects every argv the agent actually executes, which
+    is how "left audio alone" is asserted as NOTHING RAN rather than as a
+    return value that merely looks passive."""
+    cs.shutil.which = lambda b: "/usr/bin/" + b
+    cs._pactl_sinks = lambda: [{"name": n, "hdmi": False, "available": False}
+                               for n in sinks]
+
+    def fake_run(argv, **kw):
+        ran.append(list(argv))
+        if argv[:2] == ["pactl", "get-default-sink"]:
+            return {"ok": True, "stdout": default[0], "stderr": "", "exit_code": 0}
+        if argv[:2] == ["pactl", "set-default-sink"]:
+            default[0] = argv[2]
+            return {"ok": True, "stdout": "", "stderr": "", "exit_code": 0}
+        return {"ok": True, "stdout": "", "stderr": "", "exit_code": 0}
+
+    cs._couch_run = fake_run
+
+
+def _reset():
+    cs._PRIOR_DEFAULT_SINK = None
+
+
+def test_round_trip():
+    """The user's own device comes back verbatim -- including a virtual sink,
+    which is exactly the case the old name-guess could never restore."""
+    print("test_round_trip")
+    _reset()
+    ran, default = [], ["sink-sunshine-stereo"]
+    _stub(sinks=["sink-sunshine-stereo", "alsa_output.pci-0000_00.hdmi"],
+          default=default, ran=ran)
+    cs._remember_default_sink()
+    cs._couch_run(["pactl", "set-default-sink", "alsa_output.pci-0000_00.hdmi"])
+    check("audio moved to the TV", default[0], "alsa_output.pci-0000_00.hdmi")
+    r = cs._restore_default_sink()
+    check("restore ran", r.get("skipped"), None)
+    check("exact prior device restored", default[0], "sink-sunshine-stereo")
+
+
+def test_first_writer_wins():
+    """Entering Couch Mode twice must not overwrite the ORIGINAL device with the
+    TV sink we ourselves set -- otherwise the second entry makes the TV the
+    thing we 'restore' to, and the user never gets their device back."""
+    print("test_first_writer_wins")
+    _reset()
+    ran, default = [], ["my-usb-dac"]
+    _stub(sinks=["my-usb-dac", "hdmi-sink"], default=default, ran=ran)
+    cs._remember_default_sink()
+    default[0] = "hdmi-sink"          # as if Couch Mode already moved it
+    cs._remember_default_sink()       # second entry must be a no-op
+    cs._restore_default_sink()
+    check("still restores the ORIGINAL device", default[0], "my-usb-dac")
+
+
+def test_nothing_recorded_is_a_no_op():
+    """Agent restarted mid-session, or the box never entered Couch Mode through
+    us: leave audio alone rather than guess."""
+    print("test_nothing_recorded_is_a_no_op")
+    _reset()
+    ran, default = [], ["whatever-the-user-picked"]
+    _stub(sinks=["whatever-the-user-picked", "speaker-sink"], default=default, ran=ran)
+    r = cs._restore_default_sink()
+    check("skipped", r.get("skipped"), True)
+    check("default untouched", default[0], "whatever-the-user-picked")
+    check("no pactl command ran", ran, [])
+
+
+def test_vanished_device_is_a_no_op():
+    """The remembered sink is gone (DAC unplugged). A stale name would fail, or
+    worse match something else -- so skip."""
+    print("test_vanished_device_is_a_no_op")
+    _reset()
+    ran, default = [], ["my-usb-dac"]
+    _stub(sinks=["my-usb-dac"], default=default, ran=ran)
+    cs._remember_default_sink()
+    default[0] = "hdmi-sink"
+    cs._pactl_sinks = lambda: [{"name": "hdmi-sink", "hdmi": True,
+                                "available": True}]  # DAC unplugged
+    r = cs._restore_default_sink()
+    check("skipped", r.get("skipped"), True)
+    check("default left where it is", default[0], "hdmi-sink")
+
+
+def test_already_default_is_a_no_op():
+    """Nothing to do -- and it must not issue a pointless set-default-sink."""
+    print("test_already_default_is_a_no_op")
+    _reset()
+    ran, default = [], ["my-usb-dac"]
+    _stub(sinks=["my-usb-dac"], default=default, ran=ran)
+    cs._remember_default_sink()
+    before = len(ran)
+    r = cs._restore_default_sink()
+    check("skipped", r.get("skipped"), True)
+    check("no set-default-sink issued",
+          [a for a in ran[before:] if a[:2] == ["pactl", "set-default-sink"]], [])
+
+
+def test_desktop_mode_never_guesses():
+    """THE REGRESSION. A box with an obvious "speaker" sink present and nothing
+    recorded: desktop_mode must not touch audio. The old code would have seized
+    on that sink by name and made it the system default."""
+    print("test_desktop_mode_never_guesses")
+    _reset()
+    ran, default = [], ["sink-sunshine-stereo"]
+    _stub(sinks=["alsa_output.pci-0000_00.analog-stereo", "sink-sunshine-stereo"],
+          default=default, ran=ran)
+    cs._session_to_desktop = lambda: {"ok": True}
+    res = cs.desktop_mode()
+    check("audio step skipped", res["steps"]["audio"].get("skipped"), True)
+    check("default untouched", default[0], "sink-sunshine-stereo")
+    check("no set-default-sink issued",
+          [a for a in ran if a[:2] == ["pactl", "set-default-sink"]], [])
+
+
+if __name__ == "__main__":
+    for fn in (test_round_trip,
+               test_first_writer_wins,
+               test_nothing_recorded_is_a_no_op,
+               test_vanished_device_is_a_no_op,
+               test_already_default_is_a_no_op,
+               test_desktop_mode_never_guesses):
+        fn()
+    if FAILURES:
+        print("\nFAILED: %d" % len(FAILURES))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Field report:

> The first time I connected, it changed my SteamOS PC's default audio device to the sunshine audio sink and audio stopped playing on my TV. I had to manually change the audio device back.

## Cause

Leaving Couch Mode never restored anything — it **substituted**. `desktop_mode()` called `_internal_audio_sink()`, which picked whichever sink had `speaker`, `analog` or `pci` in its **name** and made that the system default:

```python
if not s["hdmi"] and ("speaker" in low or "analog" in low or "pci" in low):
```

Anyone whose default was a USB DAC, a Bluetooth speaker, or any virtual sink got it replaced with something they never chose. And nothing recorded what the default had been — `pactl get-default-sink` appeared **nowhere** in the agent.

## Fix

Capture the prior default immediately **before** any `set-default-sink`, put it back verbatim on the way out. `_internal_audio_sink` is deleted — name-guessing a device is the bug, not a fallback for it.

**Degrades closed in three places, and in each the safe answer is to do nothing:**

| Situation | Behaviour |
|---|---|
| Nothing recorded (agent restarted, or Couch Mode wasn't entered through us) | skip |
| Remembered sink no longer exists | skip — a stale name would fail, or worse, match something else |
| Already the default | skip |

Doing nothing is always recoverable. Moving a user's audio somewhere they didn't choose is what caused this.

Capture is **first-writer-wins**, so entering Couch Mode twice can't overwrite the original device with the TV sink we set ourselves.

Held **in memory, not persisted** — this is ephemeral state belonging to one Couch Mode session, and `config.json` is the user's file, not a scratch pad. The cost: an agent restart mid-session forgets it, and the restore then skips rather than guessing. Same safe answer.

## Tests — `tests/test_audio_sink_restore.py`

Round trip (including restoring a **virtual** sink, which the old name-match could never have found), first-writer-wins, and all three skip paths.

The last test is the regression: a box with a tempting `analog` sink present and nothing recorded must issue **no pactl command at all**.

**Controlled.** I reconstructed the old implementation verbatim and ran it against the same stubs:

```
OLD code picked sink : alsa_output.pci-0000_00.analog-stereo
OLD set-default-sink : [['pactl','set-default-sink','alsa_output.pci-0000_00.analog-stereo']]
OLD default became   : alsa_output.pci-0000_00.analog-stereo
```

Both new assertions fail against it. The test catches the bug it was written for, rather than merely passing.

Full agent suite green (19 files). New CI step wired with its WHY comment.

## NOT established

**Whether this is the exact mechanism behind the report.** The user described ending up on a *Sunshine* virtual sink, and neither picker should select a null sink — `_tv_audio_sink()` requires a port reporting `type: HDMI` and available. Settling that needs `pactl list sinks` from their box while Sunshine is loaded.

The substitution bug is real and proven independently of that question, and fixing it means Couchside can only ever put audio back where it found it.

Also worth telling the reporter: Couchside does **not** touch audio on connect. All `set-default-sink` calls are user-invoked (`couchmode_start`, the ceremony, `desktop_mode`), and `couchModeStart` has exactly one caller — the Fling button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
