### PR TITLE
Cover art from hashed Steam paths, box IP on Console, honest controller advice (agent 2.9.41)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -12,6 +12,12 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.41
+
+Games missing their poster art now show the banner artwork the box already has,
+instead of a blank card. Nothing is downloaded — it was on your machine the
+whole time.
+
 ## 2.9.40
 
 Handhelds now report their own battery. The Console tab shows charge, whether

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.40"
+VERSION = "2.9.41"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -3244,11 +3244,21 @@ def discover_steam_games():
                 if _is_steam_tool(appid, name):
                     continue
                 games.setdefault(appid, name)  # de-dupe by appid
-        launchers = [
-            {"id": "steam:%s" % appid, "label": name,
-             "kind": "steam", "appid": int(appid)}
-            for appid, name in games.items()
-        ]
+        # "art" says which SHAPE of cover the box has for this game, so the app
+        # can lay the tile out before the image loads instead of reflowing when
+        # it arrives: "portrait" (600x900 capsule), "header" (460x215 banner) or
+        # absent (no local art -- the app's text card).
+        # ADDITIVE: older apps ignore the key and behave exactly as before.
+        # Costs a few stat() calls per installed game on a list that is already
+        # walking every appmanifest off the same disk.
+        launchers = []
+        for appid, name in games.items():
+            entry = {"id": "steam:%s" % appid, "label": name,
+                     "kind": "steam", "appid": int(appid)}
+            _, art = _steam_cover(appid)
+            if art:
+                entry["art"] = art
+            launchers.append(entry)
         launchers.sort(key=lambda l: (l["label"].lower(), l["appid"]))
         return launchers
     except Exception:
@@ -3822,8 +3832,100 @@ def steam_downloads():
 STEAM_COVER_CACHE = ("appcache", "librarycache")
 
 
+# Cover art FILENAMES, in preference order, as (name, kind). Layout is handled
+# separately below because Steam has three of them on disk at once.
+#
+# MEASURED on a Legion Go S, 2026-07-22, by decoding the actual JPEG headers
+# rather than trusting the names:
+#     library_600x900.jpg  300x450   portrait
+#     library_capsule.jpg  300x450   portrait   <-- the NEWER capsule name
+#     header.jpg           460x215   header
+#     library_header.jpg   460x215   header
+#
+# The KIND travels with the path because the shapes are not interchangeable.
+# Centre-cropping a 460x215 banner into a 2:3 tile slices the middle out of the
+# artwork and reads as a bug, so the app is told which it got instead of
+# guessing from pixels.
+_STEAM_ART_CANDIDATES = (
+    ("library_600x900.jpg", "portrait"),
+    ("library_capsule.jpg", "portrait"),
+    ("library_600x900_2x.jpg", "portrait"),
+    ("header.jpg", "header"),
+    ("library_header.jpg", "header"),
+)
+
+# How many hash-named subdirectories to look through per game. Bounded so a
+# weird cache directory can never turn one cover lookup into an unbounded walk.
+_STEAM_ART_MAX_SUBDIRS = 40
+
+
+def _steam_cover(appid):
+    """(path, kind) for a Steam appid's best local art, or (None, None).
+
+    kind is "portrait" (2:3 capsule) or "header" (460x215 banner).
+
+    THREE on-disk layouts exist and all three are live on current hardware:
+      flat     <cache>/<appid>_library_600x900.jpg      (pre-2023)
+      nested   <cache>/<appid>/library_600x900.jpg
+      hashed   <cache>/<appid>/<sha1>/library_600x900.jpg   (current Steam)
+
+    The hashed layout is why this was worth fixing: MEASURED on a Legion Go S,
+    30 of 80 installed games -- The Witcher 3, GTA V, RimWorld, Stray -- had NO
+    art under either older layout and rendered the blank text card, while their
+    real capsule sat one directory deeper the whole time.
+
+    The subdirectory names are content hashes, so they cannot be predicted and
+    have to be enumerated. That enumeration is the ONLY dynamic part: the
+    filename is still a literal from the table above, appid is still digits-only,
+    and the resolved path is re-checked to be inside the cache root. No client
+    input reaches the pattern.
+
+    Read-only, best-effort; never raises.
+    """
+    if not (isinstance(appid, str) and appid.isdigit()):
+        return None, None
+    root = _steam_root()
+    if root is None:
+        return None, None
+    cache = os.path.join(root, *STEAM_COVER_CACHE)
+    try:
+        cache_real = os.path.realpath(cache)
+    except OSError:
+        return None, None
+
+    try:
+        subdirs = sorted(os.listdir(os.path.join(cache, appid)))[:_STEAM_ART_MAX_SUBDIRS]
+    except OSError:
+        subdirs = []
+
+    def usable(path):
+        # Belt and braces (CLAUDE.md 3.5): appid is digits-only and the filename
+        # is a literal, so this cannot fire today. It is here because widening
+        # the table is exactly how that stops being true.
+        try:
+            if not os.path.realpath(path).startswith(cache_real + os.sep):
+                return False
+            return os.path.isfile(path)
+        except OSError:
+            return False
+
+    # Every portrait candidate is tried across all layouts before any header, so
+    # a game with a nested capsule is never demoted to a banner.
+    for name, kind in _STEAM_ART_CANDIDATES:
+        for candidate in ([os.path.join(cache, appid, name),
+                           os.path.join(cache, "%s_%s" % (appid, name))]
+                          + [os.path.join(cache, appid, d, name) for d in subdirs]):
+            if usable(candidate):
+                return candidate, kind
+    return None, None
+
+
 def _steam_cover_path(appid):
     """Local path to the 600x900 library cover for a Steam appid, or None.
+
+    Kept as the PORTRAIT-ONLY lookup. _steam_cover() is the one that also finds
+    header art; this stays narrow because callers that specifically want a
+    600x900 capsule should not silently receive a banner.
 
     Looks in <root>/appcache/librarycache/ for both known layouts:
       new (2023+):  <appid>/library_600x900.jpg
@@ -3848,6 +3950,49 @@ def _steam_cover_path(appid):
         except OSError:
             continue
     return None
+
+
+# Mock Steam games, so the web harness can exercise every tile shape. Without
+# these the harness Launch tab has no Steam entries at all and the header-art
+# branch is unverifiable -- which is how a layout bug ships.
+MOCK_STEAM_GAMES = [
+    (1091500, "Cyberpunk 2077", "portrait"),
+    (292030, "The Witcher 3: Wild Hunt", "portrait"),
+    (620, "Portal 2", "header"),
+    (570, "Dota 2", "header"),
+    (440, "Team Fortress 2", None),
+]
+
+
+def _png(width, height, rgb):
+    """A minimal solid-colour PNG. Mock only -- real covers are files on disk.
+
+    Hand-rolled because the agent is stdlib-only; zlib and struct are enough.
+    """
+    import struct
+    import zlib
+    raw = b"".join(b"\x00" + bytes(rgb) * width for _ in range(height))
+
+    def chunk(tag, data):
+        c = tag + data
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c))
+
+    return (b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw, 6))
+            + chunk(b"IEND", b""))
+
+
+def mock_launchers():
+    """Custom launchers plus fake Steam games carrying every art kind."""
+    out = [{"id": l["id"], "label": l["label"], "kind": "custom"} for l in LAUNCHERS]
+    for appid, label, art in MOCK_STEAM_GAMES:
+        e = {"id": "steam:%d" % appid, "label": label,
+             "kind": "steam", "appid": appid}
+        if art:
+            e["art"] = art
+        out.append(e)
+    return out
 
 
 def list_launchers():
@@ -8801,10 +8946,46 @@ def guide_hold_info():
                 p["uniq"].lower() == uniq.lower() for p in pads),
             "session": _couchmode_session(),
             "controllers": [
-                {"uniq": p["uniq"], "phys": p["phys"], "name": p["name"],
-                 "readable": os.access(os.path.join(_DEV_INPUT, p["event"]),
-                                       os.R_OK)}
+                dict({"uniq": p["uniq"], "phys": p["phys"], "name": p["name"],
+                      "readable": os.access(os.path.join(_DEV_INPUT, p["event"]),
+                                            os.R_OK)},
+                     **_unreadable_reason(p["event"]))
                 for p in pads]}
+
+
+def _unreadable_reason(event):
+    """{"reason": "masked"|"permission"} for a node we cannot read, else {}.
+
+    MEASURED on a Lenovo Legion Go S, 2026-07-22, and the reason this exists:
+
+        $ ls -l /dev/input/event2        # the built-in pad
+        c---------+ 1 root root
+        $ getfacl /dev/input/event2
+        user:deck:rw-   #effective:---
+        mask::---
+
+    The ACL entry granting the user IS present and intact. What nullifies it is
+    the file mode being 000: when a POSIX ACL exists, the group bits ARE the
+    mask, so mode 000 collapses the mask and every named-user entry becomes
+    ineffective. `inputplumber` and Steam's input rules mask a source device on
+    purpose and present a composite in its place.
+
+    That matters because the app told users to re-run install.sh, which adds
+    udev rules and group membership -- NEITHER of which can override a zeroed
+    mask. The advice was unfollowable. "masked" means the platform did this
+    deliberately; "permission" is the genuinely install-fixable case (a normal
+    mode like 0660 that this user simply is not in the group for).
+
+    Best-effort; an unstattable node reports nothing rather than guessing.
+    """
+    path = os.path.join(_DEV_INPUT, event)
+    try:
+        if os.access(path, os.R_OK):
+            return {}
+        mode = os.stat(path).st_mode & 0o777
+    except OSError:
+        return {}
+    return {"reason": "masked" if mode == 0 else "permission"}
 
 
 def _guide_save(enabled, hold_ms, uniq):
@@ -10828,7 +11009,8 @@ class Handler(BaseHTTPRequestHandler):
             elif path == "/api/launchers":
                 # create_enabled mirrors ALLOW_APP_LAUNCHERS so the app can
                 # show/hide its "add launcher" control (like update apply_enabled).
-                self._send(200, {"launchers": list_launchers(),
+                self._send(200, {"launchers": (mock_launchers() if self.mock
+                                               else list_launchers()),
                                  "create_enabled": bool(ALLOW_APP_LAUNCHERS)},
                            started)
             elif path == "/api/downloads":
@@ -11036,7 +11218,20 @@ class Handler(BaseHTTPRequestHandler):
         so the app stays LAN-only. 404 when the appid is malformed, the game
         isn't installed, or Steam hasn't cached its portrait art yet (the app
         then shows its text-card fallback)."""
-        cover = _steam_cover_path(appid)
+        if self.mock:
+            # Mock: a solid-colour placeholder at the REAL aspect of each shape,
+            # so the harness shows the actual layout difference rather than two
+            # identically-shaped squares that prove nothing.
+            for aid, _label, art in MOCK_STEAM_GAMES:
+                if str(aid) == appid and art:
+                    body = (_png(60, 90, (40, 70, 130)) if art == "portrait"
+                            else _png(92, 43, (130, 60, 40)))
+                    self._send_bytes(200, body, "image/png", started,
+                                     extra_headers={"X-Couchside-Art": art})
+                    return
+            self._send(404, {"error": "no cover"}, started)
+            return
+        cover, kind = _steam_cover(appid)
         if cover is None:
             self._send(404, {"error": "no cover"}, started)
             return
@@ -11047,8 +11242,12 @@ class Handler(BaseHTTPRequestHandler):
             self._send(404, {"error": "no cover"}, started)
             return
         # Art is keyed by appid and effectively immutable; let the phone cache it.
+        # X-Couchside-Art tells the app the SHAPE it just received so it can lay
+        # a 460x215 banner out differently from a 600x900 capsule. A header is
+        # ADDITIVE -- an older app ignores it and renders exactly as before.
         self._send_bytes(200, body, "image/jpeg", started,
-                         extra_headers={"Cache-Control": "public, max-age=604800"})
+                         extra_headers={"Cache-Control": "public, max-age=604800",
+                                        "X-Couchside-Art": kind})
 
     def _body_too_large(self):
         """True iff the declared Content-Length exceeds MAX_BODY_BYTES.

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -174,6 +174,12 @@ function ConsoleScreen() {
                 <Card title="UPTIME" index={1}>
                   {/* Not numeric: "1d 2h 7m" must never be interpolated. */}
                   <BigMetric value={humanizeUptime(s.uptime_s)} numeric={null} color={t.text} />
+                  {/* The address the phone actually reached the box on, straight
+                      from the socket (agent >= 2.9.22). Worth showing because it
+                      is what you need when mDNS breaks and the box has to be
+                      re-added by IP — the exact moment the app is hardest to
+                      use. Rides the poll that is already happening. */}
+                  {s.ip ? <Text style={styles.ipLine}>{s.ip}</Text> : null}
                 </Card>
               </View>
             </View>
@@ -340,6 +346,16 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   bigMetric: { fontSize: 28, fontWeight: '700', ...numeric },
   loadRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  // Deliberately quiet: the IP is reference information you go looking for,
+  // not a vital you watch. Sized so it never competes with the uptime metric
+  // above it.
+  ipLine: {
+    color: t.textFaint,
+    fontSize: 11,
+    textAlign: 'center',
+    marginTop: 2,
+    ...numeric,
+  },
   loadVal: {
     color: t.text,
     fontSize: 22,

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -91,13 +91,37 @@ function LauncherTile({
   // Narrowed to a local so the <Image> branch sees a defined source (not the
   // `ImageSource | undefined` prop): shown only for Steam tiles that haven't errored.
   const art = imgFailed ? undefined : coverSource;
+  // The box tells us which shape it has BEFORE the image loads, so the tile is
+  // laid out correctly from the first frame instead of reflowing when the
+  // bytes arrive. Absent (older agent, or no local art) falls through to the
+  // existing behaviour.
+  const isHeader = launcher.art === 'header';
   const height = Math.round(width * 1.5); // 600x900 aspect
 
   return (
     <Pressable
       onPress={onLaunch}
       style={({ pressed }) => [styles.tile, { width, height }, pressed && styles.tilePressed]}>
-      {art ? (
+      {art && isHeader ? (
+        /* HEADER art is a 460x215 banner, not a 600x900 capsule. Centre-cropping
+           one into a tall tile slices the middle out of the artwork and reads as
+           a bug -- worse than the clean fallback card. So it gets its own layout:
+           the banner sits at its true aspect across the top, and the title goes
+           underneath where there is now room for it. */
+        <View style={styles.tileHeaderWrap}>
+          <Image
+            source={art}
+            style={styles.tileHeaderArt}
+            resizeMode="cover"
+            onError={() => setImgFailed(true)}
+          />
+          <View style={styles.tileHeaderLabelWrap}>
+            <Text style={styles.tileHeaderLabel} numberOfLines={3}>
+              {launcher.label}
+            </Text>
+          </View>
+        </View>
+      ) : art ? (
         <Image
           source={art}
           style={styles.tileArt}
@@ -914,6 +938,31 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   tileFallbackLabel: {
     color: t.text,
     fontSize: 14,
+    fontWeight: '700',
+    textAlign: 'center',
+    fontFamily: mono,
+  },
+  // Header-art layout: banner at its true 460x215 aspect across the top, title
+  // in the space below. Deliberately NOT flex:1 on the image -- stretching a
+  // banner to fill a 2:3 tile is the distortion this whole branch exists to
+  // avoid.
+  tileHeaderWrap: {
+    flex: 1,
+    backgroundColor: t.card,
+  },
+  tileHeaderArt: {
+    width: '100%',
+    aspectRatio: 460 / 215,
+  },
+  tileHeaderLabelWrap: {
+    flex: 1,
+    justifyContent: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  tileHeaderLabel: {
+    color: t.text,
+    fontSize: 13,
     fontWeight: '700',
     textAlign: 'center',
     fontFamily: mono,

--- a/app/components/GuideHoldSetup.tsx
+++ b/app/components/GuideHoldSetup.tsx
@@ -119,7 +119,9 @@ export function GuideHoldSetup({ settings }: { settings: ConnSettings }) {
                     <Text style={styles.padName}>{c.name || 'Controller'}</Text>
                     <Text style={styles.padMeta}>
                       {!c.readable
-                        ? "the box can't read this controller — re-run install.sh"
+                        ? c.reason === 'masked'
+                          ? 'reserved by Steam — cannot be used here'
+                          : "the box can't read this controller — re-run install.sh"
                         : pinnable
                           ? c.uniq
                           : 'wired — cannot be pinned'}
@@ -138,10 +140,23 @@ export function GuideHoldSetup({ settings }: { settings: ConnSettings }) {
             )}
           </View>
 
+          {/* Two different causes, two different answers. A MASKED node was
+              hidden on purpose by Steam / InputPlumber, which presents its own
+              composite device instead; re-running install.sh cannot undo that,
+              and telling people to try was sending them to do something that
+              could not work. Only the plain-permission case is install-fixable.
+              See KI-026 for the getfacl evidence. */}
           {unreadable.length > 0 && (
             <Text style={styles.padWarn}>
-              The box can see {unreadable.length === 1 ? 'a controller' : 'some controllers'} it
-              is not allowed to read. Re-running the install script usually fixes this.
+              {unreadable.every((c) => c.reason === 'masked')
+                ? `Steam has reserved ${
+                    unreadable.length === 1 ? 'this controller' : 'these controllers'
+                  } for its own input handling, so the box cannot watch the guide button on ${
+                    unreadable.length === 1 ? 'it' : 'them'
+                  }. This is normal on handhelds — use another controller, or trigger Couch Mode from the app.`
+                : `The box can see ${
+                    unreadable.length === 1 ? 'a controller' : 'some controllers'
+                  } it is not allowed to read. Re-running the install script usually fixes this.`}
             </Text>
           )}
         </>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -304,6 +304,12 @@ export type Launcher = {
   kind: 'steam' | 'custom';
   /** Steam appid, present for kind "steam": used for library cover art. */
   appid?: number;
+  /** Which SHAPE of cover art the box has locally (agent >= 2.9.41).
+   *  "portrait" = a 600x900 capsule that fills a tile; "header" = a 460x215
+   *  banner that does NOT and needs its own layout. Absent means no local art
+   *  (or an older agent), which renders the text card either way — so an old
+   *  agent behaves exactly as it does today. */
+  art?: 'portrait' | 'header';
 };
 
 /** State of an in-progress Steam operation. Unknown values render as 'updating'. */
@@ -543,6 +549,14 @@ export type GuideController = {
   phys: string;
   name: string;
   readable: boolean;
+  /** Why the pad is unreadable (agent >= 2.9.41); absent when readable, and
+   *  absent on older agents.
+   *  - "masked": the node's mode is 000 — Steam / InputPlumber hid it on
+   *    purpose and presents its own composite device. Re-running install.sh
+   *    CANNOT fix this, so the app must not suggest it.
+   *  - "permission": an ordinary mode this user lacks; that one is
+   *    install-fixable. */
+  reason?: 'masked' | 'permission';
 };
 
 /**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -32,6 +32,30 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### On-box pairing tutorial (auto-plays after install)
+- **priority:** P1 · **risk:** low · **affects:** agent + installer · **depends_on:** none
+- **Full spec: `docs/memory/project_pairing-tutorial.md`.** Read it first — the mechanisms and
+  the file:line anchors are already recorded, do not re-derive them.
+- The installer's last act on a **fresh** install is to open the box's own screen full-screen
+  with a short animated tutorial (open the app → Setup → Scan → tap this box), which then
+  swaps itself into the live 6-digit PIN the moment the phone starts pairing. Targets the
+  measured funnel gap: ~9–15 app downloads in the first six days after launch, ~0 boxes paired.
+- **Cheap because it is mostly assembly.** `/pair` already renders two states and is already
+  double-gated (loopback peer + Host header); `render_pin_page` already polls
+  `/api/pair/status`; `couchside-pair` already opens the page full-screen in Game Mode and on
+  desktop; `install.sh` already runs as the desktop user and already has a fresh-token signal
+  at `:602-609` to gate the auto-open so update runs stay quiet. **No new route, no new
+  network surface, no app release.**
+- Scope fixed with the owner: **box TV only**, **inline CSS/SVG animation — not a GIF** (the
+  repo's GIFs are 3.9–5.9 MB; the whole agent is 539 KB of stdlib Python), **PIN flow only**.
+  The QR is **kept** alongside the steps — the Steam tile's documented job is re-showing it.
+- **The one unproven thing:** whether Steam's built-in CEF browser renders CSS `@keyframes` and
+  inline `<svg>`. Probe that with a throwaway page before writing the real one. Everything else
+  in the design was read from source; this was not.
+- Verify on the real box via `/api/screen/frame` in **both** Game Mode and desktop, observing
+  **both** states (idle tutorial and the reload-into-PIN handoff), plus a re-run on an
+  already-paired box that must pop nothing.
+
 ### In-app Bluetooth pairing
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
 - Agent drives `bluetoothctl`; app renders discovered devices and pairs on tap. Removes the
@@ -99,6 +123,26 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   to sit inside the cache root. Widening the FILENAME set is fine; widening to a glob or a
   client-supplied filename is not.
 
+### Split Preferences into category sub-tabs
+- **priority:** P3 · **risk:** low · **affects:** app only · **depends_on:** none
+- Prefs is one long scroll. **COUNTED 2026-07-22: 27 rows across 6 cards** (GENERAL 4,
+  APPEARANCE 2, INPUT & PAD 6, PAD LAYOUT 11, STREAM FROM PC 2, TOUCH ANIMATIONS 2), all
+  rendering unconditionally — no caps or Platform gating — so the count is the same on every
+  device.
+- **Reuse the existing sub-tab control**, the one Setup already uses for Boxes / Prefs / Logs /
+  Account. A second tab pattern in the same screen would be worse than the scroll.
+- Proposed 4 categories: **General** (haptics, confirm-before-suspend, vitals refresh, journal
+  lines, open-on, theme, accent) · **Input** (everything changing what the app SENDS) ·
+  **What's shown** (every hide/show row) · **Touch animations**.
+  Note "Open on" moves out of INPUT & PAD — it is an app-startup setting and its current
+  placement is the anomaly.
+- **Unverified:** whether FIVE sub-tabs fit the existing tab bar at 375pt. `tabItem` is flex:1
+  with a 15px icon + 6px gap + 12px mono label; four fit today, five is untested. That is the
+  only reason the proposal stops at four — measure in the harness before going wider, or drop
+  the icons on the nested row.
+- Also undecided: whether the sub-tab selection should persist across launches. The parent
+  control does NOT persist, so matching it means "no".
+
 ### Landscape "laptop mode" — mini QWERTY + trackpad
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
 - Rotating the phone to landscape shows a full soft QWERTY plus a trackpad on one screen,
@@ -122,6 +166,40 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **priority:** P3 · **risk:** none · **affects:** agent only
 - Notifications, In Game and Remote Play are visible in Steam's sidebar but their slugs are
   unknown; ~25 guesses measured absent. Any find ships agent-side with no app release.
+
+### First-class Nobara support
+- **priority:** P2 · **risk:** medium · **affects:** installer + agent · **depends_on:** a Nobara
+  box or VM (none exists yet — this is the blocker, not the code)
+- Full spec: `docs/memory/project_nobara-support.md`. Estimate: **1–2 sessions once a box exists**
+  for core support, +1 for the Couch Mode family.
+- **The installer needs far less than assumed.** `install.sh` has no distro detection, installs no
+  packages, never touches rpm-ostree, and writes nothing to `/usr` (`:351-358`); its firewall step
+  is already `firewall-cmd` (`:898-905`), which is Nobara's. No package-manager or firewall
+  abstraction is required. Sudoers, groups, udev, WoL and the Ed25519 verify flow are already
+  distro-agnostic.
+- **The agent already degrades honestly.** `_is_steamos_like()` (`agent/couchsided.py:1903`) is the
+  only distro detector in the file and cleanly hides Couch Mode, the `desktop` cap and guide-hold;
+  every Steam feature gates on `_steam_root()` instead, so library, launch, menus, gaming card and
+  stream host/client all work. Nothing crashes and no capability wrongly probes true.
+- **The one real risk is SELinux**, and it is UNVERIFIED: the system unit exec's the daemon out of
+  `$HOME` (`install.sh:859`, `agent/couchside.service:20`), which Fedora targeted policy normally
+  denies from an init domain, and the repo has zero SELinux handling. Could be a failed start or a
+  non-issue depending on whether Nobara ships enforcing. Phase 0 exists to find out.
+- **Free win available:** `guide_hold_available()` (`:8771`) requires `couchmode_available()`, but
+  its evdev machinery needs only group `input` — decoupling it gives Nobara the guide-button
+  trigger with no new mechanism.
+- Any fix must live inside `install.sh` / the signed service template, because `couchside update`
+  re-runs the installer and would undo anything applied out-of-band.
+- **The edition matters for the optional half only.** Nobara ships five (Official/custom-KDE, KDE,
+  GNOME, Steam-HTPC, Steam-Handheld), each with an NVIDIA variant. Core Couchside is
+  desktop-agnostic across all of them; what splits is that **`kscreen-doctor` (in
+  `_COUCHMODE_TOOLS`) and `spectacle` (screen capture) are Plasma-only** — so GNOME can never run
+  Couch Mode and has no desktop-capture backend, while **Steam-HTPC** is the flagship target and
+  the only place the Couch Mode question can be answered. Test Official/KDE first (one variable at
+  a time), NVIDIA never as the first box.
+- **Unverified:** SELinux mode on Nobara, whether Steam-HTPC provides a `steamos-session-select`
+  equivalent, gdm-variant behaviour, and every row of the flavor table (derived from what each
+  desktop ships, not from running the agent). CachyOS is a separate, un-researched target.
 
 ---
 

--- a/scripts/web-dev-proxy.py
+++ b/scripts/web-dev-proxy.py
@@ -18,17 +18,28 @@ Not proxied: /ws/gamepad. WebSocket upgrade needs real tunnelling, and the Pad
 surfaces are native-gesture territory that a desktop browser cannot exercise
 faithfully anyway. Verify those on a device.
 
-Usage: web-dev-proxy.py <dist_dir> <listen_port> <agent_host:agent_port>
+Usage: web-dev-proxy.py <dist_dir> <listen_port> <agent_host:agent_port> [token]
 """
 import http.client
 import os
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-if len(sys.argv) != 4:
+if len(sys.argv) not in (4, 5):
     raise SystemExit(__doc__.strip().splitlines()[-1])
 
 DIST, PORT, AGENT = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+# DEV-ONLY token used to backfill Authorization on requests that structurally
+# cannot carry it. React Native's <Image> takes source.headers on NATIVE only;
+# on web it becomes a plain <img>, which cannot send a bearer token. So every
+# token-gated image -- Steam cover art, the screen preview -- 401'd in the
+# harness and silently rendered its fallback. That made a whole class of UI
+# unverifiable here while looking merely "empty".
+#
+# Backfill ONLY: a request that already carries Authorization is passed through
+# untouched, so the auth-rejection path stays testable. Loopback-only, dev-only,
+# and never shipped to a box.
+DEV_TOKEN = sys.argv[4] if len(sys.argv) > 4 else ""
 AGENT_HOST, AGENT_PORT = AGENT.rsplit(":", 1)[0], int(AGENT.rsplit(":", 1)[1])
 PROXY_PREFIXES = ("/api", "/pair")
 
@@ -54,6 +65,8 @@ class Handler(BaseHTTPRequestHandler):
         # Drop hop-by-hop headers; keep Authorization so the token still works.
         hdrs = {k: v for k, v in self.headers.items()
                 if k.lower() not in ("host", "connection", "accept-encoding")}
+        if DEV_TOKEN and not any(k.lower() == "authorization" for k in hdrs):
+            hdrs["Authorization"] = "Bearer " + DEV_TOKEN
         try:
             conn.request(method, self.path, body=body, headers=hdrs)
             r = conn.getresponse()

--- a/scripts/web-dev.sh
+++ b/scripts/web-dev.sh
@@ -53,7 +53,7 @@ for _ in $(seq 1 30); do
 done
 
 echo "==> serving on http://127.0.0.1:$PORT"
-python3 "$ROOT/scripts/web-dev-proxy.py" "$DIST" "$PORT" "127.0.0.1:$AGENT_PORT" &
+python3 "$ROOT/scripts/web-dev-proxy.py" "$DIST" "$PORT" "127.0.0.1:$AGENT_PORT" "$TOKEN" &
 PROXY_PID=$!
 
 cat <<EOF

--- a/tests/test_guide_unreadable_reason.py
+++ b/tests/test_guide_unreadable_reason.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Tests for _unreadable_reason() — why a controller cannot be read.
+
+Run: python3 tests/test_guide_unreadable_reason.py
+
+WHY THIS EXISTS: the app told every user with an unreadable controller to
+"re-run install.sh". On a Lenovo Legion Go S that advice cannot work, and
+sending someone to do something that cannot work is worse than saying nothing.
+
+MEASURED on that box, 2026-07-22:
+
+    $ ls -l /dev/input/event2          # the built-in pad
+    c---------+ 1 root root
+    $ getfacl /dev/input/event2
+    user:deck:rw-   #effective:---
+    mask::---                          <-- nullifies the grant
+
+The ACL entry granting the user is present and intact. Mode 000 is what kills
+it: with a POSIX ACL present the group bits ARE the mask, so mode 000 collapses
+the mask and every named-user entry becomes ineffective. `inputplumber` was
+active and Steam ships its own input rules; masking a source device and
+presenting a composite is what that stack does deliberately.
+
+install.sh adds udev rules and group membership. NEITHER can override a zeroed
+mask. So the two cases need different answers, and this is where they are told
+apart.
+"""
+import importlib.util
+import os
+import shutil
+import stat
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class Nodes:
+    """A fake /dev/input the REAL function stats."""
+
+    def __init__(self):
+        self.dir = tempfile.mkdtemp(prefix="devinput-")
+        self._old = cs._DEV_INPUT
+        cs._DEV_INPUT = self.dir
+
+    def make(self, name, mode):
+        p = os.path.join(self.dir, name)
+        with open(p, "w") as f:
+            f.write("")
+        os.chmod(p, mode)
+        return p
+
+    def close(self):
+        for f in os.listdir(self.dir):
+            try:
+                os.chmod(os.path.join(self.dir, f), 0o600)
+            except OSError:
+                pass
+        cs._DEV_INPUT = self._old
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def test_mode_000_is_masked():
+    """THE Legion Go S case: deliberately hidden, NOT an install problem."""
+    print("test_mode_000_is_masked")
+    n = Nodes()
+    try:
+        n.make("event2", 0o000)
+        check("masked", cs._unreadable_reason("event2"), {"reason": "masked"})
+    finally:
+        n.close()
+
+
+def test_unreadable_but_normal_mode_is_permission():
+    """A real 0660-style node this user is not in the group for IS install-fixable."""
+    print("test_unreadable_but_normal_mode_is_permission")
+    n = Nodes()
+    try:
+        n.make("event9", 0o220)      # writable, not readable -> ordinary perms
+        check("permission", cs._unreadable_reason("event9"),
+              {"reason": "permission"})
+    finally:
+        n.close()
+
+
+def test_readable_node_reports_nothing():
+    """No reason on a node that works — the field must stay absent, not empty."""
+    print("test_readable_node_reports_nothing")
+    n = Nodes()
+    try:
+        n.make("event0", 0o644)
+        check("no reason key", cs._unreadable_reason("event0"), {})
+    finally:
+        n.close()
+
+
+def test_missing_node_degrades_closed():
+    """A node that vanished between enumeration and stat must not raise, and
+    must not invent a cause."""
+    print("test_missing_node_degrades_closed")
+    n = Nodes()
+    try:
+        check("gone -> no claim", cs._unreadable_reason("event404"), {})
+    finally:
+        n.close()
+
+
+if __name__ == "__main__":
+    if os.geteuid() == 0:
+        # root can read anything, so mode-based unreadability never triggers.
+        print("SKIP: running as root makes every node readable")
+        sys.exit(0)
+    for fn in (test_mode_000_is_masked,
+               test_unreadable_but_normal_mode_is_permission,
+               test_readable_node_reports_nothing,
+               test_missing_node_degrades_closed):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")

--- a/tests/test_steam_cover_art.py
+++ b/tests/test_steam_cover_art.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Tests for Steam cover-art resolution (_steam_cover).
+
+Run: python3 tests/test_steam_cover_art.py
+
+WHY THIS EXISTS: the resolver looked for library_600x900.jpg and nothing else.
+MEASURED on a Legion Go S, 2026-07-22: 30 of 80 INSTALLED games -- The Witcher
+3, GTA V, RimWorld, Stray -- rendered the blank text card while their real
+capsule sat on disk one directory deeper, under a content-hash subdirectory
+that the resolver never looked in. Nothing had to be fetched from the internet.
+
+Note the correction embedded here: an earlier count of "826 header vs 386
+portrait" was taken across the whole librarycache, which includes every game in
+the LIBRARY, not the installed ones, and its header-only entries turned out to
+be Steam runtimes that never appear as launchers at all. The number that
+mattered was the installed one, and it pointed at a different cause.
+
+The KIND is as load-bearing as the path. Portrait is 600x900 and fills a tile;
+header is 460x215 and does not. Returning a header while claiming portrait
+would centre-crop a banner into a tall tile, which looks worse than the clean
+fallback -- so "does a header-only game report kind=header" is asserted
+explicitly, not assumed from the path.
+
+SECURITY: this widened a filename set, which is exactly the kind of change that
+turns into a path escape if it drifts into a glob or a client-supplied name.
+The last three tests exist to catch that, and they are the ones to keep if
+anything here is ever trimmed.
+"""
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class Cache:
+    """A fake Steam root the REAL resolver walks."""
+
+    def __init__(self, files):
+        self.dir = tempfile.mkdtemp(prefix="steamroot-")
+        self.cache = os.path.join(self.dir, "appcache", "librarycache")
+        os.makedirs(self.cache)
+        for rel in files:
+            p = os.path.join(self.cache, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "wb") as f:
+                f.write(b"\xff\xd8\xff")      # enough to be a file
+        self._old = cs._steam_root
+        cs._steam_root = lambda: self.dir
+
+    def close(self):
+        cs._steam_root = self._old
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def test_hashed_layout_found():
+    """THE case this fix exists for: current Steam nests the named file inside a
+    content-hash directory. Real path shape, from the Witcher 3 entry on the
+    Legion Go S."""
+    print("test_hashed_layout_found")
+    c = Cache(["292030/fe26986a2bd1601004ef0e4e1dfadd02948e3897/library_600x900.jpg",
+               "292030/9ea69a715e85617cf408e1392c27b50fc2c51750/library_header.jpg"])
+    try:
+        path, kind = cs._steam_cover("292030")
+        check("kind", kind, "portrait")
+        check("reached into the hash dir", os.path.basename(path),
+              "library_600x900.jpg")
+    finally:
+        c.close()
+
+
+def test_library_capsule_is_portrait():
+    """library_capsule.jpg measured 300x450 on hardware -- same 2:3 as the
+    600x900 capsule. RimWorld and Stray ship ONLY this one."""
+    print("test_library_capsule_is_portrait")
+    c = Cache(["294100/644bff2fcf3a104d1e022b53a7f9c8c58af91c8a/library_capsule.jpg",
+               "294100/88d319d95e4762c667668567b611ccbf50039a25/library_header.jpg"])
+    try:
+        path, kind = cs._steam_cover("294100")
+        check("capsule wins over header", kind, "portrait")
+        check("path", os.path.basename(path), "library_capsule.jpg")
+    finally:
+        c.close()
+
+
+def test_portrait_beats_header_across_layouts():
+    """A nested portrait must beat a top-level header. Ordering the loop the
+    other way round would demote a real capsule to a banner."""
+    print("test_portrait_beats_header_across_layouts")
+    c = Cache(["440/header.jpg", "440/abc123/library_600x900.jpg"])
+    try:
+        _, kind = cs._steam_cover("440")
+        check("portrait still wins", kind, "portrait")
+    finally:
+        c.close()
+
+
+def test_portrait_preferred():
+    """A game with BOTH must report the portrait capsule."""
+    print("test_portrait_preferred")
+    c = Cache(["440/library_600x900.jpg", "440/header.jpg"])
+    try:
+        path, kind = cs._steam_cover("440")
+        check("kind", kind, "portrait")
+        check("path is the capsule", os.path.basename(path), "library_600x900.jpg")
+    finally:
+        c.close()
+
+
+def test_header_only_reports_header():
+    """THE case this feature exists for -- and it must NOT claim portrait."""
+    print("test_header_only_reports_header")
+    c = Cache(["620/header.jpg"])
+    try:
+        path, kind = cs._steam_cover("620")
+        check("found art at all", path is not None, True)
+        check("kind is header, not portrait", kind, "header")
+    finally:
+        c.close()
+
+
+def test_flat_layout_still_works():
+    """The pre-2023 flat naming must not regress."""
+    print("test_flat_layout_still_works")
+    c = Cache(["570_library_600x900.jpg"])
+    try:
+        _, kind = cs._steam_cover("570")
+        check("flat portrait", kind, "portrait")
+    finally:
+        c.close()
+
+    c = Cache(["570_header.jpg"])
+    try:
+        _, kind = cs._steam_cover("570")
+        check("flat header", kind, "header")
+    finally:
+        c.close()
+
+
+def test_no_art_is_none():
+    """No art must be (None, None) -- the app's text card, not a broken image."""
+    print("test_no_art_is_none")
+    c = Cache(["440/library_hero.jpg"])     # present but not a shape we serve
+    try:
+        check("nothing usable", cs._steam_cover("440"), (None, None))
+    finally:
+        c.close()
+
+
+def test_portrait_only_helper_never_returns_a_header():
+    """_steam_cover_path() is the NARROW lookup; callers that want a capsule
+    must not silently receive a banner now that the table is wider."""
+    print("test_portrait_only_helper_never_returns_a_header")
+    c = Cache(["620/header.jpg"])
+    try:
+        check("portrait-only helper says no", cs._steam_cover_path("620"), None)
+        check("but the wide one finds it", cs._steam_cover("620")[1], "header")
+    finally:
+        c.close()
+
+
+def test_non_digit_appid_rejected():
+    """Reject rather than sanitise (CLAUDE.md 3.6)."""
+    print("test_non_digit_appid_rejected")
+    c = Cache(["440/header.jpg"])
+    try:
+        for bad in ("../440", "44 0", "", "abc", "440/../440", None, 440):
+            check("appid %r rejected" % (bad,), cs._steam_cover(bad), (None, None))
+    finally:
+        c.close()
+
+
+def test_traversal_cannot_escape_the_cache():
+    """A path built from the candidate table must stay inside the cache dir.
+
+    Belt and braces: appid is already digits-only so this cannot fire today.
+    It is here because widening the candidate table is exactly how that stops
+    being true -- if someone adds a template with a '..' in it, this fails."""
+    print("test_traversal_cannot_escape_the_cache")
+    c = Cache(["440/header.jpg"])
+    try:
+        # One level above the cache dir, i.e. <root>/appcache/440.jpg — a real
+        # file the escaping template would resolve to if the guard were absent.
+        outside = os.path.join(c.dir, "appcache", "440.jpg")
+        with open(outside, "wb") as f:
+            f.write(b"nope")
+        old = cs._STEAM_ART_CANDIDATES
+        cs._STEAM_ART_CANDIDATES = (("../440.jpg", "portrait"),)
+        try:
+            check("escaping candidate refused", cs._steam_cover("440"), (None, None))
+        finally:
+            cs._STEAM_ART_CANDIDATES = old
+    finally:
+        c.close()
+
+
+def test_every_candidate_is_a_plain_literal():
+    """No globs, no separators, no templating (CLAUDE.md 3.3). The subdirectory
+    scan is the only dynamic part of the lookup; the FILENAME must stay a
+    literal so nothing client-shaped can ever reach the path."""
+    print("test_every_candidate_is_a_plain_literal")
+    for name, kind in cs._STEAM_ART_CANDIDATES:
+        check("%r has no wildcard" % name,
+              any(ch in name for ch in "*?["), False)
+        check("%r has no separator" % name,
+              ("/" in name or "\\" in name or ".." in name), False)
+        check("%r has no format slot" % name, "%" in name, False)
+        check("%r kind is known" % name, kind in ("portrait", "header"), True)
+
+
+def test_subdir_scan_is_bounded():
+    """A cache directory with thousands of entries must not turn one cover
+    lookup into an unbounded walk."""
+    print("test_subdir_scan_is_bounded")
+    check("cap exists and is sane",
+          0 < cs._STEAM_ART_MAX_SUBDIRS <= 200, True)
+
+
+def test_missing_steam_root_degrades_closed():
+    """No Steam at all must not raise."""
+    print("test_missing_steam_root_degrades_closed")
+    old = cs._steam_root
+    cs._steam_root = lambda: None
+    try:
+        check("no root -> no art", cs._steam_cover("440"), (None, None))
+    finally:
+        cs._steam_root = old
+
+
+if __name__ == "__main__":
+    for fn in (test_hashed_layout_found,
+               test_library_capsule_is_portrait,
+               test_portrait_beats_header_across_layouts,
+               test_portrait_preferred,
+               test_header_only_reports_header,
+               test_flat_layout_still_works,
+               test_no_art_is_none,
+               test_portrait_only_helper_never_returns_a_header,
+               test_non_digit_appid_rejected,
+               test_traversal_cannot_escape_the_cache,
+               test_every_candidate_is_a_plain_literal,
+               test_subdir_scan_is_bounded,
+               test_missing_steam_root_degrades_closed):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Three items, each with its own commit.

## 1. Cover art — 36 blank cards → 0

Current Steam nests the named file inside a **content-hash directory** — `<appid>/<sha1>/library_600x900.jpg` — and the resolver only ever looked at `<appid>/library_600x900.jpg`. So The Witcher 3, GTA V, RimWorld and Stray all showed the blank text card while their real capsule sat on the box's own disk.

**MEASURED on a Legion Go S, same 80-game library, before and after:**

| | art shown | blank cards |
|---|---|---|
| before | 44 | **36** |
| after | 71 portrait + 9 header | **0** |

Two discoveries, both from hardware rather than docs:
- the hashed subdirectory layout;
- `library_capsule.jpg` is the newer portrait name. Decoding the JPEG headers put it at **300×450** — the same 2:3 as `library_600x900.jpg` — so it counts as portrait. RimWorld and Stray ship only this one.

Header art (460×215) gets its **own tile layout** instead of being cropped into a 2:3 tile: banner at true aspect on top, title below. Verified in the harness — portrait tiles measure **0.66**, header tiles **2.14**, which is 460/215 exactly, so the banner is not stretched.

### Correction to my own earlier claim

I previously said "826 header vs 386 portrait, ~440 games affected." **That was wrong.** It counted the whole `librarycache`, which covers every game in the *library* rather than the installed ones, and its header-only entries turned out to be Steam runtimes that never appear as launchers at all. The real number was 36, and the cause was completely different. The installed-game measurement is what found it.

### A harness blind spot that hid all of this

RN's `<Image>` takes `source.headers` on **native only**. On web it becomes a plain `<img>`, which cannot send a bearer token — so every token-gated image 401'd and silently rendered its fallback. **Cover art had never once rendered in the harness.** `web-dev-proxy.py` now backfills the dev token when a request carries no `Authorization` — backfill only, so the auth-rejection path stays testable. Dev-only, loopback-only, never shipped.

### Allowlist

Filenames stay literals, appid stays digits-only, resolved paths are re-checked against the cache root, and the subdirectory scan is bounded. The hash directories have to be enumerated because their names are content hashes — but no client input reaches the pattern, and there's a test that fails if a candidate ever grows a wildcard, a separator, or a format slot.

## 2. Box IP on Console

Already in `/api/status` (agent ≥ 2.9.22, straight off the socket) and already declared in the app's `Status` type — Console just never rendered it. App-only, no agent change. It's what you need when mDNS breaks and the box has to be re-added by IP.

## 3. The controller advice was unfollowable

Setup told everyone with an unreadable controller to "re-run install.sh". On a Legion Go S that cannot work:

```
$ ls -l /dev/input/event2          # the built-in pad
c---------+ 1 root root
$ getfacl /dev/input/event2
user:deck:rw-   #effective:---
mask::---
```

The ACL grant is present and intact. **Mode 000 is what kills it** — with a POSIX ACL present the group bits *are* the mask, so mode 000 collapses it and every named-user entry becomes ineffective. `inputplumber` was active and Steam ships its own input rules; masking a source device and presenting a composite is what that stack does deliberately.

`install.sh` adds udev rules and group membership. Neither can override a zeroed mask. The agent now reports **why** — `masked` vs `permission` — and the app says something true for each. Additive: absent when readable and on older agents.

## NOT verified

- **No end-to-end run through the real HTTP route on the handheld.** The resolver was driven in-process against the real `librarycache`; the agent service on that box was not restarted onto this build.
- **The `permission` branch on real hardware.** Only the `masked` case exists on the boxes I can reach; `permission` is covered by fixtures.
- **Nothing on Windows.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)