### PR TITLE
feat(app): swipe out of Steam, quieter Actions, simpler Couch Mode

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -191,11 +191,21 @@ function ActionsScreen() {
                 style={({ pressed }) => [styles.card, pressed && styles.pressed]}>
                 <View style={styles.cardHead}>
                   <Text style={styles.cardLabel}>{a.label}</Text>
-                  <View style={[styles.badge, { backgroundColor: DANGER_COLOR[a.danger] }]}>
-                    <Text style={styles.badgeText}>{BADGE_TEXT[a.danger]}</Text>
-                  </View>
+                  {/* Only the destructive one keeps a badge. "routine" under a
+                      ROUTINE header and "interrupts" under CHANGES WHAT'S ON
+                      SCREEN said the same thing twice on every single row —
+                      that repetition was the reported noise. Ending your
+                      session is worth repeating; the other two are not. */}
+                  {a.danger === 'high' && (
+                    <View style={[styles.badge, { backgroundColor: DANGER_COLOR[a.danger] }]}>
+                      <Text style={styles.badgeText}>{BADGE_TEXT[a.danger]}</Text>
+                    </View>
+                  )}
                 </View>
-                <Text style={styles.cardDesc}>{a.description}</Text>
+                {/* The description is NOT lost — confirm() already shows it in
+                    full before anything runs, which is where the detail belongs.
+                    On the row it mostly restated the label ("Switch to Desktop"
+                    / "Leave Game Mode for the SteamOS desktop"). */}
               </Pressable>
             ))}
             </View>
@@ -269,7 +279,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingVertical: 3,
   },
   badgeText: { color: '#0b1220', fontSize: 11, fontWeight: '800' },
-  cardDesc: { color: t.textDim, fontSize: 13, lineHeight: 18 },
   pressed: { opacity: 0.7 },
   emptyCard: {
     backgroundColor: t.card,

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1185,12 +1185,20 @@ function PadScreen() {
         // chips across five sections -- taller than the pane on a phone. The
         // Actions tab gets scrolling from its own ScrollView; Pad has none, so
         // without this the bottom sections are unreachable.
-        <ScrollView
-          style={styles.menusScroll}
-          contentContainerStyle={styles.menusContent}
-          showsVerticalScrollIndicator={false}>
-          <SteamMenusPanel menus={steamMenus} />
-        </ScrollView>
+        <>
+          <ScrollView
+            style={styles.menusScroll}
+            contentContainerStyle={styles.menusContent}
+            showsVerticalScrollIndicator={false}>
+            <SteamMenusPanel menus={steamMenus} />
+          </ScrollView>
+          {/* The mode-switch swipe lives on this bar, so a segment that omits it
+              is a segment you cannot swipe out of — Steam was the only one, and
+              it stranded people until they found the tab row. It sits BELOW the
+              ScrollView, so vertical scrolling of the menus and the bar's
+              horizontal swipe never contend. */}
+          {keyboardBar}
+        </>
       ) : mode === 'remote' ? (
         <>
           <RemoteView client={client} settings={settings} />

--- a/app/components/CouchModeSheet.tsx
+++ b/app/components/CouchModeSheet.tsx
@@ -274,14 +274,38 @@ function CeremonyView({
     (s) => s.state === 'failed' && !s.fatal);
   const fatalStage = job.stages.find((s) => s.state === 'failed' && s.fatal);
 
+  // Show the per-stage breakdown ONLY when something went wrong.
+  //
+  // Reported as too much information for what is, when it works, a mode switch:
+  // five rows of internals for "put this on the TV". So the happy path is now a
+  // spinner, then a checkmark.
+  //
+  // The staged VERIFICATION underneath is untouched, and the rows come straight
+  // back the moment a stage fails or soft-fails. That is not a compromise, it is
+  // the point: this ceremony exists because "Ready" once meant "a subprocess
+  // exited 0" and cheerfully reported success onto a black TV. Hiding detail
+  // that nobody needs is fine; hiding it when the thing actually broke would
+  // rebuild the original bug in the UI layer.
+  const showStages = failed || softFail;
+
   return (
     <>
-      <View style={styles.stageList}>
-        {job.stages.map((s) => <StageRow key={s.key} stage={s} t={t} styles={styles} />)}
-      </View>
+      {showStages && (
+        <View style={styles.stageList}>
+          {job.stages.map((s) => <StageRow key={s.key} stage={s} t={t} styles={styles} />)}
+        </View>
+      )}
 
       {running && (
-        <Text style={styles.summaryRunning}>Flinging to the TV…</Text>
+        <View style={styles.simpleState}>
+          <ActivityIndicator size="large" color={t.blue} />
+          <Text style={styles.summaryRunning}>Flinging to the TV…</Text>
+        </View>
+      )}
+      {job.state === 'done' && !softFail && (
+        <View style={styles.simpleState}>
+          <Ionicons name="checkmark-circle" size={44} color={t.green} />
+        </View>
       )}
       {job.state === 'done' && !softFail && (
         <Text style={[styles.summary, { color: t.green }]}>On the TV.</Text>
@@ -386,6 +410,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   stageReason: { color: t.textDim, fontSize: 12, marginTop: 2, lineHeight: 16 },
   summary: { fontSize: 14, fontWeight: '600', marginTop: 10 },
   summaryRunning: { color: t.textDim, fontSize: 14, marginTop: 10 },
+  simpleState: { alignItems: 'center', justifyContent: 'center', paddingVertical: 18, gap: 10 },
   ceremonyBtns: { flexDirection: 'row', gap: 10, marginTop: 6 },
   ceremonyBtn: { flex: 1, marginTop: 8 },
   ceremonyBtnSecondary: { backgroundColor: t.inset },


### PR DESCRIPTION
Three pieces of the same feedback: the app says too much, and traps you in one place.

## 1. Steam segment couldn't be swiped out of

The mode-switch swipe lives on the KEYBOARD bar, and the `steam` branch was **the only one of five** that didn't render it. So the gesture that moves between every other mode did nothing there — you had to find the tab row.

It now renders the same bar, **below** the menus ScrollView, so vertical scrolling and the bar's horizontal swipe never contend.

## 2. Actions said everything twice

Every row carried a badge repeating its own group header — `routine` under **ROUTINE**, `interrupts` under **CHANGES WHAT'S ON SCREEN** — plus a description that mostly restated the label (*"Switch to Desktop"* / *"Leave Game Mode for the SteamOS desktop"*).

Both gone from the row. Two deliberate exceptions:

- **`ends session` stays.** Repetition is noise on a routine action and a safeguard on a destructive one.
- **The description isn't lost** — `confirm()` already showed it in full before anything runs, which is where detail belongs. That was CompC's own suggestion.

## 3. Couch Mode showed five stage rows for a mode switch

Happy path is now a spinner, then a checkmark.

**The staged verification underneath is untouched**, and the rows come straight back on any failure or soft-failure. That's the point, not a compromise: this ceremony exists because "Ready" once meant *"a subprocess exited 0"* and reported success onto a black TV. Hiding detail nobody needs is fine; hiding it when the thing actually broke would rebuild the original bug in the UI layer.

## Verified

Actions, in the harness: three groups render with **no badges** on routine/interrupts rows, **no descriptions**, and `ends session` still on all three destructive rows. `npx tsc --noEmit` clean.

## NOT verified in the harness

The Steam swipe and the ceremony view, and both for structural reasons rather than oversight:

- The **Steam segment only renders in Game Mode**, which the mock never reports (I gated it there deliberately in #189).
- The **ceremony** needs a live staged job.

Confirmed at the code level instead: all five mode branches now render `{keyboardBar}`, and the stage list is gated on `failed || softFail`. Both want a look on the next device build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
