### PR TITLE
fix(agent): report the disk the user can actually fill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
       - name: Unit tests (couch ceremony)
         run: python3 tests/test_couch_ceremony.py
 
+      # Which filesystems the dashboard reports. A Deck owner was shown
+      # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
+      # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts
+      # both directions of the read-only rule, and that one filesystem reached by
+      # two paths is one row rather than two identical ones.
+      - name: Unit tests (disk mounts)
+        run: python3 tests/test_disk_mounts.py
+
       # The desktop switch must honour the box's CONFIGURED session. SteamOS
       # ships both, and steamos-session-select maps the bare "plasma" arg to the
       # X11 one -- so passing it silently downgraded a Wayland-configured box to

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1002,16 +1002,44 @@ def read_mem():
         return {"total_mb": 0, "used_mb": 0, "available_mb": 0}
 
 
+# Filesystems worth showing, in the order they should appear. "/home" is here
+# because on SteamOS the user's storage IS /home and "/" is a small read-only
+# rootfs -- reporting only "/" showed a Steam Deck owner "3.5 / 5.0 GB, 69%" on a
+# machine with far more space, which reads as a nearly-full disk and is not even
+# a filesystem they can write to.
+_DISK_MOUNTS = ("/", "/home", "/var")
+
+
 def read_disks():
     disks = []
-    for mount in ("/", "/var"):
+    seen_devices = set()
+    for mount in _DISK_MOUNTS:
         try:
+            # Same filesystem reached by two paths (the common case where /home
+            # is not split out) must not be listed twice.
+            try:
+                dev = os.stat(mount).st_dev
+            except OSError:
+                continue
+            if dev in seen_devices:
+                continue
+
+            # Read-only roots are not the user's storage and nothing they do can
+            # change the number, so showing one is pure alarm. This is what hides
+            # the immutable rootfs on SteamOS and Fedora Atomic derivatives.
+            try:
+                if os.statvfs(mount).f_flag & os.ST_RDONLY:
+                    continue
+            except (OSError, AttributeError):
+                pass  # unreadable -> fall through to the size check
+
             du = shutil.disk_usage(mount)
             # Skip synthetic mounts with no real capacity (e.g. the composefs
             # read-only / on Bazzite/Fedora Atomic reports a tiny total that is
             # always "100% used": meaningless and alarming on the dashboard).
             if du.total < 1024 ** 3:
                 continue
+            seen_devices.add(dev)
             total_gb = du.total / (1024 ** 3)
             used_gb = du.used / (1024 ** 3)
             free_gb = du.free / (1024 ** 3)

--- a/tests/test_disk_mounts.py
+++ b/tests/test_disk_mounts.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Tests for which filesystems the dashboard reports.
+
+Run: python3 tests/test_disk_mounts.py
+
+The bug this exists to stop: a Steam Deck owner was shown "3.5 / 5.0 GB, 69%"
+on a machine with far more space. read_disks() only ever looked at ("/", "/var"),
+and on SteamOS "/" is a small READ-ONLY rootfs -- so the dashboard reported a
+filesystem the user cannot write to, at a fill level that reads as nearly full,
+while their actual storage (/home) was never mentioned at all.
+
+Two rules come out of that, and both are tested here in BOTH directions:
+  - a read-only filesystem is not the user's storage, so it is not reported;
+  - the same filesystem reached by two paths is reported once, not twice.
+
+The second is not hypothetical either: on a machine with a sealed system volume,
+the old code listed "/" and "/var" as two rows with identical numbers.
+
+The environment primitives are stubbed rather than the logic reimplemented, so
+the real read_disks() is what runs. Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+import shutil
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+GB = 1024 ** 3
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class _Usage:
+    def __init__(self, total, used):
+        self.total = total
+        self.used = used
+        self.free = total - used
+
+
+class _Statvfs:
+    def __init__(self, ro):
+        self.f_flag = os.ST_RDONLY if ro else 0
+
+
+def _run(layout):
+    """Drive the REAL read_disks() against a fake mount table.
+
+    layout: {mount: (total_bytes, used_bytes, device_id, read_only)}
+    A mount absent from the layout raises OSError, like a path that isn't there.
+    """
+    def fake_stat(path):
+        if path not in layout:
+            raise OSError("no such mount: %s" % path)
+        class S:
+            st_dev = layout[path][2]
+        return S()
+
+    def fake_statvfs(path):
+        if path not in layout:
+            raise OSError("no such mount: %s" % path)
+        return _Statvfs(layout[path][3])
+
+    def fake_usage(path):
+        if path not in layout:
+            raise OSError("no such mount: %s" % path)
+        total, used, _dev, _ro = layout[path]
+        return _Usage(total, used)
+
+    real = (os.stat, os.statvfs, shutil.disk_usage)
+    os.stat, os.statvfs, shutil.disk_usage = fake_stat, fake_statvfs, fake_usage
+    try:
+        return cs.read_disks()
+    finally:
+        os.stat, os.statvfs, shutil.disk_usage = real
+
+
+def test_steamos_shape():
+    """The reported bug: read-only 5GB rootfs + the real /home beside it."""
+    print("test_steamos_shape")
+    disks = _run({
+        "/":     (5 * GB, 3 * GB, 1, True),    # small, READ-ONLY: not the user's
+        "/home": (512 * GB, 100 * GB, 2, False),
+    })
+    check("only one filesystem reported", len(disks), 1)
+    check("and it is /home, not /", disks[0]["mount"] if disks else None, "/home")
+    check("size is the real one", disks[0]["total_gb"] if disks else None, 512.0)
+    check("not the alarming 69%", disks[0]["pct"] if disks else None, 20)
+
+
+def test_read_only_root_is_hidden():
+    """Both directions: identical filesystem, only the ro flag differs."""
+    print("test_read_only_root_is_hidden")
+    ro = _run({"/": (500 * GB, 250 * GB, 1, True)})
+    check("read-only root omitted", ro, [])
+    rw = _run({"/": (500 * GB, 250 * GB, 1, False)})
+    check("the same filesystem writable IS reported", len(rw), 1)
+    check("with the right numbers", rw[0]["pct"] if rw else None, 50)
+
+
+def test_same_device_reported_once():
+    """/ and /var on one filesystem is one row, not two identical ones."""
+    print("test_same_device_reported_once")
+    disks = _run({
+        "/":    (900 * GB, 800 * GB, 7, False),
+        "/var": (900 * GB, 800 * GB, 7, False),   # same st_dev
+    })
+    check("deduped to a single row", len(disks), 1)
+    check("keeps the first candidate", disks[0]["mount"] if disks else None, "/")
+
+
+def test_distinct_devices_all_reported():
+    """The dedupe must not swallow genuinely separate storage."""
+    print("test_distinct_devices_all_reported")
+    disks = _run({
+        "/":     (100 * GB, 50 * GB, 1, False),
+        "/home": (900 * GB, 100 * GB, 2, False),
+    })
+    check("both reported", [d["mount"] for d in disks], ["/", "/home"])
+
+
+def test_tiny_synthetic_mount_skipped():
+    """The composefs case the size guard was written for still works."""
+    print("test_tiny_synthetic_mount_skipped")
+    disks = _run({
+        "/":     (200 * 1024 ** 2, 200 * 1024 ** 2, 1, False),  # 200MB, 100% used
+        "/home": (256 * GB, 8 * GB, 2, False),
+    })
+    check("tiny mount omitted", [d["mount"] for d in disks], ["/home"])
+
+
+def test_missing_mount_is_not_fatal():
+    """A box with no /home or /var must still report what it has."""
+    print("test_missing_mount_is_not_fatal")
+    disks = _run({"/": (64 * GB, 32 * GB, 1, False)})
+    check("still returns the root", [d["mount"] for d in disks], ["/"])
+
+
+if __name__ == "__main__":
+    for fn in (test_steamos_shape,
+               test_read_only_root_is_hidden,
+               test_same_device_reported_once,
+               test_distinct_devices_all_reported,
+               test_tiny_synthetic_mount_skipped,
+               test_missing_mount_is_not_fatal):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
> "Not sure what is going on here but it's not reading my disks correctly, I have more than 5 GB of space lol"

Reported alongside a screenshot showing **`3.5 / 5.0 GB · 69%`** on a Steam Deck.

## Cause

`read_disks()` only ever looked at `("/", "/var")`. On SteamOS **`/` is a small read-only rootfs**, so the dashboard reported a filesystem the user *cannot write to*, at a fill level that reads as nearly full — and never mentioned `/home`, where their storage actually is.

The existing guard only skipped mounts under 1 GiB. That catches Bazzite's composefs; a 5 GB rootfs sails straight past it.

## Changes

- **`/home` joins the candidate list** — on SteamOS that *is* the storage.
- **Read-only filesystems are skipped.** Nothing the user does can move that number, so showing it is pure alarm. It's also a cleaner rule than size-guessing at which roots are synthetic.
- **Results deduped by `st_dev`.** Not hypothetical — see below.

Response shape unchanged: same keys, same types, only *which* mounts appear differs. Older app versions render it fine.

## Measured, not reasoned about

This Mac has the same topology as SteamOS — sealed read-only root plus a writable data volume — so it's a real proxy:

| | rows returned |
|---|---|
| **before** | `/` → 926.3 GB, 96%, **read-only** · `/var` → 926.3 GB, 96% |
| **after** | `/var` → 926.3 GB, 96% |

The old code was emitting a **duplicate row** on any machine with a sealed system volume. I didn't know that until I measured it.

## NOT verified

**The SteamOS numbers themselves.** The Deck wasn't reachable from this network (it's on the home LAN, I'm on the work one), so the 5 GB rootfs figure comes from the reporter's screenshot, not from a box I measured. What's proven is the mechanism: a read-only root is now excluded, demonstrated live in both directions.

Worth a look at the Deck's Console card once it's back on the network.

## Tests

`tests/test_disk_mounts.py` drives the **real** `read_disks()` against a stubbed mount table — no reimplementation of the logic under test. Includes a fixture shaped like the reported Deck (5 GB ro `/` + 512 GB `/home`) and asserts the read-only rule **in both directions**: the same filesystem is hidden when ro and reported when rw. Wired as its own CI step.

VERSION deliberately untouched — #186 already carries the 2.9.37 bump, so leaving it here avoids a collision; whichever merges second inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
