### PR TITLE
feat: raise the phone keyboard when the box raises its own (agent 2.9.38)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,17 @@ jobs:
       - name: Unit tests (usb wake)
         run: python3 tests/test_usb_wake.py
 
+      # On-screen-keyboard detection: when Steam raises its keyboard on the TV,
+      # the phone raises its own. There is no general text-field-focus signal on
+      # this platform, so the agent reads Steam's own UI log -- the same trick
+      # stream_host_online() uses. Measured on a live Bazzite box: each open
+      # emits exactly TWO lines (hence dedupe), and the NEGATIVE CONTROL matters
+      # most -- navigating the library/tabs/store produced zero markers, which is
+      # what makes the signal keyboard-specific rather than focus-in-general.
+      # The marker is undocumented, so every path degrades closed.
+      - name: Unit tests (osk watch)
+        run: python3 tests/test_osk_watch.py
+
       # The desktop switch must honour the box's CONFIGURED session. SteamOS
       # ships both, and steamos-session-select maps the bare "plasma" arg to the
       # X11 one -- so passing it silently downgraded a Wayland-configured box to

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.37"
+VERSION = "2.9.38"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1093,6 +1093,113 @@ def usb_wake_devices():
             "writable": os.access(wake_path, os.W_OK),
         })
     return out
+
+
+# ---------------------------------------------------------------------------
+# On-screen-keyboard detection
+#
+# When Steam raises its own keyboard on the TV, the phone should raise ITS
+# keyboard too, so you can type (or paste) instead of thumb-picking letters on
+# a grid with a d-pad.
+#
+# There is no general way to learn that a text field took focus on the box:
+# Wayland exposes no such thing, and gamescope has no client API for it. But
+# "Steam's on-screen keyboard opened" is a different and much narrower question,
+# and Steam writes it in plain text to its own UI log. Reading a Steam log for a
+# signal is established practice here — stream_host_online() already parses
+# Steam's remote-connection log the same way.
+#
+# MEASURED on a live Bazzite box in Game Mode, 2026-07-21:
+#   - Opening the keyboard emits exactly TWO identical lines, every time, across
+#     ten observed events. Hence the dedupe window below.
+#   - NEGATIVE CONTROL: navigating the library, opening a game page and moving
+#     between tabs produced "Trying to change focus to already selected tab",
+#     "updating PluginView", store page loads -- and ZERO keyboard markers. The
+#     signal is specific to the keyboard, not to focus in general.
+#   - Twenty minutes of an idle box produced zero markers.
+#   - Write latency is sub-second: detection timestamps matched Steam's own
+#     stamp within the 1s resolution of the test, twice landing in the same
+#     second. Steam does not buffer this log.
+#
+# This is an UNDOCUMENTED log line and Valve can rename it in any update, so it
+# degrades closed at every step: no log file, no marker, or a renamed marker all
+# mean the feature silently never fires. Nothing else depends on it.
+_OSK_LOG = os.path.expanduser("~/.steam/steam/logs/webhelper_js.txt")
+_OSK_MARKER = "giving focus to keyboard"
+_OSK_POLL_S = 0.25
+# Two lines per open, same second. Anything inside this window is one event.
+_OSK_DEDUPE_S = 1.5
+_OSK_GEN = 0
+_OSK_LOCK = threading.Lock()
+
+
+def osk_available():
+    """True when this box has the Steam UI log to watch. Never raises."""
+    try:
+        return os.path.isfile(_OSK_LOG)
+    except OSError:
+        return False
+
+
+def _osk_notify():
+    """Tell the CURRENT holder its box just raised a keyboard.
+
+    Only the holder: a waiter cannot type, so popping its keyboard would be a
+    lie. Best-effort — _wsend_json never raises."""
+    with GAMEPAD_LOCK:
+        holder = GAMEPAD_HOLDER
+    if holder is not None:
+        _wsend_json(holder, {"t": "osk"})
+
+
+def _osk_watch(gen):
+    """Tail the Steam UI log and fire _osk_notify on each keyboard-open.
+
+    Starts at END of file, so an agent restart never replays a keyboard that
+    opened an hour ago. Handles truncation/rotation by resetting the offset."""
+    try:
+        pos = os.path.getsize(_OSK_LOG)
+    except OSError:
+        return
+    last = 0.0
+    while True:
+        with _OSK_LOCK:
+            if gen != _OSK_GEN:
+                return  # superseded by a newer watcher
+        time.sleep(_OSK_POLL_S)
+        try:
+            size = os.path.getsize(_OSK_LOG)
+            if size < pos:      # rotated or truncated
+                pos = 0
+            if size == pos:
+                continue
+            with open(_OSK_LOG, "r", encoding="utf-8", errors="replace") as f:
+                f.seek(pos)
+                chunk = f.read()
+                pos = f.tell()
+        except OSError:
+            continue            # log vanished mid-read: try again next tick
+        if _OSK_MARKER not in chunk:
+            continue
+        now = time.monotonic()
+        if now - last < _OSK_DEDUPE_S:
+            continue            # the second line of the same open
+        last = now
+        _osk_notify()
+
+
+def osk_arm(mock=False):
+    """(Re)start the OSK watcher. Generation-guarded like the guide watcher, so
+    a restart cannot leave two live watchers both firing."""
+    global _OSK_GEN
+    with _OSK_LOCK:
+        _OSK_GEN += 1
+        gen = _OSK_GEN
+    if mock or not osk_available():
+        return
+    threading.Thread(target=_osk_watch, args=(gen,), daemon=True,
+                     name="osk-watch").start()
+    print("[osk] watching %s" % _OSK_LOG, flush=True)
 
 
 def read_disks():
@@ -12223,6 +12330,7 @@ def main():
     set_power_schedule(args.mock)
     set_screensaver(args.mock)
     set_guide(args.mock)  # arms the guide-hold watcher when opted in
+    osk_arm(args.mock)  # tails Steam's UI log; silent no-op without it
     set_couchmode(args.mock)  # ceremony engine honors --mock
     set_caps(args.mock)  # after the detectors above; snapshots CAPS
     port = args.port if args.port is not None else (CONFIG_PORT or DEFAULT_PORT)

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -347,6 +347,10 @@ if (typeof globalThis !== 'undefined') {
 const KB_ACCESSORY_ID = 'couchside-kb-accessory';
 
 type KeyboardBarProps = {
+  /** Bumped when the BOX raised its own keyboard; each increment focuses this
+      bar's field so the phone keyboard comes up too. A counter rather than a
+      boolean so two opens in a row both register. */
+  autoOpenSignal?: number;
   onText: (s: string) => void;
   onBackspace: () => void;
   onEnter: () => void;
@@ -367,7 +371,7 @@ type KeyboardBarProps = {
  * while the real keyboard is down (or vice-versa). `open` is mirrored into a ref
  * so callbacks always see the live value without stale closures.
  */
-function KeyboardBar({ onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarProps) {
+function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarProps) {
   const inputRef = useRef<TextInput>(null);
   const [open, setOpen] = useState(false);
   // Live ref so the once-created swipe responder sees the current callback.
@@ -405,6 +409,22 @@ function KeyboardBar({ onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarP
     // keyboard. The input is always mounted, so the ref is ready here.
     inputRef.current?.focus();
   }, [setOpenSynced]);
+
+  // The BOX raised its keyboard, so raise ours. Skips the first render: the
+  // signal starts at 0 and only a real event increments it, otherwise every
+  // mount would pop the keyboard unprompted.
+  //
+  // NOTE this is the one focus() path NOT inside a touch handler, which iOS can
+  // legitimately refuse (see the comment above). Refusal is a no-op — the bar
+  // simply stays closed — but it is the reason this needs a device check rather
+  // than a harness one.
+  const lastAutoOpen = useRef(autoOpenSignal ?? 0);
+  useEffect(() => {
+    const sig = autoOpenSignal ?? 0;
+    if (sig === lastAutoOpen.current) return;
+    lastAutoOpen.current = sig;
+    if (sig > 0 && !openRef.current) focus();
+  }, [autoOpenSignal, focus]);
 
   // Lift for the floating HIDE pill: measured, not framework-magic. The pill
   // is absolutely positioned inside the SCREEN container, but the keyboard's
@@ -809,6 +829,13 @@ function PadScreen() {
 
     client.onControlRequest((name) => setControlReq(name));
 
+    // Box raised its keyboard -> raise ours, unless the user turned it off.
+    // Read through the ref so flipping the pref takes effect without
+    // re-subscribing (and without tearing down the socket).
+    client.onOsk(() => {
+      if (autoKeyboardRef.current) setOskSignal((n) => n + 1);
+    });
+
     const connect = () => {
       focusedRef.current = true;
       client.connect(settingsRef.current, {
@@ -852,6 +879,7 @@ function PadScreen() {
       client.onStatus(null);
       client.onInputBlocked(null);
       client.onControlRequest(null);
+      client.onOsk(null);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- connection
     // identity only; settingsRef carries the rest without re-running.
@@ -969,6 +997,13 @@ function PadScreen() {
   const showDesktopNav = usePref('padDesktopNav');
   const showWinShortcuts = usePref('padWinShortcuts');
   const showKeyboardBar = usePref('padKeyboardBar');
+  // Auto-raise the phone keyboard when the box raises its own. The counter is
+  // what KeyboardBar watches; the ref lets the (memoised) socket callback read
+  // the current pref without re-subscribing.
+  const autoKeyboard = usePref('autoKeyboard');
+  const autoKeyboardRef = useRef(autoKeyboard);
+  autoKeyboardRef.current = autoKeyboard;
+  const [oskSignal, setOskSignal] = useState(0);
 
   const trig = useCallback(
     (k: TriggerKey) => ({
@@ -1152,6 +1187,7 @@ function PadScreen() {
       onBackspace={kbBackspace}
       onEnter={kbEnter}
       onSwipeMode={cycleMode}
+      autoOpenSignal={oskSignal}
     />
   ) : null;
 

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -646,6 +646,7 @@ function SetupBody() {
   const confirmSuspend = usePref('confirmSuspend');
   const defaultPadMode = usePref('defaultPadMode');
   const landingTab = usePref('landingTab');
+  const autoKeyboard = usePref('autoKeyboard');
   const statusIntervalMs = usePref('statusIntervalMs');
   const journalLines = usePref('journalLines');
   const swipeSensitivity = usePref('swipeSensitivity');
@@ -1355,6 +1356,15 @@ function SetupBody() {
                 value={askToSwitchControl}
                 onValueChange={(v) => {
                   void setPref('askToSwitchControl', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Open keyboard with the box"
+                sub="When the box raises its own on-screen keyboard, raise this phone's too — so you can type or paste instead of picking letters with a d-pad. Needs a recent Couchside service."
+                value={autoKeyboard}
+                onValueChange={(v) => {
+                  void setPref('autoKeyboard', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -294,6 +294,8 @@ export class GamepadClient {
   // Pass/Keep. controlRequest holds the pending requester name (or null).
   private controlRequest: string | null = null;
   private controlReqListener: ((name: string | null) => void) | null = null;
+  /** Fires when the BOX raised its on-screen keyboard (agent >= 2.9.38). */
+  private oskListener: (() => void) | null = null;
   /** Ask-to-pass vs grab-control, read from prefs at connect() time. */
   private handoffAsk = true;
   /** This device's label, sent so the holder's prompt can name the requester. */
@@ -362,6 +364,17 @@ export class GamepadClient {
     if (this.controlRequest === name) return;
     this.controlRequest = name;
     if (this.controlReqListener) this.controlReqListener(name);
+  }
+
+  /**
+   * Register the on-screen-keyboard listener (agent >= 2.9.38).
+   *
+   * Fires when the BOX raised its own keyboard, so the phone can raise its
+   * keyboard and let you type or paste instead of thumb-picking letters on a
+   * grid. An older agent simply never sends the frame, so this stays inert.
+   */
+  onOsk(fn: (() => void) | null): void {
+    this.oskListener = fn;
   }
 
   /** Holder taps "Pass control": hand off to the waiting device. */
@@ -761,6 +774,10 @@ export class GamepadClient {
         this.dev = typeof msg.holder === 'string' ? msg.holder : null;
         this.setStatus('waiting', this.dev);
         this.startPing();
+      } else if (msg.t === 'osk') {
+        // The box raised its keyboard. Purely advisory — nothing breaks if the
+        // app ignores it, and an older agent never sends it.
+        if (this.oskListener) this.oskListener();
       } else if (msg.t === 'control_request') {
         // We HOLD control and another device wants it — prompt Pass/Keep.
         this.setControlRequest(typeof msg.name === 'string' ? msg.name : 'A device');

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -34,6 +34,14 @@ export type Prefs = {
    *  would move every existing user's landing screen, so it stays on the
    *  observed behaviour and the choice becomes theirs. */
   landingTab: LandingTab;
+  /** Raise the phone's keyboard when the BOX raises its own.
+   *
+   *  Steam's on-screen keyboard is a letter grid you drive with a d-pad. When
+   *  it opens, you almost always want to type on the phone instead — so the
+   *  agent reports the event and the app focuses its compose field. Default ON:
+   *  it only fires at the exact moment a keyboard is already wanted. Agent
+   *  >= 2.9.38; older agents never send the frame and this stays inert. */
+  autoKeyboard: boolean;
   /** Input mode a newly paired box starts on. */
   defaultPadMode: PadMode;
   /** How often the console/header polls the box for vitals (ms). */
@@ -107,6 +115,7 @@ export type Prefs = {
 export const DEFAULTS: Prefs = {
   confirmSuspend: true,
   landingTab: 'index',
+  autoKeyboard: true,
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
   journalLines: 100,
@@ -195,6 +204,7 @@ function normalize(raw: unknown): Prefs {
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     landingTab,
+    autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),
     defaultPadMode: padMode,
     statusIntervalMs: num(o.statusIntervalMs, STATUS_INTERVAL_OPTIONS, DEFAULTS.statusIntervalMs),
     journalLines: num(o.journalLines, JOURNAL_LINE_OPTIONS, DEFAULTS.journalLines),

--- a/tests/test_osk_watch.py
+++ b/tests/test_osk_watch.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tests for on-screen-keyboard detection (the {"t":"osk"} push).
+
+Run: python3 tests/test_osk_watch.py
+
+When Steam raises its keyboard on the TV, the phone should raise its own, so you
+can type or paste instead of thumb-picking letters off a grid with a d-pad.
+
+There is no general "a text field took focus" signal on this platform — Wayland
+exposes none and gamescope has no client API for it. But Steam writes the
+narrower event to its own UI log, and reading a Steam log for a signal is
+already how stream_host_online() works.
+
+MEASURED on a live Bazzite box in Game Mode, 2026-07-21, and every number below
+is from that session rather than from documentation:
+
+  - Opening the keyboard emits EXACTLY TWO identical lines each time, across ten
+    observed events. Hence the dedupe window.
+  - NEGATIVE CONTROL: navigating the library, opening a game page and changing
+    tabs produced "Trying to change focus to already selected tab", "updating
+    PluginView after changes" and store page loads -- and ZERO keyboard markers.
+    The signal is specific to the keyboard, not to focus in general. That test
+    is what made this feature worth building, so it is asserted below.
+  - Twenty idle minutes produced zero markers.
+  - Sub-second write latency; Steam does not buffer this log.
+
+The marker is UNDOCUMENTED and Valve can rename it in any update, so every path
+degrades closed: no log, no marker, or a renamed marker means the feature
+silently never fires.
+"""
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# VERBATIM lines off the live box. The keyboard markers are the two that fired
+# when the keyboard opened; everything else is what NAVIGATION produced in the
+# same window and must not trigger anything.
+OPEN_EVENT = [
+    "[2026-07-21 23:31:16] SteamUI: INFO: giving focus to keyboard 2",
+    "[2026-07-21 23:31:16] SteamUI: INFO: giving focus to keyboard 2",
+]
+NAVIGATION_NOISE = [
+    "[2026-07-21 23:38:46] SteamUI: INFO: RegisterOnActionDescriptionsChangedCallback",
+    "[2026-07-21 23:38:50] SteamUI: INFO: Trying to change focus to already selected tab",
+    "[2026-07-21 23:38:52] SteamUI: INFO: updating PluginView after changes",
+    "[2026-07-21 23:38:54] SteamUI: INFO: Chat: f1912293206 friend trying to load 100 messages",
+    "[2026-07-21 23:31:16] SteamUI: INFO: ~~ Search result sets:  ~~",
+    "[2026-07-21 23:10:35] SteamUI: WARNING: MultiSourceImage created with no image src",
+]
+
+
+class Harness:
+    """Drive the REAL _osk_watch against a temp log, counting notifies."""
+
+    def __init__(self):
+        self.dir = tempfile.mkdtemp(prefix="osk-")
+        self.path = os.path.join(self.dir, "webhelper_js.txt")
+        with open(self.path, "w") as f:
+            f.write("[start] pre-existing content the watcher must NOT replay\n")
+        self.fired = 0
+        self._old_log = cs._OSK_LOG
+        self._old_poll = cs._OSK_POLL_S
+        self._old_notify = cs._osk_notify
+        cs._OSK_LOG = self.path
+        cs._OSK_POLL_S = 0.02          # keep the suite fast
+        cs._osk_notify = self._count
+
+    def _count(self):
+        self.fired += 1
+
+    def append(self, lines):
+        with open(self.path, "a") as f:
+            f.write("\n".join(lines) + "\n")
+
+    def settle(self, s=0.25):
+        time.sleep(s)
+
+    def close(self):
+        cs._OSK_LOG = self._old_log
+        cs._OSK_POLL_S = self._old_poll
+        cs._osk_notify = self._old_notify
+        with cs._OSK_LOCK:
+            cs._OSK_GEN += 1           # retire the watcher thread
+        time.sleep(0.1)
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def start(h):
+    cs.osk_arm(mock=False)
+    time.sleep(0.1)
+
+
+def test_keyboard_open_fires_once():
+    """Two identical lines are ONE keyboard, not two."""
+    print("test_keyboard_open_fires_once")
+    h = Harness()
+    try:
+        start(h)
+        h.append(OPEN_EVENT)
+        h.settle()
+        check("one open -> one notify (deduped)", h.fired, 1)
+    finally:
+        h.close()
+
+
+def test_navigation_fires_nothing():
+    """THE control. Moving around Steam must never pop the phone keyboard."""
+    print("test_navigation_fires_nothing")
+    h = Harness()
+    try:
+        start(h)
+        h.append(NAVIGATION_NOISE)
+        h.settle()
+        check("navigation noise -> no notify", h.fired, 0)
+    finally:
+        h.close()
+
+
+def test_two_opens_fire_twice():
+    """Deduping must not swallow a genuine second open."""
+    print("test_two_opens_fire_twice")
+    h = Harness()
+    try:
+        start(h)
+        h.append(OPEN_EVENT)
+        h.settle()
+        time.sleep(cs._OSK_DEDUPE_S)
+        h.append(OPEN_EVENT)
+        h.settle()
+        check("two separate opens -> two notifies", h.fired, 2)
+    finally:
+        h.close()
+
+
+def test_existing_content_not_replayed():
+    """An agent restart must not fire for a keyboard opened an hour ago."""
+    print("test_existing_content_not_replayed")
+    h = Harness()
+    try:
+        with open(h.path, "a") as f:
+            f.write("\n".join(OPEN_EVENT) + "\n")   # BEFORE the watcher starts
+        start(h)
+        h.settle()
+        check("pre-existing markers ignored", h.fired, 0)
+    finally:
+        h.close()
+
+
+def test_truncation_does_not_wedge():
+    """Steam rotating its log must not blind the watcher forever."""
+    print("test_truncation_does_not_wedge")
+    h = Harness()
+    try:
+        start(h)
+        h.append(["filler"] * 50)
+        h.settle()
+        with open(h.path, "w") as f:      # rotate: file shrinks
+            f.write("")
+        h.settle()
+        h.append(OPEN_EVENT)
+        h.settle()
+        check("still fires after truncation", h.fired, 1)
+    finally:
+        h.close()
+
+
+def test_missing_log_degrades_closed():
+    """No Steam (a server box, Windows, a fresh install) must not raise."""
+    print("test_missing_log_degrades_closed")
+    old = cs._OSK_LOG
+    cs._OSK_LOG = "/nonexistent/steam/logs/webhelper_js.txt"
+    try:
+        check("osk_available() is False", cs.osk_available(), False)
+        cs.osk_arm(mock=False)       # must be a silent no-op, not a crash
+        check("arming without a log does not raise", True, True)
+    finally:
+        cs._OSK_LOG = old
+
+
+def test_mock_never_arms():
+    """--mock must not tail a real user's Steam log."""
+    print("test_mock_never_arms")
+    h = Harness()
+    try:
+        cs.osk_arm(mock=True)
+        h.append(OPEN_EVENT)
+        h.settle()
+        check("mock mode fires nothing", h.fired, 0)
+    finally:
+        h.close()
+
+
+if __name__ == "__main__":
+    for fn in (test_keyboard_open_fires_once,
+               test_navigation_fires_nothing,
+               test_two_opens_fire_twice,
+               test_existing_content_not_replayed,
+               test_truncation_does_not_wedge,
+               test_missing_log_degrades_closed,
+               test_mock_never_arms):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Steam's on-screen keyboard is a letter grid you drive with a d-pad. When it opens you almost always want to type on the **phone** instead — so the agent now reports the event and the app focuses its compose field, which is also where the PASTE button from #200 lives.

## I was wrong earlier, and the reframing is what unlocked it

I said the box can't detect a focused text field. True — Wayland exposes no such signal and gamescope has no client API for it.

But *"Steam's keyboard opened"* is a much narrower question, and **Steam writes it in plain text to its own UI log**. Reading a Steam log for a signal is already established practice here — `stream_host_online()` does exactly this.

## Measured on hardware, not inferred

Live Bazzite box in Game Mode, 2026-07-21:

| observation | result |
|---|---|
| Each keyboard open | **exactly 2 identical lines**, across ten events → hence the 1.5s dedupe |
| **Negative control** — navigating library, game pages, tabs | **zero** markers, while producing plenty of focus/tab/store chatter |
| Twenty idle minutes | zero markers |
| Write latency | **sub-second**; two samples landed in the same second as Steam's own stamp |

That negative control is the reason this was worth building at all — it proves the signal is *keyboard-specific*, not focus-in-general. It's asserted as a test rather than left in a comment.

## Degrading closed, deliberately

The marker is **undocumented** and Valve can rename it in any release. So: no log, no marker, or a renamed marker all mean the feature silently never fires, and nothing else is affected.

- **Generation-guarded** like the guide watcher, so a re-arm can't leave two threads firing
- **Starts at end-of-file**, so an agent restart never replays a keyboard opened an hour ago
- **Only the holder is notified** — a waiter can't type, so popping its keyboard would be a lie

## App side

`{"t":"osk"}` → a counter → `KeyboardBar` focuses its field. Behind a new `autoKeyboard` pref (all 3 sites), **default ON** because it only fires at the exact moment a keyboard is already wanted. Older agents never send the frame, so the app stays inert against them.

## Tests

`tests/test_osk_watch.py` drives the **real** `_osk_watch` against a temp log seeded with verbatim lines off that box. Eight assertions, including:

- **navigation noise fires nothing** (the control)
- two identical lines are one event; two genuine opens are two events
- pre-existing content is never replayed
- survives log rotation/truncation
- missing log degrades closed; `--mock` never tails a real user's Steam log

## NOT verified

**The phone actually raising its keyboard.** That `focus()` is the one path *not* inside a touch handler, which iOS can legitimately refuse — a no-op if so, but it needs a device build. The harness can't test it at all, since `web-dev-proxy.py` doesn't tunnel `/ws/gamepad`.

Also untested: whether this behaves on the KDE desktop, which uses a different keyboard entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
