### PR TITLE
Keyboard mode: send keys instead of creating a virtual gamepad (agent 2.9.39)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.38"
+VERSION = "2.9.39"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -9979,7 +9979,17 @@ def _make_holder(entry, mock):
     # also inflates _own_pad_count and so hides a real controller from the
     # gaming card. Reuse keeps a handoff ping-pong presenting ONE stable
     # controller to Steam instead of a parade.
-    if entry.get("device") is None:
+    #
+    # KEYBOARD-ONLY sessions (?nopad=1) never get a pad at all. The point is not
+    # to save a few ioctls: creating one makes Steam announce "controller
+    # connected", and disconnecting announces it again — so a phone that
+    # foregrounds and backgrounds spams the TV with notifications, and a game
+    # already running sees a SECOND controller that can steal player 1. A client
+    # that only sends arrows/enter/esc has no use for the pad, so it asks not to
+    # have one. Mouse and keyboard are still created below; only the pad is
+    # skipped, and gamepad frames from such a session are dropped in
+    # _handle_frame rather than lazily creating one behind our back.
+    if not entry.get("nopad") and entry.get("device") is None:
         try:
             entry["device"] = MockGamepad() if mock else UInputGamepad()
         except Exception as e:
@@ -9989,7 +9999,8 @@ def _make_holder(entry, mock):
             return False
     entry["held"] = True
     entry["requested"] = False
-    _wsend_json(entry, {"t": "hello", "dev": entry["device"].name,
+    dev = entry["device"].name if entry.get("device") is not None else "keyboard only"
+    _wsend_json(entry, {"t": "hello", "dev": dev,
                         "text": _text_caps(mock)})
     for slot, factory in (("mouse", MockMouse if mock else UInputMouse),
                           ("keyboard", MockKeyboard if mock else UInputKeyboard)):
@@ -11955,9 +11966,13 @@ class Handler(BaseHTTPRequestHandler):
         # 'ask' = request control from the holder; anything else (incl. old
         # clients that send no param) = grab it, the pre-2.9.2 behavior.
         ask = q.get("handoff", ["takeover"])[0] == "ask"
+        # Keyboard-only client: do not create a virtual pad for this session.
+        # Opt-IN so every existing client keeps its pad; an old app sends no
+        # param and is unaffected. See _make_holder for why it matters.
+        nopad = q.get("nopad", ["0"])[0] == "1"
         entry = {"conn": conn, "device": None, "mouse": None, "keyboard": None,
                  "name": name, "held": False, "requested": False,
-                 "slock": threading.Lock()}
+                 "nopad": nopad, "slock": threading.Lock()}
 
         # ---- decide this session's initial role -------------------------------
         demoted = None      # a holder we bumped (takeover): notify after unlock
@@ -12228,7 +12243,14 @@ class Handler(BaseHTTPRequestHandler):
         target = entry.get(slot)
         if target is None:
             if factory is None:
-                return True  # gamepad device gone (mid-teardown): drop frame
+                # Gamepad frame with no pad. Two ways to get here and BOTH must
+                # drop rather than create: mid-teardown (the pad is gone), and a
+                # keyboard-only session (?nopad=1) that never had one. There is
+                # deliberately no lazy factory for the pad, so a nopad session
+                # cannot be tricked into materialising a controller by sending a
+                # button frame — which would put back the exact Steam
+                # "controller connected" spam it asked to avoid.
+                return True
             try:
                 target = factory()
             except Exception as e:

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -44,7 +44,7 @@ import type { SteamMenus } from '@/lib/api';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status } from '@/lib/api';
-import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
+import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, SpecialKey, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles } from '@/lib/theme';
@@ -170,6 +170,17 @@ const TAP_SLOP = 12;
 const TAP_MS = 450;
 
 type DpadKey = 'du' | 'dd' | 'dl' | 'dr';
+
+// Keyboard-mode equivalent for the swipe surface. Arrow keys were measured
+// driving Steam Game Mode on a Bazzite box (three DOWN taps moved the selection
+// two rows and stopped at the list end; one UP moved it back; a Ctrl+9 control
+// moved nothing).
+const SWIPE_KEY: Record<DpadKey, SpecialKey> = {
+  du: 'up',
+  dd: 'down',
+  dl: 'left',
+  dr: 'right',
+};
 
 type SwipeSurfaceProps = {
   onStep: (k: DpadKey) => void;
@@ -749,12 +760,20 @@ function PadScreen() {
   // SettingsContext.update() is a silent no-op and the mode toggle looked
   // functional but did nothing. Local fallback keeps it switchable (session-
   // only) until a box exists — then the box's padMode takes over.
+  // Keyboard instead of a virtual gamepad. Steam navigates identically from
+  // arrow keys, and the pad has a cost the keyboard does not -- see the pref's
+  // doc comment in lib/prefs.ts. Read here rather than inside the surfaces so
+  // ONE value drives both the send path and which segments exist.
+  const keyboardMode = usePref('keyboardMode');
   const [localMode, setLocalMode] = useState<PadMode>(getPref('defaultPadMode'));
   // EMPTY_SETTINGS hardcodes padMode:'swipe', so key off "is a box paired"
   // rather than ?? — otherwise the local fallback never engages.
-  const mode: PadMode = settings.host.trim().length > 0
+  const rawMode: PadMode = settings.host.trim().length > 0
     ? settings.padMode ?? 'swipe'
     : localMode;
+  // In keyboard mode the agent is asked NOT to create a pad, so the PAD screen
+  // has nothing to drive. Fall back rather than render sticks that go nowhere.
+  const mode: PadMode = keyboardMode && rawMode === 'gamepad' ? 'swipe' : rawMode;
   const [status, setStatus] = useState<GamepadStatus>('closed');
   const [dev, setDev] = useState<string | null>(null);
   // Non-null when the box is refusing input injection (locked / not the active
@@ -767,6 +786,10 @@ function PadScreen() {
   const askToSwitch = usePref('askToSwitchControl');
   const askToSwitchRef = useRef(askToSwitch);
   askToSwitchRef.current = askToSwitch;
+  // The no-pad decision is made at HANDSHAKE time, so the live value has to be
+  // reachable from the focus effect's connect(), not just from render.
+  const keyboardModeRef = useRef(keyboardMode);
+  keyboardModeRef.current = keyboardMode;
 
   // Hardware volume buttons -> box/TV volume across EVERY input mode (Pad,
   // Swipe, Track, Remote), mounted here on the always-present Pad screen rather
@@ -841,6 +864,7 @@ function PadScreen() {
       client.connect(settingsRef.current, {
         handoffAsk: askToSwitchRef.current,
         deviceName: DEVICE_LABEL,
+        noPad: keyboardModeRef.current,
       });
       if (Platform.OS !== 'web') {
         // Honor the "keep screen awake on Pad" pref; if it was turned off while
@@ -898,6 +922,23 @@ function PadScreen() {
     }
   }, [keepAwakeOn]);
 
+  // Toggling keyboard mode has to RE-HANDSHAKE: whether the agent creates a
+  // virtual pad is decided once, from the connect URL. Without this, turning the
+  // mode on would leave the already-created pad alive until the next reconnect,
+  // and the box would keep reporting a controller the app claims it did not make.
+  // connect() itself notices the changed flag and tears the socket down; this
+  // effect only has to call it.
+  useEffect(() => {
+    if (!ready) return;
+    const st = client.getStatus();
+    if (st !== 'connected' && st !== 'connecting') return;
+    client.connect(settingsRef.current, {
+      handoffAsk: askToSwitchRef.current,
+      deviceName: DEVICE_LABEL,
+      noPad: keyboardMode,
+    });
+  }, [client, ready, keyboardMode]);
+
   // A freshly-learned lastIp should reach the client's stored conn so future
   // reconnects can use it. connect() with an unchanged host/port/token just
   // refreshes the stored conn: it never drops a live socket.
@@ -926,7 +967,11 @@ function PadScreen() {
       if (canForce) client.forceControl();
       else client.requestControl();
     } else if (status !== 'connected') {
-      client.connect(settings, { handoffAsk: askToSwitch, deviceName: DEVICE_LABEL });
+      client.connect(settings, {
+        handoffAsk: askToSwitch,
+        deviceName: DEVICE_LABEL,
+        noPad: keyboardMode,
+      });
     }
   }, [client, settings, status, canForce, askToSwitch]);
 
@@ -982,8 +1027,11 @@ function PadScreen() {
   // The segments this box actually has. Mode cycling walks THIS list, not
   // MODES, so a swipe can never land on a segment that isn't rendered.
   const modes = useMemo(
-    () => MODES.filter((m) => m.key !== 'menus' || (hasSteamMenus && inGameMode)),
-    [hasSteamMenus, inGameMode],
+    () => MODES.filter(
+      (m) => (m.key !== 'menus' || (hasSteamMenus && inGameMode))
+        && (m.key !== 'gamepad' || !keyboardMode),
+    ),
+    [hasSteamMenus, inGameMode, keyboardMode],
   );
   const desk = useCallback(
     (name: DesktopKey | 'esc') => () =>
@@ -1093,6 +1141,7 @@ function PadScreen() {
     timer: null,
   });
   const dpadRelease = useCallback(() => {
+    if (keyboardMode) return;   // nothing was ever held down
     const h = dpadHeld.current;
     if (h.timer) {
       clearTimeout(h.timer);
@@ -1102,9 +1151,16 @@ function PadScreen() {
       client.sendButton(h.key, 0);
       h.key = null;
     }
-  }, [client]);
+  }, [client, keyboardMode]);
   const dpadStep = useCallback(
     (k: DpadKey) => {
+      // Keyboard mode: one arrow-key TAP per step. Steam moves one row per tap,
+      // so there is nothing to latch and nothing to release -- which also
+      // removes this surface's whole class of stuck-direction bugs.
+      if (keyboardMode) {
+        client.sendKey(SWIPE_KEY[k]);
+        return;
+      }
       const h = dpadHeld.current;
       if (h.timer) clearTimeout(h.timer);
       if (h.key !== k) {
@@ -1125,13 +1181,17 @@ function PadScreen() {
         }
       }, 250);
     },
-    [client],
+    [client, keyboardMode],
   );
   const selectTap = useCallback(() => {
     haptic();
+    if (keyboardMode) {
+      client.sendKey('enter');
+      return;
+    }
     client.sendButton('a', 1);
     setTimeout(() => client.sendButton('a', 0), 50);
-  }, [client]);
+  }, [client, keyboardMode]);
 
   // Trackpad handlers (protocol v2 mouse).
   // Drags emit a subtle "texture" tick per TP_HAPTIC_PX of pointer travel,
@@ -1294,27 +1354,37 @@ function PadScreen() {
           <View style={styles.swipeBtnRow}>
             <PadButton
               label="‹ BACK"
-              {...btn('b')}
+              {...(keyboardMode
+                ? { onDown: () => client.sendKey('esc'), onUp: NOOP }
+                : btn('b'))}
               style={styles.swipeBtn}
               color={t.red}
               fontSize={12}
             />
-            <PadButton
-              label="STEAM"
-              {...btn('guide')}
-              style={[styles.swipeBtn, styles.guideBtn]}
-              color={t.blue}
-              fontSize={12}
-            />
-            <PadButton
-              label="⋯"
-              onDown={qam}
-              onUp={NOOP}
-              style={[styles.swipeBtn, styles.guideBtn]}
-              color={t.blue}
-              fontSize={26}
-            />
-            <PadButton label="MENU" {...btn('start')} style={styles.swipeBtn} fontSize={12} />
+            {/* STEAM, QAM and MENU all ride gamepad buttons. Steam Game Mode
+                exposes no keyboard equivalent for any of them -- Ctrl+1/Ctrl+2
+                fired once on the box and then failed to reproduce -- so in
+                keyboard mode they are removed rather than left to do nothing. */}
+            {!keyboardMode && (
+              <>
+                <PadButton
+                  label="STEAM"
+                  {...btn('guide')}
+                  style={[styles.swipeBtn, styles.guideBtn]}
+                  color={t.blue}
+                  fontSize={12}
+                />
+                <PadButton
+                  label="⋯"
+                  onDown={qam}
+                  onUp={NOOP}
+                  style={[styles.swipeBtn, styles.guideBtn]}
+                  color={t.blue}
+                  fontSize={26}
+                />
+                <PadButton label="MENU" {...btn('start')} style={styles.swipeBtn} fontSize={12} />
+              </>
+            )}
           </View>
           {keyboardBar}
         </>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -659,6 +659,7 @@ function SetupBody() {
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
   const askToSwitchControl = usePref('askToSwitchControl');
+  const keyboardMode = usePref('keyboardMode');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
   const hideStreamFromPc = usePref('hideStreamFromPc');
@@ -1347,6 +1348,15 @@ function SetupBody() {
                 value={padHints}
                 onValueChange={(v) => {
                   void setPref('padHints', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Send keys instead of a controller"
+                sub="Steam navigates the same from arrow keys, and the box stops announcing a controller every time you connect — so a game already running can't lose player one to your phone. Swipe and Remote send keys; the Pad screen is hidden. Steam and QAM buttons need a controller, so they're not available. Needs the Couchside service 2.9.39 or newer."
+                value={keyboardMode}
+                onValueChange={(v) => {
+                  void setPref('keyboardMode', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -16,7 +16,7 @@ import {
 import { usePoll } from '@/hooks/usePoll';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { api, hostKey, Status, Tv, TvKey, TvOp } from '@/lib/api';
-import { GamepadClient } from '@/lib/gamepad';
+import { GamepadClient, SpecialKey } from '@/lib/gamepad';
 import { hapticLight, hapticWarning } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { Settings } from '@/lib/settings';
@@ -38,6 +38,21 @@ type IoniconName = React.ComponentProps<typeof Ionicons>['name'];
  * menu/home/back/settings/brightness). Without RS-232 only BOX exists and the
  * TV-specific clusters stay hidden — CEC/soft setups keep a clean remote.
  */
+// Gamepad button -> keyboard key, for keyboard mode. Only the entries proven
+// to drive Steam Game Mode are here; a button with no entry is HIDDEN by the
+// caller, never sent as a no-op key.
+const KEYBOARD_EQUIV: Partial<Record<
+  'du' | 'dd' | 'dl' | 'dr' | 'a' | 'b' | 'start' | 'select',
+  SpecialKey
+>> = {
+  du: 'up',
+  dd: 'down',
+  dl: 'left',
+  dr: 'right',
+  a: 'enter',
+  b: 'esc',
+};
+
 export function RemoteView({
   client,
   settings,
@@ -206,13 +221,28 @@ export function RemoteView({
     [settings],
   );
 
+  // Keyboard mode: no virtual pad exists to press, so the same taps go out as
+  // arrow keys. MEASURED on a Bazzite box in Game Mode -- three DOWN taps moved
+  // the selection two rows and stopped at the end of the list, one UP moved it
+  // back, and a Ctrl+9 control moved nothing. Keys are TAPS, not holds, so the
+  // latched-axis bookkeeping the pad needs has no equivalent here.
+  //
+  // start/select are deliberately absent from the map: Steam Game Mode exposes
+  // no keyboard equivalent for them, so they are hidden rather than sent as a
+  // key that does nothing. See PAD_KEY_ONLY below.
+  const keyboardMode = usePref('keyboardMode');
   const padTap = useCallback(
     (k: 'du' | 'dd' | 'dl' | 'dr' | 'a' | 'b' | 'start' | 'select') => {
       hapticLight();
+      if (keyboardMode) {
+        const key = KEYBOARD_EQUIV[k];
+        if (key) client.sendKey(key);
+        return;
+      }
       client.sendButton(k, 1);
       setTimeout(() => client.sendButton(k, 0), 50);
     },
-    [client],
+    [client, keyboardMode],
   );
 
   const steam = useCallback(() => {
@@ -297,6 +327,11 @@ export function RemoteView({
   const navRight = () => (nav === 'tv' ? tvKey('right') : padTap('dr'));
   const navOk = () => (nav === 'tv' ? tvKey('ok') : padTap('a'));
   const navBack = () => (nav === 'tv' ? tvKey('back') : padTap('b'));
+  // In keyboard mode these three have no equivalent, so they go out as silent
+  // no-ops: padTap drops a button with no KEYBOARD_EQUIV, and the agent drops a
+  // gamepad frame on a session that asked for no pad. They stay in the layout
+  // because the nav circle is a fixed geometry -- removing spokes would deform
+  // it -- and because they DO work whenever the target is a TV.
   const navMenu = () => (nav === 'tv' ? tvKey('menu') : padTap('start'));
   const navHome = () => (nav === 'tv' ? tvKey('home') : steam());
   const navSettings = () => (nav === 'tv' ? tvKey('settings') : padTap('select'));
@@ -440,8 +475,17 @@ export function RemoteView({
               tvOp('mute');
             }}
           />
-          <MidBtn icon="logo-steam" label="STEAM" color={t.green} onPress={steam} />
-          <MidBtn icon="ellipsis-horizontal" label="QAM" color={t.amber} onPress={qam} />
+          {/* Both ride the gamepad Guide button, which does not exist in
+              keyboard mode. Ctrl+1 / Ctrl+2 looked like Steam-menu and QAM
+              bindings in one on-box trial and then failed to reproduce from
+              the same state, so nothing replaces them -- a button that works
+              intermittently is worse than a button that is not there. */}
+          {!keyboardMode && (
+            <>
+              <MidBtn icon="logo-steam" label="STEAM" color={t.green} onPress={steam} />
+              <MidBtn icon="ellipsis-horizontal" label="QAM" color={t.amber} onPress={qam} />
+            </>
+          )}
         </View>
         {hasTvKeys ? (
           <Rocker

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -298,6 +298,11 @@ export class GamepadClient {
   private oskListener: (() => void) | null = null;
   /** Ask-to-pass vs grab-control, read from prefs at connect() time. */
   private handoffAsk = true;
+  /** Ask the agent NOT to create a virtual gamepad for this session (agent
+   *  >= 2.9.39). Set when the user has chosen keyboard mode: without it the
+   *  agent creates a pad on connect and Steam announces a controller every
+   *  time the app foregrounds. Older agents ignore the param. */
+  private noPad = false;
   /** This device's label, sent so the holder's prompt can name the requester. */
   private deviceName = 'A device';
 
@@ -436,8 +441,15 @@ export class GamepadClient {
    * StrictMode double-invokes, and repeated focus events can't tear down a
    * healthy socket.
    */
-  connect(conn: Conn, opts?: { handoffAsk?: boolean; deviceName?: string }): void {
+  connect(conn: Conn, opts?: { handoffAsk?: boolean; deviceName?: string; noPad?: boolean }): void {
     if (opts?.handoffAsk != null) this.handoffAsk = opts.handoffAsk;
+    if (opts?.noPad != null && opts.noPad !== this.noPad) {
+      // The flag is read at HANDSHAKE time, so a change only takes effect on a
+      // new socket. Drop the current one so toggling the pref applies now
+      // rather than at the next accidental reconnect.
+      this.noPad = opts.noPad;
+      this.teardownSocket(false);
+    }
     if (opts?.deviceName) this.deviceName = opts.deviceName;
     const same =
       this.conn != null &&
@@ -686,7 +698,8 @@ export class GamepadClient {
     const url =
       `ws://${target}:${port}/ws/gamepad?token=${encodeURIComponent(token)}` +
       `&handoff=${this.handoffAsk ? 'ask' : 'takeover'}` +
-      `&name=${encodeURIComponent(this.deviceName)}`;
+      `&name=${encodeURIComponent(this.deviceName)}` +
+      (this.noPad ? '&nopad=1' : '');
 
     let ws: WebSocket;
     try {

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -42,6 +42,21 @@ export type Prefs = {
    *  it only fires at the exact moment a keyboard is already wanted. Agent
    *  >= 2.9.38; older agents never send the frame and this stays inert. */
   autoKeyboard: boolean;
+  /** Drive the swipe/remote surfaces with KEYBOARD keys instead of a virtual
+   *  gamepad.
+   *
+   *  Steam navigates identically from arrow keys, but the pad has a cost the
+   *  keyboard does not: the agent creates a virtual controller on connect, so
+   *  the PC announces "controller connected" every time the app foregrounds,
+   *  and a game already running sees a SECOND controller that can steal player
+   *  one. In keyboard mode the agent is asked not to create a pad at all.
+   *
+   *  Off by default — the pad is what the app has always sent, and the d-pad
+   *  path is better tested. Needs agent >= 2.9.39; older agents ignore the
+   *  request and keep creating a pad, so the app still works, just without the
+   *  benefit. The dedicated PAD screen always sends gamepad frames regardless:
+   *  a gamepad screen with no gamepad would be a lie. */
+  keyboardMode: boolean;
   /** Input mode a newly paired box starts on. */
   defaultPadMode: PadMode;
   /** How often the console/header polls the box for vitals (ms). */
@@ -116,6 +131,7 @@ export const DEFAULTS: Prefs = {
   confirmSuspend: true,
   landingTab: 'index',
   autoKeyboard: true,
+  keyboardMode: false,
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
   journalLines: 100,
@@ -205,6 +221,7 @@ function normalize(raw: unknown): Prefs {
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     landingTab,
     autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),
+    keyboardMode: bool(o.keyboardMode, DEFAULTS.keyboardMode),
     defaultPadMode: padMode,
     statusIntervalMs: num(o.statusIntervalMs, STATUS_INTERVAL_OPTIONS, DEFAULTS.statusIntervalMs),
     journalLines: num(o.journalLines, JOURNAL_LINE_OPTIONS, DEFAULTS.journalLines),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,22 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **Value is narrower than it looks:** the shipped Bluetooth button already reaches Steam's
   own pairing UI, which handles agents and PINs correctly.
 
+### Landscape "laptop mode" — mini QWERTY + trackpad
+- **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
+- Rotating the phone to landscape shows a full soft QWERTY plus a trackpad on one screen,
+  laid out like a laptop, for driving the box's DESKTOP. Portrait is unchanged.
+- Landscape is free real estate: `app.json` is `"orientation": "default"` and no screen
+  uses landscape for anything today, so the rotation is an unused gesture rather than a
+  new control to find.
+- **Distinct from keyboard mode** (arrows/enter/esc instead of a virtual gamepad, agent
+  asked for `?nopad=1`). That one is about NOT creating a controller in Game Mode. This one
+  is about typing and pointing at a desktop. They can ship independently; a later pass can
+  decide whether rotating should also imply no-pad.
+- Both halves already exist as portrait components (`Trackpad`, the keyboard bar) — the work
+  is the landscape layout and the key set, not new input plumbing.
+- **Unverified:** whether the existing surfaces survive a landscape re-layout at all; no
+  screen has ever been rendered rotated.
+
 ### Find the missing Steam settings slugs
 - **priority:** P3 · **risk:** none · **affects:** agent only
 - Notifications, In Game and Remote Play are visible in Steam's sidebar but their slugs are

--- a/tests/test_gamepad_handoff.py
+++ b/tests/test_gamepad_handoff.py
@@ -44,6 +44,27 @@ cs._wsend_json = lambda entry, obj: _sent.append(obj)
 cs._wsend_op = lambda entry, op, payload=b"": None
 
 
+import json
+
+
+class _NullLock:
+    """entry["slock"] stand-in; _wsend_json is stubbed so it is never contended."""
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+class _HandlerStub:
+    """Just enough of Handler for _gamepad_message: it reads self.mock and the
+    class-level type tables, and nothing else on the instance."""
+    mock = True
+    _MOUSE_TYPES = cs.Handler._MOUSE_TYPES
+    _KEYBOARD_TYPES = cs.Handler._KEYBOARD_TYPES
+    _CONTROL_TYPES = cs.Handler._CONTROL_TYPES
+
+
 def test_repromotion_reuses_pad():
     print("re-promotion reuses the session's pad")
     entry = {"name": "test-phone"}
@@ -68,6 +89,71 @@ def test_repromotion_reuses_pad():
     check("session marked held again", entry.get("held"), True)
 
 
+def test_nopad_session_never_creates_a_pad():
+    """?nopad=1 -> keyboard and mouse, but NO virtual controller.
+
+    The point is not saving ioctls. Creating a pad makes Steam announce
+    "controller connected", and destroying it announces again — so a phone that
+    foregrounds and backgrounds spams the TV, and a game already running sees a
+    SECOND controller that can steal player 1. A client that only sends
+    arrows/enter/esc asks not to have one."""
+    print("nopad session gets no pad, but keeps mouse + keyboard")
+    _sent.clear()
+    entry = {"name": "kb-phone", "nopad": True}
+    ok = cs._make_holder(entry, mock=True)
+    check("promotion succeeds without a pad", ok, True)
+    check("NO gamepad created", entry.get("device") is None, True)
+    check("mouse still created", entry.get("mouse") is not None, True)
+    check("keyboard still created", entry.get("keyboard") is not None, True)
+    check("still marked holder", entry.get("held"), True)
+    hello = [m for m in _sent if m.get("t") == "hello"]
+    check("hello still sent (it IS the you-have-control signal)", len(hello), 1)
+    check("hello reports no controller", hello[0].get("dev"), "keyboard only")
+
+
+def test_nopad_gamepad_frame_is_dropped_not_lazily_created():
+    """The load-bearing guard: a button frame must NOT materialise a pad.
+
+    Without it, a nopad session could be tricked into creating the very
+    controller it asked to avoid just by sending one button — putting back the
+    Steam "controller connected" spam the flag exists to prevent."""
+    print("gamepad frames on a nopad session drop instead of creating a pad")
+    entry = {"name": "kb-phone", "nopad": True, "held": True,
+             "slock": _NullLock()}
+    cs._make_holder(entry, mock=True)
+    check("no pad before", entry.get("device") is None, True)
+
+    # Drive the REAL dispatch. Handler is a BaseHTTPRequestHandler subclass, so
+    # it is never instantiated here — the method is called unbound with a stub
+    # carrying only what it touches (self.mock and the type tables).
+    stub = _HandlerStub()
+    keep = cs.Handler._gamepad_message(
+        stub, None, entry, json.dumps({"t": "b", "k": "a", "v": 1}).encode())
+    check("frame accepted (session stays alive)", keep, True)
+    check("STILL no pad after a button frame", entry.get("device") is None, True)
+
+
+def test_normal_session_unaffected_by_the_opt_in():
+    """An old app sends no nopad param and must be completely unchanged."""
+    print("sessions without the flag still get a pad")
+    entry = {"name": "old-phone"}          # no 'nopad' key at all
+    ok = cs._make_holder(entry, mock=True)
+    check("promotion succeeds", ok, True)
+    check("pad created as before", entry.get("device") is not None, True)
+
+
+def test_nopad_release_is_clean():
+    """Demoting a pad-less session must not raise, and must keep mouse/kbd."""
+    print("releasing a nopad session is clean")
+    entry = {"name": "kb-phone", "nopad": True}
+    cs._make_holder(entry, mock=True)
+    mouse, kbd = entry.get("mouse"), entry.get("keyboard")
+    cs._release_devices(entry)             # would raise if it assumed a pad
+    check("no pad to release, no crash", entry.get("device") is None, True)
+    check("mouse kept for instant re-promotion", entry.get("mouse") is mouse, True)
+    check("keyboard kept too", entry.get("keyboard") is kbd, True)
+
+
 def test_fresh_session_still_gets_devices():
     print("fresh session still gets a pad")
     entry = {"name": "fresh-phone"}
@@ -81,7 +167,12 @@ def test_fresh_session_still_gets_devices():
 
 
 if __name__ == "__main__":
-    for fn in (test_repromotion_reuses_pad, test_fresh_session_still_gets_devices):
+    for fn in (test_repromotion_reuses_pad,
+               test_fresh_session_still_gets_devices,
+               test_nopad_session_never_creates_a_pad,
+               test_nopad_gamepad_frame_is_dropped_not_lazily_created,
+               test_normal_session_unaffected_by_the_opt_in,
+               test_nopad_release_is_clean):
         fn()
     print()
     if FAILURES:


### PR DESCRIPTION
Opt-in mode where the app drives Steam with **arrow keys** and asks the agent **not to create a virtual controller**, via a new `?nopad=1` on the gamepad socket. Off by default.

## Why

Connecting the app makes the box announce "controller connected" every time it foregrounds, and a game already running sees a *second* pad that can take player one. Steam navigates identically from arrow keys, so for menu driving the pad buys nothing and costs that.

## Allowlist verification

No new route, no new client-supplied identifier, no subprocess takes client input.

- `nopad` is parsed as `q.get("nopad", ["0"])[0] == "1"` — a **boolean**, not a value that indexes anything. Any other string is false.
- It can only ever cause the agent to do **less**: skip constructing a uinput device. There is no input it can steer toward creating something different.
- Gamepad frames on a nopad session hit the pre-existing `factory is None` drop path — the same one teardown uses — so no later frame can lazily create the pad.
- Auth is unchanged: the socket still requires the bearer token.

## Tests

`tests/test_gamepad_handoff.py`, 4 new lifecycle tests (registered in `__main__` — this file has no auto-discovery, and unregistered tests silently never run):

- a nopad session never creates a pad
- a **button frame** on a nopad session is dropped, not lazily created — the "STILL no pad after a button frame" assertion is the one that matters
- a normal session is unaffected by the opt-in
- nopad release is clean

Full agent suite passes. `tsc --noEmit` exits 0.

## Verified how

**On a real Bazzite box in Game Mode, by screen capture** — arrow keys drive Steam: three DOWN taps moved the Decky selection two rows and stopped at the end of the list; one UP moved it back one. **Control:** Ctrl+9 (not a binding) moved nothing — 18423 bytes before and after, selection unmoved — so "a key moved the UI" is not an artifact.

**In the web harness, both states, by pressing the toggle** (not by rendering it):

| | toggle OFF | toggle ON |
|---|---|---|
| segments | PAD SWIPE MOUSE REMOTE | SWIPE MOUSE REMOTE |
| swipe buttons | BACK STEAM ⋯ MENU | BACK |
| socket URL | `…&name=A%20device` | `…&name=A%20device&nopad=1` |

The URL row is the load-bearing one: `window.WebSocket` was hooked and the app's own connect captured, so the flag is proven on the wire rather than assumed from the pref.

## NOT verified

- **The end-to-end path on hardware.** The harness does not proxy `/ws/gamepad`, so app-sends-key → agent-injects → Steam-moves has never run as one chain. The two halves are each proven separately (app emits `nopad=1`; arrow keys move Steam) but the joint has not been exercised. Needs a device.
- **Whether a running game actually keeps player one.** That is the motivating claim and it is untested — it needs a game running plus a second physical pad.

## Known gap — KI-024

STEAM, QAM and MENU ride gamepad buttons and are **hidden** in keyboard mode rather than remapped. Ctrl+1 opened the Steam menu and Ctrl+2 opened the QAM on the first on-box trial (capture-confirmed), then Ctrl+1 produced no change from the same state, and a 3-trial re-test returned 0/3 — though that run is contaminated, the box had drifted onto a Steam store page with a video playing, which makes a frame-size delta meaningless. One hit, two misses, no explanation. An intermittent button is worse than no button, so nothing was wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)