### PR TITLE
chore(app): 2.9.18

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.17",
+    "version": "2.9.18",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,4 +1,7 @@
-New in 2.9.17
+New in 2.9.18
 
-• Touch animations. Preferences can now draw a ring wherever you tap, and a trail of dots while a finger moves, so a screen recording or a support screen-share shows what was actually pressed. Both are off by default.
-• Clearer wording on the unlock screen.
+• Pick which tab the app opens on, in Preferences.
+• The trackpad is now called Mouse, its buttons say LEFT / MID / RIGHT, and it always has an Esc key.
+• Hide the "Stream from PC" section, or the TV volume target, if you don't use them.
+• Cover art no longer repeats the game's name.
+• Fixed black-on-black text in the power menu, and drag trails that drew specks instead of a line.


### PR DESCRIPTION
Marketing version bump `2.9.17` → `2.9.18`, plus release notes.

`buildNumber` (71) and `versionCode` (53) deliberately untouched — `autoIncrement` derives 72 / 54 at build time.

## Why now

The tester who filed most of this week's feedback is on **2.9.9**, the public App Store build. Seven of his reports are already fixed on `main` and none of it is reachable to him. 2.9.17 (build 71) is still `WAITING_FOR_REVIEW`, and even that predates every fix below.

## Contents

- #184 drag-trail interpolation
- #185 power-sheet black-on-black text
- #187 landing-tab preference
- #189 Pad labels, always-present Esc, Game Mode / Desktop Mode wording
- #190 hide Stream from PC + the TV volume target
- #191 cover art no longer repeats the game name

Agent-side fixes (audio-device restore, disk mounts) already shipped separately as **agent 2.9.37**, published and signature-verified.

## Cut for TestFlight, not the App Store

2.9.17 stays in review untouched. This build goes to TestFlight only.

Changelog rewritten — it still held 2.9.17's text, which is the documented way that file ships wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)