### PR TITLE
feat(agent): read-only probe for USB wake sources (/api/usb-wake)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,18 @@ jobs:
       - name: Unit tests (disk mounts)
         run: python3 tests/test_disk_mounts.py
 
+      # USB wake sources (/api/usb-wake), read-only. Two field reports are
+      # encoded here: arming only the ROOT HUBS misses controllers (their signal
+      # arrives through a dongle further down the tree), and arming EVERY device
+      # with a writable wakeup file causes spurious wakes (a controller powering
+      # itself off is a disconnect, which the kernel counts as a wake — one
+      # reporter's machine woke 15 minutes after he slept it). Fixtures are
+      # verbatim off a live Bazzite box, Xbox dongle included, and one test
+      # exists purely to keep the `transient` heuristic's known counterexample
+      # visible rather than rediscovered by a user.
+      - name: Unit tests (usb wake)
+        run: python3 tests/test_usb_wake.py
+
       # The desktop switch must honour the box's CONFIGURED session. SteamOS
       # ships both, and steamos-session-select maps the bare "plasma" arg to the
       # X11 one -- so passing it silently downgraded a Wayland-configured box to

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1010,6 +1010,91 @@ def read_mem():
 _DISK_MOUNTS = ("/", "/home", "/var")
 
 
+# Sysfs root for USB wake, as a module constant so tests can point it at
+# fixtures (same pattern as _DRM_DIR / _PROC_INPUT_DEVICES).
+_USB_DEVICES_DIR = "/sys/bus/usb/devices"
+# A USB *interface* node is "<device>:<config>.<iface>" (e.g. 1-2:1.0). Only
+# DEVICES own power/wakeup; interfaces never do. Measured on a live Bazzite box:
+# every ":" node had no wakeup file at all, so listing them is pure noise.
+_USB_IFACE_RE = re.compile(r":")
+_USB_ROOT_HUB_RE = re.compile(r"^usb\d+$")
+
+
+def _usb_read(path):
+    """First line of a sysfs file, or None. Never raises."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            return f.readline().strip()
+    except OSError:
+        return None
+
+
+def usb_wake_devices():
+    """Every USB device that can be a wake source, and whether it is armed.
+
+    READ-ONLY. Arming needs root and is deliberately not done here — this exists
+    so the app can show what a box could wake from BEFORE anyone changes system
+    state, and so a user can see why their controller does not wake it.
+
+    Why per-device rather than the root hubs everyone starts with: a field report
+    on a DIY SteamOS box had keyboard and mouse waking the machine while
+    controllers did not, because only the root hubs were armed and a controller's
+    signal arrives through a dongle further down the tree.
+
+    `transient` is the load-bearing field. The same reporter then armed every
+    device with a writable wakeup file and hit the opposite problem: a controller
+    powering itself off after 15 minutes is a DISCONNECT, the kernel counts that
+    as a bus state change, and the machine woke straight back up. Arming a device
+    that goes away is how you get spurious wakes; arming the dongle it hangs off
+    does not have that failure mode, because the dongle never leaves. Hubs and
+    root hubs stay put, so they are marked persistent.
+
+    Never raises: returns [] when the sysfs root is unreadable, and omits any
+    device whose attributes cannot be read rather than guessing at them."""
+    out = []
+    try:
+        names = sorted(os.listdir(_USB_DEVICES_DIR))
+    except OSError:
+        return []
+    for name in names:
+        if _USB_IFACE_RE.search(name):
+            continue  # interface node: never owns power/wakeup
+        base = os.path.join(_USB_DEVICES_DIR, name)
+        wake_path = os.path.join(base, "power", "wakeup")
+        state = _usb_read(wake_path)
+        if state not in ("enabled", "disabled"):
+            # No wakeup file (or an unreadable one) means this device cannot be a
+            # wake source. Omitting it beats reporting a control that does
+            # nothing — a dead button costs more trust than a missing one.
+            continue
+        cls = _usb_read(os.path.join(base, "bDeviceClass")) or ""
+        is_root = bool(_USB_ROOT_HUB_RE.match(name))
+        is_hub = cls == "09" or is_root
+        out.append({
+            "id": name,
+            "vendor": _usb_read(os.path.join(base, "idVendor")) or "",
+            "product_id": _usb_read(os.path.join(base, "idProduct")) or "",
+            "name": (_usb_read(os.path.join(base, "product"))
+                     or _usb_read(os.path.join(base, "manufacturer")) or ""),
+            "wake": state,
+            "armed": state == "enabled",
+            "root_hub": is_root,
+            "hub": is_hub,
+            # HEURISTIC, and a deliberately weak one: "not a hub". A hub is
+            # certainly persistent; a leaf device only MIGHT power itself off.
+            # Measured counterexample on a live box: the Xbox wireless dongle
+            # (045e:02e6) is a leaf and reports transient, yet it never leaves —
+            # it is exactly the device you would want armed. Sysfs exposes
+            # nothing that distinguishes "dongle that stays" from "controller
+            # that sleeps", so this is a hint for the UI to phrase a warning
+            # around, NOT a fact to gate on. Do not make arming decisions from
+            # it without asking the user.
+            "transient": not is_hub,
+            "writable": os.access(wake_path, os.W_OK),
+        })
+    return out
+
+
 def read_disks():
     disks = []
     seen_devices = set()
@@ -10554,6 +10639,27 @@ class Handler(BaseHTTPRequestHandler):
                 # TVs" picker instead of a manual IP. Always 200 (possibly an
                 # empty list) — it is an action, not a probe-and-appear cap.
                 self._send(200, {"tvs": tv_discover(self.mock)}, started)
+            elif path == "/api/usb-wake":
+                # READ-ONLY inventory of possible wake sources. Probe-and-appear:
+                # 404 when the box exposes none (no sysfs, or nothing armable),
+                # so a box that cannot do this shows no control at all.
+                #
+                # Arming is NOT done here and never will be from this route: it
+                # writes /sys/.../power/wakeup, which needs root. That stays a
+                # deliberate, documented, opt-in step.
+                devs = ([{"id": "1-2", "vendor": "28de", "product_id": "1304",
+                          "name": "Steam Controller Puck", "wake": "disabled",
+                          "armed": False, "root_hub": False, "hub": False,
+                          "transient": True, "writable": True},
+                         {"id": "usb1", "vendor": "1d6b", "product_id": "0002",
+                          "name": "xHCI Host Controller", "wake": "disabled",
+                          "armed": False, "root_hub": True, "hub": True,
+                          "transient": False, "writable": True}]
+                        if self.mock else usb_wake_devices())
+                if not devs:
+                    self._send(404, {"error": "not found"}, started)
+                else:
+                    self._send(200, {"devices": devs}, started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app

--- a/tests/test_usb_wake.py
+++ b/tests/test_usb_wake.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Tests for the USB wake-source probe (/api/usb-wake).
+
+Run: python3 tests/test_usb_wake.py
+
+Two field reports shaped this, and both are encoded here as tests.
+
+(1) Arming only the ROOT HUBS is not enough. A DIY SteamOS box had keyboard and
+    mouse waking the machine while controllers did not, because a controller's
+    signal arrives through a dongle further down the tree. So the probe must
+    report leaf devices, not just usbN.
+
+(2) Arming EVERY device with a writable wakeup file causes spurious wakes. The
+    same reporter did that and found his controller powering itself off after 15
+    minutes woke the machine straight back up — a disconnect is a bus state
+    change, and the kernel counts it as a wake. Hence `transient`: a device that
+    can go away is the dangerous one to arm; a hub that stays put is not.
+
+The fixture below is copied VERBATIM off a live Bazzite box (2026-07-21),
+including its Steam Controller Puck, its two USB 2.0 hubs, the USB LAN adapter
+that is already armed for Wake-on-LAN, and a device with no wakeup file at all.
+The interface nodes are real too — every "1-2:1.0"-style node had no power/wakeup
+on that hardware, which is exactly why they must be skipped.
+"""
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# name -> (wakeup|None, idVendor, idProduct, product, bDeviceClass)
+# VERBATIM off a live Bazzite box, 2026-07-21.
+FIXTURE = {
+    "1-0:1.0":   (None, None, None, None, None),          # interface: no wakeup
+    "1-10":      ("disabled", "8087", "0029", None, "e0"),  # Intel BT
+    "1-10:1.0":  (None, None, None, None, None),
+    "1-2":       ("disabled", "28de", "1304", "Steam Controller Puck", "ef"),
+    "1-2:1.0":   (None, None, None, None, None),
+    "1-2:1.4":   (None, None, None, None, None),
+    "1-5":       ("disabled", "1a40", "0101", "USB 2.0 Hub", "09"),
+    "1-5:1.0":   (None, None, None, None, None),
+    # Xbox wireless dongle, captured with it plugged in. Already armed on that
+    # box, and the counterexample to the `transient` heuristic — see
+    # test_transient_is_a_heuristic_not_a_fact.
+    "1-5.1":     ("enabled", "045e", "02e6", "XBOX ACC", "00"),
+    "1-6":       ("enabled", "0bda", "8152", "USB 10/100 LAN", "00"),   # WoL
+    "1-6:1.0":   (None, None, None, None, None),
+    "1-7":       ("disabled", "1a40", "0101", "USB 2.0 Hub", "09"),
+    "1-7.2":     (None, "2757", "0100", "Hitevision Board", "00"),  # NO wakeup
+    "2-0:1.0":   (None, None, None, None, None),
+    "usb1":      ("disabled", "1d6b", "0002", "xHCI Host Controller", "09"),
+    "usb2":      ("disabled", "1d6b", "0003", "xHCI Host Controller", "09"),
+}
+
+
+def build_tree(spec, readonly_wakeup=()):
+    """Materialise a fake /sys/bus/usb/devices. Returns the temp root."""
+    root = tempfile.mkdtemp(prefix="usbwake-")
+    for name, (wake, vid, pid, prod, cls) in spec.items():
+        d = os.path.join(root, name)
+        os.makedirs(os.path.join(d, "power"), exist_ok=True)
+        if wake is not None:
+            p = os.path.join(d, "power", "wakeup")
+            with open(p, "w") as f:
+                f.write(wake + "\n")
+            if name in readonly_wakeup:
+                os.chmod(p, 0o444)
+        for attr, val in (("idVendor", vid), ("idProduct", pid),
+                          ("product", prod), ("bDeviceClass", cls)):
+            if val is not None:
+                with open(os.path.join(d, attr), "w") as f:
+                    f.write(val + "\n")
+    return root
+
+
+def run(spec, readonly_wakeup=()):
+    root = build_tree(spec, readonly_wakeup)
+    old = cs._USB_DEVICES_DIR
+    cs._USB_DEVICES_DIR = root
+    try:
+        return cs.usb_wake_devices()
+    finally:
+        cs._USB_DEVICES_DIR = old
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def test_interfaces_are_skipped():
+    """":"-nodes never own power/wakeup; listing them is pure noise."""
+    print("test_interfaces_are_skipped")
+    ids = [d["id"] for d in run(FIXTURE)]
+    check("no interface nodes reported", [i for i in ids if ":" in i], [])
+
+
+def test_device_without_wakeup_omitted():
+    """A control that cannot do anything is worse than no control."""
+    print("test_device_without_wakeup_omitted")
+    ids = [d["id"] for d in run(FIXTURE)]
+    check("1-7.2 (no wakeup file) omitted", "1-7.2" in ids, False)
+    check("1-2 (has wakeup) reported", "1-2" in ids, True)
+
+
+def test_real_box_inventory():
+    """The whole fixture, as the app would see it."""
+    print("test_real_box_inventory")
+    got = {d["id"]: d for d in run(FIXTURE)}
+    check("exactly the wake-capable devices",
+          sorted(got), ["1-10", "1-2", "1-5", "1-5.1", "1-6", "1-7",
+                        "usb1", "usb2"])
+    check("puck named", got["1-2"]["name"], "Steam Controller Puck")
+    check("puck vendor:product", (got["1-2"]["vendor"], got["1-2"]["product_id"]),
+          ("28de", "1304"))
+    check("USB LAN already armed (Wake-on-LAN)", got["1-6"]["armed"], True)
+    check("puck not armed", got["1-2"]["armed"], False)
+
+
+def test_transient_vs_persistent():
+    """The field-report distinction: what is safe to arm.
+
+    A hub stays plugged in. A controller dongle's CHILD can power itself off,
+    and that disconnect is what woke the reporter's machine 15 minutes after he
+    put it to sleep."""
+    print("test_transient_vs_persistent")
+    got = {d["id"]: d for d in run(FIXTURE)}
+    check("root hub is persistent", got["usb1"]["transient"], False)
+    check("root hub flagged as root", got["usb1"]["root_hub"], True)
+    check("class-09 hub is persistent", got["1-5"]["transient"], False)
+    check("hub not flagged as root", got["1-5"]["root_hub"], False)
+    check("puck is transient", got["1-2"]["transient"], True)
+    check("BT radio is transient", got["1-10"]["transient"], True)
+
+
+def test_transient_is_a_heuristic_not_a_fact():
+    """The Xbox dongle is the counterexample, and it is REAL hardware.
+
+    `transient` means only "not a hub". The Xbox wireless adapter (045e:02e6)
+    is a leaf device, so it reports transient — yet it never unplugs itself and
+    is exactly the device you would want armed. Sysfs exposes nothing that
+    separates "dongle that stays" from "controller that sleeps", so this field
+    is a hint to phrase a warning around, never something to gate arming on.
+
+    Asserted so the limitation stays visible instead of being rediscovered by a
+    user whose machine will not stay asleep."""
+    print("test_transient_is_a_heuristic_not_a_fact")
+    got = {d["id"]: d for d in run(FIXTURE)}
+    check("xbox dongle present", got["1-5.1"]["name"], "XBOX ACC")
+    check("and reports transient despite never leaving",
+          got["1-5.1"]["transient"], True)
+    check("it was already armed on the real box", got["1-5.1"]["armed"], True)
+
+
+def test_writable_is_reported():
+    """Arming needs root. The probe says whether it is even possible."""
+    print("test_writable_is_reported")
+    got = {d["id"]: d for d in run(FIXTURE, readonly_wakeup=("1-2",))}
+    check("read-only wakeup reported not writable", got["1-2"]["writable"], False)
+    check("writable one still writable", got["1-5"]["writable"], True)
+
+
+def test_missing_sysfs_degrades_closed():
+    """No /sys (macOS, a container, a locked-down box) must not raise."""
+    print("test_missing_sysfs_degrades_closed")
+    old = cs._USB_DEVICES_DIR
+    cs._USB_DEVICES_DIR = "/nonexistent/usb/devices"
+    try:
+        check("returns empty list, never raises", cs.usb_wake_devices(), [])
+    finally:
+        cs._USB_DEVICES_DIR = old
+
+
+def test_unreadable_wakeup_value_omitted():
+    """Garbage in the wakeup file is not a wake source."""
+    print("test_unreadable_wakeup_value_omitted")
+    spec = dict(FIXTURE)
+    spec["1-2"] = ("something-else", "28de", "1304", "Steam Controller Puck", "ef")
+    ids = [d["id"] for d in run(spec)]
+    check("unknown wakeup value omitted", "1-2" in ids, False)
+
+
+if __name__ == "__main__":
+    for fn in (test_interfaces_are_skipped,
+               test_device_without_wakeup_omitted,
+               test_real_box_inventory,
+               test_transient_vs_persistent,
+               test_transient_is_a_heuristic_not_a_fact,
+               test_writable_is_reported,
+               test_missing_sysfs_degrades_closed,
+               test_unreadable_wakeup_value_omitted):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Groundwork for waking a box with a controller. **Read-only on purpose** — arming writes `/sys/.../power/wakeup`, which needs root, and that stays a deliberate opt-in step. This reports what a box *could* wake from and what's already armed.

## Two field reports, encoded as tests

**Root hubs alone aren't enough.** likwidtech's DIY SteamOS box had keyboard and mouse waking it while controllers didn't — the upstream script only armed `usb*`, and a controller's signal arrives through a dongle further down the tree.

**Arming everything is worse.** He then armed every device with a writable wakeup file and hit the opposite failure:

> "I will use the controller to manually put the machine to sleep. Then 15 mins later the controller goes to sleep but wakes up the machine."

A disconnect is a bus state change, and the kernel counts it as a wake. That's not a bug in his edit — it's inherent, and it's the trap I'd have shipped had I implemented from the docs and declared victory the first time a button press woke it.

## Honest limitation, asserted in its own test

Running the probe on **real hardware immediately produced a counterexample to my own heuristic**:

```
1-5.1  dev  armed=True  transient=True  045e:02e6  XBOX ACC
```

`transient` means only *"not a hub"*. The Xbox dongle is a leaf device, so it reports transient — yet it never leaves, and it's exactly what you'd want armed. Sysfs exposes nothing separating "dongle that stays" from "controller that sleeps".

So it's a hint for the UI to phrase a warning around, **never something to gate arming on**, and `test_transient_is_a_heuristic_not_a_fact` exists purely so that stays visible rather than being rediscovered by someone whose machine won't stay asleep.

## Details

- **Interface nodes skipped** (`1-2:1.0`) — measured on hardware, none own `power/wakeup`.
- **Missing/unrecognised wakeup value → omitted**, not shown as an inert control.
- `_USB_DEVICES_DIR` is a module constant so tests repoint it at fixtures, matching `_DRM_DIR` / `_PROC_INPUT_DEVICES`.
- **Degrades closed:** no `/sys`, unreadable root, or nothing armable → `[]` and a 404, so an incapable box shows no control.

## Verified on live hardware, not just fixtures

The probe enumerated the Steam Controller Puck, both USB 2.0 hubs, the already-armed USB LAN adapter (that's your Wake-on-LAN), both root hubs, and the Xbox dongle — and correctly reported `writable=False` throughout, because it ran as the user, not root. Fixtures are verbatim from that box.

No capability key yet — nothing in the app consumes this, and the five edit sites belong with the UI that uses them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
