### PR TITLE
feat(app): let people choose which tab the app opens on

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -4,11 +4,15 @@ import { useEffect, useRef } from 'react';
 
 import { useCapsSync } from '@/hooks/useCapsSync';
 import { hapticSelection } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
 import { useBoxes } from '@/lib/SettingsContext';
 import { useTheme } from '@/lib/theme';
 
-// Default screen = the swipe Remote (Pad). First-run (empty fleet) is redirected
-// to Setup below so the user pairs a box before landing on the remote.
+// NOT the landing screen. This governs back-behaviour within the tab group; on a
+// cold start the index route (Console) is what renders. The comment that used to
+// sit here claimed "Default screen = the swipe Remote (Pad)", which was never
+// true — measured in the harness, loading "/" leaves Console active. What the app
+// opens on is the `landingTab` preference, applied by the redirect below.
 export const unstable_settings = {
   initialRouteName: 'pad',
 };
@@ -16,6 +20,7 @@ export const unstable_settings = {
 export default function TabLayout() {
   const t = useTheme();
   const { boxes, activeBox, ready } = useBoxes();
+  const landingTab = usePref('landingTab');
   const segments = useSegments();
   // Always-mounted caps safety net: heals a stale persisted caps snapshot
   // (e.g. couchmode:false cached before the box became capable) no matter
@@ -30,15 +35,30 @@ export default function TabLayout() {
   const hideLaunch = caps?.steam === false;
 
   // On true first run (persisted fleet loaded, but empty) send the user to
-  // Setup to pair. Runs once. After that, the Pad initial route stands.
+  // Setup to pair. Otherwise honour the landing-tab preference.
+  //
+  // The redirect is how the landing tab is chosen at all: `unstable_settings.
+  // initialRouteName` below does NOT decide what opens on a cold start — the
+  // index route (Console) wins, which is why the app has always opened on
+  // Console despite that setting naming 'pad'. Measured in the harness: loading
+  // "/" leaves Console as the active tab.
+  //
+  // Pairing beats the preference. Someone with no box who set the landing tab to
+  // Pad still needs Setup first, or they land on a remote wired to nothing.
   const redirected = useRef(false);
   useEffect(() => {
     if (!ready || redirected.current) return;
     redirected.current = true;
     if (boxes.length === 0) {
       router.replace('/(tabs)/setup');
+      return;
     }
-  }, [ready, boxes.length]);
+    // 'index' is already what renders, so redirecting to it would be a wasted
+    // navigation on every cold start.
+    if (landingTab !== 'index') {
+      router.replace(`/(tabs)/${landingTab}`);
+    }
+  }, [ready, boxes.length, landingTab]);
 
   // Bounce off a tab hidden for the active box — landing on the Pad initial
   // route for a server box, or switching from an HTPC to a server box while the

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -645,6 +645,7 @@ function SetupBody() {
   const scheme = useResolvedScheme();
   const confirmSuspend = usePref('confirmSuspend');
   const defaultPadMode = usePref('defaultPadMode');
+  const landingTab = usePref('landingTab');
   const statusIntervalMs = usePref('statusIntervalMs');
   const journalLines = usePref('journalLines');
   const swipeSensitivity = usePref('swipeSensitivity');
@@ -1216,6 +1217,21 @@ function SetupBody() {
                   ios_backgroundColor={t.inset}
                 />
               </View>
+              <SegPref
+                label="Open on"
+                sub="The tab the app starts on. Pairing wins on first run — with no box paired you still land on Setup."
+                options={[
+                  { value: 'index', label: 'Console' },
+                  { value: 'actions', label: 'Actions' },
+                  { value: 'pad', label: 'Pad' },
+                  { value: 'launch', label: 'Launch' },
+                ]}
+                value={landingTab}
+                onSelect={(v) => {
+                  void setPref('landingTab', v);
+                  hapticSelection();
+                }}
+              />
               <SegPref
                 label="Default input mode"
                 sub="The view the Pad tab opens on. Applies to the active box now, and seeds newly paired boxes."

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -14,9 +14,26 @@ import { Platform } from 'react-native';
 
 import { PadMode } from './settings';
 
+/** Tabs the app can open on. Values are the expo-router route names ('index' is
+ *  Console). Setup is deliberately not offered: nobody wants to land there, and
+ *  first-run already forces it when no box is paired. */
+export const LANDING_TABS = ['index', 'actions', 'pad', 'launch'] as const;
+export type LandingTab = (typeof LANDING_TABS)[number];
+
 export type Prefs = {
   /** Ask before suspending the box (the Suspend button in the header). */
   confirmSuspend: boolean;
+  /** Which tab the app opens on.
+   *
+   *  Defaults to 'index' (Console) because that is what the app has ALWAYS
+   *  actually done, whatever the layout claimed. `unstable_settings.
+   *  initialRouteName = 'pad'` sits in app/(tabs)/_layout.tsx under a comment
+   *  saying "Default screen = the swipe Remote (Pad)", but the index route wins
+   *  on cold start and Console is what opens — verified in the harness, where
+   *  loading "/" leaves Console as the active tab. Changing the default here
+   *  would move every existing user's landing screen, so it stays on the
+   *  observed behaviour and the choice becomes theirs. */
+  landingTab: LandingTab;
   /** Input mode a newly paired box starts on. */
   defaultPadMode: PadMode;
   /** How often the console/header polls the box for vitals (ms). */
@@ -71,6 +88,7 @@ export type Prefs = {
 
 export const DEFAULTS: Prefs = {
   confirmSuspend: true,
+  landingTab: 'index',
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
   journalLines: 100,
@@ -150,9 +168,13 @@ function normalize(raw: unknown): Prefs {
     o.defaultPadMode === 'remote'
       ? o.defaultPadMode
       : 'swipe';
+  const landingTab: LandingTab = LANDING_TABS.includes(o.landingTab as LandingTab)
+    ? (o.landingTab as LandingTab)
+    : DEFAULTS.landingTab;
   return {
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
+    landingTab,
     defaultPadMode: padMode,
     statusIntervalMs: num(o.statusIntervalMs, STATUS_INTERVAL_OPTIONS, DEFAULTS.statusIntervalMs),
     journalLines: num(o.journalLines, JOURNAL_LINE_OPTIONS, DEFAULTS.journalLines),


### PR DESCRIPTION
> "Being able to set the default tab on app launch would be great. I'd probably want to use the Pad tab most often, so having the app open directly to that would be pretty nice."

## This was a bug too, not just a missing feature

`app/(tabs)/_layout.tsx` already carried:

```tsx
// Default screen = the swipe Remote (Pad).
export const unstable_settings = { initialRouteName: 'pad' };
```

**That has never been what happens.** `initialRouteName` governs back-behaviour *within* the tab group; on a cold start the index route wins, and the index route is Console. Measured in the harness — loading `/` leaves **Console** active, not Pad.

So the comment asserted behaviour the code didn't produce. Same shape as the CEC docstring and the drag trail: a plausible claim, never observed. It's corrected in place rather than left to mislead.

## The change

The landing tab is a preference, applied by the **same mount-time redirect that already handles first run** — no new mechanism.

- **Pairing still wins.** With no box paired you land on Setup; a remote wired to nothing is not a useful first screen.
- **Default is `index` (Console)** — deliberately the *observed* behaviour, not what the old comment claimed. Shipping `pad` as the default would move every existing user's landing screen in order to fix a comment. Say the word if you'd rather flip it; the intent in that comment suggests Pad was always wanted.
- **Setup isn't offered** as a choice — nobody wants to land there, and first run already forces it when it matters.
- Redirecting to `index` is skipped, since it's already what renders — no wasted navigation on every cold start.

## Verified

Driven in the harness by **pressing the control**, both states, on a cold load of `/`:

| `landingTab` | result |
|---|---|
| unset (default) | `/` — **Console** active |
| `pad`, set via the Setup segment | `/pad` — **Pad** active |

The value was read back out of `couchside.prefs.v1` (`"landingTab":"pad"`) rather than inferred from the UI, and the selected segment was confirmed by computed colour.

`npx tsc --noEmit` clean. All three `prefs.ts` edit sites wired (type, `DEFAULTS`, `normalize()`), so the value actually persists.

## Not verified

Not run on a device. It's a redirect on mount with no native surface, so risk is low — but the first-run interaction (empty fleet → Setup) is worth a glance on a real cold start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
