### PR TITLE
chore(app): record build 72 as shipped (2.9.18)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "71",
+      "buildNumber": "72",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bookkeeping after the 2.9.18 TestFlight cut.

| | |
|---|---|
| iOS | build **72** — `VALID`, on the public-link group |
| Android | vc **53** unchanged — no Android build cut |
| Agent | **2.9.37** — published and signature-verified |

Number came from EAS `autoIncrement` and was **read back out of App Store Connect**, not taken from the build output.

TestFlight only: 2.9.17 stays in App Store review untouched. The tester who filed most of this week's feedback is on 2.9.9, so none of #184–#191 was reachable to him.

**Still pending, not blocking this PR:** build 72's Beta App Review submission returns `INVALID_QC_STATE`. Build state, export compliance and review contact all look valid, so it is most likely the build's age at Apple's end or the one-beta-review-at-a-time limit (build 71 is `WAITING_FOR_REVIEW`). The public link opens when 71 clears; 72 needs its own approval to supersede it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)