### PR TITLE
chore(app): record 2.9.20 build numbers (ios 74 / vc 54)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "73",
+      "buildNumber": "74",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 53
+      "versionCode": 54
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
`autoIncrement` writes build numbers on the build machine, not into the repo. Left uncommitted, the next build increments from the **stale** values and the numbers drift from what is actually inside the shipped binaries.

Read out of the two production builds rather than assumed:

| | was | now |
|---|---|---|
| android `versionCode` | 53 | **54** |
| ios `buildNumber` | 73 | **74** |

Next floors: vc ≥ 55, iOS build ≥ 75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)