### PR TITLE
Console: report the box's own battery on handhelds (agent 2.9.40)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.38"
+VERSION = "2.9.40"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1296,7 +1296,7 @@ def set_caps(mock):
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
                  "screensaver", "couchmode", "desktop", "steamlink", "gaming",
-                 "streamhost", "steammenus")}
+                 "streamhost", "steammenus", "boxbattery")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1312,6 +1312,7 @@ def set_caps(mock):
         "gaming": safe(gaming_available),
         "streamhost": safe(streamhost_available),
         "steammenus": safe(steammenus_available),
+        "boxbattery": safe(box_battery_available),
     }
 
 
@@ -1725,6 +1726,7 @@ def real_status():
     load = read_load()
     temp = read_cpu_temp_c()
     mem = read_mem()
+    battery = read_box_battery()
     now = int(time.time())
     _record_history(now, temp, load[0] if load else None, mem)
     return {
@@ -1735,6 +1737,11 @@ def real_status():
         "cpu_temp_c": temp,
         "mem": mem,
         "disks": read_disks(),
+        # The machine's OWN battery, on handhelds and laptops. ADDITIVE and
+        # OMITTED entirely on a mains desktop, so old apps are unaffected and
+        # new ones can treat "absent" as "this box has no battery" rather than
+        # having to distinguish that from 0%.
+        **({"battery": battery} if battery else {}),
         "net": net_info_cached(),
         "agent_version": VERSION,
         # CAPS is a boot-time snapshot, but "desktop" is SESSION-volatile (it
@@ -2889,6 +2896,10 @@ def mock_status():
             {"mount": "/var", "total_gb": 465.1, "used_gb": 198.2,
              "free_gb": 266.9, "pct": 43},
         ],
+        # Mock is a HANDHELD so the battery row is exercisable in the web
+        # harness -- a mains desktop would render nothing and prove nothing.
+        "battery": {"pct": 58, "status": "Discharging",
+                    "on_ac": False, "minutes": 251},
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
@@ -9167,6 +9178,101 @@ def _running_game():
     except Exception:
         pass
     return None
+
+
+# ---------------------------------------------------------------------------
+# Box battery (handhelds: Steam Deck, Legion Go / Go S, ROG Ally, laptops).
+#
+# Distinct from _pad_battery(), which reports a CONTROLLER's charge by joining
+# its MAC to a supply node. This is the machine's OWN battery, and until now the
+# agent never read it at all -- so a handheld running Couchside showed no battery
+# anywhere, despite the kernel exposing it.
+#
+# MEASURED VERBATIM on a Lenovo Legion Go S (Bazzite), 2026-07-22. Two things in
+# that real uevent drive the parser and are not obvious from documentation:
+#   * POWER_SUPPLY_TYPE appears TWICE in the same file. Last-wins is fine here
+#     (both say Battery) but a parser that assumed one occurrence per key would
+#     be relying on luck.
+#   * It is an ENERGY-based gauge (ENERGY_NOW/ENERGY_FULL, microwatt-hours), not
+#     a CHARGE-based one. Both exist in the wild, so both are read.
+# A mains-only desktop has no Battery node at all; that is the normal case and
+# returns {} rather than zeroes, so the cap degrades closed.
+
+def _uevent(path):
+    """Parse a power_supply uevent into a dict. Never raises; {} on any error."""
+    out = {}
+    try:
+        with open(path) as f:
+            for line in f:
+                k, _, v = line.strip().partition("=")
+                if k:
+                    out[k] = v
+    except OSError:
+        return {}
+    return out
+
+
+def read_box_battery():
+    """{"pct", "status", "on_ac"[, "minutes"]} for the machine's own battery, or
+    {} when this machine has none.
+
+    Read-only, best-effort, never raises. An unreadable or malformed node yields
+    {} -- "unavailable" -- never a fabricated percentage.
+    """
+    try:
+        names = os.listdir(_POWER_SUPPLY_DIR)
+    except OSError:
+        return {}
+
+    batt, on_ac = None, None
+    for name in sorted(names):
+        u = _uevent(os.path.join(_POWER_SUPPLY_DIR, name, "uevent"))
+        kind = u.get("POWER_SUPPLY_TYPE")
+        if kind == "Battery" and batt is None:
+            # PRESENT=0 means a bay with no pack in it -- not this machine's
+            # battery, and reporting 0% for it would be a lie.
+            if u.get("POWER_SUPPLY_PRESENT") == "0":
+                continue
+            batt = u
+        elif kind == "Mains" and u.get("POWER_SUPPLY_ONLINE") in ("0", "1"):
+            # Any online mains supply counts as plugged in.
+            on_ac = on_ac or u["POWER_SUPPLY_ONLINE"] == "1"
+
+    if batt is None:
+        return {}
+
+    try:
+        pct = int(batt["POWER_SUPPLY_CAPACITY"])
+    except (KeyError, ValueError):
+        return {}
+    if not 0 <= pct <= 100:
+        return {}
+
+    out = {"pct": pct, "status": batt.get("POWER_SUPPLY_STATUS", "Unknown")}
+    if on_ac is not None:
+        out["on_ac"] = on_ac
+
+    # Runtime left, when the gauge reports a draw. ENERGY_* is microwatt-hours
+    # against POWER_NOW microwatts; CHARGE_* is microamp-hours against
+    # CURRENT_NOW microamps. Both divide to hours. Only meaningful while
+    # discharging -- on AC, POWER_NOW is the CHARGE rate, and dividing by it
+    # would report a confident, entirely wrong "time left".
+    if out["status"] == "Discharging":
+        for now_k, rate_k in (("POWER_SUPPLY_ENERGY_NOW", "POWER_SUPPLY_POWER_NOW"),
+                              ("POWER_SUPPLY_CHARGE_NOW", "POWER_SUPPLY_CURRENT_NOW")):
+            try:
+                now, rate = int(batt[now_k]), int(batt[rate_k])
+            except (KeyError, ValueError):
+                continue
+            if now > 0 and rate > 0:
+                out["minutes"] = int(now * 60 // rate)
+                break
+    return out
+
+
+def box_battery_available():
+    """True when this machine has a readable battery."""
+    return bool(read_box_battery())
 
 
 def _norm_mac(s):

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -14,7 +14,7 @@ import { usePref } from '@/lib/prefs';
 import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { noteBoxReachable } from '@/lib/review';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
+import { batteryColor, mono, numeric, pctColor, tempColor, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 
 function unitColor(active: string, t: Palette): string {
@@ -217,6 +217,27 @@ function ConsoleScreen() {
                 </View>
               ))}
             </Card>
+
+            {/* Probe-and-appear: the agent OMITS `battery` on a mains desktop
+                and on agents older than 2.9.40, so presence of the key is the
+                whole gate -- no cap check, no placeholder, no "0%" on a machine
+                that has no pack. */}
+            {s.battery && (
+              <Card title="BATTERY" index={5}>
+                <View style={styles.barLabelRow}>
+                  <Text style={styles.barLabel}>
+                    {s.battery.on_ac ? 'On AC' : 'On battery'}
+                    {s.battery.minutes != null
+                      ? `   ${Math.floor(s.battery.minutes / 60)}h ${s.battery.minutes % 60}m left`
+                      : ''}
+                  </Text>
+                  <Text style={[styles.barLabel, { color: batteryColor(s.battery.pct, t) }]}>
+                    {s.battery.pct}%
+                  </Text>
+                </View>
+                <Bar pct={s.battery.pct} color={batteryColor(s.battery.pct, t)} />
+              </Card>
+            )}
           </>
         )}
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -122,6 +122,13 @@ export type BoxCaps = {
    */
   steammenus?: boolean;
   /**
+   * The BOX's own battery (agent >= 2.9.40) — a handheld or laptop, not a
+   * controller. Linux-only: it reads /sys/class/power_supply.
+   * Optional, so undefined reads as "unknown, probe" and only an explicit false
+   * means "this machine runs on mains".
+   */
+  boxbattery?: boolean;
+  /**
    * Gaming card: this box has Steam, so a "what's running now" card (GPU/game/
    * output/controllers/session) is worth showing. Gates the Console-tab card.
    * Optional: absent on agents < 2.9.25, so undefined reads as "unknown, probe"
@@ -234,6 +241,17 @@ export type Status = {
   caps?: BoxCaps;
   /** Recent-vitals ring for sparklines (agent >= 2.8.3); undefined on older agents. */
   history?: StatusHistory;
+  /** The BOX's own battery (agent >= 2.9.40). ABSENT on a mains desktop and on
+      older agents alike — the agent omits the key entirely rather than sending
+      zeroes, so "no battery card" needs no separate flag. `minutes` is present
+      only while discharging: on AC the same counter measures the CHARGE rate,
+      and reporting it as time-remaining would be confidently wrong. */
+  battery?: {
+    pct: number;
+    status: string;
+    on_ac?: boolean;
+    minutes?: number;
+  };
 };
 
 export type UnitScope = 'system' | 'user';
@@ -775,7 +793,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.steamlink === b.steamlink &&
     a.gaming === b.gaming &&
     a.streamhost === b.streamhost &&
-    a.steammenus === b.steammenus
+    a.steammenus === b.steammenus &&
+    a.boxbattery === b.boxbattery
   );
 }
 

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -243,9 +243,13 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // key above it: omit it here and the cap never persists, so the app re-probes
   // /api/steam/menus on every launch.
   const steammenus = bool('steammenus');
+  // boxbattery arrived with agent 2.9.40 — same optional-cap drop trap. A box
+  // with no battery reports false, which is a real answer, not "unknown".
+  const boxbattery = bool('boxbattery');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
+    boxbattery,
   };
 }
 

--- a/app/lib/theme.ts
+++ b/app/lib/theme.ts
@@ -134,6 +134,15 @@ export function pctColor(pct: number, t: Palette = dark): string {
   return t.red;
 }
 
+/** Battery charge -> colour. INVERTED relative to pctColor: a disk at 95% is in
+ *  trouble, a battery at 95% is fine. Reusing pctColor here would paint a full
+ *  battery red. */
+export function batteryColor(pct: number, t: Palette = dark): string {
+  if (pct <= 15) return t.red;
+  if (pct <= 30) return t.amber;
+  return t.green;
+}
+
 // ---------------------------------------------------------------------------
 // Persisted theme preferences (self-contained external store; mirrors the
 // prefs.ts / haptics.ts pattern so a segmented control reads/writes live).

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -177,6 +177,7 @@
       "linux"
     ],
     "keys": [
+      "boxbattery",
       "gaming",
       "steamlink",
       "steammenus",

--- a/tests/test_box_battery.py
+++ b/tests/test_box_battery.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Tests for the box's OWN battery (read_box_battery).
+
+Run: python3 tests/test_box_battery.py
+
+WHY THIS EXISTS: a handheld running Couchside showed no battery anywhere,
+because the agent only ever read a CONTROLLER's battery (_pad_battery, joined by
+MAC). The machine's own pack was never read at all.
+
+Every fixture below is copied VERBATIM from real hardware -- a Lenovo Legion Go
+S running Bazzite, 2026-07-22 -- because two things in the real file are not
+what documentation would lead you to write:
+
+  * POWER_SUPPLY_TYPE appears TWICE in BAT0's uevent. A parser that assumed one
+    occurrence per key would pass here by luck rather than by design, so the
+    duplicate is kept in the fixture and asserted.
+  * The gauge is ENERGY-based (ENERGY_NOW / POWER_NOW, microwatt-hours and
+    microwatts). Plenty of hardware is CHARGE-based instead (CHARGE_NOW /
+    CURRENT_NOW). Both are exercised.
+
+The mains-desktop case matters just as much: a machine with no battery must
+report "unavailable" (an empty dict), never a fabricated 0%.
+"""
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# VERBATIM off the Legion Go S. Note the repeated POWER_SUPPLY_TYPE line.
+BAT0 = """DEVTYPE=power_supply
+POWER_SUPPLY_NAME=BAT0
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_CHARGE_TYPES=Fast
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_TECHNOLOGY=Li-poly
+POWER_SUPPLY_CYCLE_COUNT=53
+POWER_SUPPLY_VOLTAGE_MIN_DESIGN=11700000
+POWER_SUPPLY_VOLTAGE_NOW=11705000
+POWER_SUPPLY_POWER_NOW=22543000
+POWER_SUPPLY_ENERGY_FULL_DESIGN=55500000
+POWER_SUPPLY_ENERGY_FULL=55500000
+POWER_SUPPLY_ENERGY_NOW=32350000
+POWER_SUPPLY_CAPACITY=58
+POWER_SUPPLY_CAPACITY_LEVEL=Normal
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_MODEL_NAME=L24M3PK8
+POWER_SUPPLY_MANUFACTURER=SMP
+POWER_SUPPLY_SERIAL_NUMBER=2399
+"""
+
+ACAD_OFFLINE = """DEVTYPE=power_supply
+POWER_SUPPLY_NAME=ACAD
+POWER_SUPPLY_TYPE=Mains
+POWER_SUPPLY_ONLINE=0
+POWER_SUPPLY_TYPE=Mains
+"""
+
+ACAD_ONLINE = ACAD_OFFLINE.replace("ONLINE=0", "ONLINE=1")
+
+# Also verbatim from the same box: USB-C PD ports show up as power supplies too
+# and must not be mistaken for either a battery or mains.
+USBC = """DEVTYPE=power_supply
+POWER_SUPPLY_NAME=ucsi-source-psy-USBC000:001
+POWER_SUPPLY_TYPE=USB
+POWER_SUPPLY_ONLINE=0
+"""
+
+
+class Supplies:
+    """A fake /sys/class/power_supply the REAL reader walks."""
+
+    def __init__(self, nodes):
+        self.dir = tempfile.mkdtemp(prefix="psy-")
+        for name, uevent in nodes.items():
+            d = os.path.join(self.dir, name)
+            os.makedirs(d)
+            with open(os.path.join(d, "uevent"), "w") as f:
+                f.write(uevent)
+        self._old = cs._POWER_SUPPLY_DIR
+        cs._POWER_SUPPLY_DIR = self.dir
+
+    def close(self):
+        cs._POWER_SUPPLY_DIR = self._old
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def test_real_handheld():
+    """The exact hardware that prompted this."""
+    print("test_real_handheld")
+    s = Supplies({"BAT0": BAT0, "ACAD": ACAD_OFFLINE, "ucsi-source-psy-USBC000:001": USBC})
+    try:
+        got = cs.read_box_battery()
+        check("percent", got.get("pct"), 58)
+        check("status", got.get("status"), "Discharging")
+        check("not on AC", got.get("on_ac"), False)
+        # 32350000 uWh / 22543000 uW = 1.4350h -> 86 minutes
+        check("minutes remaining", got.get("minutes"), 86)
+        check("cap is available", cs.box_battery_available(), True)
+    finally:
+        s.close()
+
+
+def test_duplicate_type_key():
+    """THE fixture trap: POWER_SUPPLY_TYPE really is repeated on this hardware."""
+    print("test_duplicate_type_key")
+    check("fixture still has the duplicate",
+          BAT0.count("POWER_SUPPLY_TYPE=Battery"), 2)
+    s = Supplies({"BAT0": BAT0})
+    try:
+        check("parsed anyway", cs.read_box_battery().get("pct"), 58)
+    finally:
+        s.close()
+
+
+def test_mains_desktop_degrades_closed():
+    """No battery must be UNAVAILABLE, never a fabricated 0%."""
+    print("test_mains_desktop_degrades_closed")
+    s = Supplies({"ACAD": ACAD_ONLINE})
+    try:
+        check("empty, not zero", cs.read_box_battery(), {})
+        check("cap is false", cs.box_battery_available(), False)
+    finally:
+        s.close()
+
+
+def test_no_power_supply_dir_at_all():
+    """A desktop with no /sys/class/power_supply must not raise."""
+    print("test_no_power_supply_dir_at_all")
+    old = cs._POWER_SUPPLY_DIR
+    cs._POWER_SUPPLY_DIR = "/nonexistent/power_supply"
+    try:
+        check("empty", cs.read_box_battery(), {})
+        check("cap is false", cs.box_battery_available(), False)
+    finally:
+        cs._POWER_SUPPLY_DIR = old
+
+
+def test_charge_based_gauge():
+    """Hardware that reports CHARGE_NOW/CURRENT_NOW instead of ENERGY_*."""
+    print("test_charge_based_gauge")
+    charge = """POWER_SUPPLY_NAME=BAT1
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_CHARGE_NOW=3000000
+POWER_SUPPLY_CURRENT_NOW=1500000
+POWER_SUPPLY_CAPACITY=42
+"""
+    s = Supplies({"BAT1": charge})
+    try:
+        got = cs.read_box_battery()
+        check("percent", got.get("pct"), 42)
+        check("minutes from charge/current", got.get("minutes"), 120)
+    finally:
+        s.close()
+
+
+def test_charging_reports_no_time_left():
+    """On AC, POWER_NOW is the CHARGE rate. Dividing by it would produce a
+    confident, entirely wrong 'time remaining' -- so there must be none."""
+    print("test_charging_reports_no_time_left")
+    s = Supplies({"BAT0": BAT0.replace("STATUS=Discharging", "STATUS=Charging"),
+                  "ACAD": ACAD_ONLINE})
+    try:
+        got = cs.read_box_battery()
+        check("status", got.get("status"), "Charging")
+        check("on AC", got.get("on_ac"), True)
+        check("no minutes while charging", "minutes" in got, False)
+    finally:
+        s.close()
+
+
+def test_empty_bay_is_not_a_battery():
+    """PRESENT=0 is a bay with no pack. Reporting its 0% would be a lie."""
+    print("test_empty_bay_is_not_a_battery")
+    s = Supplies({"BAT0": """POWER_SUPPLY_NAME=BAT0
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_PRESENT=0
+POWER_SUPPLY_CAPACITY=0
+"""})
+    try:
+        check("empty bay ignored", cs.read_box_battery(), {})
+    finally:
+        s.close()
+
+
+def test_garbage_capacity_rejected():
+    """Reject rather than sanitise (CLAUDE.md 3.6)."""
+    print("test_garbage_capacity_rejected")
+    for bad in ("", "abc", "-5", "9999"):
+        s = Supplies({"BAT0": """POWER_SUPPLY_NAME=BAT0
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_CAPACITY=%s
+""" % bad})
+        try:
+            check("capacity %r rejected" % bad, cs.read_box_battery(), {})
+        finally:
+            s.close()
+
+
+if __name__ == "__main__":
+    for fn in (test_real_handheld,
+               test_duplicate_type_key,
+               test_mains_desktop_degrades_closed,
+               test_no_power_supply_dir_at_all,
+               test_charge_based_gauge,
+               test_charging_reports_no_time_left,
+               test_empty_bay_is_not_a_battery,
+               test_garbage_capacity_rejected):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
A Legion Go S running Couchside showed no battery anywhere. The agent only ever read a **controller's** charge (`_pad_battery`, joined by MAC) — the machine's own pack was never read at all, so the Console tab had nothing to render. This is a new capability, not a display fix.

## Allowlist verification

No new route, no client-supplied identifier, no subprocess. `read_box_battery()` walks a fixed directory (`/sys/class/power_supply`), reads only `uevent`, and takes no input from anyone. Read-only and never raises.

Degrades closed per §3.7: an unreadable node, a malformed one, `PRESENT=0` (an empty bay), or a capacity outside 0–100 all yield `{}` — "unavailable" — never a fabricated percentage.

## Six edit sites, not five

CLAUDE.md lists five for a capability key. There is a **sixth**: `protocol/protocol.json`, which `tests/test_protocol_parity.py` enforces. It caught this half-wired:

```
FAIL  linux: no undeclared caps (extra: ['boxbattery'])
```

`boxbattery` goes in `linuxOnlyCapabilities` — it reads sysfs, and the Windows agent has no equivalent, so the both-platforms group would fail there instead. Worth folding into CLAUDE.md separately.

## Verified how

**On real hardware, both states, with ground truth:**

| box | `read_box_battery()` | cap | `battery` key in `/api/status` |
|---|---|---|---|
| Legion Go S (handheld) | `{'pct': 58, 'status': 'Discharging', 'on_ac': False, 'minutes': 251}` | `True` | present |
| bazzite (desktop) | `{}` | `False` | **absent** |

The handheld reading was checked against `cat /sys/class/power_supply/BAT0/capacity` → `58`, `status` → `Discharging`, `ACAD/online` → `0`. All three match. Existing payload keys were asserted intact, so no response shape changed.

**In the web harness:** the mock is a handheld, so the card is exercisable — it renders `BATTERY / On battery 4h 11m left / 58%`. The desktop control above is what proves the *absence* case rather than assuming it.

**Fixtures are verbatim from the Legion Go S**, and carry two traps that a from-documentation parser would get wrong:
- `POWER_SUPPLY_TYPE` appears **twice** in the same uevent. The duplicate is kept in the fixture and asserted, so passing is by design rather than luck.
- The gauge is **energy**-based (`ENERGY_NOW`/`POWER_NOW`); plenty of hardware is **charge**-based (`CHARGE_NOW`/`CURRENT_NOW`). Both are exercised.

Time remaining is reported **only while discharging**: on AC the same counter measures the charge rate, and dividing by it would produce a confident, entirely wrong "time left". There is a test asserting no `minutes` while charging.

`batteryColor()` is deliberately not `pctColor()` — a disk at 95% is in trouble, a battery at 95% is fine, and reusing it would paint a full battery red.

## NOT verified

- **No end-to-end run through the real HTTP route on the handheld.** `real_status()` was called directly in-process; the agent service on that box was not restarted onto this build, so `GET /api/status` over the wire is unexercised.
- **Charging state on hardware.** The box was discharging throughout; `on_ac: true` and the charging branch are covered by fixtures only.
- **Windows.** No battery support added; the cap is Linux-only by declaration.

## Version note

Claims agent **2.9.40**. [#204](https://github.com/emerytech/couchside/pull/204) claims 2.9.39 and is independent — this deliberately skips a number so the two cannot collide whichever merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)