### PR TITLE
chore(app): 2.9.19

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.18",
+    "version": "2.9.19",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,7 +1,7 @@
-New in 2.9.18
+New in 2.9.19
 
-• Pick which tab the app opens on, in Preferences.
-• The trackpad is now called Mouse, its buttons say LEFT / MID / RIGHT, and it always has an Esc key.
-• Hide the "Stream from PC" section, or the TV volume target, if you don't use them.
-• Cover art no longer repeats the game's name.
-• Fixed black-on-black text in the power menu, and drag trails that drew specks instead of a line.
+• Fixed the connection dropping while the phone sat idle.
+• Paste from your phone into a text box on the box, with a new PASTE button.
+• When the box opens its on-screen keyboard, your phone's keyboard opens too.
+• The Steam tab can now be swiped out of like every other one.
+• Quieter Actions list, and Couch Mode no longer narrates every step.


### PR DESCRIPTION
Marketing version bump `2.9.18` → `2.9.19`, plus release notes.

`buildNumber` (72) and `versionCode` (53) deliberately untouched — `autoIncrement` derives 73 / 54 at build time.

## Contents

| PR | |
|---|---|
| #195 | visible compose field (prerequisite for paste) |
| #196 | keepalive instrumentation |
| #197 | **keepalive fix** — the idle disconnect |
| #198 | USB wake probe (agent, read-only) |
| #199 | Steam swipe-out, quieter Actions, simpler Couch Mode |
| #200 | **PASTE** button — adds `expo-clipboard`, so this build is required to test it at all |
| #201 | phone keyboard opens when the box opens its own (agent 2.9.38) |

## Needs the agent released too

**#198 and #201 are agent-side.** Agent is **2.9.38** on main; published is still **2.9.37**. The app build alone won't light them up — `release-agent.sh` runs alongside this.

## Deliberately not in this release

Both flagged rather than half-built:

- **Keyboard-instead-of-gamepad** — the value is in *not creating the virtual pad*, which is the create → hold → hand off → reap path CLAUDE.md singles out for tests. Routing the keys without that delivers none of the benefit and touches the riskiest code in the repo.
- **HDR / refresh / resolution readout** — refresh rate, make/model, external-vs-internal and VRR are ready from `gamescopectl`. HDR is not: this gamescope runs **without `--hdr-enabled`** and no reachable display reports HDR, so the detector could only ever be observed saying "SDR". That's the battery-row trap, and it waits for hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
