### PR TITLE
fix(app): drop the Steam sub-tab from Actions, it lives on Pad now

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -9,19 +9,15 @@ import {
   View,
 } from 'react-native';
 
-import { Ionicons } from '@expo/vector-icons';
-
 import { Gated } from '@/components/Gated';
-import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import { ActionInfo, ActionResult, api, Danger, hostKey, SteamMenus } from '@/lib/api';
+import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
 import {
   hapticError,
   hapticHeavy,
   hapticLight,
-  hapticSelection,
   hapticSuccess,
 } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
@@ -65,41 +61,6 @@ type RunRecord = {
   running: boolean;
 };
 
-type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
-
-/** Sub-tabs across the top of Actions, mirroring the Setup screen's strip. */
-type SubTab = 'actions' | 'steam';
-const SUB_TABS: { key: SubTab; label: string; icon: IoniconName }[] = [
-  { key: 'actions', label: 'Actions', icon: 'flash-outline' },
-  { key: 'steam', label: 'Steam', icon: 'settings-outline' },
-];
-
-function SubTabs({ tab, onTab }: { tab: SubTab; onTab: (t: SubTab) => void }) {
-  const pal = useTheme();
-  const styles = useThemedStyles(makeStyles);
-  return (
-    <View style={styles.subTabBar}>
-      {SUB_TABS.map((t) => {
-        const active = t.key === tab;
-        return (
-          <Pressable
-            key={t.key}
-            onPress={() => {
-              hapticSelection();
-              onTab(t.key);
-            }}
-            style={[styles.subTabItem, active && styles.subTabItemActive]}>
-            <Ionicons name={t.icon} size={15} color={active ? pal.text : pal.textFaint} />
-            <Text style={[styles.subTabLabel, active && styles.subTabLabelActive]}>
-              {t.label}
-            </Text>
-          </Pressable>
-        );
-      })}
-    </View>
-  );
-}
-
 export default function ActionsTab() {
   useLockOrientation('portrait');
   return (
@@ -133,27 +94,14 @@ function ActionsScreen() {
     hostKey(settings), // clear the previous box's actions on switch
   );
 
-  // Steam settings deep links (agent >= 2.9.31). Static list, so poll rarely —
-  // probe-and-appear leaves data null on an older agent and the section hides.
-  // Sub-tab, mirroring the Setup screen's category strip. The strip is only
-  // rendered when the box actually offers Steam menus — see hasSteamMenus.
-  // Steam is the default: the danger-grouped Actions are rare, deliberate
-  // operations, while the Steam shortcuts are the everyday reason to open this
-  // tab. Falls back to 'actions' automatically when the box offers no menus.
-  const [sub, setSub] = useState<SubTab>('steam');
-
-  const steamMenus = usePoll<SteamMenus | null>(
-    () => api.steamMenus(settings),
-    300000,
-    ready && configured,
-    hostKey(settings),
-  );
-
-  const hasSteamMenus = !!steamMenus.data?.menus?.length;
-  // If the Steam sub-tab disappears while it is selected (box swapped for one
-  // without Steam, agent downgraded), fall back rather than render a blank
-  // screen. Never trust `sub` alone.
-  const activeSub: SubTab = hasSteamMenus ? sub : 'actions';
+  // The Steam settings shortcuts used to live here as a sub-tab, and were even
+  // the DEFAULT one — so opening Actions landed on Steam rather than actions.
+  // They now have their own segment on the Pad tab, one swipe past Remote, which
+  // is where the everyday reason to reach them already is. Two routes to the
+  // same panel is the duplication this app has been getting feedback about, so
+  // this screen keeps only what it is named for. The panel itself is unchanged
+  // and still lives in components/SteamMenusPanel, driven by the Pad tab's own
+  // poll — nothing was deleted, only the second door.
 
   const execute = useCallback(
     async (action: ActionInfo) => {
@@ -231,12 +179,7 @@ function ActionsScreen() {
         {configured && !actions.data && actions.error == null && (
           <Text style={styles.dim}>loading…</Text>
         )}
-        {hasSteamMenus && <SubTabs tab={activeSub} onTab={setSub} />}
-        {activeSub === 'steam' ? (
-          <SteamMenusPanel menus={steamMenus.data!.menus} />
-        ) : null}
-        {activeSub === 'actions' &&
-          groups.map((g) => (
+        {groups.map((g) => (
           <View key={g.danger} style={styles.group}>
             <Text style={[styles.groupTitle, { color: DANGER_COLOR[g.danger] }]}>
               {GROUP_TITLE[g.danger]}
@@ -306,38 +249,6 @@ function ActionsScreen() {
 
 const makeStyles = (t: Palette) => StyleSheet.create({
   screen: { flex: 1, backgroundColor: t.bg, paddingHorizontal: 14 },
-  subTabBar: {
-    flexDirection: 'row',
-    gap: 4,
-    padding: 4,
-    borderRadius: 12,
-    backgroundColor: t.inset,
-    borderWidth: 1,
-    borderColor: t.cardBorder,
-    marginBottom: 14,
-  },
-  subTabItem: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 6,
-    paddingVertical: 9,
-    borderRadius: 9,
-  },
-  subTabItemActive: {
-    backgroundColor: t.card,
-    borderWidth: 1,
-    borderColor: t.cardBorder,
-  },
-  subTabLabel: {
-    color: t.textFaint,
-    fontSize: 12,
-    fontWeight: '700',
-    letterSpacing: 0.3,
-    fontFamily: mono,
-  },
-  subTabLabelActive: { color: t.text },
   title: { color: t.text, fontSize: 26, fontWeight: '700', marginBottom: 12, fontFamily: mono },
   list: { flex: 1 },
   group: { marginBottom: 16 },


### PR DESCRIPTION
> "now that steam shortcuts are a tab after remote. they dont need to also be a tab in the actions bottom tab"

The Steam settings shortcuts were reachable **two ways**: a segment on the Pad tab one swipe past Remote, and a sub-tab inside Actions. Two doors to the same panel is the duplication this app keeps getting feedback about.

Worse — **Steam was the default sub-tab**, so opening the tab named *Actions* landed on Steam rather than on any action.

## What changed

Only the second door. `components/SteamMenusPanel` is untouched and still renders on the Pad tab from its own poll.

Actions also loses its **redundant `/api/steam/menus` poll** — the same static list was being fetched twice per box.

Removed as newly dead: the `SubTab` type, `SUB_TABS` table, `SubTabs` component, five `subTab*` style keys, and the `Ionicons` / `IoniconName` / `hapticSelection` / `SteamMenus` / `SteamMenusPanel` imports that only it used.

## Verified

Both screens, in the harness:

| screen | result |
|---|---|
| Actions | ROUTINE / CHANGES WHAT'S ON SCREEN / ENDS YOUR SESSION, **no sub-tab strip**, no "Steam" label present |
| Pad | segments still read `PAD / SWIPE / MOUSE / REMOTE / STEAM` |

`npx tsc --noEmit` clean.

## Not verified

Not run on a device. This is a removal plus dead-code cleanup with no native surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
