### PR TITLE
chore(app): 2.9.20

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.19",
+    "version": "2.9.20",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,7 +1,8 @@
-New in 2.9.19
+New in 2.9.20
 
-• Fixed the connection dropping while the phone sat idle.
-• Paste from your phone into a text box on the box, with a new PASTE button.
-• When the box opens its on-screen keyboard, your phone's keyboard opens too.
-• The Steam tab can now be swiped out of like every other one.
-• Quieter Actions list, and Couch Mode no longer narrates every step.
+• Games showing a blank card now show their poster art — it was already on your box.
+• Handhelds report their own battery, with time remaining.
+• Fixed the hide-keyboard button being covered by the text field.
+• Fixed the setup guide link running off the edge on Android.
+• New option: send keys instead of creating a virtual controller, so a running game keeps player one.
+• Your box's IP now shows under uptime.


### PR DESCRIPTION
Release prep for 2.9.20. Version string only — `buildNumber` (73) and `versionCode` (53) are deliberately left for EAS `autoIncrement`, since pre-bumping them is how the numbers drift out of sync with what is actually in the binaries.

Play notes rewritten: that file is **stale by default** (nothing generates it, so it still described 2.9.19), now 443 chars against Play's 500-**character** cap.

## What this release carries

| | |
|---|---|
| Cover art from hashed Steam paths | 36 blank tiles → 0 on a real 80-game library (agent 2.9.41) |
| Box battery on handhelds | agent 2.9.40 |
| Keyboard mode | opt-in, no virtual controller (agent 2.9.39) |
| HIDE keyboard button | was occluded, and unclickable |
| Android setup-link overflow | **still unverified — see below** |
| Box IP on Console | app-only |
| Honest controller advice | `masked` vs `permission` |

## Please check on device

The **Android setup-link overflow** fix has never been verified. I said so at the time: the harness structurally cannot see it, because on RN Web a `Text` in a flex row gets CSS `flex-shrink: 1` for free and always wraps, while native does not. Both bundles measured identical, zero overflow, before and after. This Android build is the first real test of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)