### PR TITLE
fix(gaming): Close Game reported success without closing anything (agent 2.9.44)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,11 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.44
+
+Closing a game from the phone now actually closes it. The button reported
+success without stopping anything.
+
 ## 2.9.43
 
 Storage now reports how full a drive really is. It was dividing by space you

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.43"
+VERSION = "2.9.44"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -9551,6 +9551,12 @@ def _appid_from_cmdline(cmdline):
         return None
 
 
+# How long to wait for a game to actually exit after SIGTERM before reporting
+# that it did not. Long enough for a save-on-quit, short enough that the phone
+# is not left spinning: a game that has not gone in this window is not going.
+_GAME_STOP_GRACE_S = 6.0
+
+
 def stop_running_game():
     """Ask the game running right now to close. {"stopped": bool, ...}.
 
@@ -9572,8 +9578,26 @@ def stop_running_game():
     if not game or not game.get("pid"):
         return {"stopped": False, "reason": "nothing running"}
     pid = game["pid"]
+
+    # Signal the process GROUP, not just the pid.
+    #
+    # MEASURED FAILURE, 2026-07-22: signalling the reaper pid alone returned
+    # success and the game kept running. `reaper` is Steam's supervisor wrapper;
+    # the game is its CHILD, so SIGTERM to the wrapper does not reach the thing
+    # the user is looking at. The group is the launch job -- game plus its
+    # helpers -- which is exactly the unit "close this game" means.
+    #
+    # Guarded: a pgid of 0 or 1, or OUR OWN group, would mean signalling
+    # everything including this agent. Refuse rather than risk it.
     try:
-        os.kill(pid, signal.SIGTERM)
+        pgid = os.getpgid(pid)
+    except OSError:
+        pgid = None
+    try:
+        if pgid and pgid > 1 and pgid != os.getpgid(0):
+            os.killpg(pgid, signal.SIGTERM)
+        else:
+            os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
         # It exited between resolving and signalling. That is the outcome the
         # caller wanted, so report it as such rather than as an error.
@@ -9582,7 +9606,18 @@ def stop_running_game():
         return {"stopped": False, "reason": "not permitted"}
     except OSError as e:
         return {"stopped": False, "reason": e.__class__.__name__}
-    return {"stopped": True, "game": game}
+
+    # VERIFY, do not assume. The previous version reported success because
+    # os.kill did not raise -- which only means the signal was delivered, not
+    # that anything closed. That is how a button that does nothing reported 200.
+    # Games take a moment to save and exit, so give it a grace period.
+    deadline = time.monotonic() + _GAME_STOP_GRACE_S
+    while time.monotonic() < deadline:
+        time.sleep(0.4)
+        if _running_game() is None:
+            return {"stopped": True, "game": game}
+    return {"stopped": False, "game": game,
+            "reason": "still running after SIGTERM"}
 
 
 def _proc_uptime_s(pid):

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -40,6 +40,7 @@ import { hapticError, hapticLight, hapticMedium, hapticSelection, hapticSuccess 
 import { setPref, usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import { NowPlayingCard } from '@/components/GamingCard';
 
 /** Cross-platform confirm (Alert buttons are no-ops on web). */
 function confirmDelete(label: string, onConfirm: () => void) {
@@ -748,6 +749,12 @@ function LaunchScreen() {
             tintColor={t.textDim}
           />
         }>
+        {/* What's playing, ABOVE downloads: if a game is running it is the most
+            urgent thing on this screen, and the reason you opened the tab was
+            probably to do something about it. Also stays on the Console tab --
+            seeing what is running belongs in both places. */}
+        <NowPlayingCard />
+
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
         <DownloadsSection downloads={downloads} />
 

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -61,6 +61,73 @@ function humanizeRun(secs: number): string {
   return `${Math.floor(m / 60)}h ${m % 60}m`;
 }
 
+/**
+ * Compact "what's playing" card for the Launch tab.
+ *
+ * Deliberately NOT the full GamingCard: GPU temperature and VRAM belong on
+ * Console, where you went to look at vitals. Here the only questions are what
+ * is running, how long it has been, and how to stop it -- so it renders nothing
+ * else, and nothing at all when no game is running.
+ *
+ * Polls independently of the Console card. They are on different tabs and never
+ * mounted together, so this costs one request on whichever tab you are looking
+ * at rather than two.
+ */
+export function NowPlayingCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+  const [stopping, setStopping] = useState(false);
+  const poll = usePoll<Gaming | null>(
+    () => api.gaming(settings), 5000, ready && configured, hostKey(settings));
+  const g = poll.data;
+  if (!g?.game) return null;
+  const game = g.game;
+
+  return (
+    <View style={styles.nowCard}>
+      <View style={styles.nowHeader}>
+        <Ionicons name="play-circle" size={14} color={t.green} />
+        <Text style={styles.nowHeaderText}>PLAYING NOW</Text>
+        {game.running_s != null && (
+          <Text style={styles.nowTime}>{humanizeRun(game.running_s)}</Text>
+        )}
+      </View>
+      <Text style={styles.nowTitle} numberOfLines={2}>
+        {game.label ?? `App ${game.appid}`}
+      </Text>
+      <Pressable
+        onPress={() => {
+          hapticLight();
+          Alert.alert(
+            'Close this game?',
+            `${game.label ?? 'The running game'} will be asked to quit. Unsaved progress may be lost.`,
+            [
+              { text: 'Cancel', style: 'cancel' },
+              {
+                text: 'Close game',
+                style: 'destructive',
+                onPress: () => {
+                  setStopping(true);
+                  void api.stopGame(settings).finally(() => {
+                    setStopping(false);
+                    poll.refresh();
+                  });
+                },
+              },
+            ],
+          );
+        }}
+        disabled={stopping}
+        style={({ pressed }) => [styles.stopBtn, pressed && { opacity: 0.7 }]}>
+        <Ionicons name="stop-circle-outline" size={15} color={t.red} />
+        <Text style={styles.stopText}>{stopping ? 'CLOSING…' : 'CLOSE GAME'}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
 export function GamingCard() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -282,6 +349,19 @@ const makeStyles = (t: Palette) =>
     // Destructive, so it reads as one: red text on a red hairline rather than a
   // filled button. It sits inside a card of read-only vitals and must not look
   // like just another row.
+  nowCard: {
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 14,
+    marginBottom: 12,
+    gap: 8,
+  },
+  nowHeader: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  nowHeaderText: { color: t.textDim, fontSize: 11, letterSpacing: 1, fontFamily: mono },
+  nowTime: { color: t.textDim, fontSize: 11, marginLeft: 'auto', fontFamily: mono },
+  nowTitle: { color: t.text, fontSize: 16, fontWeight: '700' },
   stopBtn: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/tests/test_game_stop.py
+++ b/tests/test_game_stop.py
@@ -37,26 +37,48 @@ def check(name, got, want):
 
 
 class Killed:
-    """Capture what would have been signalled, instead of signalling."""
+    """Capture what would have been signalled, instead of signalling.
 
-    def __init__(self, game, exc=None):
-        self.sent = []
-        self._game, self._exc = game, exc
-        self._old_kill, self._old_running = os.kill, cs._running_game
+    `exits` decides what _running_game() reports AFTER the signal: True means
+    the game went away (the success path), False means it survived. That
+    distinction is the whole point -- the shipped bug reported success purely
+    because os.kill did not raise.
+    """
+
+    def __init__(self, game, exc=None, exits=True, pgid=4242):
+        self.sent = []          # ("kill"|"killpg", target, signal)
+        self._game, self._exc, self._exits, self._pgid = game, exc, exits, pgid
+        self._signalled = False
+        self._old = (os.kill, getattr(os, "killpg", None), os.getpgid,
+                     cs._running_game, cs._GAME_STOP_GRACE_S)
 
     def __enter__(self):
         outer = self
 
         def fake_kill(pid, sig):
-            outer.sent.append((pid, sig))
+            outer.sent.append(("kill", pid, sig))
+            outer._signalled = True
             if outer._exc:
                 raise outer._exc
-        os.kill = fake_kill
-        cs._running_game = lambda: outer._game
+
+        def fake_killpg(pgid, sig):
+            outer.sent.append(("killpg", pgid, sig))
+            outer._signalled = True
+            if outer._exc:
+                raise outer._exc
+
+        def fake_getpgid(pid):
+            return os.getpid() if pid == 0 else outer._pgid
+
+        os.kill, os.killpg, os.getpgid = fake_kill, fake_killpg, fake_getpgid
+        cs._running_game = lambda: (
+            None if (outer._signalled and outer._exits) else outer._game)
+        cs._GAME_STOP_GRACE_S = 1.0      # keep the suite fast
         return self
 
     def __exit__(self, *a):
-        os.kill, cs._running_game = self._old_kill, self._old_running
+        (os.kill, os.killpg, os.getpgid,
+         cs._running_game, cs._GAME_STOP_GRACE_S) = self._old
 
 
 def test_takes_no_argument():
@@ -66,16 +88,53 @@ def test_takes_no_argument():
     check("zero parameters", cs.stop_running_game.__code__.co_argcount, 0)
 
 
-def test_sends_sigterm_to_the_resolved_pid():
-    """SIGTERM, never SIGKILL: Steam's reaper forwards it so the game saves."""
-    print("test_sends_sigterm_to_the_resolved_pid")
+def test_signals_the_process_GROUP_not_just_the_pid():
+    """THE bug that shipped. Signalling the reaper pid alone did nothing --
+    reaper is Steam's supervisor and the game is its CHILD, so SIGTERM to the
+    wrapper never reaches what the user is looking at. MEASURED on hardware:
+    the route returned 200 and the game kept running."""
+    print("test_signals_the_process_GROUP_not_just_the_pid")
     game = {"appid": 570, "label": "Dota 2", "pid": 4242}
-    with Killed(game) as k:
+    with Killed(game, pgid=4242) as k:
         res = cs.stop_running_game()
         check("stopped", res.get("stopped"), True)
         check("one signal", len(k.sent), 1)
-        check("to the resolved pid", k.sent[0][0], 4242)
-        check("SIGTERM not SIGKILL", k.sent[0][1], signal.SIGTERM)
+        check("signalled the GROUP", k.sent[0][0], "killpg")
+        check("the game's group", k.sent[0][1], 4242)
+        check("SIGTERM not SIGKILL", k.sent[0][2], signal.SIGTERM)
+
+
+def test_survivor_reports_failure_not_success():
+    """THE other half of the bug. It reported success because os.kill did not
+    raise -- which only means the signal was DELIVERED. A game that is still
+    there afterwards must be reported as still there."""
+    print("test_survivor_reports_failure_not_success")
+    game = {"appid": 570, "label": "Dota 2", "pid": 4242}
+    with Killed(game, exits=False):
+        res = cs.stop_running_game()
+        check("not stopped", res.get("stopped"), False)
+        check("says why", res.get("reason"), "still running after SIGTERM")
+
+
+def test_never_signals_our_own_group():
+    """A pgid equal to this process's own group would take the AGENT down with
+    the game. Fall back to the single pid rather than signalling ourselves."""
+    print("test_never_signals_our_own_group")
+    game = {"appid": 570, "label": "Dota 2", "pid": 4242}
+    with Killed(game, pgid=os.getpid()) as k:
+        cs.stop_running_game()
+        check("used kill, not killpg", k.sent[0][0], "kill")
+
+
+def test_never_signals_pgid_0_or_1():
+    """pgid 0 means 'every process in our group' and 1 is init. Both would be
+    catastrophic; neither is ever the right target."""
+    print("test_never_signals_pgid_0_or_1")
+    for bad in (0, 1):
+        game = {"appid": 570, "pid": 4242}
+        with Killed(game, pgid=bad) as k:
+            cs.stop_running_game()
+            check("pgid %d -> single pid" % bad, k.sent[0][0], "kill")
 
 
 def test_nothing_running_signals_nothing():
@@ -158,7 +217,10 @@ def test_uptime_parses_a_comm_containing_spaces_and_parens():
 
 if __name__ == "__main__":
     for fn in (test_takes_no_argument,
-               test_sends_sigterm_to_the_resolved_pid,
+               test_signals_the_process_GROUP_not_just_the_pid,
+               test_survivor_reports_failure_not_success,
+               test_never_signals_our_own_group,
+               test_never_signals_pgid_0_or_1,
                test_nothing_running_signals_nothing,
                test_game_without_a_pid_signals_nothing,
                test_already_exited_reads_as_success,


### PR DESCRIPTION
Owner pressed it on a real game and nothing closed. The journal shows `POST /api/game/stop 200` — so the agent found the reaper, signalled it, and called that a win.

**Two bugs, both mine, both shipped in 2.9.21.**

## 1. It signalled the wrong thing

`reaper` is Steam's supervisor wrapper; the game is its **child**. SIGTERM to the wrapper never reaches what's on screen.

Now signals the process **group** — the launch job, which is exactly the unit "close this game" means. Guarded against pgid `0`, `1`, and our own group, any of which would take the agent down with the game.

## 2. It lied about the result

It returned `stopped: true` because `os.kill` didn't raise — which only means the signal was *delivered*. It now waits up to 6s for the game to actually go, and reports `still running after SIGTERM` when it doesn't.

That's the part that made this hard to spot: a button that couldn't work was returning 200.

## The tests were part of the problem

They passed throughout, because they asserted the *buggy* behaviour — that a signal was sent, never that anything stopped. The harness now models whether the process survives, and the two regression tests are named for the bugs rather than the mechanism:

- `test_signals_the_process_GROUP_not_just_the_pid`
- `test_survivor_reports_failure_not_success`

Plus guards: `test_never_signals_our_own_group`, `test_never_signals_pgid_0_or_1`.

## Also: card placement

"Playing now" moves **above** the downloads card on Launch as a compact card — if a game is running it's the most urgent thing on that screen. The full `GamingCard` stays on Console, since GPU and VRAM belong with the vitals rather than above your downloads.

## NOT VERIFIED

**The fix has not been tested against a real running game.** The box was idle again by the time this was written. The mechanism is reasoned from the observed failure and covered by tests, but the end-to-end close is exactly as unproven as the first version was — and the first version is why this PR exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)