### PR TITLE
Disk percent, game drives, battery draw/profile, and real update progress (agent 2.9.43)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.43
+
+Storage now reports how full a drive really is. It was dividing by space you
+cannot actually use, so a nearly-full drive could read several points low.
+
+Game drives appear too — a Steam Deck's SD card was invisible before.
+
+Handhelds also show current power draw and the machine's power profile.
+
 ## 2.9.42
 
 Adds the box-side half of the app's new Steam search button.

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -27,6 +27,9 @@ Game drives appear too — a Steam Deck's SD card was invisible before.
 
 Handhelds also show current power draw and the machine's power profile.
 
+While the box updates itself, the app now shows what it is actually doing, and
+the box's own screen shows an update page so you are not staring at a frozen TV.
+
 ## 2.9.42
 
 Adds the box-side half of the app's new Steam search button.

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -27,6 +27,10 @@ Game drives appear too — a Steam Deck's SD card was invisible before.
 
 Handhelds also show current power draw and the machine's power profile.
 
+Game cover art now appears on Android. It never has — the phone was quietly
+dropping the credential on image requests, so every tile fell back to a plain
+card.
+
 While the box updates itself, the app now shows what it is actually doing, and
 the box's own screen shows an update page so you are not staring at a frozen TV.
 

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -27,6 +27,9 @@ Game drives appear too — a Steam Deck's SD card was invisible before.
 
 Handhelds also show current power draw and the machine's power profile.
 
+You can close the running game from your phone. The Gaming card shows what is
+playing and how long it has been on, with a button to quit it.
+
 Game cover art now appears on Android. It never has — the phone was quietly
 dropping the credential on image requests, so every tile fell back to a plain
 card.

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -25,6 +25,10 @@ cannot actually use, so a nearly-full drive could read several points low.
 
 Game drives appear too — a Steam Deck's SD card was invisible before.
 
+Memory now shows swap in use and, when the box is actually struggling, how much
+time it spends stalled waiting on memory — the thing you feel as stutter, which
+a used-percentage does not tell you.
+
 Handhelds also show current power draw and the machine's power profile — and
 while charging, how long until the battery is full.
 

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -25,7 +25,8 @@ cannot actually use, so a nearly-full drive could read several points low.
 
 Game drives appear too — a Steam Deck's SD card was invisible before.
 
-Handhelds also show current power draw and the machine's power profile.
+Handhelds also show current power draw and the machine's power profile — and
+while charging, how long until the battery is full.
 
 You can close the running game from your phone. The Gaming card shows what is
 playing and how long it has been on, with a button to quit it.

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -25,6 +25,10 @@ cannot actually use, so a nearly-full drive could read several points low.
 
 Game drives appear too — a Steam Deck's SD card was invisible before.
 
+The GPU no longer looks like it has half a gigabyte. Handhelds share memory
+with the system, and only the small dedicated slice was being reported — it now
+shows the whole pool, plus how busy the GPU actually is.
+
 Memory now shows swap in use and, when the box is actually struggling, how much
 time it spends stalled waiting on memory — the thing you feel as stutter, which
 a used-percentage does not tell you.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -9491,15 +9491,37 @@ def _gpu_sensors():
             milli = _read_int(temp_path)
             if milli is not None:
                 gpu["temp_c"] = round(milli / 1000.0, 1)
-        # VRAM is documented as BYTES but was not observable this session. Sanity-
-        # gate the magnitude before trusting the unit — a total under ~64 MB is
-        # almost certainly not bytes, so drop it rather than report a lie.
+        # VRAM is in BYTES. Sanity-gate the magnitude before trusting the unit --
+        # a total under ~64 MB is almost certainly not bytes, so drop it rather
+        # than report a lie.
         total = _read_int(os.path.join(dev, "mem_info_vram_total"))
         used = _read_int(os.path.join(dev, "mem_info_vram_used"))
         if total is not None and total > (64 << 20):
             gpu["vram_total_mb"] = total >> 20
             if used is not None:
                 gpu["vram_used_mb"] = used >> 20
+
+        # GTT: system memory the GPU may use. On an APU this is the number that
+        # matters and VRAM alone is actively misleading -- MEASURED on a Legion
+        # Go S, mem_info_vram_total is a 512 MB BIOS carve-out sitting at 89%
+        # used, while mem_info_gtt_total is 15.3 GB barely touched. Reporting
+        # only VRAM made a 32 GB handheld look like a full 0.5 GB graphics card.
+        #
+        # Both are reported rather than summed: they are different pools with
+        # different performance, and adding them would invent a number the
+        # hardware does not have. The app decides how to present it.
+        gtt_total = _read_int(os.path.join(dev, "mem_info_gtt_total"))
+        gtt_used = _read_int(os.path.join(dev, "mem_info_gtt_used"))
+        if gtt_total is not None and gtt_total > (64 << 20):
+            gpu["gtt_total_mb"] = gtt_total >> 20
+            if gtt_used is not None:
+                gpu["gtt_used_mb"] = gtt_used >> 20
+
+        # How hard the GPU is actually working. A VRAM bar says what is
+        # allocated, not whether anything is happening.
+        busy = _read_int(os.path.join(dev, "gpu_busy_percent"))
+        if busy is not None and 0 <= busy <= 100:
+            gpu["busy_pct"] = busy
         return gpu
     return {}
 
@@ -9991,7 +10013,10 @@ def mock_gaming():
     external output, a pad with battery, Game Mode."""
     return {
         "gpu": {"name": "amdgpu", "temp_c": 61.0,
-                "vram_used_mb": 3300, "vram_total_mb": 8192},
+                "vram_used_mb": 3300, "vram_total_mb": 8192,
+                # Mock a DISCRETE card: gtt smaller than vram, so the app takes
+                # the non-shared branch. A handheld APU is the other shape.
+                "gtt_used_mb": 210, "gtt_total_mb": 4096, "busy_pct": 63},
         "game": {"appid": 1091500, "label": "Cyberpunk 2077"},
         "output": {"name": "DP-1", "internal": False},
         "controllers": [{"uniq": "dc:2c:26:aa:bb:cc",

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.42"
+VERSION = "2.9.43"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1202,10 +1202,38 @@ def osk_arm(mock=False):
     print("[osk] watching %s" % _OSK_LOG, flush=True)
 
 
+def _steam_library_mounts():
+    """Filesystems that hold Steam libraries, as mount-ish paths.
+
+    Why this exists: _DISK_MOUNTS is a fixed list, so a Deck's SD card or a
+    second games drive never appeared -- MEASURED on a Legion Go S, a 1.4 TB
+    card at /run/media/deck/SD1T5 was invisible while a 5 GB OS partition was
+    shown. Games are the whole reason storage matters on these boxes.
+
+    Deriving this from Steam's OWN library list rather than globbing /run/media
+    or /mnt keeps it principled: it shows exactly the drives games live on, and
+    reuses machinery that is already read-only and already allowlist-safe. A box
+    with no Steam simply gets nothing extra.
+
+    Never raises; returns [] on any problem.
+    """
+    out = []
+    try:
+        root = _steam_root()
+        if root is None:
+            return []
+        for steamapps in _steam_libraries_cached(root):
+            # steamapps dir -> the library root that contains it.
+            out.append(os.path.dirname(steamapps) or steamapps)
+    except Exception:
+        return []
+    return out
+
+
 def read_disks():
     disks = []
     seen_devices = set()
-    for mount in _DISK_MOUNTS:
+    for mount in list(_DISK_MOUNTS) + _steam_library_mounts():
         try:
             # Same filesystem reached by two paths (the common case where /home
             # is not split out) must not be listed twice.
@@ -1235,7 +1263,19 @@ def read_disks():
             total_gb = du.total / (1024 ** 3)
             used_gb = du.used / (1024 ** 3)
             free_gb = du.free / (1024 ** 3)
-            pct = int(round(du.used * 100.0 / du.total)) if du.total else 0
+            # Percent full against what the user can ACTUALLY use, i.e.
+            # used/(used+free), not used/total. `total` counts root-reserved
+            # blocks an unprivileged user can never touch, so dividing by it
+            # under-reports fullness -- MEASURED on a Legion Go S, /home showed
+            # 91% when df said 96%, because 92 GB of it is reserved. A storage
+            # warning that reads low exactly when the disk is nearly full is
+            # worse than none. (shutil's `free` is already f_bavail.)
+            usable = du.used + du.free
+            # Round UP, like df does. This number drives a warning colour, and
+            # for "how full am I" the conservative direction is the honest one:
+            # 96.2% should read 97, not 96.
+            pct = -(-du.used * 100 // usable) if usable else 0
+            pct = int(min(100, max(0, pct)))
             disks.append({
                 "mount": mount,
                 "total_gb": round(total_gb, 1),
@@ -2898,8 +2938,8 @@ def mock_status():
         ],
         # Mock is a HANDHELD so the battery row is exercisable in the web
         # harness -- a mains desktop would render nothing and prove nothing.
-        "battery": {"pct": 58, "status": "Discharging",
-                    "on_ac": False, "minutes": 251},
+        "battery": {"pct": 58, "status": "Discharging", "on_ac": False,
+                    "minutes": 251, "watts": 7.7, "profile": "balanced"},
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
@@ -9433,6 +9473,28 @@ def read_box_battery():
     if on_ac is not None:
         out["on_ac"] = on_ac
 
+    # Instantaneous power flow in watts. The SIGN is the status, not the number:
+    # while charging this same counter is the CHARGE rate, so it is labelled by
+    # `status` rather than presented as "discharge". Some gauges report
+    # microwatts directly (POWER_NOW); others only amps x volts.
+    watts = None
+    try:
+        watts = int(batt["POWER_SUPPLY_POWER_NOW"]) / 1e6
+    except (KeyError, ValueError):
+        try:
+            watts = (int(batt["POWER_SUPPLY_CURRENT_NOW"])
+                     * int(batt["POWER_SUPPLY_VOLTAGE_NOW"])) / 1e12
+        except (KeyError, ValueError):
+            watts = None
+    # A zero or negative reading is a gauge that is not measuring, not a box
+    # drawing no power. Report nothing rather than a confident 0.0 W.
+    if watts is not None and watts > 0:
+        out["watts"] = round(watts, 1)
+
+    profile = read_power_profile()
+    if profile:
+        out["profile"] = profile
+
     # Runtime left, when the gauge reports a draw. ENERGY_* is microwatt-hours
     # against POWER_NOW microwatts; CHARGE_* is microamp-hours against
     # CURRENT_NOW microamps. Both divide to hours. Only meaningful while
@@ -9449,6 +9511,31 @@ def read_box_battery():
                 out["minutes"] = int(now * 60 // rate)
                 break
     return out
+
+
+_PLATFORM_PROFILE = "/sys/firmware/acpi/platform_profile"
+
+
+def read_power_profile():
+    """The machine's ACPI platform profile (low-power / balanced / performance),
+    or None when the machine has no such control.
+
+    MEASURED on a Legion Go S, 2026-07-22: the file read "custom" while
+    platform_profile_choices listed "low-power balanced performance" -- Steam's
+    own TDP control had set a profile outside the advertised set. So the current
+    value is reported VERBATIM and is NOT validated against the choices list; a
+    reader that insisted on a known value would have shown nothing on the exact
+    hardware this was written for.
+
+    READ-ONLY. Writing this file would change how the machine performs and is a
+    deliberately separate decision -- it is not exposed here.
+    """
+    try:
+        with open(_PLATFORM_PROFILE) as f:
+            value = f.read().strip()
+    except OSError:
+        return None
+    return value or None
 
 
 def box_battery_available():

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -23,6 +23,7 @@ import random
 import re
 import select
 import shutil
+import signal
 import socket
 import ssl
 import struct
@@ -9467,6 +9468,63 @@ def _appid_from_cmdline(cmdline):
         return None
 
 
+def stop_running_game():
+    """Ask the game running right now to close. {"stopped": bool, ...}.
+
+    THE SECURITY SHAPE, and it is the whole design: this takes NO ARGUMENT. The
+    caller cannot name a pid, an appid, or anything else -- the agent
+    re-resolves the target itself, here, at the moment of the call. A client that
+    cannot name a process cannot be steered into killing one. Accepting a pid
+    "to be explicit" would turn this into a remote kill-anything primitive,
+    which is exactly what CLAUDE.md 3.1 forbids.
+
+    SIGTERM only, and never SIGKILL: Steam's reaper forwards it so the game
+    saves and exits the way it would from its own menu. A hard kill risks
+    losing progress, and the user can always hold the power button.
+
+    Degrades closed: nothing running is a plain "not stopped", never a
+    best-effort sweep of anything that looks game-shaped.
+    """
+    game = _running_game()
+    if not game or not game.get("pid"):
+        return {"stopped": False, "reason": "nothing running"}
+    pid = game["pid"]
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        # It exited between resolving and signalling. That is the outcome the
+        # caller wanted, so report it as such rather than as an error.
+        return {"stopped": True, "game": game, "note": "already exited"}
+    except PermissionError:
+        return {"stopped": False, "reason": "not permitted"}
+    except OSError as e:
+        return {"stopped": False, "reason": e.__class__.__name__}
+    return {"stopped": True, "game": game}
+
+
+def _proc_uptime_s(pid):
+    """Seconds a pid has been running, or None.
+
+    Field 22 of /proc/<pid>/stat is the process start time in clock ticks since
+    BOOT, so it is compared against /proc/uptime rather than wall time -- a
+    clock change must not make a game look like it started tomorrow. The comm
+    field can contain spaces and parentheses, so the fields are taken from after
+    the LAST ')' rather than by splitting the whole line.
+    """
+    try:
+        with open("/proc/%d/stat" % pid) as f:
+            raw = f.read()
+        fields = raw[raw.rindex(")") + 2:].split()
+        start_ticks = int(fields[19])          # field 22, 1-based, after comm
+        hz = os.sysconf("SC_CLK_TCK") or 100
+        with open("/proc/uptime") as f:
+            up = float(f.read().split()[0])
+        secs = int(up - (start_ticks / float(hz)))
+        return secs if secs >= 0 else None
+    except (OSError, ValueError, IndexError, ZeroDivisionError):
+        return None
+
+
 def _running_game():
     """{"appid": int[, "label": str]} for the Steam game running now, or None.
     Scans /proc/*/cmdline for the reaper wrapper; label from the appinfo cache
@@ -9484,6 +9542,16 @@ def _running_game():
                 name = _steam_appinfo_names().get(int(appid))
                 if name:
                     game["label"] = name
+                # The pid the appid was found on, plus how long it has been up.
+                # Both are additive; existing callers ignore them.
+                try:
+                    pid = int(entry.split("/")[2])
+                    game["pid"] = pid
+                    secs = _proc_uptime_s(pid)
+                    if secs is not None:
+                        game["running_s"] = secs
+                except (IndexError, ValueError):
+                    pass
                 return game
     except Exception:
         pass
@@ -11630,6 +11698,19 @@ class Handler(BaseHTTPRequestHandler):
             # allowlist — Steam would silently open its DEFAULT page for an
             # unknown slug, so forwarding one would look like success while
             # landing somewhere else entirely.
+            if path == "/api/game/stop":
+                # Deliberately takes NO BODY. The agent resolves what is running
+                # itself; a client that cannot name a process cannot be steered
+                # into killing one. Any body sent is ignored rather than parsed.
+                if self.mock:
+                    self._send(200, {"stopped": True,
+                                     "game": {"appid": 1091500,
+                                              "label": "Cyberpunk 2077"}}, started)
+                    return
+                res = stop_running_game()
+                self._send(200 if res.get("stopped") else 409, res, started)
+                return
+
             if path == "/api/steam/goto":
                 # Navigate the Steam UI to one allowlisted destination. Exists so
                 # the app's search button has a KNOWN starting screen before it

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -994,13 +994,66 @@ def read_mem():
                     info[parts[0].rstrip(":")] = int(parts[1])  # kB
         total_mb = info.get("MemTotal", 0) // 1024
         avail_mb = info.get("MemAvailable", 0) // 1024
-        return {
+        out = {
             "total_mb": total_mb,
             "used_mb": total_mb - avail_mb,
             "available_mb": avail_mb,
         }
+        # Swap in use. On SteamOS/Bazzite handhelds this is where a big game
+        # starts paying for itself in stutter, and it is invisible in a
+        # used/total bar.
+        sw_total = info.get("SwapTotal", 0) // 1024
+        if sw_total:
+            out["swap_total_mb"] = sw_total
+            out["swap_used_mb"] = sw_total - (info.get("SwapFree", 0) // 1024)
+        pressure = read_mem_pressure()
+        if pressure:
+            out["pressure"] = pressure
+        return out
     except Exception:
         return {"total_mb": 0, "used_mb": 0, "available_mb": 0}
+
+
+def read_mem_pressure():
+    """Linux PSI memory pressure as {"some10","some60","full10","full60"}, or {}.
+
+    WHY THIS AND NOT JUST used/total: a used-percentage says how much memory is
+    SPOKEN FOR, not whether anything is hurting. A handheld with a big page
+    cache can read "26% used" while a game stutters, and can read "90% used"
+    while everything is fine. PSI measures the thing you actually feel -- the
+    share of time work was STALLED waiting on memory.
+
+      some = at least one task stalled
+      full = EVERY task stalled (the machine is effectively frozen)
+
+    avg10/avg60 are percentages the kernel already averages over 10s and 60s, so
+    nothing needs sampling here.
+
+    MEASURED on a Legion Go S: /proc/pressure/memory exists and reads
+    "some avg10=0.00 ... total=366363677" when idle -- zeros now, but a live
+    cumulative counter. Absent on kernels built without CONFIG_PSI, which is why
+    this returns {} rather than zeros: "no pressure" and "cannot tell" must not
+    look the same.
+    """
+    try:
+        with open("/proc/pressure/memory") as f:
+            raw = f.read()
+    except OSError:
+        return {}
+    out = {}
+    for line in raw.splitlines():
+        parts = line.split()
+        if not parts or parts[0] not in ("some", "full"):
+            continue
+        kind = parts[0]
+        for field in parts[1:]:
+            key, _, value = field.partition("=")
+            if key in ("avg10", "avg60"):
+                try:
+                    out["%s%s" % (kind, key[3:])] = round(float(value), 2)
+                except ValueError:
+                    pass
+    return out
 
 
 # Filesystems worth showing, in the order they should appear. "/home" is here
@@ -3007,7 +3060,13 @@ def mock_status():
     base = 55.0 + 4.5 * math.sin(now / 97.0)
     temp = round(base + random.uniform(-0.8, 0.8), 1)
     load1 = round(random.uniform(0.2, 1.4), 2)
-    mem = {"total_mb": 15803, "used_mb": 6212, "available_mb": 9591}
+    # Non-zero swap and pressure on purpose: the app hides both when they are
+    # quiet, so a mock that reports zeros would render a row nobody can see and
+    # prove nothing.
+    mem = {"total_mb": 15803, "used_mb": 6212, "available_mb": 9591,
+           "swap_total_mb": 8192, "swap_used_mb": 1433,
+           "pressure": {"some10": 4.2, "some60": 2.8,
+                        "full10": 0.9, "full60": 0.3}}
     # Feed the same history ring as real mode so sparklines are exercisable in
     # --mock (rate-limited exactly the same way).
     _record_history(int(now), temp, load1, mem)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -11132,6 +11132,34 @@ class Handler(BaseHTTPRequestHandler):
         supplied = auth[len("Bearer "):].strip()
         return hmac.compare_digest(supplied, self.token)
 
+    def _authorized_image(self, parsed):
+        """Auth for IMAGE responses only, which additionally accept ?token=.
+
+        WHY THIS EXISTS, measured rather than assumed: React Native's <Image>
+        takes source.headers, and on Android those headers are DROPPED before
+        the request leaves the phone. Instrumenting the agent showed every cover
+        request arriving as `auth_header='' len=0  ua='okhttp/4.9.2'` -- so the
+        header path cannot work there and cover art was blank on every Android
+        device.
+
+        The bearer header is still preferred and tried first. The query fallback
+        is deliberately scoped to image GETs -- it is NOT a general auth bypass,
+        and no state-changing route may ever use it.
+
+        Safe to log: the access logger already replaces any query string with
+        "?<redacted>", so the token never reaches the journal. Same
+        constant-time comparison as the header path. Precedent: /ws/gamepad has
+        always authenticated with ?token= for the same reason (a WebSocket
+        handshake cannot carry a custom header from RN either).
+        """
+        if self._authorized():
+            return True
+        try:
+            supplied = (parse_qs(parsed.query).get("token") or [""])[0]
+        except Exception:
+            return False
+        return bool(supplied) and hmac.compare_digest(supplied, self.token)
+
     # -- verbs ---------------------------------------------------------------
 
     def do_OPTIONS(self):
@@ -11209,6 +11237,19 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(404, {"error": "not found"}, started)
                 return
 
+            if path.startswith("/api/steam/") and path.endswith("/cover"):
+                # Handled BEFORE the shared auth gate because it accepts an
+                # additional ?token= form -- see _authorized_image for why
+                # (Android's image loader drops source.headers). It is still
+                # AUTHENTICATED, just by a check that tolerates that: an
+                # unauthorised request gets the same 401 as everything else.
+                if not self._authorized_image(parsed):
+                    self._send(401, {"error": "unauthorized"}, started)
+                    return
+                appid = path[len("/api/steam/"):-len("/cover")]
+                self._handle_steam_cover(appid, started)
+                return
+
             if not self._authorized():
                 self._send(401, {"error": "unauthorized"}, started)
                 return
@@ -11271,9 +11312,6 @@ class Handler(BaseHTTPRequestHandler):
                 # reflects the box-side toggle without waiting out the TTL.
                 data = dict(data, apply_enabled=bool(ALLOW_APP_UPDATE))
                 self._send(200, data, started)
-            elif path.startswith("/api/steam/") and path.endswith("/cover"):
-                appid = path[len("/api/steam/"):-len("/cover")]
-                self._handle_steam_cover(appid, started)
             elif path == "/api/tv":
                 # Probe-and-appear: 404 when no TV backend so the app shows no
                 # TV strip; a body only when a backend is live.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3028,6 +3028,8 @@ def mock_status():
         ],
         # Mock is a HANDHELD so the battery row is exercisable in the web
         # harness -- a mains desktop would render nothing and prove nothing.
+        # Mock is DISCHARGING by default; flip status/on_ac and swap
+        # minutes for minutes_to_full to exercise the charging layout.
         "battery": {"pct": 58, "status": "Discharging", "on_ac": False,
                     "minutes": 251, "watts": 7.7, "profile": "balanced"},
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
@@ -9651,6 +9653,32 @@ def read_box_battery():
     profile = read_power_profile()
     if profile:
         out["profile"] = profile
+
+    # Time to FULL while charging. Separate field, NOT folded into `minutes`:
+    # that one means "runtime left on battery" to every app already shipped, and
+    # reusing it here would make a 2.9.40-era app cheerfully report "42m left"
+    # while the box is plugged in and filling up.
+    #
+    # MEASURED live on a Legion Go S while charging, 2026-07-22:
+    #   ENERGY_NOW 34530000, ENERGY_FULL 55500000, POWER_NOW 30197000
+    #   -> (55500000-34530000)/30197000 h = 41.7 min
+    if out["status"] == "Charging":
+        for now_k, full_k, rate_k in (
+                ("POWER_SUPPLY_ENERGY_NOW", "POWER_SUPPLY_ENERGY_FULL",
+                 "POWER_SUPPLY_POWER_NOW"),
+                ("POWER_SUPPLY_CHARGE_NOW", "POWER_SUPPLY_CHARGE_FULL",
+                 "POWER_SUPPLY_CURRENT_NOW")):
+            try:
+                now, full, rate = (int(batt[now_k]), int(batt[full_k]),
+                                   int(batt[rate_k]))
+            except (KeyError, ValueError):
+                continue
+            # A full battery still on the charger reports a trickle rate; a
+            # "time to full" of hours would be nonsense, so only report while
+            # there is a real gap left to close.
+            if rate > 0 and full > now:
+                out["minutes_to_full"] = int((full - now) * 60 // rate)
+            break
 
     # Runtime left, when the gauge reports a draw. ENERGY_* is microwatt-hours
     # against POWER_NOW microwatts; CHARGE_* is microamp-hours against

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1433,13 +1433,102 @@ def mock_update_check():
             "checked_at": int(time.time())}
 
 
+UPDATE_LOG = "/tmp/couchside-update.log"
+
+
+def read_update_log(limit=40):
+    """Last `limit` lines of the installer transcript, or [] when absent.
+
+    The installer already wrote this file; nothing ever read it, so the app sat
+    on a canned "this can take a minute" while the box knew exactly which step
+    it was on. The PATH IS A CONSTANT -- no client input selects a file.
+    Read-only, best-effort, never raises.
+    """
+    try:
+        with open(UPDATE_LOG, "r", errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return []
+    out = [ln.rstrip() for ln in lines if ln.strip()]
+    return out[-limit:]
+
+
+def render_update_page():
+    """The progress page shown on the BOX'S OWN screen during an update.
+
+    Deliberately SELF-CONTAINED and served once, because the agent restarts
+    partway through an update and anything it would have to serve mid-flight
+    disappears with it. The page is already loaded in Steam's browser by then,
+    so its script keeps running across the restart and polls /api/ping -- the
+    one deliberately pre-auth endpoint -- until the version changes.
+
+    No external assets: Steam's browser may have no network route while the box
+    is mid-update, and a spinner that 404s is worse than no spinner.
+    """
+    return """<!doctype html><html><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Couchside is updating</title>
+<style>
+ html,body{margin:0;height:100%;background:#0b1220;color:#e8eaed;
+   font-family:system-ui,-apple-system,sans-serif;display:flex;
+   align-items:center;justify-content:center}
+ .w{text-align:center;padding:2rem}
+ h1{font-size:2.2rem;margin:0 0 .6rem;font-weight:600}
+ p{font-size:1.15rem;color:#93a1b5;margin:.3rem 0}
+ .dots span{opacity:.25;animation:b 1.2s infinite}
+ .dots span:nth-child(2){animation-delay:.2s}
+ .dots span:nth-child(3){animation-delay:.4s}
+ @keyframes b{0%,100%{opacity:.25}50%{opacity:1}}
+ .ok{color:#5ad18f}
+</style></head><body><div class="w">
+<h1 id="t">Updating Couchside</h1>
+<p id="s">Keep the box powered on. This takes about a minute.</p>
+<p class="dots" id="d"><span>&#9679;</span><span>&#9679;</span><span>&#9679;</span></p>
+</div><script>
+var was=null, misses=0;
+function tick(){
+  fetch('/api/ping',{cache:'no-store'}).then(function(r){return r.json()}).then(function(j){
+    if(was===null){ was=j.version; }
+    else if(j.version!==was){
+      document.getElementById('t').textContent='Updated';
+      document.getElementById('t').className='ok';
+      document.getElementById('s').textContent='Now running '+j.version+'.';
+      document.getElementById('d').style.display='none';
+      return;                                  /* stop polling */
+    }
+    misses=0;
+    setTimeout(tick,2000);
+  }).catch(function(){
+    /* The agent restarts mid-update, so a failed poll is EXPECTED, not an
+       error. Only say something after it has been gone a while. */
+    misses++;
+    if(misses>8){ document.getElementById('s').textContent=
+      'Restarting the service\u2026'; }
+    setTimeout(tick,2000);
+  });
+}
+tick();
+</script></body></html>"""
+
+
+def update_show_on_box(port):
+    """Put the progress page on the box's own screen. Same mechanism as the
+    pairing PIN page, which is already shipped and proven: Steam's built-in
+    browser in Game Mode, xdg-open on the desktop. Best-effort and detached --
+    an update must never fail because a browser would not open."""
+    try:
+        pair_show_on_box_url("http://localhost:%d/update" % port)
+    except Exception:
+        pass
+
+
 def update_apply():
     """Spawn a DETACHED box-side update (the signed installer) so it survives
     this agent's own restart, and return immediately. The caller MUST have
     verified ALLOW_APP_UPDATE first. The installer verifies the release
     signature before installing, so a triggered update can only ever install an
     authentic release — never arbitrary code."""
-    log = "/tmp/couchside-update.log"
+    log = UPDATE_LOG
     # start_new_session detaches the child into its own session/process group:
     # when the installer restarts couchside.service and kills this agent, the
     # update keeps running to completion.
@@ -10727,9 +10816,17 @@ def pair_pin_check(pin):
 
 def pair_show_on_box(port):
     """Open the loopback /pair page on the BOX'S own screen so the PIN is
-    visible there. Game Mode -> Steam's built-in browser (steam://openurl);
-    desktop -> xdg-open. Best-effort, detached, never blocks the request."""
-    url = "http://localhost:%d/pair" % port
+    visible there."""
+    pair_show_on_box_url("http://localhost:%d/pair" % port)
+
+
+def pair_show_on_box_url(url):
+    """Open a LOOPBACK url on the box's own screen. Game Mode -> Steam's
+    built-in browser (steam://openurl); desktop -> xdg-open. Best-effort,
+    detached, never blocks the request.
+
+    Shared by the pairing PIN page and the update progress page. Callers pass a
+    url this module built; nothing here comes from a client."""
     gamescope = _couchmode_session() == "gamescope"
 
     def go():
@@ -11068,6 +11165,16 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_html(200, html, started)
                 return
 
+            if path == "/update":
+                # LOCALHOST-ONLY, same two gates as /pair. This page is meant for
+                # the screen physically attached to the box; nothing on the LAN
+                # has any business rendering it.
+                if not self._is_loopback() or not self._host_header_is_local():
+                    self._send(403, {"error": "forbidden"}, started)
+                    return
+                self._send_html(200, render_update_page(), started)
+                return
+
             if path == "/api/pair/status":
                 # Loopback-only: the on-screen /pair PIN page polls this to learn
                 # when its session ended (paired/expired), so it can clear itself
@@ -11146,6 +11253,13 @@ class Handler(BaseHTTPRequestHandler):
                 # 404 -> the app hides the section (probe-and-appear via 404->null).
                 downloads = mock_downloads() if self.mock else steam_downloads()
                 self._send(200, {"downloads": downloads}, started)
+            elif path == "/api/update/log":
+                # The installer transcript, so the app can show what the box is
+                # actually doing instead of a canned "this can take a minute".
+                # MUST live AFTER the auth gate: the log carries hostnames and
+                # paths, and /api/ping is the only deliberately pre-auth route.
+                # Reads a CONSTANT path -- no client input selects a file.
+                self._send(200, {"lines": read_update_log()}, started)
             elif path == "/api/update/check":
                 # Box-side update check (agent >= 2.9.5). The app reads this over
                 # the LAN so the app never touches the internet; the box (already
@@ -11550,7 +11664,13 @@ class Handler(BaseHTTPRequestHandler):
                                      "(enable with: couchside allow-updates on)"},
                                started)
                     return
-                result = ({"started": True, "log": "/tmp/couchside-update.log"}
+                if not self.mock:
+                    # Put the progress page on the box's own screen FIRST, so it
+                    # is loaded in the browser before this agent restarts out
+                    # from under it. Best-effort: an update must never fail
+                    # because a browser would not open.
+                    update_show_on_box(self.port)
+                result = ({"started": True, "log": UPDATE_LOG}
                           if self.mock else update_apply())
                 self._send(200, result, started)
                 return

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -50,6 +50,13 @@ function fmtLastSeen(ts: number | null): string {
   return `${Math.floor(m / 60)}h ${m % 60}m ago`;
 }
 
+/** "1h 24m" / "40m" — minutes only under an hour, so a short charge does not
+ *  read as "0h 40m". */
+function fmtDuration(mins: number): string {
+  if (mins < 60) return `${mins}m`;
+  return `${Math.floor(mins / 60)}h ${mins % 60}m`;
+}
+
 export default function ConsoleTab() {
   useLockOrientation('portrait');
   return (
@@ -232,10 +239,19 @@ function ConsoleScreen() {
               <Card title="BATTERY" index={5}>
                 <View style={styles.barLabelRow}>
                   <Text style={styles.barLabel}>
-                    {s.battery.on_ac ? 'On AC' : 'On battery'}
-                    {s.battery.minutes != null
-                      ? `   ${Math.floor(s.battery.minutes / 60)}h ${s.battery.minutes % 60}m left`
-                      : ''}
+                    {s.battery.status === 'Charging'
+                      ? 'Charging'
+                      : s.battery.on_ac
+                        ? 'On AC'
+                        : 'On battery'}
+                    {/* Two different clocks, never both: time-to-full while
+                        charging, runtime-left while discharging. The agent
+                        keeps them as separate fields for exactly that reason. */}
+                    {s.battery.minutes_to_full != null
+                      ? `   ${fmtDuration(s.battery.minutes_to_full)} to full`
+                      : s.battery.minutes != null
+                        ? `   ${fmtDuration(s.battery.minutes)} left`
+                        : ''}
                   </Text>
                   <Text style={[styles.barLabel, { color: batteryColor(s.battery.pct, t) }]}>
                     {s.battery.pct}%

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -242,6 +242,25 @@ function ConsoleScreen() {
                   </Text>
                 </View>
                 <Bar pct={s.battery.pct} color={batteryColor(s.battery.pct, t)} />
+                {/* Draw and power profile, each independently optional so a box
+                    that reports only one still shows it. The watts figure is
+                    labelled by STATUS -- the same counter is the charge rate
+                    when plugged in, so calling it "draw" while charging would
+                    be wrong. */}
+                {(s.battery.watts != null || s.battery.profile) && (
+                  <Text style={styles.ipLine}>
+                    {[
+                      s.battery.watts != null
+                        ? `${s.battery.watts.toFixed(1)}W ${
+                            s.battery.status === 'Charging' ? 'in' : 'draw'
+                          }`
+                        : null,
+                      s.battery.profile,
+                    ]
+                      .filter(Boolean)
+                      .join('  ·  ')}
+                  </Text>
+                )}
               </Card>
             )}
           </>

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -87,6 +87,11 @@ function ConsoleScreen() {
 
   const s = status.data;
   const reachable = configured && status.error == null && s != null;
+  // Show the 60s average, not the 10s: a momentary spike while a game loads is
+  // normal and not worth a number that jumps every poll. Only surfaced once it
+  // is above a floor, so an idle box stays quiet.
+  const memPressure =
+    s?.mem.pressure?.some60 != null && s.mem.pressure.some60 >= 1 ? s.mem.pressure.some60 : null;
   const memPct = s ? Math.round((s.mem.used_mb / s.mem.total_mb) * 100) : 0;
 
   // The app did its job: a paired box answered. Counted at most once per launch
@@ -213,6 +218,24 @@ function ConsoleScreen() {
               {/* Fixed 0-100 scale: a memory sparkline that auto-scales would
                   make a 2% wiggle look like a cliff. */}
               <Spark values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
+              {/* Swap and stall pressure, each shown ONLY when it is saying
+                  something. Zero pressure on an idle box is the normal state and
+                  printing "0.0%" every second would train you to ignore the row
+                  that matters. PSI is absent entirely on kernels without
+                  CONFIG_PSI, which is why undefined and 0 are treated
+                  differently here. */}
+              {(memPressure != null || (s.mem.swap_used_mb ?? 0) > 0) && (
+                <Text style={styles.ipLine}>
+                  {[
+                    memPressure != null ? `stalled ${memPressure.toFixed(1)}%` : null,
+                    (s.mem.swap_used_mb ?? 0) > 0
+                      ? `swap ${(s.mem.swap_used_mb! / 1024).toFixed(1)}G`
+                      : null,
+                  ]
+                    .filter(Boolean)
+                    .join('  ·  ')}
+                </Text>
+              )}
             </Card>
 
             <Card title="DISKS" index={4}>

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -36,8 +36,8 @@ import {
   SteamDownload,
   SteamLink,
 } from '@/lib/api';
-import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
-import { usePref } from '@/lib/prefs';
+import { hapticError, hapticLight, hapticMedium, hapticSelection, hapticSuccess } from '@/lib/haptics';
+import { setPref, usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -306,6 +306,7 @@ function SteamLinkSection({
   const styles = useThemedStyles(makeStyles);
   const hideOffline = usePref('hideOfflineStreamHosts');
   const hideSection = usePref('hideStreamFromPc');
+  const collapsed = usePref('streamCollapsed');
   // Expand the freshest host by default, preferring one that's actually up.
   // `online` is absent on agents older than 2.9.32, and undefined !== false, so
   // those fall through to hosts[0] — exactly the old behaviour.
@@ -321,11 +322,30 @@ function SteamLinkSection({
   const hosts = hideOffline ? data.hosts.filter((h) => h.online !== false) : data.hosts;
   return (
     <View style={styles.dlCard}>
-      <View style={styles.dlHeader}>
+      {/* The whole card folds to its header. Collapsing is NOT hiding: a folded
+          card still says the feature exists and reopens in one tap, where a
+          hidden one leaves you wondering where it went. The host count stays
+          visible while folded so it is still worth something closed. */}
+      <Pressable
+        onPress={() => {
+          hapticSelection();
+          void setPref('streamCollapsed', !collapsed);
+        }}
+        style={styles.dlHeader}>
         <Ionicons name="tv-outline" size={14} color={t.blue} />
         <Text style={styles.dlHeaderText}>STREAM FROM PC</Text>
-      </View>
-      {hosts.length === 0 ? (
+        <View style={styles.streamHeaderRight}>
+          {collapsed && hosts.length > 0 && (
+            <Text style={styles.streamCount}>{hosts.length}</Text>
+          )}
+          <Ionicons
+            name={collapsed ? 'chevron-down' : 'chevron-up'}
+            size={15}
+            color={t.textDim}
+          />
+        </View>
+      </Pressable>
+      {collapsed ? null : hosts.length === 0 ? (
         // Every host was filtered out by the pref. Say so — a card that just
         // vanished looks like the feature broke.
         <Text style={styles.slHint}>
@@ -680,7 +700,18 @@ function LaunchScreen() {
     setTimeout(() => setRefreshing(false), 600);
   }, [list]);
 
-  const launchers = list.data?.launchers ?? [];
+  const allLaunchers = list.data?.launchers ?? [];
+  // Filter by name. With 70+ games the grid is a long scroll and finding one by
+  // eye is the slowest thing on this screen. Case- and space-insensitive so
+  // "deadcells" finds "Dead Cells", which is how people actually type on a
+  // phone. Client-side on a list the app already has -- no round trip, and it
+  // stays responsive on a box that is busy installing something.
+  const [query, setQuery] = useState('');
+  const launchers = useMemo(() => {
+    const q = query.trim().toLowerCase().replace(/\s+/g, '');
+    if (!q) return allLaunchers;
+    return allLaunchers.filter((l) => l.label.toLowerCase().replace(/\s+/g, '').includes(q));
+  }, [allLaunchers, query]);
   const rows = useMemo(() => {
     const out: Launcher[][] = [];
     for (let i = 0; i < launchers.length; i += COLS) {
@@ -775,6 +806,41 @@ function LaunchScreen() {
           </View>
         )}
 
+        {/* Filter. Only once there is enough to be worth filtering -- a search
+            box above four tiles is clutter, above seventy it is the fastest
+            control on the screen. Counts the UNFILTERED list so it does not
+            vanish as soon as a query narrows things down. */}
+        {allLaunchers.length >= 8 && (
+          <View style={styles.searchWrap}>
+            <Ionicons name="search" size={15} color={t.textDim} />
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder={`Search ${allLaunchers.length} games`}
+              placeholderTextColor={t.textFaint}
+              style={styles.searchInput}
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="search"
+              clearButtonMode="never"
+            />
+            {query.length > 0 && (
+              <Pressable
+                onPress={() => setQuery('')}
+                hitSlop={10}
+                accessibilityLabel="Clear search">
+                <Ionicons name="close-circle" size={17} color={t.textDim} />
+              </Pressable>
+            )}
+          </View>
+        )}
+
+        {/* Nothing matched. Say so rather than showing an empty screen that
+            reads as "the box has no games". */}
+        {query.trim().length > 0 && launchers.length === 0 && (
+          <Text style={styles.noMatch}>No game matches &ldquo;{query.trim()}&rdquo;.</Text>
+        )}
+
         {/* Grid */}
         {rows.map((row, ri) => (
           <View key={ri} style={[styles.row, { gap: GAP, marginBottom: GAP }]}>
@@ -849,6 +915,22 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     gap: 12,
   },
   dlHeader: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  searchWrap: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: 1,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 9,
+    marginBottom: 12,
+  },
+  searchInput: { flex: 1, color: t.text, fontSize: 15, padding: 0 },
+  noMatch: { color: t.textDim, fontSize: 13, textAlign: 'center', marginBottom: 14 },
+  streamHeaderRight: { marginLeft: 'auto', flexDirection: 'row', alignItems: 'center', gap: 6 },
+  streamCount: { color: t.textDim, fontSize: 12, fontFamily: mono },
   dlHeaderGap: {
     marginTop: 4,
     borderTopColor: t.cardBorder,

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -21,6 +21,27 @@ import type { Palette } from '@/lib/theme';
 
 const POLL_MS = 30 * 60 * 1000; // twice an hour; the box caches for ~6h anyway
 
+/**
+ * Pick the most recent line worth showing from the installer transcript.
+ *
+ * This is raw shell output, so most of it is noise a person on a couch cannot
+ * act on — curl progress meters, blank lines, `+ set -x` traces. Showing the
+ * literal last line would usually show garbage. install.sh marks its real steps
+ * with "==>", so prefer those and fall back to the last plain line only when
+ * there are none yet.
+ */
+function lastMeaningful(lines: string[]): string | null {
+  const clean = lines
+    .map((l) => l.replace(/\u001b\[[0-9;]*m/g, '').trim())
+    .filter((l) => l.length > 0 && !/^\++\s/.test(l) && !/^\s*\d+\s+\d+/.test(l));
+  const steps = clean.filter((l) => l.startsWith('==>'));
+  const pick = steps.length ? steps[steps.length - 1] : clean[clean.length - 1];
+  if (!pick) return null;
+  const text = pick.replace(/^==>\s*/, '');
+  // Long paths and URLs blow out a one-line status; keep it glanceable.
+  return text.length > 68 ? text.slice(0, 67) + '…' : text;
+}
+
 export function AgentUpdateBanner() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -37,6 +58,7 @@ export function AgentUpdateBanner() {
   const [expanded, setExpanded] = useState(false);
   const [dismissed, setDismissed] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
+  const [step, setStep] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
   const applyingRef = useRef(false);
   // Manual "Check for updates": undefined = not checked yet, else the forced
@@ -67,10 +89,23 @@ export function AgentUpdateBanner() {
       let done = false;
       for (let i = 0; i < 40 && !done; i++) {
         await new Promise((r) => setTimeout(r, 3000));
+        // Show what the box is ACTUALLY doing. The installer writes a
+        // transcript the app never read, so this used to be a canned message
+        // for the whole minute. Best-effort: updateLog resolves [] while the
+        // agent is restarting, and an empty result must not clear a line we
+        // already showed.
+        try {
+          const lines = await api.updateLog(settings);
+          const last = lastMeaningful(lines);
+          if (last) setStep(last);
+        } catch {
+          // ignore — the progress line is a nicety, never a blocker
+        }
         try {
           const p = await api.ping(settings);
           if (p.version === target) {
             setMsg(`Updated to ${target}. `);
+            setStep(null);
             poll.refresh();
             done = true;
           }
@@ -84,6 +119,7 @@ export function AgentUpdateBanner() {
       setMsg(`Couldn't start the update (${detail}). You can run \`couchside update\` on the box.`);
     } finally {
       setApplying(false);
+      setStep(null);
       applyingRef.current = false;
     }
   }, [check?.latest, poll, settings]);
@@ -168,7 +204,13 @@ export function AgentUpdateBanner() {
       ) : null}
 
       {msg ? (
-        <Text style={styles.msg}>{msg}</Text>
+        <>
+          <Text style={styles.msg}>{msg}</Text>
+          {/* What the box is actually doing right now, straight from the
+              installer. Rendered UNDER the headline rather than replacing it,
+              so the reassuring sentence stays put while the detail changes. */}
+          {step ? <Text style={styles.step}>{step}</Text> : null}
+        </>
       ) : check.apply_enabled ? (
         <Pressable
           onPress={() => {
@@ -231,6 +273,9 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   btnPressed: { opacity: 0.85 },
   btnText: { color: '#0b1220', fontSize: 14, fontWeight: '700' },
   msg: { color: t.text, fontSize: 13, lineHeight: 19 },
+  // Quieter and monospaced: this is machine output, and it should read as
+  // detail under the headline rather than competing with it.
+  step: { color: t.textDim, fontSize: 11, lineHeight: 16, fontFamily: mono, marginTop: 3 },
   hint: { color: t.textDim, fontSize: 12, lineHeight: 18 },
   code: { fontFamily: mono, color: t.text },
 });

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -9,7 +9,8 @@
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React, { useEffect, useState } from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { Alert, Image, Pressable, StyleSheet, Text, View } from 'react-native';
+import { hapticLight } from '@/lib/haptics';
 
 import { usePoll } from '@/hooks/usePoll';
 import { api, Gaming, hostKey } from '@/lib/api';
@@ -53,6 +54,13 @@ function GameCover({ appid, label }: { appid: number; label?: string }) {
   );
 }
 
+/** "1h 24m" / "6m" — a glanceable session length, not a stopwatch. */
+function humanizeRun(secs: number): string {
+  const m = Math.floor(secs / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h ${m % 60}m`;
+}
+
 export function GamingCard() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -63,6 +71,7 @@ export function GamingCard() {
   // Adaptive cadence: fast while a game is running, slow when idle. `fast` is
   // declared before the poll that reads it and flipped by the effect below.
   const [fast, setFast] = useState(false);
+  const [stopping, setStopping] = useState(false);
   const poll = usePoll<Gaming | null>(
     () => api.gaming(settings), fast ? 5000 : 20000, ready && configured, hostKey(settings));
   const g = poll.data;
@@ -97,6 +106,51 @@ export function GamingCard() {
       </View>
 
       {g.game && <GameCover appid={g.game.appid} label={g.game.label} />}
+
+      {/* Close the game from the couch. You could always START one from the
+          phone and never stop one, which is the half that matters when the TV
+          is showing a game you cannot get out of.
+          Confirmed first: this is not undoable, and an accidental tap could
+          lose unsaved progress. */}
+      {g.game && (
+        <View style={styles.block}>
+          <View style={styles.lineRow}>
+            <Text style={styles.lineLabel}>RUNNING</Text>
+            {g.game.running_s != null && (
+              <Text style={styles.dim}>{humanizeRun(g.game.running_s)}</Text>
+            )}
+          </View>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              Alert.alert(
+                'Close this game?',
+                `${g.game?.label ?? 'The running game'} will be asked to quit. Unsaved progress may be lost.`,
+                [
+                  { text: 'Cancel', style: 'cancel' },
+                  {
+                    text: 'Close game',
+                    style: 'destructive',
+                    onPress: () => {
+                      setStopping(true);
+                      void api.stopGame(settings).finally(() => {
+                        setStopping(false);
+                        // Refresh either way: on success the card should empty,
+                        // and on failure the truth is whatever the box says.
+                        poll.refresh();
+                      });
+                    },
+                  },
+                ],
+              );
+            }}
+            disabled={stopping}
+            style={({ pressed }) => [styles.stopBtn, pressed && { opacity: 0.7 }]}>
+            <Ionicons name="stop-circle-outline" size={15} color={t.red} />
+            <Text style={styles.stopText}>{stopping ? 'CLOSING…' : 'CLOSE GAME'}</Text>
+          </Pressable>
+        </View>
+      )}
 
       {gpu && (
         <View style={styles.block}>
@@ -205,5 +259,20 @@ const makeStyles = (t: Palette) =>
 
     barLabelRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     barTrack: { height: 6, borderRadius: 3, backgroundColor: t.cardBorder, overflow: 'hidden' },
-    barFill: { height: '100%', borderRadius: 3 },
+    // Destructive, so it reads as one: red text on a red hairline rather than a
+  // filled button. It sits inside a card of read-only vitals and must not look
+  // like just another row.
+  stopBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+    marginTop: 6,
+    paddingVertical: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: t.red,
+  },
+  stopText: { color: t.red, fontSize: 12, fontWeight: '700', letterSpacing: 1, fontFamily: mono },
+  barFill: { height: '100%', borderRadius: 3 },
   });

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -83,9 +83,25 @@ export function GamingCard() {
   if (!g) return null;
 
   const gpu = g.gpu;
+  // SHARED-MEMORY GPUs (every handheld APU) carve out a token amount of "VRAM"
+  // and do the real work in GTT, which is system RAM. MEASURED on a Legion Go S:
+  // 512 MB VRAM sitting at 89% next to 15.3 GB of GTT barely touched. Showing
+  // the VRAM bar alone told the owner his GPU had 0.5 GB and was nearly full.
+  //
+  // When GTT dwarfs VRAM the two pools are the same physical memory, so adding
+  // them describes something real: total graphics footprint. On a discrete card
+  // they are genuinely separate and VRAM is the honest number, so the sum is
+  // NOT applied there.
+  const shared = gpu?.gtt_total_mb != null && gpu.gtt_total_mb > (gpu.vram_total_mb ?? 0);
+  const memUsed = shared
+    ? (gpu?.vram_used_mb ?? 0) + (gpu?.gtt_used_mb ?? 0)
+    : gpu?.vram_used_mb;
+  const memTotal = shared
+    ? (gpu?.vram_total_mb ?? 0) + (gpu?.gtt_total_mb ?? 0)
+    : gpu?.vram_total_mb;
   const vramPct =
-    gpu?.vram_used_mb != null && gpu?.vram_total_mb
-      ? Math.round((gpu.vram_used_mb / gpu.vram_total_mb) * 100)
+    memUsed != null && memTotal
+      ? Math.round((memUsed / memTotal) * 100)
       : null;
   const inGameMode = g.session === 'gamescope';
 
@@ -156,17 +172,21 @@ export function GamingCard() {
         <View style={styles.block}>
           <View style={styles.lineRow}>
             <Text style={styles.lineLabel}>GPU</Text>
+            {gpu.busy_pct != null && (
+              <Text style={styles.dim}>{gpu.busy_pct}% busy</Text>
+            )}
             {gpu.temp_c != null && (
               <Text style={[styles.lineVal, { color: tempColor(gpu.temp_c, t) }]}>
                 {gpu.temp_c.toFixed(1)}°C
               </Text>
             )}
           </View>
-          {vramPct != null && gpu.vram_total_mb != null && (
+          {vramPct != null && memTotal != null && (
             <>
               <View style={styles.barLabelRow}>
                 <Text style={styles.dim}>
-                  {(gpu.vram_used_mb! / 1024).toFixed(1)} / {(gpu.vram_total_mb / 1024).toFixed(1)} GB
+                  {(memUsed! / 1024).toFixed(1)} / {(memTotal / 1024).toFixed(1)} GB
+                  {shared ? ' shared' : ''}
                 </Text>
                 <Text style={[styles.dim, { color: pctColor(vramPct, t) }]}>{vramPct}%</Text>
               </View>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -228,7 +228,21 @@ export type Status = {
   uptime_s: number;
   load: [number, number, number];
   cpu_temp_c: number | null;
-  mem: { total_mb: number; used_mb: number; available_mb: number };
+  mem: {
+    total_mb: number;
+    used_mb: number;
+    available_mb: number;
+    /** Swap in use (agent >= 2.9.43); absent when the box has no swap. */
+    swap_total_mb?: number;
+    swap_used_mb?: number;
+    /** Linux PSI memory pressure (agent >= 2.9.43): the share of time work was
+     *  STALLED waiting on memory, which is what you actually feel — a used
+     *  percentage says how much is spoken for, not whether anything hurts.
+     *  `some` = at least one task stalled, `full` = everything stalled.
+     *  ABSENT (not zero) on kernels without CONFIG_PSI: "no pressure" and
+     *  "cannot tell" must not render the same. */
+    pressure?: { some10?: number; some60?: number; full10?: number; full60?: number };
+  };
   disks: DiskInfo[];
   /** Network facts for the power/Wake-on-LAN path (agent >= 2.6). */
   net?: NetInfo;

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -418,6 +418,15 @@ export type Gaming = {
     temp_c?: number;
     vram_used_mb?: number;
     vram_total_mb?: number;
+    /** System memory the GPU may use (agent >= 2.9.43). On an APU this is the
+     *  number that matters: a Legion Go S carves out 512 MB of "VRAM" that sits
+     *  at 89% while 15.3 GB of GTT is barely touched, so VRAM alone made a 32 GB
+     *  handheld look like a full 0.5 GB graphics card. */
+    gtt_used_mb?: number;
+    gtt_total_mb?: number;
+    /** How hard the GPU is actually working, 0-100 (agent >= 2.9.43). A memory
+     *  bar says what is allocated, not whether anything is happening. */
+    busy_pct?: number;
   };
   game?: {
     appid: number;

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1252,6 +1252,20 @@ export const api = {
    * Resolves false on an older agent (404) rather than throwing, so the caller
    * can skip the key walk instead of blindly sending arrows.
    */
+  /**
+   * Tail of the box-side installer transcript (agent >= 2.9.43).
+   *
+   * The installer has always written this file; nothing read it, so the app sat
+   * on a canned "this can take a minute" while the box knew exactly which step
+   * it was on. Resolves [] on an older agent (404) or while the box is
+   * restarting mid-update — both are expected, not errors.
+   */
+  updateLog(settings: ConnSettings): Promise<string[]> {
+    return request<{ lines: string[] }>(settings, '/api/update/log')
+      .then((r) => (Array.isArray(r?.lines) ? r.lines : []))
+      .catch(() => []);
+  },
+
   steamGoto(settings: ConnSettings, id: 'home'): Promise<boolean> {
     return request<{ ok: boolean }>(settings, '/api/steam/goto', {
       method: 'POST',

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -400,7 +400,15 @@ export type Gaming = {
     vram_used_mb?: number;
     vram_total_mb?: number;
   };
-  game?: { appid: number; label?: string };
+  game?: {
+    appid: number;
+    label?: string;
+    /** Seconds the game has been running (agent >= 2.9.43). From the process
+        start time in /proc, compared against uptime rather than wall time, so a
+        clock change cannot make it look like the game started tomorrow. */
+    running_s?: number;
+    pid?: number;
+  };
   output?: { name: string; internal: boolean };
   controllers?: {
     uniq: string;
@@ -1264,6 +1272,22 @@ export const api = {
     return request<{ lines: string[] }>(settings, '/api/update/log')
       .then((r) => (Array.isArray(r?.lines) ? r.lines : []))
       .catch(() => []);
+  },
+
+  /**
+   * Ask the running game to close (agent >= 2.9.43).
+   *
+   * Sends NO body on purpose: the agent resolves what is running itself. The
+   * app cannot name a process, which is what stops this from being a remote
+   * kill-anything primitive. Do not "helpfully" start passing the appid.
+   *
+   * Resolves false on 409 (nothing running) or on an older agent, so the caller
+   * can just refresh rather than treat it as an error.
+   */
+  stopGame(settings: ConnSettings): Promise<boolean> {
+    return request<{ stopped: boolean }>(settings, '/api/game/stop', { method: 'POST' })
+      .then((r) => !!r?.stopped)
+      .catch(() => false);
   },
 
   steamGoto(settings: ConnSettings, id: 'home'): Promise<boolean> {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1366,8 +1366,22 @@ export const api = {
    */
   steamCoverSource(settings: ConnSettings, appid: number): ImageSource {
     const host = resolveEffectiveHost(settings);
+    // The token goes in BOTH the header and the query, on purpose.
+    //
+    // MEASURED, not assumed: React Native's <Image> accepts source.headers, and
+    // on Android they are DROPPED before the request leaves the phone.
+    // Instrumenting the agent showed every cover request arriving as
+    // `auth_header='' len=0  ua='okhttp/4.9.2'`, so cover art was blank on every
+    // Android device while iOS was fine.
+    //
+    // The header stays because it is the better mechanism where it works. The
+    // query is the fallback the image loader cannot strip. The agent's access
+    // log already replaces any query string with "?<redacted>", so the token
+    // does not reach the journal. Needs agent >= 2.9.43 for the query form;
+    // older agents still honour the header, so iOS is unaffected either way.
+    const qs = `?token=${encodeURIComponent(settings.token)}`;
     return {
-      uri: `${baseUrl({ host, port: settings.port })}/api/steam/${appid}/cover`,
+      uri: `${baseUrl({ host, port: settings.port })}/api/steam/${appid}/cover${qs}`,
       headers: { Authorization: `Bearer ${settings.token}` },
     };
   },

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -251,6 +251,16 @@ export type Status = {
     status: string;
     on_ac?: boolean;
     minutes?: number;
+    /** Instantaneous power flow in watts (agent >= 2.9.43). The SIGN is
+        `status`, not the number: while charging this is the CHARGE rate, so
+        never label it "discharge" without checking. Absent when the gauge
+        reports nothing — a box drawing 0 W does not exist. */
+    watts?: number;
+    /** ACPI platform profile, verbatim (agent >= 2.9.43). NOT guaranteed to be
+        one of the usual low-power/balanced/performance values: a Legion Go S
+        reported "custom" because Steam's TDP control set one. Render whatever
+        arrives; do not switch on a fixed set. */
+    profile?: string;
   };
 };
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -256,6 +256,11 @@ export type Status = {
         never label it "discharge" without checking. Absent when the gauge
         reports nothing — a box drawing 0 W does not exist. */
     watts?: number;
+    /** Minutes until the battery is FULL, while charging (agent >= 2.9.43).
+        Deliberately separate from `minutes`, which means "runtime left on
+        battery" — folding them together would make an older app report
+        "42m left" while the box is plugged in and filling up. */
+    minutes_to_full?: number;
     /** ACPI platform profile, verbatim (agent >= 2.9.43). NOT guaranteed to be
         one of the usual low-power/balanced/performance values: a Legion Go S
         reported "custom" because Steam's TDP control set one. Render whatever

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -67,6 +67,11 @@ export type Prefs = {
    *  decision — and 'off' exists because a control you never use is still a
    *  control you can fat-finger. */
   searchButtonSide: 'left' | 'right' | 'off';
+  /** Collapse the "Stream from PC" card on the Launch tab to just its header.
+   *  Distinct from hiding it: a collapsed card still says the feature is there
+   *  and reopens in one tap, which a hidden one cannot. Persisted, because a
+   *  section you fold away should stay folded. */
+  streamCollapsed: boolean;
   defaultPadMode: PadMode;
   /** How often the console/header polls the box for vitals (ms). */
   statusIntervalMs: number;
@@ -142,6 +147,7 @@ export const DEFAULTS: Prefs = {
   autoKeyboard: true,
   keyboardMode: false,
   searchButtonSide: 'left',
+  streamCollapsed: false,
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
   journalLines: 100,
@@ -223,6 +229,7 @@ function normalize(raw: unknown): Prefs {
     o.defaultPadMode === 'remote'
       ? o.defaultPadMode
       : 'swipe';
+  const streamCollapsed = bool(o.streamCollapsed, DEFAULTS.streamCollapsed);
   const searchSide: 'left' | 'right' | 'off' =
     o.searchButtonSide === 'right' || o.searchButtonSide === 'off'
       ? o.searchButtonSide
@@ -232,6 +239,7 @@ function normalize(raw: unknown): Prefs {
     : DEFAULTS.landingTab;
   return {
     searchButtonSide: searchSide,
+    streamCollapsed,
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     landingTab,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,6 +131,29 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   restarts it / leaves a zombie, and whether the reaper is the right target at all versus the
   game binary. Needs a game actually running on a box.
 
+### More Console sensors (battery health, CPU governor, GPU power)
+- **priority:** P3 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- All read-only sysfs, no new capability, no client input. **PROBED on a Legion Go S,
+  2026-07-22** — every value below was actually read off that box, not assumed available.
+- **Battery health** — `energy_full` 55500000 vs `energy_full_design` 55500000 = **100%**,
+  `cycle_count` **54**. Answers "is my battery dying", which nothing else in the app can, and
+  it is two file reads. Highest value of the set.
+- **CPU governor + current frequency** — `scaling_governor` = `powersave`,
+  `scaling_cur_freq` = 2160 MHz. On a handheld this explains "why is it slow" more often than
+  temperature does.
+- **GPU power draw** — `hwmon/power1_average` = **5.07 W**. Next to the box battery draw it
+  shows where the watts are going. Note `power1_cap` was NOT present on this box, so a
+  TDP-limit readout cannot be assumed.
+- **GPU clock** — `hwmon/freq1_input` = 800 MHz. Cheap, but the least informative of the set
+  on its own.
+- **Fan RPM** — **NOT available here**: no `fan1_input` under any hwmon. Probe-and-appear only,
+  and do not promise it in copy until a box is found that has one.
+- Every one of these is absent on some hardware, so each is independently optional and must
+  degrade to "not shown" rather than to zero — the same rule that made PSI return `{}` instead
+  of `0.00`.
+- **Unverified:** none of these have been read on a DISCRETE-GPU box or a desktop; the
+  hwmon paths in particular vary by driver.
+
 ### Show the box IP and live network throughput on Console
 - **priority:** P3 · **risk:** low · **affects:** agent + app · **depends_on:** none
 - **The IP is already in the payload.** `/api/status` carries `ip` (the address the phone

--- a/tests/test_box_battery.py
+++ b/tests/test_box_battery.py
@@ -120,6 +120,81 @@ def test_real_handheld():
         s.close()
 
 
+def test_watts_from_power_now():
+    """Instantaneous draw. VERBATIM off the Legion Go S: POWER_SUPPLY_POWER_NOW
+    7708000 uW -> 7.7 W."""
+    print("test_watts_from_power_now")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_POWER_NOW=22543000",
+                                       "POWER_SUPPLY_POWER_NOW=7708000")})
+    try:
+        check("watts", cs.read_box_battery().get("watts"), 7.7)
+    finally:
+        s.close()
+
+
+def test_watts_from_current_times_voltage():
+    """Gauges without POWER_NOW still report amps and volts."""
+    print("test_watts_from_current_times_voltage")
+    s = Supplies({"BAT1": """POWER_SUPPLY_NAME=BAT1
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_CAPACITY=50
+POWER_SUPPLY_CURRENT_NOW=1000000
+POWER_SUPPLY_VOLTAGE_NOW=12000000
+"""})
+    try:
+        check("1A x 12V = 12.0 W", cs.read_box_battery().get("watts"), 12.0)
+    finally:
+        s.close()
+
+
+def test_zero_draw_is_omitted_not_reported():
+    """A gauge reading 0 is not measuring; it is not a box using no power.
+    Reporting a confident 0.0 W would be a lie."""
+    print("test_zero_draw_is_omitted_not_reported")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_POWER_NOW=22543000",
+                                       "POWER_SUPPLY_POWER_NOW=0")})
+    try:
+        check("no watts key", "watts" in cs.read_box_battery(), False)
+    finally:
+        s.close()
+
+
+def test_profile_reported_verbatim_even_when_not_a_listed_choice():
+    """THE hardware trap. The Legion Go S reported "custom" while
+    platform_profile_choices listed "low-power balanced performance" -- Steam's
+    TDP control had set something outside the advertised set. A reader that
+    validated against the choices would show nothing on that exact box."""
+    print("test_profile_reported_verbatim_even_when_not_a_listed_choice")
+    import tempfile
+    d = tempfile.mkdtemp(prefix="pp-")
+    path = os.path.join(d, "platform_profile")
+    old = cs._PLATFORM_PROFILE
+    cs._PLATFORM_PROFILE = path
+    try:
+        for written, want in (("custom", "custom"),
+                              ("balanced\n", "balanced"),
+                              ("low-power", "low-power")):
+            with open(path, "w") as f:
+                f.write(written)
+            check("%r -> %r" % (written, want), cs.read_power_profile(), want)
+    finally:
+        cs._PLATFORM_PROFILE = old
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_missing_platform_profile_is_none():
+    """Desktops and older kernels have no such file."""
+    print("test_missing_platform_profile_is_none")
+    old = cs._PLATFORM_PROFILE
+    cs._PLATFORM_PROFILE = "/nonexistent/acpi/platform_profile"
+    try:
+        check("None", cs.read_power_profile(), None)
+    finally:
+        cs._PLATFORM_PROFILE = old
+
+
 def test_duplicate_type_key():
     """THE fixture trap: POWER_SUPPLY_TYPE really is repeated on this hardware."""
     print("test_duplicate_type_key")
@@ -222,6 +297,11 @@ POWER_SUPPLY_CAPACITY=%s
 
 if __name__ == "__main__":
     for fn in (test_real_handheld,
+               test_watts_from_power_now,
+               test_watts_from_current_times_voltage,
+               test_zero_draw_is_omitted_not_reported,
+               test_profile_reported_verbatim_even_when_not_a_listed_choice,
+               test_missing_platform_profile_is_none,
                test_duplicate_type_key,
                test_mains_desktop_degrades_closed,
                test_no_power_supply_dir_at_all,

--- a/tests/test_box_battery.py
+++ b/tests/test_box_battery.py
@@ -250,6 +250,43 @@ POWER_SUPPLY_CAPACITY=42
         s.close()
 
 
+def test_time_to_full_while_charging():
+    """VERBATIM off a Legion Go S while actually plugged in, 2026-07-22:
+    ENERGY_NOW 34530000, ENERGY_FULL 55500000, POWER_NOW 30197000
+    -> (55500000-34530000)*60/30197000 = 41 minutes."""
+    print("test_time_to_full_while_charging")
+    charging = (BAT0.replace("POWER_SUPPLY_STATUS=Discharging",
+                             "POWER_SUPPLY_STATUS=Charging")
+                    .replace("POWER_SUPPLY_ENERGY_NOW=32350000",
+                             "POWER_SUPPLY_ENERGY_NOW=34530000")
+                    .replace("POWER_SUPPLY_POWER_NOW=22543000",
+                             "POWER_SUPPLY_POWER_NOW=30197000"))
+    s = Supplies({"BAT0": charging, "ACAD": ACAD_ONLINE})
+    try:
+        got = cs.read_box_battery()
+        check("minutes_to_full", got.get("minutes_to_full"), 41)
+        check("and NOT the discharge clock", "minutes" in got, False)
+    finally:
+        s.close()
+
+
+def test_full_on_the_charger_reports_no_time_to_full():
+    """A topped-up battery still on the charger trickles. 'time to full' of
+    hours would be nonsense, so report nothing."""
+    print("test_full_on_the_charger_reports_no_time_to_full")
+    full = (BAT0.replace("POWER_SUPPLY_STATUS=Discharging",
+                         "POWER_SUPPLY_STATUS=Charging")
+                .replace("POWER_SUPPLY_ENERGY_NOW=32350000",
+                         "POWER_SUPPLY_ENERGY_NOW=55500000")
+                .replace("POWER_SUPPLY_POWER_NOW=22543000",
+                         "POWER_SUPPLY_POWER_NOW=120000"))
+    s = Supplies({"BAT0": full, "ACAD": ACAD_ONLINE})
+    try:
+        check("no bogus estimate", "minutes_to_full" in cs.read_box_battery(), False)
+    finally:
+        s.close()
+
+
 def test_charging_reports_no_time_left():
     """On AC, POWER_NOW is the CHARGE rate. Dividing by it would produce a
     confident, entirely wrong 'time remaining' -- so there must be none."""
@@ -306,6 +343,8 @@ if __name__ == "__main__":
                test_mains_desktop_degrades_closed,
                test_no_power_supply_dir_at_all,
                test_charge_based_gauge,
+               test_time_to_full_while_charging,
+               test_full_on_the_charger_reports_no_time_to_full,
                test_charging_reports_no_time_left,
                test_empty_bay_is_not_a_battery,
                test_garbage_capacity_rejected):

--- a/tests/test_disk_mounts.py
+++ b/tests/test_disk_mounts.py
@@ -32,6 +32,7 @@ sys.modules["couchsided"] = cs
 _spec.loader.exec_module(cs)
 
 FAILURES = []
+MB = 1024 ** 2
 GB = 1024 ** 3
 
 
@@ -44,10 +45,13 @@ def check(name, got, want):
 
 
 class _Usage:
-    def __init__(self, total, used):
+    def __init__(self, total, used, free=None):
         self.total = total
         self.used = used
-        self.free = total - used
+        # free defaults to "everything not used", but REAL filesystems reserve
+        # blocks an unprivileged user can never touch, so free < total - used.
+        # That gap is the whole subject of test_percent_excludes_reserved.
+        self.free = total - used if free is None else free
 
 
 class _Statvfs:
@@ -76,8 +80,10 @@ def _run(layout):
     def fake_usage(path):
         if path not in layout:
             raise OSError("no such mount: %s" % path)
-        total, used, _dev, _ro = layout[path]
-        return _Usage(total, used)
+        entry = layout[path]
+        total, used, _dev, _ro = entry[:4]
+        free = entry[4] if len(entry) > 4 else None
+        return _Usage(total, used, free)
 
     real = (os.stat, os.statvfs, shutil.disk_usage)
     os.stat, os.statvfs, shutil.disk_usage = fake_stat, fake_statvfs, fake_usage
@@ -98,6 +104,78 @@ def test_steamos_shape():
     check("and it is /home, not /", disks[0]["mount"] if disks else None, "/home")
     check("size is the real one", disks[0]["total_gb"] if disks else None, 512.0)
     check("not the alarming 69%", disks[0]["pct"] if disks else None, 20)
+
+
+def test_percent_excludes_reserved():
+    """Percent full must be used/(used+free), NOT used/total.
+
+    VERBATIM from a Legion Go S, 2026-07-22: /home is 1812 GB with 1653.8 GB
+    used and only 66.1 GB available -- 92 GB is root-reserved. Dividing by total
+    reported 91% while df said 97%. A storage warning that reads LOW exactly
+    when the disk is nearly full is worse than no warning, which is why this is
+    asserted rather than left to the obvious-looking arithmetic.
+    """
+    print("test_percent_excludes_reserved")
+    disks = _run({
+        "/home": (1812 * GB, 1654 * GB, 2, False, 66 * GB),
+    })
+    got = {d["mount"]: d["pct"] for d in disks}
+    check("/home is 97%, not 91%", got.get("/home"), 97)
+
+
+def test_percent_rounds_up_like_df():
+    """df rounds up; so do we. This number drives a warning colour and the
+    conservative direction is the honest one for 'how full am I'."""
+    print("test_percent_rounds_up_like_df")
+    disks = _run({
+        # 80.4% by exact arithmetic -> must present as 81, not 80.
+        "/": (5 * GB, 3500 * MB, 1, False, 850 * MB),
+    })
+    check("80.4% presents as 81", disks[0]["pct"], 81)
+
+
+def test_percent_never_exceeds_100():
+    """A full filesystem must not render 101% on a bar clamped to 100."""
+    print("test_percent_never_exceeds_100")
+    disks = _run({"/": (5 * GB, 5 * GB, 1, False, 0)})
+    check("clamped", disks[0]["pct"], 100)
+
+
+def test_steam_library_drive_is_included():
+    """A Deck's SD card holds the games and was invisible: _DISK_MOUNTS is a
+    fixed list. Library drives come from Steam's OWN library list rather than
+    globbing /run/media, so a box with no Steam gets nothing extra."""
+    print("test_steam_library_drive_is_included")
+    old_root, old_libs = cs._steam_root, cs._steam_libraries_cached
+    cs._steam_root = lambda: "/home/deck/.steam/steam"
+    cs._steam_libraries_cached = lambda root: [
+        "/home/deck/.steam/steam/steamapps",
+        "/run/media/deck/SD1T5/steamapps",
+    ]
+    try:
+        disks = _run({
+            "/home": (512 * GB, 100 * GB, 2, False),
+            "/home/deck/.steam/steam": (512 * GB, 100 * GB, 2, False),   # same dev as /home
+            "/run/media/deck/SD1T5": (1400 * GB, 10 * GB, 9, False),
+        })
+        mounts = [d["mount"] for d in disks]
+        check("SD card listed", "/run/media/deck/SD1T5" in mounts, True)
+        check("library on the same device as /home is not duplicated",
+              mounts.count("/home"), 1)
+        check("no duplicate device entries", len(mounts), len(set(mounts)))
+    finally:
+        cs._steam_root, cs._steam_libraries_cached = old_root, old_libs
+
+
+def test_no_steam_adds_nothing():
+    """A box without Steam must not gain phantom drives."""
+    print("test_no_steam_adds_nothing")
+    old_root = cs._steam_root
+    cs._steam_root = lambda: None
+    try:
+        check("no library mounts", cs._steam_library_mounts(), [])
+    finally:
+        cs._steam_root = old_root
 
 
 def test_read_only_root_is_hidden():
@@ -150,6 +228,11 @@ def test_missing_mount_is_not_fatal():
 
 if __name__ == "__main__":
     for fn in (test_steamos_shape,
+               test_percent_excludes_reserved,
+               test_percent_rounds_up_like_df,
+               test_percent_never_exceeds_100,
+               test_steam_library_drive_is_included,
+               test_no_steam_adds_nothing,
                test_read_only_root_is_hidden,
                test_same_device_reported_once,
                test_distinct_devices_all_reported,

--- a/tests/test_game_stop.py
+++ b/tests/test_game_stop.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Tests for stop_running_game() — closing the game from the phone.
+
+Run: python3 tests/test_game_stop.py
+
+THE SECURITY SHAPE IS THE FEATURE. This function takes NO ARGUMENT: the caller
+cannot name a pid, an appid, or anything else. The agent re-resolves the target
+itself at the moment of the call, so a client that cannot name a process cannot
+be steered into killing one. Accepting a pid "to be explicit" would turn a
+close-my-game button into a remote kill-anything primitive.
+
+The first test asserts that signature directly, because a future refactor that
+"helpfully" adds a pid parameter is exactly how this becomes a hole, and it
+would look like a convenience at review time.
+"""
+import importlib.util
+import os
+import signal
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class Killed:
+    """Capture what would have been signalled, instead of signalling."""
+
+    def __init__(self, game, exc=None):
+        self.sent = []
+        self._game, self._exc = game, exc
+        self._old_kill, self._old_running = os.kill, cs._running_game
+
+    def __enter__(self):
+        outer = self
+
+        def fake_kill(pid, sig):
+            outer.sent.append((pid, sig))
+            if outer._exc:
+                raise outer._exc
+        os.kill = fake_kill
+        cs._running_game = lambda: outer._game
+        return self
+
+    def __exit__(self, *a):
+        os.kill, cs._running_game = self._old_kill, self._old_running
+
+
+def test_takes_no_argument():
+    """THE test. If this ever accepts a pid, the button becomes a remote
+    kill-anything primitive (CLAUDE.md 3.1)."""
+    print("test_takes_no_argument")
+    check("zero parameters", cs.stop_running_game.__code__.co_argcount, 0)
+
+
+def test_sends_sigterm_to_the_resolved_pid():
+    """SIGTERM, never SIGKILL: Steam's reaper forwards it so the game saves."""
+    print("test_sends_sigterm_to_the_resolved_pid")
+    game = {"appid": 570, "label": "Dota 2", "pid": 4242}
+    with Killed(game) as k:
+        res = cs.stop_running_game()
+        check("stopped", res.get("stopped"), True)
+        check("one signal", len(k.sent), 1)
+        check("to the resolved pid", k.sent[0][0], 4242)
+        check("SIGTERM not SIGKILL", k.sent[0][1], signal.SIGTERM)
+
+
+def test_nothing_running_signals_nothing():
+    """Degrade closed: no game must not become a sweep of anything
+    game-shaped."""
+    print("test_nothing_running_signals_nothing")
+    with Killed(None) as k:
+        res = cs.stop_running_game()
+        check("not stopped", res.get("stopped"), False)
+        check("signalled nothing", len(k.sent), 0)
+
+
+def test_game_without_a_pid_signals_nothing():
+    """An older detector, or a race, can yield a game with no pid. That must
+    not fall through to signalling something arbitrary."""
+    print("test_game_without_a_pid_signals_nothing")
+    with Killed({"appid": 570, "label": "Dota 2"}) as k:
+        res = cs.stop_running_game()
+        check("not stopped", res.get("stopped"), False)
+        check("signalled nothing", len(k.sent), 0)
+
+
+def test_already_exited_reads_as_success():
+    """It exited between resolve and signal. That is what the caller wanted."""
+    print("test_already_exited_reads_as_success")
+    with Killed({"appid": 570, "pid": 99}, exc=ProcessLookupError()):
+        res = cs.stop_running_game()
+        check("stopped", res.get("stopped"), True)
+        check("noted", res.get("note"), "already exited")
+
+
+def test_permission_denied_is_reported_not_raised():
+    """A pid we may not signal must be an answer, not a traceback."""
+    print("test_permission_denied_is_reported_not_raised")
+    with Killed({"appid": 570, "pid": 1}, exc=PermissionError()):
+        res = cs.stop_running_game()
+        check("not stopped", res.get("stopped"), False)
+        check("reason", res.get("reason"), "not permitted")
+
+
+def test_uptime_parses_a_comm_containing_spaces_and_parens():
+    """/proc/<pid>/stat's comm field can contain ') (' — splitting the whole
+    line puts the fields out by however many spaces the name has, which would
+    silently report a nonsense runtime."""
+    print("test_uptime_parses_a_comm_containing_spaces_and_parens")
+    import tempfile
+    d = tempfile.mkdtemp(prefix="proc-")
+    os.makedirs(os.path.join(d, "1234"))
+    # Real shape: pid (comm) state ppid ... field 22 is starttime.
+    # The remaining line starts at STATE, so index 19 of what the parser sees
+    # is fields[18] here -- the leading "S" occupies slot 0. Getting this wrong
+    # is precisely the off-by-one the parser has to avoid.
+    fields = ["0"] * 50
+    fields[18] = "6000"
+    with open(os.path.join(d, "1234", "stat"), "w") as f:
+        f.write("1234 (My Game (x86) :) S " + " ".join(fields) + "\n")
+    with open(os.path.join(d, "uptime"), "w") as f:
+        f.write("1000.0 900.0\n")
+
+    real_open = open
+
+    def fake_open(path, *a, **kw):
+        if path == "/proc/1234/stat":
+            return real_open(os.path.join(d, "1234", "stat"), *a, **kw)
+        if path == "/proc/uptime":
+            return real_open(os.path.join(d, "uptime"), *a, **kw)
+        return real_open(path, *a, **kw)
+
+    import builtins
+    builtins.open = fake_open
+    try:
+        hz = os.sysconf("SC_CLK_TCK") or 100
+        want = int(1000.0 - 6000 / float(hz))
+        check("runtime from field 22", cs._proc_uptime_s(1234), want)
+    finally:
+        builtins.open = real_open
+        import shutil as _sh
+        _sh.rmtree(d, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    for fn in (test_takes_no_argument,
+               test_sends_sigterm_to_the_resolved_pid,
+               test_nothing_running_signals_nothing,
+               test_game_without_a_pid_signals_nothing,
+               test_already_exited_reads_as_success,
+               test_permission_denied_is_reported_not_raised,
+               test_uptime_parses_a_comm_containing_spaces_and_parens):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")

--- a/tests/test_mem_pressure.py
+++ b/tests/test_mem_pressure.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Tests for read_mem_pressure() — Linux PSI memory pressure.
+
+Run: python3 tests/test_mem_pressure.py
+
+WHY PSI AND NOT used/total: a used-percentage says how much memory is SPOKEN
+FOR, not whether anything is hurting. A handheld with a big page cache reads
+"26% used" while a game stutters, and "90% used" while everything is fine. PSI
+measures the share of time work was actually STALLED waiting on memory.
+
+MEASURED on a Legion Go S, 2026-07-22. Idle memory pressure read all zeros, so
+to prove the mechanism reports non-zero at all, CPU pressure was driven with a
+bounded load on the same kernel:
+
+    before  some avg10=0.00
+    under   some avg10=30.21
+    after   some avg10=24.74   (decaying)
+
+That is the "seen it fire AND not fire" control. Real MEMORY stall was not
+induced -- filling 32 GB on someone's live box risks OOM-killing Steam -- so the
+parser is exercised here with fixtures in the exact kernel format instead, and
+the absent-file case is asserted because it must not look like "no pressure".
+"""
+import importlib.util
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class Pressure:
+    """Point the reader at a fake /proc/pressure/memory."""
+
+    def __init__(self, text=None):
+        self.dir = tempfile.mkdtemp(prefix="psi-")
+        self.path = os.path.join(self.dir, "memory")
+        if text is not None:
+            with open(self.path, "w") as f:
+                f.write(text)
+        self._real_open = open
+        outer = self
+
+        def fake_open(path, *a, **kw):
+            if path == "/proc/pressure/memory":
+                return outer._real_open(outer.path, *a, **kw)
+            return outer._real_open(path, *a, **kw)
+        import builtins
+        self._builtins = builtins
+        builtins.open = fake_open
+
+    def close(self):
+        self._builtins.open = self._real_open
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+# VERBATIM kernel format, from the Legion Go S.
+IDLE = ("some avg10=0.00 avg60=0.00 avg300=0.00 total=366363677\n"
+        "full avg10=0.00 avg60=0.00 avg300=0.00 total=366279414\n")
+UNDER_PRESSURE = ("some avg10=30.21 avg60=8.40 avg300=1.89 total=129989666\n"
+                  "full avg10=12.05 avg60=3.10 avg300=0.44 total=129994524\n")
+
+
+def test_idle_reads_zeros():
+    print("test_idle_reads_zeros")
+    p = Pressure(IDLE)
+    try:
+        check("all zero", cs.read_mem_pressure(),
+              {"some10": 0.0, "some60": 0.0, "full10": 0.0, "full60": 0.0})
+    finally:
+        p.close()
+
+
+def test_under_pressure_reports_the_numbers():
+    """The firing state, in the kernel's exact format."""
+    print("test_under_pressure_reports_the_numbers")
+    p = Pressure(UNDER_PRESSURE)
+    try:
+        got = cs.read_mem_pressure()
+        check("some10", got.get("some10"), 30.21)
+        check("some60", got.get("some60"), 8.4)
+        check("full10", got.get("full10"), 12.05)
+        check("full60", got.get("full60"), 3.1)
+    finally:
+        p.close()
+
+
+def test_missing_file_is_EMPTY_not_zero():
+    """THE distinction that matters. A kernel without CONFIG_PSI cannot tell us
+    anything, and reporting 0.00 would claim 'no pressure' — a confident answer
+    we do not have."""
+    print("test_missing_file_is_EMPTY_not_zero")
+    old = os.path.exists
+    p = Pressure(None)          # directory exists, file does not
+    try:
+        check("empty dict", cs.read_mem_pressure(), {})
+        check("and NOT zeros", cs.read_mem_pressure() == {"some10": 0.0}, False)
+    finally:
+        p.close()
+        os.path.exists = old
+
+
+def test_garbage_lines_are_skipped_not_fatal():
+    """A kernel that adds a field, or a truncated read, must not raise."""
+    print("test_garbage_lines_are_skipped_not_fatal")
+    p = Pressure("some avg10=notanumber avg60=1.50\nnonsense\n\nfull avg10=2.00\n")
+    try:
+        got = cs.read_mem_pressure()
+        check("bad value skipped", "some10" in got, False)
+        check("good value kept", got.get("some60"), 1.5)
+        check("other line parsed", got.get("full10"), 2.0)
+    finally:
+        p.close()
+
+
+if __name__ == "__main__":
+    for fn in (test_idle_reads_zeros,
+               test_under_pressure_reports_the_numbers,
+               test_missing_file_is_EMPTY_not_zero,
+               test_garbage_lines_are_skipped_not_fatal):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Owner spotted "disk still reporting 5 GB" on a Legion Go S. Measuring turned up two worse problems and cleared the reported one.

## The 5 GB was not a bug

SteamOS's `/` genuinely **is** 5.0 GB — `df` agrees exactly. It's the immutable OS partition. It only *looked* wrong because the drive that actually mattered was missing beside it.

## The percentage was optimistic — this is the real bug

`shutil.disk_usage` was divided by **total** blocks, but filesystems reserve blocks an unprivileged user can never touch.

| mount | before | after | `df` |
|---|---|---|---|
| `/home` | 91% | **97%** | 97% |
| `/` | 69% | **81%** | 81% |

92 GB of that `/home` is reserved. **A storage warning that reads low exactly when the disk is nearly full is worse than no warning.** Now `used/(used+free)`, rounded **up** like `df` (the conservative direction is the honest one for "how full am I"), clamped to 100.

## Game drives were invisible

`_DISK_MOUNTS` is a fixed list, so a Deck's SD card never appeared — **1.4 TB unlisted** while a 5 GB OS partition was shown. Games are the whole reason storage matters on these boxes.

Extra mounts now come from **Steam's own library list** rather than globbing `/run/media` or `/mnt`. That's principled rather than heuristic: it shows exactly the drives games live on, reuses machinery that's already read-only, and a box without Steam gains nothing. Deduped by `st_dev`, so a library on `/home` doesn't double-list.

## Battery: draw and power profile

Both read-only sysfs, both optional.

`watts` is labelled by **status**, because the same counter is the *charge* rate when plugged in — calling it "draw" while charging would be wrong. A zero reading is omitted rather than shown as a confident 0.0 W: a gauge reading zero isn't measuring, it isn't a box using no power.

The profile is reported **verbatim and deliberately not validated** against `platform_profile_choices`. The Legion Go S read `custom` while advertising `low-power balanced performance`, because Steam's TDP control had set one. A reader that insisted on a listed value would show nothing on the exact hardware this was written for.

**Writing** the profile would change how the machine performs and is a separate decision — only reading is exposed here.

## Verified

On hardware against ground truth: percentages match `df` (81% / 97%), the SD card lists at 1406.8 GB, `watts` 7.7 matches `power_now = 7708000 µW`, profile matches the file.

Tests carry the real numbers, including the reserved-block case the old harness structurally couldn't catch — it set `free = total - used`, so the gap that causes the bug didn't exist in the fixture.

**NOT verified:** the `charge`-rate branch (box was discharging throughout) and any machine without `platform_profile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)