### PR TITLE
docs(roadmap): capture likwidtek's three asks, with the constraints that shape them

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,6 +70,52 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **Cannot be verified in the web harness** — RN Web emits mouse events, never touch events.
   Device only, via `adb shell input swipe` + `screencap` mid-gesture.
 
+### One-button "update everything" from the phone
+- **priority:** P1 · **risk:** MEDIUM — allowlist-sensitive · **affects:** agent + app · **depends_on:** the sudo/NOPASSWD problem below
+- **Requested by likwidtek (Discord, 2026-07-22):** actions to update Bazzite (`ujust update`),
+  Couchside, Decky + plugins, Steam, flatpaks — "all from your phone, one button".
+- **The allowlist shape is the whole design.** Each updater is its OWN explicit entry in the
+  agent's frozen action table with a FIXED argv list. "Update everything" is then a fixed
+  SEQUENCE of those entries — never a loop over names the client supplies, and never a
+  generic "run updater X" route. Today `DEFAULT_ACTIONS` has exactly three ids
+  (restart-session, reboot, poweroff); this would be the largest widening the table has ever
+  had, so each entry gets the §6 treatment: happy path, auth failure, non-allowlisted id
+  refused with nothing run.
+- **The real blocker is privilege, not plumbing.** `rpm-ostree` / `ujust update` need root,
+  and the agent runs as the desktop user. This hits the SAME wall that already breaks the
+  in-app agent update on a stock Deck (`sudo: a password is required`). Solve that first or
+  the button exists and fails.
+- **Atomic OS caveat, owner's own point:** on Bazzite an update is staged and needs a reboot,
+  and layered packages are re-applied. The UI must report "staged, reboot to apply" rather
+  than "done" — reporting success for something that has not happened yet is the exact
+  failure this project keeps paying for.
+- Flatpak (`flatpak update`) is per-user and needs no root — cheapest first slice, and the one
+  that proves the pattern end to end.
+
+### Decky self-heal (update / reinstall from the phone)
+- **priority:** P2 · **risk:** low · **affects:** agent · **depends_on:** none
+- **Requested by likwidtek (Discord, 2026-07-22):** "a solution to decky crashing and needing
+  to be updated — an action to update or reinstall decky to keep it from crashing."
+- **Partly exists:** `restart-decky` is already an INJECTED action, gated on the unit existing
+  AND the NOPASSWD grant being present (`_inject_decky_action`). What does not exist is
+  update-or-reinstall.
+- Directly related to **KI-004** (Decky Loader vanishes on every Steam CEF restart; worked
+  around, not fixed). Worth reading that before designing — a reinstall button that papers
+  over a known root cause is worse than fixing the cause.
+
+### Two-way clipboard (box <-> phone)
+- **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- **Requested by likwidtek (Discord, 2026-07-22).** **Half of this does NOT exist**, contrary
+  to what was said in that thread: the agent only ever WRITES the box clipboard, as part of
+  delivering non-ASCII text (`clipboard_paste`, agent ~8908). `wl-paste` appears solely as a
+  read-back check that `wl-copy` landed, plus restoring what was there. There is no
+  `/api/clipboard` route and no clipboard call in `app/lib/api.ts`.
+- So: phone -> box TEXT ENTRY works. **Copy on the box, paste on the phone does not exist.**
+  Neither does "put this on the box's clipboard without typing it somewhere".
+- A read route returns whatever the user last copied on their desktop — passwords included —
+  to any LAN peer holding the token. It needs the same deliberate treatment as `/pair`, not a
+  casual GET.
+
 ### In-app Bluetooth pairing
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** none
 - Agent drives `bluetoothctl`; app renders discovered devices and pairs on tap. Removes the


### PR DESCRIPTION
Three feature requests from Discord (2026-07-22), recorded as structured Planned entries.

Each says what **already exists**, because two of the three are partly built — and one was
described in that thread as finished when half of it does not exist.

## Clipboard is one-directional

The agent only ever **writes** the box clipboard, as part of delivering non-ASCII text
(`clipboard_paste`, agent ~8908). `wl-paste` appears **solely** as a read-back check that
`wl-copy` landed, plus restoring whatever was there. There is no `/api/clipboard` route and
no clipboard call in `app/lib/api.ts`.

So phone → box **text entry** works. **Copy on the box, paste on the phone does not exist**,
and neither does "put this on the box's clipboard without typing it somewhere". Worth
knowing before it becomes a promise.

Also flagged: a read route hands whatever the user last copied on their desktop — passwords
included — to any LAN peer holding the token. That needs the same deliberate treatment as
`/pair`, not a casual GET.

## Decky self-heal

`restart-decky` **already exists** as an injected action, gated on the unit existing AND the
NOPASSWD grant (`_inject_decky_action`). Update-or-reinstall does not. Cross-referenced to
**KI-004** (Decky vanishes on every Steam CEF restart — worked around, not fixed), because a
reinstall button that papers over a known root cause is worse than fixing the cause.

## One-button update everything

The design **is** its allowlist shape: one explicit entry with a **fixed argv** per updater,
and "update everything" as a fixed **sequence** of those — never a loop over client-supplied
names, never a generic "run updater X" route. `DEFAULT_ACTIONS` currently holds exactly three
ids (`restart-session`, `reboot`, `poweroff`), so this would be the largest widening that
table has ever had, and each entry earns the §6 treatment.

The real blocker is **privilege, not plumbing**: `rpm-ostree` / `ujust update` need root and
the agent runs as the desktop user — the same wall that already breaks the in-app agent
update on a stock Deck. Flatpak is per-user, needs no root, and is the cheapest slice that
proves the pattern end to end.

Atomic-OS caveat (the owner's own point in the thread): an update is staged and needs a
reboot. The UI must say "staged, reboot to apply", not "done" — reporting success for
something that has not happened yet is precisely the failure mode this project keeps paying
for.

Docs only. No code, no agent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)