### PR TITLE
docs(roadmap): search button + hide-keyboard dismiss — mechanisms proven on hardware

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -68,6 +68,47 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **Value is narrower than it looks:** the shipped Bluetooth button already reaches Steam's
   own pairing UI, which handles agents and PINs correctly.
 
+### Search button: open Steam's global search + raise the phone keyboard
+- **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
+- A search icon in the app opens Steam's global search on the box AND raises the phone's own
+  keyboard, so you type a game name on the phone instead of thumbing a d-pad across a letter
+  grid. Owner request, 2026-07-22.
+- **Most of it already exists.** The phone-keyboard half is the `{"t":"osk"}` push (agent
+  2.9.38) plus the compose field on the Pad screen; typing already rides `{"t":"kt"}`. The app
+  can also just focus its own field on tap, without waiting for the box to signal.
+- **THE ONE UNKNOWN, and it is the whole feature: how to OPEN Steam's global search from the
+  agent.** Do not guess at this — Ctrl+1/Ctrl+2 looked like the Steam-menu/QAM chord and then
+  failed 0/5 (see KI-024).
+- **MEASURED 2026-07-22 on a Legion Go S, with a bogus-URL control:**
+  - `steam://open/search` — no effect.
+  - `steam://open/bigpicture` — no effect (already in Game Mode).
+  - `steam://open/settings/search` — opens **Settings**, because an unknown settings slug
+    falls back to the default page. Not search.
+  - `steam://store/search` — opens the **Steam Store**, not the library's global search.
+  - Control (`steam://open/thisdoesnotexist`) — no effect, so "the screen changed" was not a
+    generic artifact.
+  - **Conclusion: no deep link found yet.** Next candidates worth measuring: the magnifier
+    control's own focus path, a gamepad button on the library screen, or a keyboard shortcut.
+    The search state IS reachable — it was observed live (search bar focused + Steam's OSK up),
+    just not yet reproducibly *triggered*.
+
+### Hide-keyboard should also dismiss the box's keyboard/search
+- **priority:** P3 · **risk:** medium · **affects:** app (+ agent only if a new signal is needed)
+- Today the keyboard link is one-way: the box raising its OSK raises the phone's. Pressing the
+  app's HIDE button should close the box's keyboard/search too. Owner request, 2026-07-22.
+- Likely mechanism is `sendKey('esc')`, which the app already exposes — no new route, no new
+  client id.
+- **MEASURED:** Esc is reliable BACK-navigation on the box (Store → Settings → Library), and an
+  F13 control changed nothing, so the effect is real and specific. **NOT measured:** whether Esc
+  closes Steam's OSK specifically — the box had navigated away from the keyboard state before
+  that probe ran, so the premise was stale. Re-test with the OSK actually up.
+- **The risk that decides the design:** Esc is back-navigation, not "dismiss keyboard". Firing
+  it when no keyboard is open would back the user out of whatever screen they were on, or open
+  a pause menu inside a game. So gate it on knowing the box's keyboard is up — reuse the osk
+  signal that already raised the phone's keyboard, rather than sending Esc on every HIDE tap.
+- Note the agent's osk watcher detects OPEN only. Either track "we were raised by an osk push"
+  app-side, or add a close signal; prefer the app-side flag, since it needs no agent release.
+
 ### Close the running game from the Launch tab
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
 - A card at the top of Launch showing what is running now, how long it has been running, and

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,45 +69,48 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   own pairing UI, which handles agents and PINs correctly.
 
 ### Search button: open Steam's global search + raise the phone keyboard
-- **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
-- A search icon in the app opens Steam's global search on the box AND raises the phone's own
+- **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- A search icon in the app focuses Steam's global search on the box AND raises the phone's own
   keyboard, so you type a game name on the phone instead of thumbing a d-pad across a letter
   grid. Owner request, 2026-07-22.
-- **Most of it already exists.** The phone-keyboard half is the `{"t":"osk"}` push (agent
-  2.9.38) plus the compose field on the Pad screen; typing already rides `{"t":"kt"}`. The app
-  can also just focus its own field on tap, without waiting for the box to signal.
-- **THE ONE UNKNOWN, and it is the whole feature: how to OPEN Steam's global search from the
-  agent.** Do not guess at this — Ctrl+1/Ctrl+2 looked like the Steam-menu/QAM chord and then
-  failed 0/5 (see KI-024).
-- **MEASURED 2026-07-22 on a Legion Go S, with a bogus-URL control:**
-  - `steam://open/search` — no effect.
-  - `steam://open/bigpicture` — no effect (already in Game Mode).
-  - `steam://open/settings/search` — opens **Settings**, because an unknown settings slug
-    falls back to the default page. Not search.
-  - `steam://store/search` — opens the **Steam Store**, not the library's global search.
-  - Control (`steam://open/thisdoesnotexist`) — no effect, so "the screen changed" was not a
-    generic artifact.
-  - **Conclusion: no deep link found yet.** Next candidates worth measuring: the magnifier
-    control's own focus path, a gamepad button on the library screen, or a keyboard shortcut.
-    The search state IS reachable — it was observed live (search bar focused + Steam's OSK up),
-    just not yet reproducibly *triggered*.
+- **MECHANISM PROVEN end to end on a Legion Go S in Game Mode, 2026-07-22**, driven from the
+  app on a real phone and observed through `/api/screen/frame`:
+  1. `UP`, `UP`, then `LEFT` x8 focuses the global search field (it goes bright/white; every
+     earlier frame had it dim). Overshooting LEFT is safe — LEFT at the leftmost item is a
+     no-op, and 8 exceeds the number of top-bar items.
+  2. Typing lands in it and filters LIVE: "dota" gave ALL 15 / LIBRARY 1, with DOTA 2 marked
+     IN LIBRARY. Rides the existing `{"t":"kt"}` text channel; no new route needed.
+  3. `ESC` closes it (verified against a live search with text in it; an F13 control produced a
+     byte-identical frame, so the effect is specifically ESC).
+- **NO DEEP LINK EXISTS — do not go looking again.** Measured against a bogus-URL control:
+  `steam://open/search` and `steam://open/bigpicture` do nothing; `steam://open/settings/search`
+  opens **Settings** (unknown slug falls back to the default page); `steam://store/search` opens
+  the **Store**, not library search.
+- **THE DESIGN DETAIL THAT MATTERS: Steam's own OSK does NOT open on this path.** Steam takes
+  the keys directly, so the agent's osk watcher never fires. The app must raise its OWN keyboard
+  when the button is tapped rather than wait for the `{"t":"osk"}` push — which is exactly the
+  behaviour requested, but it will not happen for free.
+- **Known fragility:** the key sequence assumes focus starts in the library grid. From a game
+  page or another tab the same sequence lands somewhere else. Worth an explicit "known
+  limitation" rather than pretending it is universal, and worth re-checking after Steam UI
+  updates — this is UI-shape-dependent, not an API.
+- Bottom bar also showed **Y = CLEAR** while search was focused, if a clear affordance is wanted.
 
 ### Hide-keyboard should also dismiss the box's keyboard/search
-- **priority:** P3 · **risk:** medium · **affects:** app (+ agent only if a new signal is needed)
-- Today the keyboard link is one-way: the box raising its OSK raises the phone's. Pressing the
-  app's HIDE button should close the box's keyboard/search too. Owner request, 2026-07-22.
-- Likely mechanism is `sendKey('esc')`, which the app already exposes — no new route, no new
-  client id.
-- **MEASURED:** Esc is reliable BACK-navigation on the box (Store → Settings → Library), and an
-  F13 control changed nothing, so the effect is real and specific. **NOT measured:** whether Esc
-  closes Steam's OSK specifically — the box had navigated away from the keyboard state before
-  that probe ran, so the premise was stale. Re-test with the OSK actually up.
-- **The risk that decides the design:** Esc is back-navigation, not "dismiss keyboard". Firing
-  it when no keyboard is open would back the user out of whatever screen they were on, or open
-  a pause menu inside a game. So gate it on knowing the box's keyboard is up — reuse the osk
-  signal that already raised the phone's keyboard, rather than sending Esc on every HIDE tap.
-- Note the agent's osk watcher detects OPEN only. Either track "we were raised by an osk push"
-  app-side, or add a close signal; prefer the app-side flag, since it needs no agent release.
+- **priority:** P3 · **risk:** medium · **affects:** app only
+- Pressing the app's HIDE button should close the box's search too. Owner request, 2026-07-22.
+- **PROVEN:** `ESC` closes an open search on the box — tested against a live search with text
+  typed, with an F13 control that produced a byte-identical frame. `sendKey('esc')` is already
+  exposed, so this is app-only: no new route, no new client id, no agent release.
+- **THE RISK THAT DECIDES THE DESIGN, and it is confirmed, not theoretical:** ESC is
+  *back-navigation*, not "dismiss keyboard". In the same session ESC walked Store → Settings →
+  Library, and closing the search also landed on Steam **Home** rather than staying put. Firing
+  it on every HIDE tap would therefore move the user when nothing was open, or open a pause
+  menu inside a game.
+- So gate it: only send ESC when the app knows it opened the box's search (i.e. the user
+  pressed the search button this session and has not dismissed it another way). An app-side
+  flag is enough; the agent's osk watcher cannot help here because Steam's OSK never opens on
+  this path.
 
 ### Close the running game from the Launch tab
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none


### PR DESCRIPTION
Both halves of the owner's request now have a **measured** mechanism, driven from the app on a real Razr 2023 against a Legion Go S, observed through `/api/screen/frame`.

## Opening Steam's global search — PROVEN

1. `UP`, `UP`, then `LEFT` ×8 focuses the global search field — it goes bright/white, where every earlier frame had it dim. Overshooting LEFT is safe: LEFT at the leftmost item is a no-op, and 8 exceeds the top-bar item count.
2. Typing lands in it and filters **live**: "dota" → ALL 15 / LIBRARY 1, DOTA 2 marked IN LIBRARY. Rides the existing `{"t":"kt"}` channel — no new route.
3. `ESC` closes it.

**No deep link exists**, and I'd rather record the dead ends than have someone repeat them. Against a bogus-URL control: `steam://open/search` and `steam://open/bigpicture` do nothing; `steam://open/settings/search` opens **Settings** (unknown slug → default page); `steam://store/search` opens the **Store**.

## The design detail that changes the feature

**Steam's own OSK never opens on this path** — Steam takes the keys directly. So the agent's `{"t":"osk"}` watcher will *not* fire, and the app must raise its own keyboard when the button is tapped. That's exactly the requested behaviour, but it won't happen for free by reusing the existing signal.

## Hide-keyboard dismiss — PROVEN, with a confirmed risk

`ESC` closes an open search, verified against a live search *with text in it*, with an F13 control that produced a byte-identical frame. `sendKey('esc')` is already exposed, so this is **app-only** — no agent release.

The risk is now confirmed rather than theoretical: **ESC is back-navigation, not "dismiss keyboard."** In the same session it walked Store → Settings → Library, and closing the search landed on Steam **Home** rather than staying put. Firing it on every HIDE tap would move the user when nothing was open, or open a pause menu mid-game. So it has to be gated on the app knowing it opened the search — an app-side flag, since the osk watcher can't help here.

## Known fragility, stated rather than glossed

The key sequence assumes focus starts in the library grid. From a game page or another tab it lands elsewhere. This is UI-shape-dependent, not an API, so it wants re-checking after Steam UI updates.

Also noted: bottom bar shows **Y = CLEAR** while search is focused, if a clear affordance is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)