### PR TITLE
fix(pair): explain that scanning only covers this device's own subnet

### DIFF
--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -40,14 +40,28 @@ export function BoxScanPair() {
       const boxes = await scanForBoxes({ timeoutMs: 3000 });
       setPhase({ k: 'list', boxes });
       if (boxes.length === 0) {
-        // Show which subnet was swept — if this isn't the boxes' subnet (e.g. a
-        // VPN skewed the phone's IP), that's why nothing was found.
+        // Say WHY, not just WHAT. The scan can only sweep this device's own
+        // /24, so a box on a different subnet is invisible to it however
+        // healthy the network is.
+        //
+        // HIT LIVE 2026-07-22 on two devices: an iPad on 10.7.1.170/24 and a
+        // phone on 10.7.1.224/24 both reported "not found" while the box sat on
+        // 10.7.0.64 — routing between them worked fine and mDNS resolved. The
+        // old copy named the swept range but never said a different range was
+        // even possible, so it read as "your network is broken" when nothing
+        // was. Mesh routers and guest VLANs make this ordinary, not exotic.
         const ip = await selfIp();
+        const subnet = ip ? ip.replace(/\.\d+$/, '.x') : null;
         setMsg({
           ok: false,
-          text: ip
-            ? `No boxes found (scanned ${ip}/24). Check the same Wi-Fi, turn off any VPN, or add one by IP below.`
-            : 'No boxes found — check the same Wi-Fi, or add one by IP below.',
+          text: subnet
+            ? `No boxes found on ${subnet} — scanning only covers this device's own network. ` +
+              `If your box is on a different one (a guest network, or a second band on a mesh ` +
+              `router) it won't show up here. Pair from an already-paired phone with Show QR, ` +
+              `or add it by IP below.`
+            : "No boxes found. Scanning only covers this device's own network — if your box is " +
+              'on a different one, pair with Show QR from an already-paired phone, or add it by ' +
+              'IP below.',
         });
       }
     } catch {


### PR DESCRIPTION
Hit live on two devices today. An iPad on `10.7.1.170/24` and a phone on `10.7.1.224/24` both said **No boxes found** while the box sat on `10.7.0.64`. Routing worked (`/api/ping` → 200 from the phone) and `steamdeck.local` resolved fine. Nothing was broken except the assumption that sweeping one /24 can see the whole house.

The old copy named the swept range but never said a *different* range was even possible, so it read as "your network is misconfigured" when it wasn't. Mesh routers, guest networks and second bands make this ordinary.

**Before:** `No boxes found (scanned 10.7.1.224/24). Check the same Wi-Fi, turn off any VPN, or add one by IP below.`

**After:** `No boxes found on 10.7.1.x — scanning only covers this device's own network. If your box is on a different one (a guest network, or a second band on a mesh router) it won't show up here. Pair from an already-paired phone with Show QR, or add it by IP below.`

Show QR is named first because that's what actually worked here — it carries host, port and token across without typing.

Shows `10.7.1.x` rather than `10.7.1.224/24`: the reader needs to compare it against their box's address, not parse CIDR. Formatting checked across 10.x, 192.168.x and 172.16.x shapes.

**Deliberately not widening the sweep.** Scanning ranges the device isn't on is slow, looks like a port scan to a router, and the owner has asked to be consulted before any network sweep. Explaining costs nothing and covers the real case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)