### PR TITLE
chore(app): record build 73 as shipped (2.9.19)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "72",
+      "buildNumber": "73",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bookkeeping after the 2.9.19 cut.

| | |
|---|---|
| iOS | build **73** — `VALID`, on the public-link group |
| Android | vc **53** unchanged — no Android build cut |
| Agent | **2.9.38** — published and signature-verified |

Build number came from EAS `autoIncrement` and was **read back out of App Store Connect**, not taken from the build output.

Agent verified the way `install.sh` does it: fetched from `releases/latest/download`, hashed against `SHA256SUMS`, Ed25519 signature checked against the key embedded in the installer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)