### PR TITLE
feat(app): let people hide the streaming section and the TV volume target

### DIFF
--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -285,6 +285,7 @@ function SteamLinkSection({
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const hideOffline = usePref('hideOfflineStreamHosts');
+  const hideSection = usePref('hideStreamFromPc');
   // Expand the freshest host by default, preferring one that's actually up.
   // `online` is absent on agents older than 2.9.32, and undefined !== false, so
   // those fall through to hosts[0] — exactly the old behaviour.
@@ -292,6 +293,10 @@ function SteamLinkSection({
     const first = data.hosts.find((h) => h.online !== false) ?? data.hosts[0];
     return first ? { [first.host]: true } : {};
   });
+  // Turned off outright in Preferences. Checked AFTER the hooks above so the
+  // hook order never changes between renders, and before the empty-host check
+  // so the reason for an absent card is the pref, not the data.
+  if (hideSection) return null;
   if (data.hosts.length === 0) return null;
   const hosts = hideOffline ? data.hosts.filter((h) => h.online !== false) : data.hosts;
   return (

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -660,6 +660,8 @@ function SetupBody() {
   const askToSwitchControl = usePref('askToSwitchControl');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
+  const hideStreamFromPc = usePref('hideStreamFromPc');
+  const hideTvVolume = usePref('hideTvVolume');
   const showTaps = usePref('showTaps');
   const traceDrags = usePref('traceDrags');
 
@@ -1369,6 +1371,15 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+              <TogglePref
+                label="Hide the TV volume target"
+                sub="Drops the Box/TV switch and always sends volume to the box. For setups where the box's own volume already drives the speakers — CEC forwarding, a soundbar or an AVR — and the TV target moves a level nothing plays through."
+                value={hideTvVolume}
+                onValueChange={(v) => {
+                  void setPref('hideTvVolume', v);
+                  hapticSelection();
+                }}
+              />
             </View>
 
             {/* The box's offline check is conservative and will sometimes call a
@@ -1381,6 +1392,15 @@ function SetupBody() {
                 value={hideOfflineStreamHosts}
                 onValueChange={(v) => {
                   void setPref('hideOfflineStreamHosts', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Hide this section"
+                sub="Removes Stream from PC from the Launch tab. For setups where you'd never stream a game off another machine."
+                value={hideStreamFromPc}
+                onValueChange={(v) => {
+                  void setPref('hideStreamFromPc', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -312,12 +312,19 @@ export function RemotePowerBar() {
   const [busy, setBusy] = React.useState(false);
   const [waking, setWaking] = React.useState(false);
 
+  // Where volume actually goes. Declared HERE, above the senders, because
+  // hiding the TV target has to bind at the SEND sites too — hiding the segment
+  // alone would strand anyone whose stored target was already 'tv': volume would
+  // keep going to the TV with no control left on screen to change it.
+  const hideTvVol = usePref('hideTvVolume');
+  const volumeTarget: VolumeTarget = hideTvVol ? 'box' : settings.volumeTarget ?? 'box';
+
   const sendTv = React.useCallback(
     async (op: TvOp) => {
       hapticLight();
       setBusy(true);
       try {
-        await api.tvSend(settings, op, settings.volumeTarget ?? 'box');
+        await api.tvSend(settings, op, volumeTarget);
         // Volume keys can clear the mute flag (dropping to 0 sets it), so
         // re-read state now rather than waiting out the poll tick.
         refreshTv();
@@ -368,7 +375,7 @@ export function RemotePowerBar() {
   const stepVolume = React.useCallback(
     (dir: 1 | -1) => {
       void api
-        .tvSend(settings, dir > 0 ? 'volume_up' : 'volume_down', settings.volumeTarget ?? 'box')
+        .tvSend(settings, dir > 0 ? 'volume_up' : 'volume_down', volumeTarget)
         .catch(() => {
           // Fire-and-forget, but don't fail totally silently: buzz at most once
           // every ~1.5s so a drag against an offline box gives some feedback.
@@ -434,7 +441,7 @@ export function RemotePowerBar() {
     hapticLight();
     setBusy(true);
     try {
-      await api.tvSend(settings, 'mute', settings.volumeTarget ?? 'box');
+      await api.tvSend(settings, 'mute', volumeTarget);
       // Re-read the mute state immediately so the button reflects it in ~100ms
       // instead of on the next poll tick.
       refreshTv();
@@ -530,7 +537,6 @@ export function RemotePowerBar() {
   const tvVol = tv?.tv_volume ?? tv?.available === true;
   const hasVolume = reachable && (boxVol || tvVol);
   const canToggleVolume = boxVol && tvVol;
-  const volumeTarget: VolumeTarget = settings.volumeTarget ?? 'box';
   const hasTvPower = reachable && tv?.tv_power === true;
   // RS-232-only capabilities (panel backend). Gated so CEC/soft boxes never
   // show these buttons — they keep the standard power/volume UI.
@@ -764,7 +770,7 @@ export function RemotePowerBar() {
 
               {hasVolume && (
                 <>
-                  {canToggleVolume && (
+                  {canToggleVolume && !hideTvVol && (
                     <View style={styles.segRow}>
                       <Pressable
                         onPress={() => void update({ volumeTarget: 'box' })}

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -72,6 +72,24 @@ export type Prefs = {
       check is conservative and does call a live host offline, so the row stays
       visible and tappable unless you ask for it gone. Agent >= 2.9.32. */
   hideOfflineStreamHosts: boolean;
+  /** Drop the Launch tab's "Stream from PC" section entirely.
+   *
+   *  Distinct from hideOfflineStreamHosts, which only filters rows: this hides
+   *  the whole card. Asked for by a user running SteamOS on their main PC with
+   *  Remote Play disabled -- every host listed was one they would never stream
+   *  from, and there was no way to make the section go away. The agent cannot
+   *  currently tell "Remote Play is off" from "no host is online", so this stays
+   *  a manual switch rather than an auto-hide; guessing wrong here removes a
+   *  working feature. */
+  hideStreamFromPc: boolean;
+  /** Drop the TV side of the Box/TV volume switch.
+   *
+   *  On a setup where the box's own volume already reaches the speakers -- CEC
+   *  forwarding, an AVR, a soundbar over ARC -- the TV target adjusts the TV's
+   *  internal speakers, which may be muted or unused. Reported by a user whose
+   *  TV outputs to a soundbar: "Box" was right and "TV" moved a volume nothing
+   *  was playing through. */
+  hideTvVolume: boolean;
   // ---- Touch indicators: making a screen recording of this app legible ----
   /** Draw a ring wherever a finger lands. iOS exposes NO public API for
       system-wide touch events -- no equivalent of Android's "Show taps", and no
@@ -106,6 +124,8 @@ export const DEFAULTS: Prefs = {
   // until the user opts in.
   volumeButtons: Platform.OS === 'android',
   hideOfflineStreamHosts: false,
+  hideStreamFromPc: false,
+  hideTvVolume: false,
   showTaps: false,
   traceDrags: false,
 };
@@ -190,6 +210,8 @@ function normalize(raw: unknown): Prefs {
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
     hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),
+    hideStreamFromPc: bool(o.hideStreamFromPc, DEFAULTS.hideStreamFromPc),
+    hideTvVolume: bool(o.hideTvVolume, DEFAULTS.hideTvVolume),
     showTaps: bool(o.showTaps, DEFAULTS.showTaps),
     traceDrags: bool(o.traceDrags, DEFAULTS.traceDrags),
   };


### PR DESCRIPTION
Two "I'd never use this, and there's no way to turn it off" reports from CompC. You'd already replied **"I'll gate that then"** to the first.

## Stream from PC

> "I have SteamOS on my main PC and have remote play disabled, so it showing the 'stream from PC' option just to stream games from my Steam Deck wouldn't make sense. Maybe I'm missing it, but I don't see an option to hide this section"

`hideOfflineStreamHosts` only filtered **rows**; this hides the **card**.

Deliberately a manual switch, not an auto-hide: the agent **cannot currently tell "Remote Play is off" from "no host is online"**, and guessing wrong would remove a working feature from someone who wanted it. If that detection ever becomes possible, auto-hide is the better answer.

## The Box/TV volume switch

> "setting this to 'Box' adjusts this correctly. But setting it to 'TV' actually adjusts my TV speaker's audio… my TV is set to output audio to the soundbar. So personally I'd want to turn off the TV tab here for volume"

## The part that isn't just a hidden control

Hiding the segment alone would have been a bug. Anyone whose stored `volumeTarget` was already `'tv'` would keep sending volume to the TV **with no control left on screen to change it**.

So the pref binds at the **send sites** too — the effective target collapses to `'box'` while it's on. The derived value is declared above the senders for that reason, and all three `api.tvSend` call sites read it instead of `settings.volumeTarget`.

## Verified

Both gates, **both states**, by flipping the pref and re-reading the rendered tree rather than trusting the toggle:

| gate | off | on |
|---|---|---|
| stream section | `STREAM FROM PC` present | absent — while `DOWNLOADING`/`QUEUED` still render, so the *section* went, not the tab |
| volume (sheet open) | `Box` **and** `TV` segments present | both absent |

All three `prefs.ts` edit sites wired for both keys, so the values actually persist. `npx tsc --noEmit` clean.

## Not verified

Not run on a device — both are conditional renders with no native surface.

Separately: the underlying **CEC volume addressing is still wrong** and this PR doesn't fix it. `_cec_argv` hardcodes `--to 0` (the TV) with a docstring claiming the TV forwards to an ARC audio system; CompC's soundbar disproves that. The correct fix addresses logical address 5 when a System Audio device is present, and needs an ARC setup to verify in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
