### PR TITLE
Fix the occluded HIDE keyboard button, and stop shipping stale agent release notes

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Agent changelog
+
+The text under each version heading becomes that GitHub release's body, which
+is what the app shows as **"What's new"** on the *Box update available* card.
+
+`scripts/release-agent.sh` extracts the section matching the tag it is given and
+**refuses to publish** if there is no matching section. That is deliberate:
+before this file existed, the script wrote one hardcoded sentence — and only
+when it had to *create* a release — so every agent release for months told users
+the same thing regardless of what actually changed.
+
+Write for the person holding the phone, not for the commit log. They are
+deciding whether to press "Update now" on a machine across the room.
+
+## 2.9.40
+
+Handhelds now report their own battery. The Console tab shows charge, whether
+you're on AC, and how long you have left.
+
+## 2.9.39
+
+New "Send keys instead of a controller" option. Steam navigates the same way,
+but the box stops announcing a controller every time you connect — so a game
+that's already running can't lose player one to your phone.
+
+## 2.9.38
+
+Couch Mode now restores the exact audio device it moved, instead of guessing at
+one by name. Disk readings no longer count the same drive twice.
+
+## 2.9.37
+
+Signed agent assets for install.sh / `couchside update`.

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -385,6 +385,11 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
     setOpen(v);
   }, []);
   const [value, setValue] = useState('');
+  // Measured height of the compose field, so the HIDE pill can sit clear of it.
+  // MEASURED rather than a constant: the field grows with the OS text-size
+  // setting, and a hardcoded 40 would re-bury the pill for anyone using large
+  // text — which is exactly the bug this fixes, just for fewer people.
+  const [composeH, setComposeH] = useState(40);
   const pal = useTheme();
   // Live mirror: onChangeText/onKeyPress are memoised, and a stale `value` in
   // their closure would diff against the wrong text and send garbage.
@@ -598,9 +603,17 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
           bottom-right (thumb range), lifted by the MEASURED keyboard overlap.
           Exists because the in-layout DONE gets covered by the raised keyboard
           and the InputAccessoryView Done bar stopped rendering under newer iOS
-          SDKs (build 30), which left the keyboard stuck open. */}
+          SDKs (build 30), which left the keyboard stuck open.
+
+          Sits ABOVE the compose field, not level with it. #195 gave the field
+          the SAME `bottom: 10 + kbLift` as this pill, and the field is
+          full-width, opaque (t.card) and one zIndex higher (61 vs 60) — so it
+          painted straight over the pill, and iOS testers reported the HIDE
+          button "missing". It was never missing; it was underneath. */}
       {open && (
-        <View pointerEvents="box-none" style={[styles.kbFloatWrap, { bottom: 10 + kbLift }]}>
+        <View
+          pointerEvents="box-none"
+          style={[styles.kbFloatWrap, { bottom: 10 + kbLift + composeH + 8 }]}>
           <Pressable
             onPress={dismiss}
             hitSlop={10}
@@ -630,6 +643,7 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
           setValue('');
         }}
         style={open ? [styles.kbCompose, { bottom: 10 + kbLift }] : styles.hiddenInput}
+        onLayout={(e) => setComposeH(e.nativeEvent.layout.height)}
         placeholder={open ? 'type or paste — sent as you go' : undefined}
         placeholderTextColor={pal.textFaint}
         autoCapitalize="none"

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -349,3 +349,20 @@ ancestor.
 **What the harness cannot cover — verify on a device:** Pad/trackpad and gamepad (no WS
 proxying; mouse != touch), iOS Local Network permission, the no-UDP behaviour, app
 backgrounding, safe-area insets, and the purchase flow (`expo-iap` is a no-op on web).
+
+## Capability keys need SIX edit sites, not five
+
+`CLAUDE.md` §4 says five (agent CAPS dict + mock tuple; app BoxCaps + normalizeCaps +
+capsEqual). There is a sixth, and it is the one that fails CI: **`protocol/protocol.json`**.
+
+`tests/test_protocol_parity.py` drives both agents' real `set_caps()` and asserts no agent
+declares a cap the spec has never heard of. Miss it and you get:
+
+    FAIL  linux: no undeclared caps (extra: ['boxbattery'])
+
+Which group matters. `capabilities` is linux+windows — putting a Linux-only key there makes
+the WINDOWS agent fail for a missing key instead. Anything reading sysfs, `/proc`, or a Steam
+path that only exists on Linux goes in `linuxOnlyCapabilities`.
+
+Observed adding `boxbattery` (agent 2.9.40): the parity test caught the wiring half-done after
+the two agent sites were written and before any app site was.

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -117,11 +117,50 @@ if ! "$ossl" pkeyutl -verify -pubin -inkey "$tmp/pub.pem" -rawin \
 fi
 echo "    signature self-verified OK"
 
-# Ensure a release exists for the tag (create from the tag if not).
+# Release notes = the matching section of agent/CHANGELOG.md.
+#
+# This used to be ONE hardcoded sentence, written only when the release had to
+# be CREATED. So every agent release carried identical "What's new" text, and
+# the in-app update card told users the same thing for months. The app is a
+# faithful pipe — it renders the GitHub release body — so the lie originated
+# exactly here.
+#
+# Failing loud is the point. A release-notes script that silently publishes
+# something stale and exits 0 has happened in this repo before; a missing
+# section must stop the release, not fall back to boilerplate.
+ver="${tag#v}"
+notes_file="$tmp/notes.md"
+# Leading/trailing blank lines are dropped in the same pass -- `sed -i` differs
+# between BSD and GNU and this script runs on both.
+awk -v v="$ver" '
+    $0 == "## " v      { grab = 1; next }
+    grab && /^## /     { exit }
+    grab               { buf[n++] = $0 }
+    END {
+        first = 0; while (first < n && buf[first] ~ /^[[:space:]]*$/) first++
+        last = n - 1; while (last >= first && buf[last] ~ /^[[:space:]]*$/) last--
+        for (i = first; i <= last; i++) print buf[i]
+    }
+' "$root/agent/CHANGELOG.md" > "$notes_file"
+
+if [ ! -s "$notes_file" ]; then
+    echo "error: agent/CHANGELOG.md has no '## $ver' section." >&2
+    echo "       Add one describing what changed for the person holding the phone," >&2
+    echo "       then re-run. Refusing to publish boilerplate release notes." >&2
+    exit 2
+fi
+echo "==> release notes for $ver:"
+sed 's/^/    | /' "$notes_file"
+
+# Ensure a release exists for the tag (create from the tag if not), then set the
+# body UNCONDITIONALLY — re-running after an agent bump must refresh the notes,
+# which the create-only path never did.
 if ! gh release view "$tag" --repo "$REPO" >/dev/null 2>&1; then
     echo "==> creating release $tag"
-    gh release create "$tag" --repo "$REPO" --title "$tag" \
-        --notes "Signed agent assets for install.sh / \`couchside update\`."
+    gh release create "$tag" --repo "$REPO" --title "$tag" --notes-file "$notes_file"
+else
+    echo "==> updating release notes on $tag"
+    gh release edit "$tag" --repo "$REPO" --notes-file "$notes_file"
 fi
 
 echo "==> uploading signed agent assets to $tag"
@@ -129,6 +168,21 @@ uploads=()
 for f in "${files[@]}"; do uploads+=("$tmp/$f"); done
 uploads+=("$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig")
 gh release upload "$tag" --repo "$REPO" --clobber "${uploads[@]}"
+
+# Read the notes BACK from GitHub. `gh release edit` exiting 0 is not evidence
+# that the body changed — this repo has already shipped a release whose notes
+# script reported success and published stale text. The app renders whatever is
+# actually on the release, so verify what is actually on the release.
+echo "==> verifying published notes"
+published="$(gh release view "$tag" --repo "$REPO" --json body --jq .body)"
+if [ "$(printf '%s' "$published" | tr -d '[:space:]')" \
+     != "$(tr -d '[:space:]' < "$notes_file")" ]; then
+    echo "error: published notes do not match agent/CHANGELOG.md '## $ver'." >&2
+    echo "--- on the release ---" >&2
+    printf '%s\n' "$published" >&2
+    exit 1
+fi
+echo "    published notes match the changelog"
 
 echo "OK: signed agent published to $REPO $tag"
 echo "    install.sh fetches these from releases/latest/download/ and verifies the sig."


### PR DESCRIPTION
Two unrelated-but-both-small fixes from on-device feedback on build 73.

## 1. The HIDE keyboard button was underneath the compose field

Reported as "on iOS the hide keyboard button is not showing now". It never stopped rendering. [#195](https://github.com/emerytech/couchside/pull/195) gave the new compose field the **same** `bottom: 10 + kbLift` as the floating pill, and the field is full-width, opaque (`t.card`) and one zIndex higher (61 vs 60) — so it painted straight over it.

**Measured in the harness, both states, 319pt viewport:**

| | pill | field | result |
|---|---|---|---|
| before | 718–733 | 706–745 | overlap; `elementFromPoint` at the pill's centre returns `INPUT` |
| after | 670–685 | 706–745 | no overlap, 21px gap |

The hit test is the part that matters: the button was not merely invisible, it was **unclickable**. The reported symptom understated the bug.

The pre-fix numbers come from an actual build of `main` in the harness, not from arithmetic — the fix was stashed, the bundle rebuilt, and the same measurement re-run.

The offset is measured via `onLayout` rather than hardcoded, because the field grows with the OS text-size setting. A constant would re-bury the pill for anyone using large text — the same bug for fewer people.

## 2. Agent release notes were a hardcoded string

The in-app *Box update available* card has shown the same "What's new" for several releases. The app is a faithful pipe (it renders the GitHub release body), and the agent is too (`update_check()` returns `meta["body"]` verbatim). The staleness originates in `scripts/release-agent.sh`, which wrote one hardcoded sentence **and only when it had to create the release** — so re-running after an agent bump never refreshed an existing body.

Now: notes come from a per-version section of a new `agent/CHANGELOG.md`, are set unconditionally (create **or** edit), and the script **refuses to publish** when the section is missing rather than falling back to boilerplate.

It then **reads the notes back from GitHub and compares**. `gh release edit` exiting 0 is not evidence the body changed, and this repo has already shipped a release whose notes script reported success and published stale text.

**Verified:** extraction returns the correct section for 2.9.38 / 2.9.39 / 2.9.40 and empty for an absent version, which exits 2. Blank-line trimming happens inside the awk pass because `sed -i` differs between BSD and GNU; `bash -n` is clean.

**NOT verified:** no release was actually published, so the `gh create` / `edit` / read-back path has not run against the real API. First real use will exercise it.

## Also recorded (docs only)

- `CONVENTIONS.md`: capability keys need **six** edit sites, not the five CLAUDE.md lists — `protocol/protocol.json` is enforced by the parity test and is the one that fails CI.
- KI-025 (local): `/api/status` response fields are **not** parity-checked, and `config_writable` has already drifted — added to the agent in 2.9.12, still absent from the app's `Status` type.

## Separate, still open

The owner also asked to split Preferences into category sub-tabs (27 rows across 6 cards today). Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)