### PR TITLE
chore(app): record 2.9.21 build numbers (ios 75 / vc 55)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "74",
+      "buildNumber": "75",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 54
+      "versionCode": 55
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
`autoIncrement` writes build numbers on the build machine, not into the repo. Left uncommitted, the next build increments from **stale** values and drifts from what's actually in the shipped binaries.

Read out of the two production builds: android 54 → **55**, ios 74 → **75**. Next floors: vc ≥ 56, iOS ≥ 76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)