### PR TITLE
Search button: open Steam's global search and raise the phone keyboard (agent 2.9.42)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,10 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.42
+
+Adds the box-side half of the app's new Steam search button.
+
 ## 2.9.41
 
 Poster art now appears for games that were showing a blank card. Recent Steam

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.41"
+VERSION = "2.9.42"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -9936,6 +9936,47 @@ def open_steam_menu(menu_id):
     return True
 
 
+# Non-settings steam:// destinations the app may ask for, as a FROZEN map of
+# id -> the exact URL. Separate from STEAM_MENUS because those are all
+# steam://open/settings/<slug>; these are whole-UI destinations.
+#
+# MEASURED on a Legion Go S in Game Mode, 2026-07-22: firing this from
+# Settings > Audio lands on Steam HOME, so it genuinely navigates rather than
+# being a no-op that only appeared to work because Steam was already there.
+# That determinism is the entire point of it -- the app's search button walks a
+# fixed key path afterwards, and a key path is only reliable from a known
+# starting screen.
+STEAM_PLACES = {
+    "home": "steam://open/games",
+}
+
+
+def steam_goto(place_id):
+    """Navigate the Steam UI to one allowlisted destination. True when dispatched.
+
+    SECURITY: place_id indexes a FROZEN dict and never reaches a shell -- the
+    URL is chosen here, not by the caller, and an unknown id is refused rather
+    than forwarded. steam:// can install games and run programs, so a caller
+    must never be able to steer this to an arbitrary URL.
+    """
+    # Type-check BEFORE the lookup: an unhashable id (a list, a dict) raises
+    # TypeError from dict.get, and this must degrade closed rather than throw.
+    # The route already rejects non-strings, but a helper that can be called
+    # from anywhere should not depend on its caller for that.
+    if not isinstance(place_id, str):
+        return False
+    url = STEAM_PLACES.get(place_id)
+    if url is None:
+        return False
+    subprocess.Popen(
+        ["steam", url],
+        env=_user_env(),
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL, start_new_session=True,
+    )
+    return True
+
+
 def streamhost_available():
     """Boot-time caps hint: Steam is present, so this box could host. The
     endpoint is the live authority. Never raises."""
@@ -11350,6 +11391,32 @@ class Handler(BaseHTTPRequestHandler):
             # allowlist — Steam would silently open its DEFAULT page for an
             # unknown slug, so forwarding one would look like success while
             # landing somewhere else entirely.
+            if path == "/api/steam/goto":
+                # Navigate the Steam UI to one allowlisted destination. Exists so
+                # the app's search button has a KNOWN starting screen before it
+                # walks a fixed key path -- MEASURED, a blind key sequence from
+                # the wrong screen opens the sidebar menu instead of search.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"},
+                               started)
+                    return
+                place = req.get("id")
+                # Looked up, never interpolated: an unknown id is a 404, not a
+                # pass-through to an arbitrary steam:// URL.
+                if not isinstance(place, str) or place not in STEAM_PLACES:
+                    self._send(404, {"error": "unknown place"}, started)
+                    return
+                if self.mock:
+                    self._send(200, {"ok": True, "id": place}, started)
+                    return
+                ok = steam_goto(place)
+                self._send(200 if ok else 500,
+                           {"ok": bool(ok), "id": place}, started)
+                return
             if path == "/api/steam/menus":
                 # _read_body() hands back BYTES, not a parsed object — decode
                 # like every other POST route here.

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -381,11 +381,12 @@ type KeyboardBarProps = {
       raise this keyboard. Absent on boxes that cannot do it, which hides the
       button entirely rather than offering a control that does nothing. */
   onSearch?: () => void;
-  /** Called when the bar is dismissed, so the caller can close whatever it
-      opened on the box. Deliberately NOT "always send Esc": Esc is
-      back-navigation on Steam, so firing it when nothing is open moves the
-      user. The caller decides. */
-  onDismiss?: () => void;
+  /** Called when the bar is dismissed. `typed` is true when the user actually
+      entered something, which the caller needs: closing the box's search after
+      a real query would throw away the results you just asked for. Deliberately
+      NOT "always send Esc" either — Esc is back-navigation on Steam, so firing
+      it when nothing is open moves the user. The caller decides. */
+  onDismiss?: (typed: boolean) => void;
 };
 
 /**
@@ -432,8 +433,10 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
     Keyboard.dismiss();
     inputRef.current?.blur();
     setOpenSynced(false);
+    // Read BEFORE clearing — the caller keys off whether a query was entered.
+    const typed = valueRef.current.length > 0;
     setValue('');
-    onDismiss?.();
+    onDismiss?.(typed);
   }, [setOpenSynced, onDismiss]);
 
   const focus = useCallback(() => {
@@ -588,11 +591,33 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
 
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const searchSide = usePref('searchButtonSide');
+  const searchBtn = (
+    <Pressable
+      onPress={onSearch}
+      hitSlop={8}
+      accessibilityLabel="Search Steam"
+      style={({ pressed }) => [
+        styles.kbSearchBtn,
+        searchSide === 'left' ? styles.kbSearchBtnLeft : styles.kbSearchBtnRight,
+        pressed && styles.btnPressed,
+      ]}>
+      <Ionicons name="search" size={17} color={t.blue} />
+    </Pressable>
+  );
   return (
     <>
       <View
         style={styles.kbBarRow}
         {...(open ? panResponder.panHandlers : modeSwipeResponder.panHandlers)}>
+        {/* Search: anchors Steam, walks focus to its global search field, and
+            raises this keyboard, so you type a game name on the phone instead
+            of picking letters off a grid with a d-pad. Only on the CLOSED bar,
+            because that is where you are when you decide to look for a game.
+            Side is a preference: the bar's right end is where the thumb rests
+            and where PASTE/HIDE appear when open, so search there is easy to
+            hit by accident -- but handedness varies, so it is not our call. */}
+        {!open && onSearch && searchSide === 'left' && searchBtn}
         <Pressable
           onPress={open ? dismiss : focus}
           style={({ pressed }) => [
@@ -609,21 +634,7 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
           </Text>
           {!open && <Text style={styles.kbSwipeCue}>›</Text>}
         </Pressable>
-        {/* Search: anchors Steam, walks focus to its global search field, and
-            raises this keyboard, so you type a game name on the phone instead
-            of picking letters off a grid with a d-pad. Only rendered when the
-            box can actually do it -- a search button that silently does nothing
-            is worse than no button. Sits on the CLOSED bar because that is
-            where you are when you decide to look for a game. */}
-        {!open && onSearch && (
-          <Pressable
-            onPress={onSearch}
-            hitSlop={8}
-            accessibilityLabel="Search Steam"
-            style={({ pressed }) => [styles.kbSearchBtn, pressed && styles.btnPressed]}>
-            <Ionicons name="search" size={17} color={t.blue} />
-          </Pressable>
-        )}
+        {!open && onSearch && searchSide === 'right' && searchBtn}
         {open && (
           <>
             {/* Android has no InputAccessoryView, so PASTE has to live here too
@@ -702,6 +713,24 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
         caretHidden={!open}
         inputAccessoryViewID={Platform.OS === 'ios' ? KB_ACCESSORY_ID : undefined}
       />
+      {/* Clear the field. Pinned INSIDE the compose field's right edge; the
+          field carries a matching paddingRight so text can never run underneath
+          it. That padding is the whole point -- an overlay without it is how
+          the HIDE button ended up invisible under this same field (#206), and
+          repeating that here would be careless. Only while there is something
+          to clear. */}
+      {open && value.length > 0 && (
+        <Pressable
+          onPress={() => {
+            setValue('');
+            inputRef.current?.focus();
+          }}
+          hitSlop={10}
+          accessibilityLabel="Clear text"
+          style={[styles.kbClearBtn, { bottom: 10 + kbLift }]}>
+          <Ionicons name="close-circle" size={19} color={pal.textFaint} />
+        </Pressable>
+      )}
       {/* Done bar pinned to the top of the iOS keyboard — always reachable,
           unlike the in-layout bar which the raised keyboard covers. */}
       {Platform.OS === 'ios' && (
@@ -1246,12 +1275,25 @@ function PadScreen() {
   // whether the STEAM tab exists) AND on being connected, so the button never
   // appears where it cannot work. steamGoto also resolves false on an older
   // agent, which stops the arrow walk rather than firing keys blindly.
-  const canSearch = hasSteamMenus && inGameMode && status === 'connected';
+  // An agent older than 2.9.42 has no /api/steam/goto, so the button would sit
+  // there doing nothing. There is no cheap way to know up front — the Pad screen
+  // carries no agent_version, and a 404 from a MISSING route is
+  // indistinguishable from a 404 refusing an id — so the button learns from its
+  // own first attempt and then hides for the session. One dead tap, not a
+  // permanently dead control.
+  const [searchUnsupported, setSearchUnsupported] = useState(false);
+  const canSearch =
+    hasSteamMenus && inGameMode && status === 'connected' && !searchUnsupported;
   const steamSearch = useCallback(() => {
     haptic();
     void (async () => {
       const anchored = await api.steamGoto(settings, 'home');
-      if (!anchored) return;   // older agent: don't fire arrows blindly
+      if (!anchored) {
+        // Older agent. Do NOT fire the arrows blindly — without the anchor they
+        // land on whatever is focused and open Steam's sidebar menu.
+        setSearchUnsupported(true);
+        return;
+      }
       // Let Steam settle on the anchored screen before walking focus.
       await new Promise((r) => setTimeout(r, STEAM_ANCHOR_SETTLE_MS));
       await client.focusSteamSearch();
@@ -1264,11 +1306,19 @@ function PadScreen() {
   // "dismiss keyboard" -- measured walking Store -> Settings -> Library -- so
   // firing it on every keyboard dismissal would move the user somewhere, or
   // open a pause menu inside a game.
-  const closeSteamSearch = useCallback(() => {
-    if (!searchOpen.current) return;
-    searchOpen.current = false;
-    client.sendKey('esc');
-  }, [client]);
+  const closeSteamSearch = useCallback(
+    (typed: boolean) => {
+      if (!searchOpen.current) return;
+      searchOpen.current = false;
+      // If a query was actually entered, LEAVE the search up. Closing it would
+      // discard the results the search was for -- you put the keyboard away to
+      // look at what you found, not to throw it away. An empty field means
+      // nothing is lost, so tidy up after the accidental open.
+      if (typed) return;
+      client.sendKey('esc');
+    },
+    [client],
+  );
 
   const selectTap = useCallback(() => {
     haptic();
@@ -2010,6 +2060,8 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   // Matches the bar's height so the row stays level; square so the glyph is
   // centred rather than drifting toward one edge.
+  kbSearchBtnLeft: { marginRight: 6, marginLeft: 0 },
+  kbSearchBtnRight: { marginLeft: 6, marginRight: 0 },
   kbSearchBtn: {
     width: 44,
     alignItems: 'center',
@@ -2018,7 +2070,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderWidth: 1,
     borderColor: t.cardBorder,
     backgroundColor: t.card,
-    marginLeft: 6,
   },
   kbDoneText: {
     color: '#0b1220',
@@ -2153,10 +2204,26 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderWidth: 1,
     borderRadius: 12,
     paddingVertical: 10,
-    paddingHorizontal: 12,
+    paddingLeft: 12,
+    // Room for the clear button. WITHOUT this the text runs underneath it --
+    // the same overlap class of bug as #206, where an opaque sibling swallowed
+    // the HIDE control. Keep in step with kbClearBtn's right + width.
+    paddingRight: 38,
     color: t.text,
     fontSize: 15,
     fontFamily: mono,
+  },
+  // Sits inside the compose field's right edge, vertically centred against its
+  // ~40px height. Higher zIndex than the field so the tap reaches it.
+  kbClearBtn: {
+    position: 'absolute',
+    right: 20,
+    height: 40,
+    width: 26,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 62,
+    elevation: 8,
   },
   hiddenInput: {
     // Invisible but FOCUSABLE. iOS won't let a fully transparent (alpha 0) or

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -169,6 +169,15 @@ const TAP_SLOP = 12;
 /** Touches longer than this aren't taps. */
 const TAP_MS = 450;
 
+// Steam needs a moment to finish drawing the anchored screen before it will
+// accept focus movement. MEASURED: 1200ms worked 3/3 starting from a
+// deliberately wrong screen (Settings > Audio), giving 3.2s tap-to-search; 3000
+// also worked but made it 5.0s, which is a long time to stare at a button.
+// 1500 keeps the proven value's margin without the extra second.
+// The failure mode if this is ever too short is visible, not silent: the walk
+// lands early and opens Steam's sidebar menu instead of search.
+const STEAM_ANCHOR_SETTLE_MS = 1500;
+
 type DpadKey = 'du' | 'dd' | 'dl' | 'dr';
 
 // Keyboard-mode equivalent for the swipe surface. Arrow keys were measured
@@ -368,6 +377,15 @@ type KeyboardBarProps = {
   /** Horizontal swipe across the (closed) bar: cycle the input mode.
       +1 = swipe left (next mode), -1 = swipe right (previous). */
   onSwipeMode?: (dir: 1 | -1) => void;
+  /** Tap the search button: anchor Steam, walk focus to its global search, and
+      raise this keyboard. Absent on boxes that cannot do it, which hides the
+      button entirely rather than offering a control that does nothing. */
+  onSearch?: () => void;
+  /** Called when the bar is dismissed, so the caller can close whatever it
+      opened on the box. Deliberately NOT "always send Esc": Esc is
+      back-navigation on Steam, so firing it when nothing is open moves the
+      user. The caller decides. */
+  onDismiss?: () => void;
 };
 
 /**
@@ -382,7 +400,8 @@ type KeyboardBarProps = {
  * while the real keyboard is down (or vice-versa). `open` is mirrored into a ref
  * so callbacks always see the live value without stale closures.
  */
-function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode }: KeyboardBarProps) {
+function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode,
+                       onSearch, onDismiss }: KeyboardBarProps) {
   const inputRef = useRef<TextInput>(null);
   const [open, setOpen] = useState(false);
   // Live ref so the once-created swipe responder sees the current callback.
@@ -414,7 +433,8 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
     inputRef.current?.blur();
     setOpenSynced(false);
     setValue('');
-  }, [setOpenSynced]);
+    onDismiss?.();
+  }, [setOpenSynced, onDismiss]);
 
   const focus = useCallback(() => {
     haptic();
@@ -566,6 +586,7 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
     [onBackspace, onEnter],
   );
 
+  const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   return (
     <>
@@ -588,6 +609,21 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
           </Text>
           {!open && <Text style={styles.kbSwipeCue}>›</Text>}
         </Pressable>
+        {/* Search: anchors Steam, walks focus to its global search field, and
+            raises this keyboard, so you type a game name on the phone instead
+            of picking letters off a grid with a d-pad. Only rendered when the
+            box can actually do it -- a search button that silently does nothing
+            is worse than no button. Sits on the CLOSED bar because that is
+            where you are when you decide to look for a game. */}
+        {!open && onSearch && (
+          <Pressable
+            onPress={onSearch}
+            hitSlop={8}
+            accessibilityLabel="Search Steam"
+            style={({ pressed }) => [styles.kbSearchBtn, pressed && styles.btnPressed]}>
+            <Ionicons name="search" size={17} color={t.blue} />
+          </Pressable>
+        )}
         {open && (
           <>
             {/* Android has no InputAccessoryView, so PASTE has to live here too
@@ -1197,6 +1233,43 @@ function PadScreen() {
     },
     [client, keyboardMode],
   );
+  // Steam global search. Three steps, and the ORDER matters:
+  //   1. anchor the Steam UI to a known screen -- MEASURED, the identical key
+  //      walk from the wrong screen opens Steam's sidebar menu instead;
+  //   2. walk focus to the search field with arrows;
+  //   3. raise this phone's keyboard. Step 3 cannot wait for the box's
+  //      {"t":"osk"} push: Steam takes these keys directly and never opens its
+  //      own on-screen keyboard on this path.
+  // searchOpen is what makes the HIDE button safe to wire to Esc -- see below.
+  const searchOpen = useRef(false);
+  // Gated on the box actually having Steam (the same signal that decides
+  // whether the STEAM tab exists) AND on being connected, so the button never
+  // appears where it cannot work. steamGoto also resolves false on an older
+  // agent, which stops the arrow walk rather than firing keys blindly.
+  const canSearch = hasSteamMenus && inGameMode && status === 'connected';
+  const steamSearch = useCallback(() => {
+    haptic();
+    void (async () => {
+      const anchored = await api.steamGoto(settings, 'home');
+      if (!anchored) return;   // older agent: don't fire arrows blindly
+      // Let Steam settle on the anchored screen before walking focus.
+      await new Promise((r) => setTimeout(r, STEAM_ANCHOR_SETTLE_MS));
+      await client.focusSteamSearch();
+      searchOpen.current = true;
+      setOskSignal((n) => n + 1);   // raise the phone keyboard
+    })();
+  }, [client, settings]);
+
+  // Only send Esc if WE opened the search. Esc on Steam is back-navigation, not
+  // "dismiss keyboard" -- measured walking Store -> Settings -> Library -- so
+  // firing it on every keyboard dismissal would move the user somewhere, or
+  // open a pause menu inside a game.
+  const closeSteamSearch = useCallback(() => {
+    if (!searchOpen.current) return;
+    searchOpen.current = false;
+    client.sendKey('esc');
+  }, [client]);
+
   const selectTap = useCallback(() => {
     haptic();
     if (keyboardMode) {
@@ -1262,6 +1335,8 @@ function PadScreen() {
       onEnter={kbEnter}
       onSwipeMode={cycleMode}
       autoOpenSignal={oskSignal}
+      onSearch={canSearch ? steamSearch : undefined}
+      onDismiss={closeSteamSearch}
     />
   ) : null;
 
@@ -1932,6 +2007,18 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 20,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  // Matches the bar's height so the row stays level; square so the glyph is
+  // centred rather than drifting toward one edge.
+  kbSearchBtn: {
+    width: 44,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    backgroundColor: t.card,
+    marginLeft: 6,
   },
   kbDoneText: {
     color: '#0b1220',

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -660,6 +660,7 @@ function SetupBody() {
   const padHints = usePref('padHints');
   const askToSwitchControl = usePref('askToSwitchControl');
   const keyboardMode = usePref('keyboardMode');
+  const searchButtonSide = usePref('searchButtonSide');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
   const hideStreamFromPc = usePref('hideStreamFromPc');
@@ -1348,6 +1349,20 @@ function SetupBody() {
                 value={padHints}
                 onValueChange={(v) => {
                   void setPref('padHints', v);
+                  hapticSelection();
+                }}
+              />
+              <SegPref
+                label="Steam search button"
+                sub="Opens Steam's search on the box and brings up your keyboard. Left by default — the right end of the bar is where your thumb rests, so it's easier to hit by accident there."
+                options={[
+                  { value: 'left', label: 'LEFT' },
+                  { value: 'right', label: 'RIGHT' },
+                  { value: 'off', label: 'OFF' },
+                ]}
+                value={searchButtonSide}
+                onSelect={(v) => {
+                  void setPref('searchButtonSide', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1231,6 +1231,26 @@ export const api = {
     });
   },
 
+  /**
+   * Navigate the Steam UI to a known destination (agent >= 2.9.42).
+   *
+   * Exists so the search button has a KNOWN starting screen before it walks a
+   * fixed key path. MEASURED on a Legion Go S: the same key path fired from the
+   * wrong screen opens Steam's sidebar menu instead of search, so anchoring is
+   * not optional polish — it is what makes the feature work twice in a row.
+   *
+   * Resolves false on an older agent (404) rather than throwing, so the caller
+   * can skip the key walk instead of blindly sending arrows.
+   */
+  steamGoto(settings: ConnSettings, id: 'home'): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/steam/goto', {
+      method: 'POST',
+      body: { id },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
   steamlink(
     settings: ConnSettings,
     caps: BoxCaps | undefined = cachedCaps(settings),

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -262,6 +262,18 @@ function q(v: number): number {
   return Math.round(clamp(v, -1, 1) * 1000) / 1000;
 }
 
+// Steam search focus walk. Counts are deliberately generous: an arrow at the
+// edge of Steam's top bar is a no-op, so overshooting is free while
+// undershooting lands on the wrong control. Both 3 and 5 UP presses were
+// measured reaching the same place.
+const SEARCH_UP_PRESSES = 4;
+const SEARCH_LEFT_PRESSES = 10;
+// Steam drops keys sent faster than its UI settles. 120ms was the interval that
+// worked on hardware; the whole walk is then well under two seconds.
+const SEARCH_KEY_GAP_MS = 120;
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
 export class GamepadClient {
   private ws: WebSocket | null = null;
   private status: GamepadStatus = 'closed';
@@ -642,6 +654,35 @@ export class GamepadClient {
   /** A single special key press+release (backspace, enter, arrows, …). */
   sendKey(key: SpecialKey): void {
     this.sendRaw({ t: 'k', key });
+  }
+
+  /**
+   * Walk Steam's focus to its global search field, then resolve.
+   *
+   * MEASURED on a Legion Go S in Game Mode, 2026-07-22, driven from a real
+   * phone and watched through /api/screen/frame:
+   *   - From Steam Home, UP then LEFT reaches the search field; typing lands in
+   *     it and filters live ("dota" -> ALL 15 / LIBRARY 1, DOTA 2 in library).
+   *   - OVERSHOOT IS SAFE and is why the counts are generous: an arrow at the
+   *     edge of the bar is a no-op, so pressing more than needed costs nothing
+   *     while pressing too few silently lands on the wrong control.
+   *   - The caller must anchor the UI first (api.steamGoto). The identical
+   *     sequence fired from the wrong screen opens Steam's SIDEBAR MENU instead
+   *     of search — observed, not theorised.
+   *
+   * Steam's own on-screen keyboard does NOT open on this path; it takes the
+   * keys directly. So the agent's {"t":"osk"} watcher never fires here and the
+   * caller has to raise the phone's keyboard itself.
+   */
+  async focusSteamSearch(): Promise<void> {
+    for (let i = 0; i < SEARCH_UP_PRESSES; i++) {
+      this.sendKey('up');
+      await sleep(SEARCH_KEY_GAP_MS);
+    }
+    for (let i = 0; i < SEARCH_LEFT_PRESSES; i++) {
+      this.sendKey('left');
+      await sleep(SEARCH_KEY_GAP_MS);
+    }
   }
 
   /**

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -58,6 +58,15 @@ export type Prefs = {
    *  a gamepad screen with no gamepad would be a lie. */
   keyboardMode: boolean;
   /** Input mode a newly paired box starts on. */
+  /** Where the Steam search button sits on the keyboard bar, or 'off' to hide
+   *  it entirely.
+   *
+   *  Defaults to LEFT: the bar's right end is where the thumb rests and where
+   *  PASTE/HIDE appear once the bar opens, so a search button there is easy to
+   *  hit by accident. Handedness varies, so side is a preference rather than a
+   *  decision — and 'off' exists because a control you never use is still a
+   *  control you can fat-finger. */
+  searchButtonSide: 'left' | 'right' | 'off';
   defaultPadMode: PadMode;
   /** How often the console/header polls the box for vitals (ms). */
   statusIntervalMs: number;
@@ -132,6 +141,7 @@ export const DEFAULTS: Prefs = {
   landingTab: 'index',
   autoKeyboard: true,
   keyboardMode: false,
+  searchButtonSide: 'left',
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
   journalLines: 100,
@@ -213,10 +223,15 @@ function normalize(raw: unknown): Prefs {
     o.defaultPadMode === 'remote'
       ? o.defaultPadMode
       : 'swipe';
+  const searchSide: 'left' | 'right' | 'off' =
+    o.searchButtonSide === 'right' || o.searchButtonSide === 'off'
+      ? o.searchButtonSide
+      : 'left';
   const landingTab: LandingTab = LANDING_TABS.includes(o.landingTab as LandingTab)
     ? (o.landingTab as LandingTab)
     : DEFAULTS.landingTab;
   return {
+    searchButtonSide: searchSide,
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     landingTab,

--- a/tests/test_steam_goto.py
+++ b/tests/test_steam_goto.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Tests for steam_goto() — the allowlisted Steam UI destination.
+
+Run: python3 tests/test_steam_goto.py
+
+WHY THIS EXISTS: the app's search button walks a FIXED key path (up, up, left
+x10) to reach Steam's global search. MEASURED on a Legion Go S: that path only
+works from a known starting screen — fired from the wrong one it opens the
+sidebar menu instead. So the button first anchors the UI here.
+
+`steam://` can install games and run programs. That is exactly why the id is
+looked up in a frozen dict and the URL is chosen HERE, never supplied by the
+caller. The refusal tests below are the point of this file; if anything gets
+trimmed, keep those.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class SpyPopen:
+    """Capture the argv instead of launching Steam."""
+
+    def __init__(self):
+        self.calls = []
+        self._real = cs.subprocess.Popen
+
+    def __enter__(self):
+        outer = self
+
+        def fake(argv, **kw):
+            outer.calls.append(argv)
+
+            class P:
+                pid = 1234
+            return P()
+        cs.subprocess.Popen = fake
+        return self
+
+    def __exit__(self, *a):
+        cs.subprocess.Popen = self._real
+
+
+def test_known_place_dispatches_a_literal_url():
+    """The URL comes from the table, not from the caller."""
+    print("test_known_place_dispatches_a_literal_url")
+    with SpyPopen() as spy:
+        check("returns True", cs.steam_goto("home"), True)
+        check("one launch", len(spy.calls), 1)
+        check("argv is a LIST (never a shell string)",
+              isinstance(spy.calls[0], list), True)
+        check("argv", spy.calls[0], ["steam", "steam://open/games"])
+
+
+def test_unknown_id_is_refused_and_launches_NOTHING():
+    """THE test. A non-allowlisted id must not reach steam://."""
+    print("test_unknown_id_is_refused_and_launches_NOTHING")
+    for bad in ("install", "rungameid/570", "../home", "", "HOME",
+                "home; rm -rf /", None, 5, ["home"]):
+        with SpyPopen() as spy:
+            check("id %r refused" % (bad,), cs.steam_goto(bad), False)
+            check("id %r launched nothing" % (bad,), len(spy.calls), 0)
+
+
+def test_no_client_string_can_reach_the_url():
+    """Every table value is a literal steam:// URL with no format slot, so no
+    caller input can be interpolated into one."""
+    print("test_no_client_string_can_reach_the_url")
+    for pid, url in cs.STEAM_PLACES.items():
+        check("%r has no format slot" % pid, "%" in url, False)
+        check("%r is a steam:// url" % pid, url.startswith("steam://"), True)
+        check("%r has no shell metacharacters" % pid,
+              any(ch in url for ch in ";|&$`<>"), False)
+
+
+def test_table_is_not_a_pattern():
+    """No globs / prefixes (CLAUDE.md 3.3) — ids are exact keys."""
+    print("test_table_is_not_a_pattern")
+    for pid in cs.STEAM_PLACES:
+        check("%r has no wildcard" % pid,
+              any(ch in pid for ch in "*?["), False)
+
+
+if __name__ == "__main__":
+    for fn in (test_known_place_dispatches_a_literal_url,
+               test_unknown_id_is_refused_and_launches_NOTHING,
+               test_no_client_string_can_reach_the_url,
+               test_table_is_not_a_pattern):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Tap search → the box jumps to Steam's global search and your phone's keyboard comes up, so you type a game name instead of picking letters off a grid with a d-pad. Dismissing the keyboard closes it again.

**Every mechanism here was measured on a Legion Go S in Game Mode**, driven from a real phone and watched through `/api/screen/frame`. None of it is inferred.

## What the measurements changed

**There is no deep link to search.** Four candidates ruled out against a bogus-URL control:

| candidate | result |
|---|---|
| `steam://open/search` | nothing |
| `steam://open/bigpicture` | nothing |
| `steam://open/settings/search` | opens **Settings** — unknown slug → default page |
| `steam://store/search` | opens the **Store** |

What works is arrow navigation: `UP` then `LEFT` reaches the field, and typing filters live — "dota" gave ALL 15 / LIBRARY 1 with DOTA 2 marked IN LIBRARY.

**But a blind key walk is not reliable.** Fired from the wrong screen the identical sequence opens Steam's **sidebar menu**. That's why `/api/steam/goto` exists — it anchors the UI to a known screen first. I verified it's load-bearing by starting the end-to-end run from Settings › Audio.

**Overshoot is free**, so the press counts are deliberately generous: an arrow at the edge of the bar is a no-op, and 3 vs 5 UP presses reached the same place. Undershooting silently lands on the wrong control; overshooting costs nothing.

**Timing was measured, not guessed.** 1200ms settle worked **3/3** from a wrong screen (3.2s tap-to-search); 3000ms also worked but cost 5.0s. Shipping 1500ms for margin. If it's ever too short the failure is *visible* — the walk lands early and opens the sidebar menu — not silent.

## Allowlist

`/api/steam/goto` takes an id that indexes a **frozen dict**; the URL is chosen agent-side and an unknown id is a 404, never a pass-through. `steam://` can install games and run programs, which is exactly why this is not a URL parameter.

`steam_goto()` also type-checks before the lookup — a test caught it raising `TypeError` on an unhashable id instead of degrading closed. Tests assert unknown ids launch **nothing**, that every table value is a literal `steam://` URL with no format slot or shell metacharacters, and that no id is a wildcard.

## Two design details that fall out of the measurements

**Esc is gated on having opened the search.** It's back-navigation, not "dismiss keyboard" — measured walking Store → Settings → Library. Wiring it to every keyboard dismissal would move the user, or open a pause menu mid-game.

**Steam's own OSK never opens on this path** — it takes the keys directly — so the `{"t":"osk"}` watcher can't raise the phone keyboard here. The app raises it itself.

## Verified end to end

From Settings › Audio (a deliberately wrong screen): anchor → walk → **search focused** → "dota" filters correctly → Esc closes it. Repeated 3×.

## NOT verified

- **The button itself has not been tapped in a shipped build.** The sequence was replayed with the shipped constants against the live box; the app UI path is typechecked but unexercised.
- **Only one box.** The key counts are UI-shape-dependent, not an API, so they want re-checking after Steam UI updates. Flagged in the roadmap as a known limitation rather than presented as universal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)