### PR TITLE
Key agent release notes on the agent version, not the app tag

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -3,8 +3,14 @@
 The text under each version heading becomes that GitHub release's body, which
 is what the app shows as **"What's new"** on the *Box update available* card.
 
-`scripts/release-agent.sh` extracts the section matching the tag it is given and
-**refuses to publish** if there is no matching section. That is deliberate:
+`scripts/release-agent.sh` extracts the section matching the AGENT version in
+`couchsided.py` — not the tag, which is an app version — and **refuses to
+publish** if there is no matching section.
+
+Only the newest section is published. Boxes routinely skip several agent
+versions between updates (2.9.38 straight to 2.9.41 here), so when a release
+bundles more than one version, the top section must describe **everything a
+user is getting**, not just the last change. That is deliberate:
 before this file existed, the script wrote one hardcoded sentence — and only
 when it had to *create* a release — so every agent release for months told users
 the same thing regardless of what actually changed.
@@ -14,9 +20,16 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.41
 
-Games missing their poster art now show the banner artwork the box already has,
-instead of a blank card. Nothing is downloaded — it was on your machine the
-whole time.
+Poster art now appears for games that were showing a blank card. Recent Steam
+files its artwork somewhere the box was not looking, so it was on your machine
+the whole time — nothing is downloaded.
+
+Handhelds report their own battery: charge, whether you are on AC, and how long
+is left.
+
+New "Send keys instead of a controller" option in the app. Steam navigates the
+same way, but the box stops announcing a controller every time you connect — so
+a game already running cannot lose player one to your phone.
 
 ## 2.9.40
 

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -128,7 +128,14 @@ echo "    signature self-verified OK"
 # Failing loud is the point. A release-notes script that silently publishes
 # something stale and exits 0 has happened in this repo before; a missing
 # section must stop the release, not fall back to boilerplate.
-ver="${tag#v}"
+#
+# Keyed on the AGENT version, NOT on the tag. The tag is an APP version
+# (v2.9.19, v2.9.20 ...) because agent assets ride the app's GitHub release, but
+# these notes describe the AGENT, which moves on its own track (2.9.41 here).
+# Using ${tag#v} would look up an app version in an agent changelog and exit 2
+# every time -- the guard would catch it, but only after a release was already
+# half cut.
+ver="$agent_ver"
 notes_file="$tmp/notes.md"
 # Leading/trailing blank lines are dropped in the same pass -- `sed -i` differs
 # between BSD and GNU and this script runs on both.
@@ -144,7 +151,7 @@ awk -v v="$ver" '
 ' "$root/agent/CHANGELOG.md" > "$notes_file"
 
 if [ ! -s "$notes_file" ]; then
-    echo "error: agent/CHANGELOG.md has no '## $ver' section." >&2
+    echo "error: agent/CHANGELOG.md has no '## $ver' section (agent VERSION)." >&2
     echo "       Add one describing what changed for the person holding the phone," >&2
     echo "       then re-run. Refusing to publish boilerplate release notes." >&2
     exit 2


### PR DESCRIPTION
Found while preparing the first real run of the release-notes machinery from [#206](https://github.com/emerytech/couchside/pull/206) — which is precisely what that fail-loud guard existed to be caught by.

## The bug

`release-agent.sh` looked up `${tag#v}` in `agent/CHANGELOG.md`. But the tag is an **app** version: agent assets ride the app's GitHub release (`v2.9.19`, `v2.9.20`, …) because boxes fetch `releases/latest/download/`. The agent moves on its own track — **2.9.41** right now.

So it would look up an app version in an agent changelog, find nothing, and `exit 2` on every single release. The guard works; it just fires after a release is already half cut. Now keyed on `$agent_ver`, which the script already reads out of `couchsided.py`.

## Only the newest section publishes

Boxes routinely skip several agent versions between updates — this release takes them **2.9.38 → 2.9.41** in one jump. The top section therefore has to describe everything the user is getting, not just the last commit, so 2.9.41's entry now covers cover art, box battery and keyboard mode. The changelog header states that rule for next time.

## Verified

Extraction returns the full 2.9.41 section; `bash -n` clean. **Not verified:** the `gh create` / `edit` / read-back path still hasn't run against the real API — that happens on the next release, which is the point of fixing this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)