### PR TITLE
Fix the setup-guide link overflowing on Android; record the harness blind spot

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -900,11 +900,11 @@ function SetupBody() {
                 void Linking.openURL(SETUP_GUIDE_URL);
               }}
               style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
-              <Ionicons name="hardware-chip-outline" size={15} color={t.blue} />
+              <Ionicons name="hardware-chip-outline" size={15} color={t.blue} style={styles.emptyLinkIcon} />
               <Text style={styles.emptyLinkText}>
                 Haven&apos;t installed the Couchside service? Setup guide
               </Text>
-              <Ionicons name="open-outline" size={13} color={t.blue} />
+              <Ionicons name="open-outline" size={13} color={t.blue} style={styles.emptyLinkIcon} />
             </Pressable>
           </View>
         ) : (
@@ -1680,11 +1680,25 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19 },
   emptyLink: {
     flexDirection: 'row',
-    alignItems: 'center',
+    // flex-start, not center: once the label wraps to two lines, centred icons
+    // float in the middle of the block instead of sitting on the first line.
+    alignItems: 'flex-start',
     gap: 6,
     marginTop: 12,
   },
-  emptyLinkText: { color: t.blue, fontSize: 13, fontWeight: '600' },
+  // flex:1 is load-bearing. Without it the Text takes its INTRINSIC width, so a
+  // label wider than the row pushes the trailing ↗ off the edge rather than
+  // wrapping. It fit on iOS and overflowed on Android, which is exactly the
+  // shape of bug that a single-platform check misses.
+  // Aligns the glyphs with the first line of a wrapped label.
+  emptyLinkIcon: { marginTop: 2 },
+  emptyLinkText: {
+    color: t.blue,
+    fontSize: 13,
+    fontWeight: '600',
+    flex: 1,
+    lineHeight: 18,
+  },
   boxCard: {
     backgroundColor: t.card,
     borderColor: t.cardBorder,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,28 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **Value is narrower than it looks:** the shipped Bluetooth button already reaches Steam's
   own pairing UI, which handles agents and PINs correctly.
 
+### Fill in missing Launch tile cover art from the box
+- **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- **MEASURED on a Legion Go S, 2026-07-22:** its `appcache/librarycache` holds 1118 entries —
+  **826** games have `header.jpg` but only **386** have `library_600x900.jpg`. `_steam_cover_path()`
+  looks for `library_600x900.jpg` and nothing else, so roughly **440 installed games render the
+  blank text-card fallback while their artwork is already on disk.**
+- Entirely local: no CDN, no scraping, no new network egress. The existing
+  `/api/steam/<appid>/cover` route already serves from the box; this widens which local files
+  it will serve, in a fixed preference order.
+- Candidate sources beyond the current two: `library_600x900_2x.jpg`, `header.jpg`,
+  `library_hero.jpg`, and user/SteamGridDB art under `userdata/<uid>/config/grid/`. **No `grid/`
+  folder existed on the Legion Go S**, so custom-art support is speculative — do not claim it
+  works until a box with one is measured.
+- **Aspect is the real design problem, not the lookup.** Tiles are 600x900 portrait; `header.jpg`
+  is 460x215 landscape. Centre-cropping a header into a portrait tile often looks worse than the
+  clean fallback card. So the agent should ADD a field saying which KIND of art it found
+  (portrait / header / none) and let the app lay each out properly — never rename or remove an
+  existing field.
+- Allowlist note: appid stays digits-only validated and the resolved path must still be verified
+  to sit inside the cache root. Widening the FILENAME set is fine; widening to a glob or a
+  client-supplied filename is not.
+
 ### Landscape "laptop mode" — mini QWERTY + trackpad
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
 - Rotating the phone to landscape shows a full soft QWERTY plus a trackpad on one screen,
@@ -57,6 +79,9 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   decide whether rotating should also imply no-pad.
 - Both halves already exist as portrait components (`Trackpad`, the keyboard bar) — the work
   is the landscape layout and the key set, not new input plumbing.
+- **Owner requirement: gate it behind a preference toggle.** Rotation must not silently change
+  the interface for people who rotate by accident or who read in bed; the pref is what makes
+  the gesture opt-in.
 - **Unverified:** whether the existing surfaces survive a landscape re-layout at all; no
   screen has ever been rendered rotated.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,39 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **Value is narrower than it looks:** the shipped Bluetooth button already reaches Steam's
   own pairing UI, which handles agents and PINs correctly.
 
+### Close the running game from the Launch tab
+- **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
+- A card at the top of Launch showing what is running now, how long it has been running, and
+  a red button to close it. Today you can start a game from the phone but not stop one, which
+  is the half that matters when the TV is black.
+- **Half of it already exists:** `_running_game()` (`agent/couchsided.py:9149`) scans
+  `/proc/*/cmdline` for Steam's reaper wrapper and returns `{"appid", "label"}`. Runtime comes
+  from field 22 (`starttime`) of `/proc/<pid>/stat` against `/proc/uptime` — no new source.
+- **THE ALLOWLIST DESIGN, do not deviate:** the stop route takes **NO client input at all** —
+  no pid, no appid, no name. `POST /api/game/stop` with an empty body, and the AGENT
+  re-resolves the target itself via `_running_game()` at the moment of the call. A client that
+  cannot name a process cannot be steered into killing one. Passing a pid or appid "to be
+  explicit" would invert that and is exactly what §3 forbids.
+- `SIGTERM` to the reaper, never `SIGKILL` first, never a shell string. Degrade closed:
+  nothing running is a 404, not a best-effort sweep.
+- **Unverified:** whether SIGTERM to the reaper closes a game cleanly or whether Steam
+  restarts it / leaves a zombie, and whether the reaper is the right target at all versus the
+  game binary. Needs a game actually running on a box.
+
+### Show the box IP and live network throughput on Console
+- **priority:** P3 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- **The IP is already in the payload.** `/api/status` carries `ip` (the address the phone
+  reached the box on, agent >= 2.9.22) and the app's `Status` type already declares it — the
+  Console tab simply never renders it. That half is app-only, no agent release needed.
+- Throughput is the real work: `/proc/net/dev` exposes cumulative byte counters, so a RATE
+  needs two samples and a delta. The agent has to hold the previous sample and its timestamp;
+  one read can only ever report totals, never speed.
+- Choose the interface the way `net_info_cached()` already does rather than inventing a second
+  rule, or the two cards will disagree about which NIC the box is on.
+- **Unverified:** what the counters do across suspend/resume or a NIC reset. A counter that
+  resets produces a large negative delta — clamp at zero and show nothing rather than
+  rendering a nonsense spike.
+
 ### Fill in missing Launch tile cover art from the box
 - **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
 - **MEASURED on a Legion Go S, 2026-07-22:** its `appcache/librarycache` holds 1118 entries —

--- a/scripts/web-dev.sh
+++ b/scripts/web-dev.sh
@@ -17,6 +17,12 @@
 #   * iOS Local Network permission, and the no-UDP behaviour
 #   * app backgrounding (iPhone Mirroring suspends WS sends)
 #   * safe-area insets, status bar, keyboard avoidance
+#   * ROW OVERFLOW. A <Text> inside a flexDirection:'row' gets CSS
+#     flex-shrink:1 for free on web, so it always wraps; on NATIVE it does not
+#     shrink unless you say flex:1, and a long label shoves its siblings off the
+#     edge. Measured 2026-07-22: the setup-guide link overflowed on Android and
+#     the harness reported ZERO overflow for the same code, before and after the
+#     fix. Row layout has to be checked on a device.
 #   * the purchase flow (expo-iap is a no-op on web by design)
 # A web build that looks perfect says nothing about any of the above.
 set -euo pipefail


### PR DESCRIPTION
From an Android photo: the empty-state link row runs off the edge and the trailing ↗ is orphaned.

## Cause

`emptyLink` is a `flexDirection: 'row'` with three children — icon, `Text`, icon — and the `Text` had no `flex`. On React Native **native**, a `Text` in a flex row does not shrink by default, so a label wider than the row pushes its siblings off the edge. iOS's metrics happened to fit; Android's did not.

Fix: `flex: 1` on the label, `alignItems: 'flex-start'` so the icons sit on the first line once it wraps, and a 2px nudge so the glyphs align to that line.

## NOT verified — and the harness cannot verify it

This is the important part. **On RN Web the `Text` gets CSS `flex-shrink: 1` for free**, so it always wraps and can never overflow. Confirmed by reading the computed style: `flexShrink: "1"`, `whiteSpace: "pre-wrap"`.

I built both bundles at a 360pt viewport and measured:

| | row | children | overflow |
|---|---|---|---|
| before fix | 29–331 | 29–44, 50–312, 318–331 | **0px** |
| after fix | 29–331 | 29–44, 50–312, 318–331 | **0px** |

Identical. So the harness measurement is evidence that the change causes **no web regression**, and **no evidence whatsoever** that it fixes Android. It needs an Android build to confirm.

I'd rather say that plainly than present a green harness result as if it proved anything — a render-only check has already shipped a broken tap in this repo once.

`scripts/web-dev.sh` now lists row overflow alongside its other known blind spots (gamepad WS, safe-area, iOS Local Network) so the next one isn't "verified" the same hollow way.

## Also in here

- **Recovers `docs/ROADMAP.md`'s cover-art entry.** It was committed but never pushed, and `gh pr merge --delete-branch` on #204 orphaned it. Cherry-picked back from the dangling object.
- **Two new roadmap entries** from owner feedback: closing the running game from Launch, and box IP + network throughput on Console.

The Launch one carries a design constraint worth reading before anyone builds it: the stop route must take **no client input at all** — no pid, no appid, no name. `POST /api/game/stop` with an empty body, and the agent re-resolves the target itself via the existing `_running_game()`. A client that cannot name a process cannot be steered into killing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)