### PR TITLE
diag(app): instrument the WS keepalive so the idle drop can be diagnosed

### DIFF
--- a/app/components/InputTracePanel.tsx
+++ b/app/components/InputTracePanel.tsx
@@ -17,9 +17,9 @@
 import React, { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
-import { clearInputTrace, getInputTrace, type InputTraceEntry } from '@/lib/gamepad';
+import { clearInputTrace, getInputTrace, getWsTrace, type InputTraceEntry } from '@/lib/gamepad';
 import { hapticSelection } from '@/lib/haptics';
-import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const DPAD = new Set(['du', 'dd', 'dl', 'dr']);
 
@@ -41,10 +41,12 @@ export function InputTracePanel() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const [rows, setRows] = useState<InputTraceEntry[] | null>(null);
+  const [ws, setWs] = useState<ReturnType<typeof getWsTrace> | null>(null);
 
   const refresh = useCallback(() => {
     hapticSelection();
     setRows(getInputTrace());
+    setWs(getWsTrace());
   }, []);
   const clear = useCallback(() => {
     hapticSelection();
@@ -75,6 +77,38 @@ export function InputTracePanel() {
           <Text style={styles.btnGhostText}>CLEAR</Text>
         </Pressable>
       </View>
+
+      {ws != null && (
+        <View style={styles.wsBox}>
+          <Text style={styles.wsTitle}>KEEPALIVE</Text>
+          {/* The agent reaps a socket after 12s of silence, so a ping that
+              never leaves this phone drops the connection while it sits idle.
+              These three counters say WHICH of the two causes it is, which
+              reading the code cannot settle. */}
+          <Text style={styles.wsLine}>
+            timer fires {ws.timerFires} · sent {ws.pingsSent} · not-open{' '}
+            {ws.pingsDroppedNotOpen} · threw {ws.pingsThrew}
+          </Text>
+          <Text style={styles.wsLine}>
+            teardowns {ws.watchdogTeardowns} · socket {ws.lastSocketState}
+          </Text>
+          <Text style={styles.wsLine}>
+            last ping {ws.pingAgeMs < 0 ? 'never' : `${Math.round(ws.pingAgeMs / 1000)}s ago`} ·
+            last inbound{' '}
+            {ws.inboundAgeMs < 0 ? 'never' : `${Math.round(ws.inboundAgeMs / 1000)}s ago`}
+          </Text>
+          {ws.lastError ? <Text style={styles.wsLine}>error: {ws.lastError}</Text> : null}
+          <Text style={styles.wsVerdict}>
+            {ws.timerFires === 0
+              ? 'Ping timer never ran — the keepalive was never started.'
+              : ws.pingsSent === 0
+                ? 'Timer runs but no ping ever left the socket.'
+                : ws.pingsDroppedNotOpen > 0 || ws.pingsThrew > 0
+                  ? 'Pings are being dropped — see not-open / threw above.'
+                  : 'Pings are leaving normally.'}
+          </Text>
+        </View>
+      )}
 
       {rows == null ? null : rows.length === 0 ? (
         <Text style={styles.empty}>No frames recorded yet.</Text>
@@ -123,6 +157,23 @@ const makeStyles = (t: Palette) =>
     btnGhost: { backgroundColor: t.inset, borderWidth: 1, borderColor: t.cardBorder },
     btnGhostText: { color: t.textDim, fontSize: 13, fontWeight: '700', letterSpacing: 0.5 },
     empty: { color: t.textFaint, fontSize: 12, fontStyle: 'italic' },
+    wsBox: {
+      marginTop: 10,
+      padding: 10,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      backgroundColor: t.bg,
+      gap: 3,
+    },
+    wsTitle: {
+      color: t.textDim,
+      fontSize: 10,
+      fontWeight: '800',
+      letterSpacing: 1,
+    },
+    wsLine: { color: t.text, fontSize: 11, fontFamily: mono },
+    wsVerdict: { color: t.amber, fontSize: 11, marginTop: 4 },
     verdict: { fontSize: 12, fontWeight: '700', lineHeight: 17 },
     log: {
       backgroundColor: t.inset,

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -156,6 +156,56 @@ function traceButton(k: string | undefined, v: number | undefined, how: string):
   if (inputTrace.length > TRACE_MAX) inputTrace.shift();
 }
 
+/**
+ * Keepalive instrumentation.
+ *
+ * The agent reaps any gamepad socket that receives NOTHING for 12s
+ * (GAMEPAD_IDLE_TIMEOUT_S), which is safe only if this client's 5s ping is
+ * actually arriving. Measured on a live box: sessions survived 22-25s while the
+ * user was touching the screen (input frames feed the same timer) and then died
+ * at exactly 12.1s once idle — while HTTP polling kept succeeding throughout. A
+ * synthetic client on the box pinging every 5s survived 40s, and the same client
+ * with pings disabled died at 12.1s. So the agent is fine and this side's ping
+ * is not landing.
+ *
+ * What that leaves is two candidates these counters separate, which reading the
+ * code cannot: the interval stops firing, or the send is swallowed. sendRaw has
+ * two silent-drop paths (socket not OPEN, and send() throwing) that were traced
+ * ONLY for button frames — a dropped ping went completely unrecorded.
+ *
+ * Module level, like inputTrace above: the client is recreated on reconnect, so
+ * instance state would be wiped by the very disconnect worth investigating.
+ */
+export const wsTrace = {
+  /** Interval callback entered. If this stops climbing, the timer died. */
+  timerFires: 0,
+  /** ws.send() returned without throwing. */
+  pingsSent: 0,
+  /** Socket was not OPEN at send time (silent drop #1). */
+  pingsDroppedNotOpen: 0,
+  /** send() threw (silent drop #2). */
+  pingsThrew: 0,
+  /** Watchdog decided the pipe was dead and tore down. */
+  watchdogTeardowns: 0,
+  lastPingAt: 0,
+  lastInboundAt: 0,
+  lastSocketState: 'none',
+  lastError: '' as string,
+};
+if (typeof globalThis !== 'undefined') {
+  (globalThis as Record<string, unknown>).__wsTrace = wsTrace;
+}
+
+/** Snapshot for the on-device panel — a device build has no JS console. */
+export function getWsTrace(): typeof wsTrace & { inboundAgeMs: number; pingAgeMs: number } {
+  const now = Date.now();
+  return {
+    ...wsTrace,
+    inboundAgeMs: wsTrace.lastInboundAt ? now - wsTrace.lastInboundAt : -1,
+    pingAgeMs: wsTrace.lastPingAt ? now - wsTrace.lastPingAt : -1,
+  };
+}
+
 /** Newest last. Copy, so callers can't mutate the buffer. */
 export function getInputTrace(): InputTraceEntry[] {
   return inputTrace.slice();
@@ -800,9 +850,14 @@ export class GamepadClient {
       // recovers in ~7s beats one frozen for ~13s. This is the Couch-Mode-switch
       // case: the mode change blips Wi-Fi, the socket half-dies mid-drag, and the
       // old 2.5-interval window left the pointer dead for 12s.
+      // Counted BEFORE any early return, so "the interval stopped firing" and
+      // "the interval fires but the send is swallowed" are distinguishable.
+      wsTrace.timerFires += 1;
+      wsTrace.lastInboundAt = this.lastInbound;
       const activelyDriving = Date.now() - this.lastInputAt < PING_INTERVAL_MS;
       const deadline = PING_INTERVAL_MS * (activelyDriving ? 1.4 : 2.5);
       if (Date.now() - this.lastInbound > deadline) {
+        wsTrace.watchdogTeardowns += 1;
         this.teardownSocket(false);
         if (this.active) {
           this.setStatus('error', null);
@@ -860,6 +915,12 @@ export class GamepadClient {
       // the agent's latched hat axis forever, with nothing anywhere recording
       // that it happened. Trace it.
       if (f.t === 'b') traceButton(f.k, f.v, 'drop:' + wsStateName(ws));
+      // A dropped PING was previously invisible here, and a ping that never
+      // leaves is exactly what the agent reaps the socket for.
+      if (f.t === 'ping') {
+        wsTrace.pingsDroppedNotOpen += 1;
+        wsTrace.lastSocketState = wsStateName(ws);
+      }
       return;
     }
     // Note real input (anything but our own keepalive ping) so the watchdog can
@@ -868,9 +929,18 @@ export class GamepadClient {
     try {
       ws.send(JSON.stringify(obj));
       if (f.t === 'b') traceButton(f.k, f.v, 'sent');
-    } catch {
+      if (f.t === 'ping') {
+        wsTrace.pingsSent += 1;
+        wsTrace.lastPingAt = Date.now();
+        wsTrace.lastSocketState = 'open';
+      }
+    } catch (e) {
       // SILENT DROP #2: socket died mid-send; onclose will handle it.
       if (f.t === 'b') traceButton(f.k, f.v, 'throw');
+      if (f.t === 'ping') {
+        wsTrace.pingsThrew += 1;
+        wsTrace.lastError = e instanceof Error ? e.message : String(e);
+      }
     }
   }
 


### PR DESCRIPTION
> "why is my couchside mobile app not staying connected? if i leave the device on my lap it disconnects"

## What was measured

On a live Bazzite box, gamepad sessions survived **22–25s** while the screen was being touched, then died at **exactly 12.1s** once idle — while HTTP `/api/ping` polls kept succeeding throughout:

| WS opened | reaped | lifetime |
|---|---|---|
| 22:19:38.34 | 22:19:50.43 | **12.1s** |
| 22:23:05.91 | 22:23:17.99 | **12.1s** |

12.1s is `GAMEPAD_IDLE_TIMEOUT_S`. The agent received **nothing** on that socket for twelve seconds and reaped it. HTTP still working rules out the network, the phone sleeping, and the app backgrounding.

## Isolated with a control

A synthetic WS client, run **on the box**, against the same agent, varying only the ping:

| client | result |
|---|---|
| **no pings** (control) | `closed_by_agent after 12.1s` |
| **ping every 5s** | `SURVIVED 40.9s, 13 frames` |

So the agent pongs correctly and a pinging client lives indefinitely. **The keepalive isn't leaving the phone.**

## Why instrument instead of guess

Reading the code can't distinguish the two remaining causes — the interval stops firing, or the send is swallowed. And `sendRaw` has **two silent drop paths** (socket not `OPEN`, and `send()` throwing) that were traced **only for button frames** (`f.t === 'b'`). A dropped ping was recorded nowhere. That blind spot is why this survived so long.

`timerFires` is incremented **before any early return**, so "never fired" and "fired but swallowed" can't be confused. Module-level like `inputTrace`, since `GamepadClient` is recreated on reconnect and instance state would be wiped by the very disconnect worth investigating.

Surfaced in the existing **InputTracePanel** rather than a console — a TestFlight build has nowhere to read a log, which is exactly why that panel exists. Capture prints the counters plus a plain-language verdict, so a screenshot is self-explaining.

## NOT verified — and it can't be here

`scripts/web-dev-proxy.py` **explicitly does not proxy `/ws/gamepad`** ("WebSocket upgrade needs real tunnelling"). No gamepad socket exists in the harness, so the counters stay zero. Stating that rather than implying I watched them climb. First real reading comes from a device.

## What IS verified

`__wsTrace` is exposed, `getWsTrace()` derives the ages, the panel renders, and **all four verdict branches** were driven with seeded values and produced distinct, correct diagnoses:

| seeded state | verdict |
|---|---|
| `timerFires: 0` | "Ping timer never ran — the keepalive was never started." |
| timer runs, `pingsSent: 0` | "Timer runs but no ping ever left the socket." |
| `pingsThrew: 2` | "Pings are being dropped — see not-open / threw above." |
| all healthy | "Pings are leaving normally." |

A verdict line that always said the same thing would be worse than none.

## Scope

**This is diagnosis, not a fix — it changes no behaviour.** I'd rather ship the measurement than pick one of two theories and "fix" the wrong one. Note the 12s reap was deliberately tightened *from 60s* on the assumption that "a healthy client never false-reaps"; that assumption is what's failing, and loosening it again would hide the bug rather than fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
