### PR TITLE
fix(app): start the WS keepalive on socket open, not on a server message

### DIFF
--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -702,6 +702,25 @@ export class GamepadClient {
     ws.onopen = () => {
       if (ws !== this.ws) return;
       this.clearConnectWatchdog();
+      // Start the keepalive HERE, on the socket opening, not on a server
+      // message.
+      //
+      // It used to start only from onmessage, on 'hello' or 'waiting'. That is
+      // one message away from never starting at all: onmessage returns early
+      // when `ws !== this.ws`, so a reconnect that replaces the socket while
+      // the previous one's callbacks are still pending can swallow the very
+      // frame the timer depended on. The socket then sits open and silent, the
+      // agent reaps it after GAMEPAD_IDLE_TIMEOUT_S (12s), the client
+      // reconnects, and it can happen again — which is exactly the measured
+      // behaviour: sessions dying at 12.1s while idle, but living 22-25s while
+      // input frames were flowing and feeding the same timer.
+      //
+      // Pinging before 'hello' is safe by construction: the agent answers ping
+      // BEFORE its holder gate (couchsided.py, `if t == "ping"` precedes
+      // `if not entry.get("held")`), so a waiter or a not-yet-promoted session
+      // is ponged just the same. startPing() is idempotent — it stops any
+      // existing timer first — so the later hello/waiting calls are harmless.
+      this.startPing();
     };
 
     ws.onmessage = (ev: WebSocketMessageEvent) => {
@@ -865,7 +884,19 @@ export class GamepadClient {
         }
         return;
       }
+      // A ping that does not leave means this socket is already dead, whatever
+      // readyState claims. Reconnect NOW rather than sitting through the
+      // watchdog deadline: the agent reaps at 12s, so waiting out 12.5s of
+      // silence guarantees the drop we are trying to avoid.
+      const before = wsTrace.pingsSent;
       this.sendRaw({ t: 'ping' });
+      if (wsTrace.pingsSent === before) {
+        this.teardownSocket(false);
+        if (this.active) {
+          this.setStatus('error', null);
+          this.scheduleReconnect();
+        }
+      }
     }, PING_INTERVAL_MS);
   }
 


### PR DESCRIPTION
> "if i leave the device on my lap it disconnects"

## Root cause

`startPing()` was only reachable from `onmessage`, on `hello` or `waiting`. That handler returns early when `ws !== this.ws` — so a reconnect that replaces the socket while the previous one's callbacks are still pending can swallow the very frame the timer depends on. **`ws.onopen` never started it.**

The socket then sits open and silent, the agent reaps it after `GAMEPAD_IDLE_TIMEOUT_S` (12s), the client reconnects — and it can happen again.

That matches the measurements exactly: sessions died at **12.1s** while idle, but lived **22–25s** while the screen was being touched, because input frames were feeding the same timer the ping should have been feeding. HTTP polling succeeded throughout, ruling out the network, the phone sleeping, and backgrounding.

## The fix

**Ping starts on `ws.onopen`.** Safe by construction — the agent answers ping *before* its holder gate (`if t == "ping"` precedes `if not entry.get("held")`), so a waiter or a not-yet-promoted session gets ponged just the same. `startPing()` stops any existing timer first, so the later `hello`/`waiting` calls stay harmless.

**A ping that doesn't leave now forces an immediate reconnect.** `sendRaw` drops silently when the socket isn't `OPEN` or `send()` throws; waiting out the 12.5s watchdog after that *guarantees* the drop, since the agent reaps at 12s.

## Verified — both states

Driven against the app's **real client** with a stubbed `WebSocket` that opens and then stays silent (i.e. `hello` never arrives):

| build | timerFires | pingsSent | frames on wire |
|---|---|---|---|
| **main (control)** | 0 | 0 | **0** |
| **with fix** | 4 | 3 | **3 × `{"t":"ping"}`** |

The control reproduces the bug; the fix resolves it. That's the whole claim, measured rather than argued.

## Not verified

**Not on a device.** `web-dev-proxy.py` doesn't tunnel `/ws/gamepad`, so this was proven against a stub, not a live agent. The keepalive counters from #196 are in **Setup › Prefs › PAD INPUT TRACE** to confirm on the phone — after this ships, that panel should read *"Pings are leaving normally."*

I did **not** touch the 12s reap. It was deliberately tightened from 60s, and loosening it would hide this rather than fix it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
