### PR TITLE
feat(app): drop the redundant game name from tiles that have cover art

### DIFF
--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -91,7 +91,6 @@ function LauncherTile({
   // Narrowed to a local so the <Image> branch sees a defined source (not the
   // `ImageSource | undefined` prop): shown only for Steam tiles that haven't errored.
   const art = imgFailed ? undefined : coverSource;
-  const showArt = art != null;
   const height = Math.round(width * 1.5); // 600x900 aspect
 
   return (
@@ -118,14 +117,11 @@ function LauncherTile({
         </View>
       )}
 
-      {/* Label overlay for art tiles keeps the name legible. */}
-      {showArt && (
-        <View style={styles.tileLabelOverlay}>
-          <Text style={styles.tileLabel} numberOfLines={1}>
-            {launcher.label}
-          </Text>
-        </View>
-      )}
+      {/* No label over art on purpose: the poster already says which game it is,
+          and a caption under every cover was reported as noise. The NO-ART path
+          keeps its label (see tileFallback above) — a tile showing only a
+          generic controller icon has nothing else to identify it, which is the
+          case that makes this conditional rather than a deletion. */}
 
       {download && isActiveDownload(download) && (
         <View style={styles.tilePill}>
@@ -922,16 +918,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     textAlign: 'center',
     fontFamily: mono,
   },
-  tileLabelOverlay: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: 'rgba(11,18,32,0.82)',
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-  },
-  tileLabel: { color: t.text, fontSize: 12, fontWeight: '700', fontFamily: mono },
   tileDelete: {
     position: 'absolute',
     top: 6,


### PR DESCRIPTION
> "The names for the games with posters are unnecessary as well, the poster already conveys what game it is."

## Conditional, not a deletion

The same screenshot carrying the complaint also showed **PRAGMATA rendering with no cover** — just a generic controller icon and its name. That tile has nothing else identifying it.

So only the label drawn **on top of a poster** goes. The no-art branch keeps its label:

| tile | renders |
|---|---|
| has cover art | `<Image>` alone |
| no cover art | `<Ionicons>` **+** `tileFallbackLabel` |

Also removes the now-dead `tileLabelOverlay` / `tileLabel` styles and the `showArt` local that existed only to gate the overlay.

## Verified

`npx tsc --noEmit` clean, and both branches read directly to confirm the fallback label survives.

**NOT rendered.** The mock agent serves zero launchers and gates creation behind `ALLOW_APP_LAUNCHERS`, so there is no tile in the harness to look at — adding one needs a real box. Flagging that rather than implying I saw the grid.

## The other half of that report is NOT fixed

> "There's also a bug where when you begin touching a poster, it gets outlined, and the outline never goes away."

I traced it but did **not** fix it, because I could not reproduce it and will not ship a guess into the touch path.

What I established:
- The only thing that outlines a tile is `tilePressed: { opacity: 0.75, borderColor: t.blue }` — so the press state is latching, not some separate focus ring. (Worth noting the same style also drops opacity to 0.75; if it were stuck you'd expect visible dimming too, which wasn't mentioned. On dark cover art that may simply not read.)
- `onLaunch` only fires a toast — no modal, so the obvious "a modal stole the press" explanation is out.
- The harness can't reproduce it: no tiles exist, and web presses are mouse events anyway.

**One suspicion worth testing on device:** `TapCapture` (#179) shipped in exactly the build CompC is testing — 2.9.17 / build 71. It's a new app-wide layer that participates in responder negotiation on every touch, and its capture handlers run even with both prefs off. A new touch-state-latching bug appearing in the same build as a new app-wide touch layer is a coincidence worth ruling out rather than assuming away. The discriminating test is whether the outline latches on a build without that layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
