### PR TITLE
feat(app): clearer Pad labels, an always-present Esc, and honest mode wording

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -597,7 +597,9 @@ export default function PadTab() {
 const MODES: { key: PadMode; label: string }[] = [
   { key: 'gamepad', label: 'PAD' },
   { key: 'swipe', label: 'SWIPE' },
-  { key: 'trackpad', label: 'TRACK' },
+  // "MOUSE", not "TRACK": the surface IS a mouse — drag moves the pointer, tap
+  // clicks. "Track" named the mechanism and left people guessing at the effect.
+  { key: 'trackpad', label: 'MOUSE' },
   { key: 'remote', label: 'REMOTE' },
   // Sits AFTER remote on purpose: it is one swipe further from the surface you
   // reach for most. Conditional -- see `modes` below; a box without Steam menus
@@ -1189,27 +1191,45 @@ function PadScreen() {
             <View style={styles.swipeBtnRow}>
               {showMouseRow && (
                 <>
+                  {/* Spelled out rather than L/M/R. Reported as unclear, and
+                      Ionicons has no honest left/middle/right-click glyph — a
+                      vague icon would trade one guessing game for another. */}
                   <PadButton
-                    label="L"
+                    label="LEFT"
                     onDown={() => client.sendMouseButton('l', 1)}
                     onUp={() => client.sendMouseButton('l', 0)}
                     style={styles.tpBtn}
-                    fontSize={14}
+                    fontSize={11}
                   />
                   <PadButton
-                    label="M"
+                    label="MID"
                     onDown={() => client.sendMouseButton('m', 1)}
                     onUp={() => client.sendMouseButton('m', 0)}
                     style={styles.tpBtn}
-                    fontSize={14}
+                    fontSize={11}
                   />
                   <PadButton
-                    label="R"
+                    label="RIGHT"
                     onDown={() => client.sendMouseButton('r', 1)}
                     onUp={() => client.sendMouseButton('r', 0)}
                     style={styles.tpBtn}
-                    fontSize={14}
+                    fontSize={11}
                   />
+                  {/* Esc ONLY when the desktop-nav row below isn't providing
+                      one. That row is gated on hasDesktop && showDesktopNav, so
+                      in Game Mode this screen had no way out at all — but
+                      showing it unconditionally puts two identical ESC keys on
+                      screen, which is the same duplication complaint this pass
+                      exists to fix. */}
+                  {!(hasDesktop && showDesktopNav) && (
+                    <PadButton
+                      label="ESC"
+                      onDown={desk('esc')}
+                      onUp={NOOP}
+                      style={styles.tpBtn}
+                      fontSize={11}
+                    />
+                  )}
                 </>
               )}
               {showSteamRow && (

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -591,8 +591,14 @@ export function RemotePowerBar() {
             size={16}
             color={inGameMode ? t.green : t.text}
           />
+          {/* Both labels name the CURRENT SESSION, and say it in the words the
+              rest of the system uses. The old pair mixed the two things a label
+              can mean: "On TV" was a state, "Couch" was an action, on one
+              button — which is why it read as arbitrary. State is the honest
+              choice here because pressing does not swap anything, it opens the
+              Couch Mode sheet, and the sheet owns the action. */}
           <Text style={[styles.couchLabel, inGameMode && { color: t.green }]}>
-            {inGameMode ? 'On TV' : 'Couch'}
+            {inGameMode ? 'Game Mode' : 'Desktop Mode'}
           </Text>
         </Pressable>
       )}


### PR DESCRIPTION
Four small changes from CompC's feedback, all on screens people live on.

| before | after | why |
|---|---|---|
| `TRACK` | **`MOUSE`** | the surface *is* a mouse; "Track" named the mechanism and left the effect to be guessed |
| `L` `M` `R` | **`LEFT` `MID` `RIGHT`** | reported as unclear |
| *(no Esc in Game Mode)* | **`ESC`** | there was one, but only in a row that Game Mode hides |
| `On TV` / `Couch` | **`Game Mode` / `Desktop Mode`** | the old pair mixed a state label and an action label on one button |

## On the icons

The request was specifically for left/middle/right-**click icons**. I spelled the words out instead: Ionicons has no honest glyph for those three, and a vague icon trades one guessing game for another. Happy to revisit if you'd rather ship a custom SVG set.

## The Esc, and the bug I introduced fixing it

`ESC` existed only in the desktop-nav row, gated on `hasDesktop && showDesktopNav` — so **in Game Mode that screen had no way out at all**.

Adding it to the mouse row unconditionally put **two identical ESC keys on screen**, which is the same duplication complaint this pass exists to reduce ("The Remote page has multiple steam buttons for some reason?"). The first version of this commit shipped exactly that; the harness caught it. It's now conditional on the nav row not already providing one.

## Verified

Read out of the rendered tree in **both states of the gate**:

| desktop nav | START buttons | ESC count |
|---|---|---|
| on | 1 | **1** (the nav row's) |
| off | 0 | **1** (the mouse row's) |

The invariant is **exactly one Esc — never zero, never two.**

Also confirmed: mode segments read `PAD / SWIPE / MOUSE / REMOTE` with no `TRACK` remaining, the mouse row reads `LEFT / MID / RIGHT`, the header reads `Desktop Mode`, and none of the longer labels overflow at 375pt.

`npx tsc --noEmit` clean.

## Not verified

Not seen on a device. These are label and layout changes with measured widths at 375pt, so the risk is small, but the mouse row is now four buttons wide on a narrow phone and is worth a glance.

## Deliberately not in this PR

The rest of the same feedback batch, each its own change: the keyboard-instead-of-gamepad mode, gating the Launch streaming section, the Box/TV volume switch, the Couch Mode ceremony simplification, and clipboard paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
