### PR TITLE
Pairing tutorial on the box screen + KI-019 fix (agent 2.9.45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,15 @@ jobs:
       - name: Unit tests (gaming card)
         run: python3 tests/test_gaming_card.py
 
+      # The on-box pairing page: both loopback gates (peer IP + Host header,
+      # anti-DNS-rebinding — a box's token must never leave its own screen), the
+      # idle tutorial + its reload-into-PIN handoff, the PIN state machine
+      # (attempt cap / expiry / single-use, previously untested — KI-020), and
+      # the KI-019 box-pop throttle. The renders + handoff were also proven on a
+      # real box's CEF; this guards the logic a refactor could quietly break.
+      - name: Unit tests (pairing page)
+        run: python3 tests/test_pair_page.py
+
       # Stream-host detection (/api/stream-host, phase 4a — detect only). The
       # fixtures are verbatim /proc/net lines off a live box, so they encode the
       # real trap: an ESTABLISHED TCP peer on 27036 is the ROUTER, not a session,

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.45
+
+Fresh installs now show a short animated guide on the box's own screen —
+open the app, Scan, tap this box — that turns into the pairing PIN the moment
+you start. No more staring at a finished terminal wondering what to do next.
+
+Also closes a small nuisance: a device on your network could pop the pairing
+screen onto your TV on repeat. It can't anymore.
+
 ## 2.9.44
 
 Closing a game from the phone now actually closes it. The button reported

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.44"
+VERSION = "2.9.45"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -10985,19 +10985,26 @@ PAIR_PIN = None
 
 def pair_pin_start():
     """Mint a fresh PIN + session (replacing any prior one) and return
-    (pin, ttl). Debounced: within PAIR_PIN_START_DEBOUNCE of the last start the
-    LIVE pin is returned unchanged, so a double-tap / retry doesn't reroll the
-    number already on screen. Caller displays it on the box."""
+    (pin, ttl, fresh). Debounced: within PAIR_PIN_START_DEBOUNCE of the last
+    start the LIVE pin is returned unchanged, so a double-tap / retry doesn't
+    reroll the number already on screen. Caller displays it on the box.
+
+    `fresh` is True only when a NEW PIN was minted, False when the debounce
+    branch returned the existing one. The caller pops the box screen ONLY on a
+    fresh mint (KI-019): without that, a repeat /start inside the debounce
+    window returns the same PIN but still throws another full-screen page onto
+    the TV — which is exactly the nuisance the debounce comment claims to
+    prevent."""
     global PAIR_PIN
     with PAIR_PIN_LOCK:
         now = time.monotonic()
         s = PAIR_PIN
         if s and now <= s["expires"] and now - s["started"] < PAIR_PIN_START_DEBOUNCE:
-            return s["pin"], int(s["expires"] - now)
+            return s["pin"], int(s["expires"] - now), False
         pin = "%06d" % (int.from_bytes(os.urandom(3), "big") % 1000000)
         PAIR_PIN = {"pin": pin, "expires": now + PAIR_PIN_TTL,
                     "attempts": 0, "started": now}
-        return pin, PAIR_PIN_TTL
+        return pin, PAIR_PIN_TTL, True
 
 
 def pair_pin_active():
@@ -11029,9 +11036,25 @@ def pair_pin_check(pin):
         return True
 
 
+_BOX_POP_LOCK = threading.Lock()
+_BOX_POP_AT = [0.0]                 # monotonic time of the last box-screen pop
+_BOX_POP_COOLDOWN = 5.0            # seconds; hard floor between pops
+
+
 def pair_show_on_box(port):
     """Open the loopback /pair page on the BOX'S own screen so the PIN is
-    visible there."""
+    visible there.
+
+    Rate-limited (KI-019, defence in depth): the caller already gates this on a
+    FRESH pin mint, so legitimate double-taps don't re-pop. This cooldown is the
+    backstop — even a stream of genuinely-fresh sessions (a LAN client looping
+    /start past the debounce) cannot throw the page onto the TV more than once
+    per _BOX_POP_COOLDOWN. The normal flow (user pairs once) never touches it."""
+    now = time.monotonic()
+    with _BOX_POP_LOCK:
+        if now - _BOX_POP_AT[0] < _BOX_POP_COOLDOWN:
+            return
+        _BOX_POP_AT[0] = now
     pair_show_on_box_url("http://localhost:%d/pair" % port)
 
 
@@ -11153,21 +11176,94 @@ def render_pair_page(token, port):
         "font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;}"
         "body{display:flex;flex-direction:column;align-items:center;"
         "justify-content:center;text-align:center;padding:4vmin;box-sizing:border-box;}"
-        "h1{font-size:min(6vmin,42px);font-weight:650;margin:0 0 3vmin;letter-spacing:.2px;}"
-        ".sub{color:#9aa4b2;font-size:min(3vmin,20px);margin:0 0 4vmin;max-width:36ch;}"
-        ".card{background:#fff;border-radius:24px;padding:min(5vmin,40px);"
+        "h1{font-size:min(5vmin,38px);font-weight:650;margin:0 0 .8vmin;letter-spacing:.2px;}"
+        ".sub{color:#9aa4b2;font-size:min(2.7vmin,18px);margin:0 0 2.4vmin;max-width:46ch;}"
+        # The stage is one row: [phone + steps] on the left, QR on the right. It
+        # must fit ONE screen with no scroll -- a TV read from the couch can't.
+        # Sized to sit in a row at ~960px wide (Steam's CEF render width, MEASURED
+        # on the box 2026-07-22 -- an earlier looser layout looked fine in Chrome
+        # at 1280 but WRAPPED the QR below the fold on the actual box). Still wraps
+        # to a column on a genuinely narrow display as a last resort.
+        ".stage{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;"
+        "gap:min(5vmin,44px);max-width:1000px;}"
+        ".left{display:flex;align-items:center;gap:min(3vmin,22px);}"
+        ".steps{display:flex;flex-direction:column;gap:min(2.6vmin,20px);"
+        "text-align:left;max-width:30ch;}"
+        ".step{display:flex;align-items:center;gap:min(2.2vmin,15px);}"
+        ".num{flex:0 0 auto;width:min(5vmin,38px);height:min(5vmin,38px);"
+        "border-radius:50%;background:#1c2430;color:#7dd3fc;font-weight:700;"
+        "font-size:min(2.8vmin,20px);display:flex;align-items:center;"
+        "justify-content:center;}"
+        ".step b{font-size:min(3vmin,20px);font-weight:600;color:#e8ecf3;}"
+        ".step span{display:block;color:#9aa4b2;font-size:min(2.4vmin,15px);margin-top:.3vmin;}"
+        # The QR keeps its white card exactly as before -- do not restyle it, the
+        # camera has to read it.
+        ".card{background:#fff;border-radius:20px;padding:min(3.4vmin,28px);"
         "box-shadow:0 12px 40px rgba(0,0,0,.5);}"
-        "#qr{display:block;image-rendering:pixelated;width:min(70vmin,560px);"
-        "height:min(70vmin,560px);}"
-        ".url{margin-top:4vmin;color:#5a6472;font-size:min(2.2vmin,14px);"
-        "word-break:break-all;max-width:80ch;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}"
+        "#qr{display:block;image-rendering:pixelated;width:min(42vmin,300px);"
+        "height:min(42vmin,300px);}"
+        ".cap{color:#9aa4b2;font-size:min(2.2vmin,14px);margin-top:1.4vmin;}"
+        ".url{margin-top:2vmin;color:#5a6472;font-size:min(1.9vmin,12px);"
+        "word-break:break-all;max-width:70ch;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;}"
         ".err{color:#ff6b6b;margin-top:3vmin;font-size:min(3vmin,18px);}"
+        # The animated phone mock. Three scenes cross-fade on a 9s loop, 3s each,
+        # driven ONLY by @keyframes -- no JS. Proven to render + cycle on Steam's
+        # CEF browser (SteamOS + Bazzite, 2026-07-22). Each scene group holds full
+        # opacity for its third of the cycle and is invisible otherwise; the 4%
+        # ramps overlap slightly so it reads as a cross-fade, not a hard cut.
+        ".phone{flex:0 0 auto;width:min(18vmin,96px);}"
+        ".scene{opacity:0;animation:cs 9s infinite;}"
+        ".scene.b{animation-delay:3s;}.scene.c{animation-delay:6s;}"
+        "@keyframes cs{0%{opacity:0}4%{opacity:1}29%{opacity:1}33%{opacity:0}100%{opacity:0}}"
+        "@media (max-width:820px){.steps{max-width:80vw}.stage{gap:4vmin}}"
         "</style></head><body>"
-        "<h1>Scan to pair Couchside</h1>"
-        "<div class=\"sub\">Point your phone&rsquo;s <b>camera</b> at this code "
-        "&mdash; it opens the Couchside app and pairs your box automatically. "
-        "The app itself has no scanner; use the camera.</div>"
-        "<div class=\"card\"><canvas id=\"qr\" width=\"560\" height=\"560\"></canvas></div>"
+        "<h1>Pair your phone</h1>"
+        "<div class=\"sub\">Get the Couchside app, then follow these three steps "
+        "&mdash; or point your phone&rsquo;s camera at the code to skip ahead.</div>"
+        "<div class=\"stage\">"
+        "<div class=\"left\">"
+        "<svg class=\"phone\" viewBox=\"0 0 120 240\" xmlns=\"http://www.w3.org/2000/svg\" "
+        "aria-hidden=\"true\">"
+        "<rect x=\"4\" y=\"4\" width=\"112\" height=\"232\" rx=\"20\" fill=\"#0b1220\" "
+        "stroke=\"#2b3648\" stroke-width=\"3\"/>"
+        "<rect x=\"12\" y=\"20\" width=\"96\" height=\"200\" rx=\"8\" fill=\"#0f1826\"/>"
+        # Scene A: the app icon, "open Couchside".
+        "<g class=\"scene a\"><rect x=\"38\" y=\"78\" width=\"44\" height=\"44\" rx=\"11\" "
+        "fill=\"#38bdf8\"/><rect x=\"46\" y=\"96\" width=\"28\" height=\"14\" rx=\"4\" "
+        "fill=\"#0b1220\"/><rect x=\"44\" y=\"92\" width=\"6\" height=\"10\" fill=\"#0b1220\"/>"
+        "<rect x=\"70\" y=\"92\" width=\"6\" height=\"10\" fill=\"#0b1220\"/>"
+        "<rect x=\"40\" y=\"134\" width=\"40\" height=\"6\" rx=\"3\" fill=\"#334155\"/></g>"
+        # Scene B: a scan list with one row highlighted, "Setup -> Scan, tap it".
+        "<g class=\"scene b\"><rect x=\"22\" y=\"70\" width=\"76\" height=\"22\" rx=\"6\" "
+        "fill=\"#38bdf8\"/><rect x=\"29\" y=\"78\" width=\"40\" height=\"6\" rx=\"3\" "
+        "fill=\"#0b1220\"/><rect x=\"22\" y=\"100\" width=\"76\" height=\"16\" rx=\"5\" "
+        "fill=\"#1c2430\"/><rect x=\"22\" y=\"124\" width=\"76\" height=\"16\" rx=\"5\" "
+        "fill=\"#1c2430\"/></g>"
+        # Scene C: the six-digit PIN appearing, "a PIN shows here".
+        "<g class=\"scene c\"><rect x=\"24\" y=\"96\" width=\"10\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/><rect x=\"38\" y=\"96\" width=\"10\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/><rect x=\"52\" y=\"96\" width=\"10\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/><rect x=\"66\" y=\"96\" width=\"10\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/><rect x=\"80\" y=\"96\" width=\"10\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/><rect x=\"94\" y=\"96\" width=\"6\" height=\"18\" rx=\"2\" "
+        "fill=\"#7dd3fc\"/></g></svg>"
+        "<div class=\"steps\">"
+        "<div class=\"step\"><div class=\"num\">1</div><div>"
+        "<b>Open Couchside on your phone</b>"
+        "<span>Free on the App Store &amp; Google Play.</span></div></div>"
+        "<div class=\"step\"><div class=\"num\">2</div><div>"
+        "<b>Setup tab &rarr; Scan for boxes</b>"
+        "<span>Then tap this box in the list.</span></div></div>"
+        "<div class=\"step\"><div class=\"num\">3</div><div>"
+        "<b>A 6-digit PIN appears here</b>"
+        "<span>Type it into the app to finish.</span></div></div>"
+        "</div>"          # .steps
+        "</div>"          # .left
+        "<div>"
+        "<div class=\"card\"><canvas id=\"qr\" width=\"300\" height=\"300\"></canvas></div>"
+        "<div class=\"cap\">Or scan with your camera</div>"
+        "</div>"
+        "</div>"          # .stage
         "<div class=\"url\">" + url_html + "</div>"
         "<div id=\"err\" class=\"err\"></div>"
         "<script>\n" + PAIR_QR_JS + "\n"
@@ -11178,7 +11274,7 @@ def render_pair_page(token, port):
         "    var n = qr.getModuleCount();\n"
         "    var quiet = 4, total = n + quiet*2;\n"
         "    var canvas = document.getElementById('qr');\n"
-        "    var px = Math.max(4, Math.floor(560/total));\n"
+        "    var px = Math.max(4, Math.floor(300/total));\n"
         "    var size = total*px; canvas.width = size; canvas.height = size;\n"
         "    var ctx = canvas.getContext('2d');\n"
         "    ctx.fillStyle = '#ffffff'; ctx.fillRect(0,0,size,size);\n"
@@ -11188,6 +11284,20 @@ def render_pair_page(token, port):
         "  } catch (e) {\n"
         "    document.getElementById('err').textContent = 'Could not render QR: ' + e;\n"
         "  }\n"
+        # THE HANDOFF. Poll /api/pair/status on the same 3000ms cadence as
+        # render_pin_page. The instant a pairing starts (active===true) reload;
+        # the route then serves render_pin_page because pair_pin_active() is now
+        # truthy, so this idle tutorial becomes the big PIN it was teaching about.
+        # Errors are swallowed and the page left alone, verbatim from
+        # render_pin_page -- an agent restart must never paint a browser error on
+        # the TV. Only ONE reload ever fires (the guard), so a slow reload can't
+        # stack.
+        "  var gone=false;\n"
+        "  setInterval(function(){\n"
+        "    fetch('/api/pair/status').then(function(r){return r.json()})\n"
+        "    .then(function(d){if(d&&d.active===true&&!gone){gone=true;\n"
+        "      location.reload();}}).catch(function(){});\n"
+        "  },3000);\n"
         "})();\n"
         "</script></body></html>"
     )
@@ -11807,8 +11917,12 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 pair_body = self._read_body()
                 if path == "/api/pair/start":
-                    _pin, ttl = pair_pin_start()
-                    pair_show_on_box(self.port)   # pop the PIN on the box screen
+                    _pin, ttl, fresh = pair_pin_start()
+                    # Pop the PIN on the box screen ONLY on a fresh mint (KI-019).
+                    # A repeat /start inside the debounce window returns the same
+                    # PIN and must NOT re-throw the page onto the user's TV.
+                    if fresh:
+                        pair_show_on_box(self.port)
                     self._send(200, {"ok": True, "ttl": ttl}, started)
                     return
                 try:

--- a/docs/memory/project_pairing-tutorial.md
+++ b/docs/memory/project_pairing-tutorial.md
@@ -1,0 +1,152 @@
+# Project — On-box pairing tutorial (auto-plays after install)
+
+Status: **SPEC / not built.** Written 2026-07-21.
+Scope decided with the owner: **box TV only**, **inline CSS/SVG animation (no GIF)**,
+**PIN flow only** (no full onboarding wall of text).
+
+Sibling spec: `project_interactive-setup-card.md` is the *phone-side* half of the same
+funnel problem. This one needs no app release and no store review; that one does. They are
+independent and can ship in either order.
+
+---
+
+## 1. What it is
+
+The installer finishes and the box's own screen lights up with a short animated tutorial:
+*open Couchside on your phone → Setup → Scan → tap this box*. The page waits. The moment the
+phone starts a pairing, the same page becomes the big 6-digit PIN it was teaching about.
+
+Motivation is the measured funnel — ~9–15 strangers downloaded the app in the first six days
+after the 2026-07-15 store launch, ~0 got an agent paired. The last mile is a user standing at
+a finished terminal with no idea what to do next. The terminal already prints a QR; the closing
+text never says "open the Couchside app."
+
+---
+
+## 2. Why this is nearly free (all read from source 2026-07-21)
+
+| Fact | Where | Consequence |
+|---|---|---|
+| `/pair` already renders **two** states — big PIN if a session is live, else the token QR | `agent/couchsided.py:10628-10643` | A third (idle-tutorial) state is a change to one existing branch, not a new route. |
+| `/pair` is gated by **both** `_is_loopback()` and `_host_header_is_local()` | `agent/couchsided.py:10632-10635` | Anything rendered there is unreachable from the LAN. No new network surface. |
+| `render_pin_page` already polls `/api/pair/status` every 3000 ms, latches `done`, and **leaves the page untouched on any fetch error** | `agent/couchsided.py:10324-10360` | The poll+swap idiom to copy already exists and already survives an agent restart. |
+| `/api/pair/status` is loopback-only and returns only `{"active": bool}` | `agent/couchsided.py:10645-10653` | The idle page can detect "a pairing just started" without learning the PIN. |
+| `render_pair_page` (QR) is self-contained inline HTML/CSS/JS + `PAIR_QR_JS` canvas | `agent/couchsided.py:10396`, `PAIR_QR_JS` at `:10019` | House style for these pages is already inline-everything, no external resources. |
+| `couchside-pair` launcher already opens `/pair` full-screen | written by `install.sh:916-957`, path const at `:152` | gamescope → `steam -ifrunning steam://openurl/`; else flatpak Chrome/Chromium `--app --start-fullscreen`; else `xdg-open`; else print URL. Nothing new to write. |
+| `install.sh` runs **as the normal desktop user**, escalating per-command with `sudo` | header `:1-15`, first sudo at `:581` | A browser launched from the installer lands in the user's own session. |
+| The agent binds at the **midpoint** of `install.sh` (`:880-889`), ~850 lines before the QR prints | | The box is already answering by the time the closing banner runs. |
+| Fresh-install signal already exists: the `else` branch that prints "generating new pairing token" | `install.sh:602-609` | Gate the auto-open on it — re-runs and updates keep their token and stay quiet. |
+| `PAIR_PIN_TTL = 120`, `MAX_ATTEMPTS = 5`, `START_DEBOUNCE = 3` | `agent/couchsided.py:10248-10250` | The PIN page can keep showing a real countdown; unchanged by this work. |
+
+**Why not a real GIF:** the repo's existing GIFs (`docs/media/*.gif`) are 3.9–5.9 MB each; the
+entire agent is 539,416 bytes of pure-stdlib single-file Python. Embedding one is a non-starter,
+and shipping it as a separate signed release asset would add a static-file route, a signing
+entry, and a missing-asset fallback path. Inline CSS keyframes + inline SVG is a few KB, stays
+crisp at any TV resolution, and is editable in the same file as the page it lives on.
+
+---
+
+## 3. Required changes
+
+### 3a. `agent/couchsided.py` — idle `/pair` gains the tutorial
+
+Today the no-PIN branch is `render_pair_page(self._current_token(), self.port)` (`:10640-10641`).
+It stays — **do not replace the QR.** The Steam tile's documented job (installer closing text,
+`install.sh:1731-1734`) is re-showing the QR, and the `.desktop` is literally titled "Pair Phone".
+
+Instead `render_pair_page` grows a step strip **beside** the QR card:
+
+- Three steps, one line each: `Open Couchside on your phone` / `Setup tab → Scan` /
+  `Tap this box — a PIN appears here`.
+- An inline `<svg>` phone mock with CSS `@keyframes` cycling the three states (app icon → scan
+  list → PIN entry). No JS drives the animation; keyframes only.
+- Layout: flex row on wide viewports (steps left, QR right), column fallback. Must fit **one
+  screen with no scrolling** — a TV read from a couch cannot scroll.
+- Reuse the existing `vmin`-based type scale in `render_pair_page` (`min(6vmin,42px)` etc.) so
+  it matches the page it is joining.
+
+### 3b. `agent/couchsided.py` — the handoff
+
+The idle page polls `/api/pair/status` on the same 3000 ms cadence as `render_pin_page`, and on
+`active === true` calls `location.reload()`. The existing route then serves the PIN page. Copy
+`render_pin_page`'s error discipline verbatim: **swallow fetch errors and leave the page alone**,
+so an agent restart never paints a browser error on the TV.
+
+No new endpoint. No new field. `/api/pair/status` keeps returning one boolean.
+
+### 3c. `install.sh` — auto-open on a fresh install only
+
+1. Set `FRESH_TOKEN=1` inside the existing `else` branch at `:602-609` (the one that prints
+   `generating new pairing token`). The two branches above it — token already present, token
+   migrated from a prior install — leave it `0`, so **update runs and re-installs stay silent**.
+2. At the closing banner (after the QR block, before `:1736`), when `FRESH_TOKEN=1` and
+   `--no-open` was not passed: launch `$PAIR_SCRIPT` detached, best-effort, never blocking and
+   never failing the install.
+3. Add `--no-open` to the flag parser (`:192` area) and to the `--help` text (`:9-14`).
+4. Update the closing text at `:1731-1734` — it currently ends on the Steam tile and never says
+   "open the Couchside app on your phone."
+
+---
+
+## 4. Allowlist / security review (CLAUDE.md §3)
+
+- **No new route, no new client-supplied identifier, no `subprocess` with client input.** The
+  only new execution is the installer launching a script whose path is a constant (`:152`).
+- `/pair` keeps both gates unchanged; `/api/pair/status` keeps its loopback gate and its
+  one-boolean response.
+- The tutorial text is a static literal. Nothing from a client reaches the page.
+- **KI-019 is not made worse but is made more visible** — any LAN peer can already pop the PIN
+  page full-screen because `pair_show_on_box` fires unconditionally at `:10999`. Worth fixing in
+  the same pass or explicitly deferring, not silently ignoring.
+
+---
+
+## 5. Tests
+
+New `tests/test_pair_page.py`, `check(cond, label)` style (canonical per DECISIONS 2026-07-19),
+pure stdlib, its own CI step:
+
+- `/pair` from a non-loopback peer → 403.
+- `/pair` from loopback with a foreign `Host` header → 403 (anti-DNS-rebinding).
+- Idle page: contains the three step labels **and** the `/api/pair/status` poll.
+- Live-PIN state: `render_pin_page` output unchanged — the PIN, not the tutorial.
+- Bonus, closes part of **KI-020**: exercise `pair_pin_start` / `pair_pin_check` (wrong PIN
+  counts an attempt, cap burns the session, expiry clears it).
+
+---
+
+## 6. Verification — the honest version
+
+**The web harness cannot prove this.** It renders the app, not the agent's own HTML, and the
+target browser is Steam's CEF, not Chrome.
+
+1. **Unproven and load-bearing: whether Steam's built-in browser renders CSS `@keyframes` and
+   inline `<svg>` at all.** Test it before writing the finished page — throw a minimal animated
+   page at a box and look. If CEF disappoints, fall back to a JS `setInterval` class swap.
+2. Prove on the real box (`10.1.1.60`, was running agent 2.9.37 on 2026-07-21) with
+   `/api/screen/frame` capture — the only way to see the TV. **Both sessions: Game Mode and
+   desktop.** They take different launcher branches.
+3. **Observe both states** (CLAUDE.md §11.2): the idle tutorial AND the reload-into-PIN handoff.
+   A tutorial that never hands off is exactly the bug this design can ship.
+4. SSH-run install has no `DISPLAY`. The launcher's gamescope branch may still work via steam
+   IPC — **test it**, and make sure a failure is silent (the terminal QR still prints).
+5. Re-run the installer on an already-paired box and confirm **nothing pops**.
+
+---
+
+## 7. Ship cost
+
+Agent + installer only — **no app release, no store review**. But `install.sh` is a signed
+release asset mirrored to couchside.tv, so shipping means: `scripts/release-agent.sh`,
+`scripts/sign-release.sh`, then the ets3d `sync-installer.mjs` pass (its `--check` drift gate
+fails the website deploy otherwise).
+
+---
+
+## 8. Explicitly out of scope
+
+- The phone-side card — separate spec, `project_interactive-setup-card.md`.
+- A recorded GIF asset — see §2.
+- Full onboarding (what Couchside is, troubleshooting, Wi-Fi/VPN/iOS-permission help). A wall of
+  text on a TV is where onboarding dies.
+- Windows agent: it has **no PIN pairing at all**. Untouched here.

--- a/install.sh
+++ b/install.sh
@@ -165,12 +165,14 @@ OLD_INSTALLS=(
 NO_SUDOERS=0
 UNINSTALL=0
 NO_DECKY=0
+NO_OPEN=0
+FRESH_TOKEN=0   # flipped to 1 only on a truly fresh token mint (see below)
 
 usage() {
     cat <<'USAGE'
 Couchside box agent installer. Run ON the box as your desktop user.
 
-Usage: install.sh [--no-sudoers] [--no-decky] [--screensaver] [--no-screensaver] [--uninstall] [--help]
+Usage: install.sh [--no-sudoers] [--no-decky] [--screensaver] [--no-screensaver] [--no-open] [--uninstall] [--help]
 
   (no flags)        install/upgrade the agent (idempotent, safe to re-run)
   --no-sudoers      skip installing /etc/sudoers.d/couchside (high-danger
@@ -178,6 +180,8 @@ Usage: install.sh [--no-sudoers] [--no-decky] [--screensaver] [--no-screensaver]
   --no-decky        skip the Decky Loader Game Mode panel even if Decky is found
   --screensaver     install the Couchside screensaver add-on without asking
   --no-screensaver  skip the Couchside screensaver add-on
+  --no-open         don't auto-open the on-screen pairing tutorial on a fresh
+                    install (it only ever opens on a first install anyway)
   --uninstall       remove the agent (asks before deleting the token/sudoers)
   --help            this text
 
@@ -193,6 +197,7 @@ for arg in "$@"; do
         --no-decky)       NO_DECKY=1 ;;
         --screensaver)    COUCHSIDE_SCREENSAVER=1 ;;
         --no-screensaver) COUCHSIDE_SCREENSAVER=0 ;;
+        --no-open)        NO_OPEN=1 ;;
         --uninstall)      UNINSTALL=1 ;;
         --help|-h)        usage; exit 0 ;;
         *) echo "error: unknown flag: $arg" >&2; usage >&2; exit 2 ;;
@@ -601,6 +606,10 @@ elif [ -n "$MIGRATED_TOKEN" ]; then
     sudo cp "$MIGRATED_TOKEN" "$TOKEN_FILE"
 else
     note "generating new pairing token"
+    # FRESH install (no prior token, nothing migrated) — this is the ONE case
+    # the pairing tutorial auto-opens for. The two branches above keep their
+    # token, so re-runs and upgrades leave FRESH_TOKEN at 0 and stay silent.
+    FRESH_TOKEN=1
     if command -v openssl >/dev/null 2>&1; then
         openssl rand -hex 24 | sudo tee "$TOKEN_FILE" > /dev/null
     else
@@ -1728,9 +1737,25 @@ else
 fi
 
 echo
-echo "To re-show the pairing QR later without a terminal: launch the"
-echo "'Couchside — Pair Phone' tile from your Steam library (Game Mode included"
-echo ", it opens in Steam's built-in browser). If the tile isn't there yet,"
-echo "restart Steam once, or add $PAIR_SCRIPT via Steam > Add a Non-Steam Game."
+echo "On your phone: install Couchside (App Store / Google Play), open it, go to"
+echo "the Setup tab and tap Scan for boxes — or point your camera at the link"
+echo "above. A 6-digit PIN will appear on this box's screen; type it in to pair."
+echo
+echo "To re-show this later without a terminal: launch the 'Couchside — Pair"
+echo "Phone' tile from your Steam library (Game Mode included, it opens in Steam's"
+echo "built-in browser). If the tile isn't there yet, restart Steam once, or add"
+echo "$PAIR_SCRIPT via Steam > Add a Non-Steam Game."
+
+# FRESH INSTALL ONLY: put the animated pairing tutorial on the box's own screen,
+# so a stranger standing at a finished terminal isn't left guessing what to do
+# next. Best-effort and DETACHED — never block the install, never fail it. The
+# launcher itself picks the right surface (Game Mode -> Steam's browser; desktop
+# -> a browser; else it just prints the URL), and an SSH install with no DISPLAY
+# simply no-ops while the terminal QR above still stands. Only on a fresh token
+# (FRESH_TOKEN) and only unless the caller passed --no-open.
+if [ "$FRESH_TOKEN" = "1" ] && [ "$NO_OPEN" != "1" ] && [ -x "$PAIR_SCRIPT" ]; then
+    ( setsid "$PAIR_SCRIPT" >/dev/null 2>&1 & ) 2>/dev/null || true
+    note "opened the pairing tutorial on this box's screen (--no-open to skip)"
+fi
 
 } # end partial-download guard — see the matching `{` near the top

--- a/tests/test_pair_page.py
+++ b/tests/test_pair_page.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Tests for the on-box pairing page — the idle tutorial, the PIN, the handoff,
+the two gates, and the KI-019 box-pop throttle.
+
+Run: python3 tests/test_pair_page.py
+
+WHY THIS EXISTS. `/pair` renders the pairing TOKEN as a QR and the live PIN, so
+it is gated to loopback on TWO axes (peer IP and Host header, anti-DNS-rebinding)
+— get either wrong and a LAN peer reads a box's token off its own screen. The
+gate tests below are the point of this file. It also covers what KI-020 flagged
+as untested: the PIN start/check state machine (attempt cap, expiry, single-use).
+
+The idle tutorial and its handoff-to-PIN are new (the pairing-tutorial feature).
+The handoff — idle page reloads into the PIN the instant a session starts — is
+the one bug the design can ship: a tutorial that never hands off. It was proven
+end to end on a real box's CEF, but the page's structural half (it polls, and it
+reloads on active===true) is asserted here so a refactor can't quietly break it.
+"""
+import importlib.util
+import os
+import sys
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# --- the two loopback gates ------------------------------------------------
+# _is_loopback and _host_header_is_local are plain methods reading
+# self.client_address / self.headers, so a tiny stand-in exercises them without
+# a socket. Half the security model is here; the other half is that /pair only
+# ever calls these, verified by reading the dispatch.
+
+class FakeHeaders(dict):
+    def get(self, k, default=None):
+        return dict.get(self, k, default)
+
+
+class FakePeer:
+    def __init__(self, ip, host_header):
+        self.client_address = (ip, 12345)
+        self.headers = FakeHeaders({"Host": host_header} if host_header else {})
+
+
+def test_loopback_gate():
+    print("test_loopback_gate")
+    il = cs.Handler._is_loopback
+    check("127.0.0.1 is loopback", il(FakePeer("127.0.0.1", "")), True)
+    check("::1 is loopback", il(FakePeer("::1", "")), True)
+    check("v4-mapped ::ffff:127.0.0.1 is loopback",
+          il(FakePeer("::ffff:127.0.0.1", "")), True)
+    # THE refusal: a real LAN peer must NOT pass. This is the gate that keeps a
+    # box's token off the LAN.
+    check("10.x LAN peer is NOT loopback", il(FakePeer("10.1.1.50", "")), False)
+    check("192.168 LAN peer is NOT loopback", il(FakePeer("192.168.1.9", "")), False)
+
+
+def test_host_header_gate():
+    print("test_host_header_gate")
+    hl = cs.Handler._host_header_is_local
+    check("Host localhost:8787 is local", hl(FakePeer("127.0.0.1", "localhost:8787")), True)
+    check("Host 127.0.0.1 is local", hl(FakePeer("127.0.0.1", "127.0.0.1:8787")), True)
+    check("Host [::1] is local", hl(FakePeer("127.0.0.1", "[::1]:8787")), True)
+    # Anti-DNS-rebinding: a loopback PEER with an attacker Host must be refused.
+    # This is exactly the case _is_loopback alone would wave through.
+    check("Host attacker.tld is NOT local",
+          hl(FakePeer("127.0.0.1", "attacker.tld:8787")), False)
+    check("Host a public IP is NOT local",
+          hl(FakePeer("127.0.0.1", "203.0.113.7:8787")), False)
+
+
+# --- the idle tutorial page ------------------------------------------------
+
+def test_idle_page_has_the_tutorial():
+    print("test_idle_page_has_the_tutorial")
+    html = cs.render_pair_page("a" * 64, 8787)
+    check("step 1 present", "Open Couchside on your phone" in html, True)
+    check("step 2 present", "Scan for boxes" in html, True)
+    check("step 3 present", "6-digit PIN appears here" in html, True)
+    # The QR must survive — the Steam tile's documented job is re-showing it.
+    check("QR canvas kept", 'id="qr"' in html and "qrcode(0)" in html, True)
+    # CSS animation, not JS — the phone mock cross-fades on @keyframes.
+    check("keyframe animation present", "@keyframes cs" in html, True)
+    check("inline svg present", "<svg" in html and "</svg>" in html, True)
+
+
+def test_idle_page_hands_off():
+    print("test_idle_page_hands_off")
+    html = cs.render_pair_page("a" * 64, 8787)
+    # THE HANDOFF, asserted structurally: it polls status and reloads when a
+    # session goes active. Both halves must be present or the tutorial strands
+    # the user on a page that never becomes the PIN.
+    check("polls /api/pair/status", "/api/pair/status" in html, True)
+    check("reloads on active", "location.reload()" in html, True)
+    check("guards against active===false", "active===true" in html, True)
+
+
+def test_live_pin_page_is_the_pin_not_the_tutorial():
+    """When a session is live the route serves render_pin_page, NOT the tutorial.
+    The two must not blur: the PIN page is a single huge number, nothing else."""
+    print("test_live_pin_page_is_the_pin_not_the_tutorial")
+    pin_html = cs.render_pin_page("123456")
+    check("shows the PIN prompt", "ENTER THIS PIN IN THE APP" in pin_html, True)
+    check("no tutorial steps on the PIN page",
+          "Open Couchside on your phone" not in pin_html, True)
+    check("no QR on the PIN page", "qrcode(0)" not in pin_html, True)
+
+
+# --- the PIN state machine (KI-020) ----------------------------------------
+
+def _reset_pin():
+    with cs.PAIR_PIN_LOCK:
+        cs.PAIR_PIN = None
+
+
+def test_pin_start_is_debounced_and_marks_fresh():
+    print("test_pin_start_is_debounced_and_marks_fresh")
+    _reset_pin()
+    pin1, ttl1, fresh1 = cs.pair_pin_start()
+    check("first start is fresh", fresh1, True)
+    check("ttl is the full window", ttl1, cs.PAIR_PIN_TTL)
+    pin2, _ttl2, fresh2 = cs.pair_pin_start()
+    # Within the debounce window: same PIN, NOT fresh. This is what gates the
+    # box-screen pop (KI-019) — a double-tap must not re-throw the page onto the
+    # TV.
+    check("second start within debounce is NOT fresh", fresh2, False)
+    check("second start returns the SAME pin", pin2, pin1)
+
+
+def test_pin_check_counts_attempts_and_caps():
+    print("test_pin_check_counts_attempts_and_caps")
+    _reset_pin()
+    pin, _ttl, _fresh = cs.pair_pin_start()
+    wrong = "000000" if pin != "000000" else "111111"
+    for i in range(cs.PAIR_PIN_MAX_ATTEMPTS):
+        try:
+            cs.pair_pin_check(wrong)
+            check("wrong pin should raise (attempt %d)" % i, True, False)
+        except ValueError as e:
+            check("attempt %d rejected" % i, "wrong PIN" in str(e), True)
+    # Cap reached: the session is burned, even a CORRECT pin now fails.
+    try:
+        cs.pair_pin_check(pin)
+        check("correct pin after cap should raise", True, False)
+    except ValueError as e:
+        check("cap burns the session", "too many" in str(e), True)
+
+
+def test_pin_check_is_single_use():
+    print("test_pin_check_is_single_use")
+    _reset_pin()
+    pin, _ttl, _fresh = cs.pair_pin_start()
+    check("correct pin accepted once", cs.pair_pin_check(pin), True)
+    # Consumed on success — a replay must not pair again.
+    try:
+        cs.pair_pin_check(pin)
+        check("replay should raise", True, False)
+    except ValueError as e:
+        check("session consumed on success", "no active pairing" in str(e), True)
+
+
+def test_pin_expiry_clears_the_session():
+    print("test_pin_expiry_clears_the_session")
+    _reset_pin()
+    pin, _ttl, _fresh = cs.pair_pin_start()
+    # Force expiry without sleeping 120s.
+    with cs.PAIR_PIN_LOCK:
+        cs.PAIR_PIN["expires"] = time.monotonic() - 1
+    check("expired session reports inactive", cs.pair_pin_active(), None)
+    try:
+        cs.pair_pin_check(pin)
+        check("check on expired should raise", True, False)
+    except ValueError as e:
+        check("expiry clears the session", "no active pairing" in str(e), True)
+
+
+# --- KI-019: the box-screen pop is throttled -------------------------------
+
+def test_box_pop_is_rate_limited():
+    """KI-019: any LAN peer could pop the page full-screen repeatedly. The pop
+    is now gated on a fresh mint AND throttled. Here we prove the throttle: back
+    -to-back pops fire ONCE."""
+    print("test_box_pop_is_rate_limited")
+    fired = []
+    real = cs.pair_show_on_box_url
+    cs.pair_show_on_box_url = lambda url: fired.append(url)
+    # reset the cooldown clock so this test is order-independent
+    with cs._BOX_POP_LOCK:
+        cs._BOX_POP_AT[0] = 0.0
+    try:
+        cs.pair_show_on_box(8787)
+        cs.pair_show_on_box(8787)
+        cs.pair_show_on_box(8787)
+        check("three rapid pops fire exactly once", len(fired), 1)
+    finally:
+        cs.pair_show_on_box_url = real
+
+
+if __name__ == "__main__":
+    for fn in (test_loopback_gate,
+               test_host_header_gate,
+               test_idle_page_has_the_tutorial,
+               test_idle_page_hands_off,
+               test_live_pin_page_is_the_pin_not_the_tutorial,
+               test_pin_start_is_debounced_and_marks_fresh,
+               test_pin_check_counts_attempts_and_caps,
+               test_pin_check_is_single_use,
+               test_pin_expiry_clears_the_session,
+               test_box_pop_is_rate_limited):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Aims squarely at the measured funnel gap: **~9–15 app downloads in the first six days after the store launch, ~0 boxes paired.** The last mile was a stranger standing at a finished install terminal with no idea what to do next.

## What it does

The idle `/pair` page (shown when no PIN session is live) grows a **three-step tutorial beside the QR** — open the app, Setup → Scan, tap this box — with an inline-`<svg>` phone mock cross-fading three scenes on pure CSS `@keyframes`. The instant a pairing starts it polls `/api/pair/status`, sees `active===true`, and reloads; the route then serves the PIN page, so **the tutorial becomes the very PIN it was teaching about.**

`install.sh` opens it on the box's own screen on a **fresh install only** (gated on the new-token branch), detached and best-effort — never blocks or fails the install, and an SSH install with no `DISPLAY` just no-ops. Adds `--no-open`. The closing text now actually tells the user to open the app on their phone.

## Security shape

No new route, no new field, no new client input. The one existing idle render branch changes; `/api/pair/status` keeps returning one boolean; both loopback gates on `/pair` (peer IP **and** Host header, anti-DNS-rebinding) are untouched. Tutorial text is a static literal.

## Also fixes KI-019

`/api/pair/start` popped the box screen **unconditionally**, so any LAN peer could throw the pairing page onto the TV on repeat — the debounce comment claimed to prevent exactly this. `pair_pin_start` now reports whether it minted a fresh PIN; the pop fires **only on fresh**, and `pair_show_on_box` is throttled to one pop per 5s as defence in depth.

## Verified on real hardware — the web harness can't prove any of this

It renders the app, not the agent's HTML, and the target is Steam's CEF, not Chrome. So, on the boxes:

- **CSS `@keyframes` + inline SVG render *and cycle* on Steam's CEF** — SteamOS (Legion Go S) **and** Bazzite, captured via `/api/screen/frame`. (This retired the one load-bearing unknown in the spec.)
- **The full handoff, end to end, on the Legion Go S:** idle tutorial → `POST /api/pair/start` → the page reloaded itself into the big PIN (`069729`). **Both states observed on the actual TV** — a tutorial that never hands off was the one shippable bug in this design.
- **A layout bug the browser at 1280 hid:** at the box's ~960px CEF width the QR wrapped below the fold. Restructured to two columns and re-verified on the box that it fits one screen with no scroll.

## Tests

`tests/test_pair_page.py` (own CI step): both loopback gates incl. the anti-DNS-rebinding Host check, the tutorial content + the handoff poll, the PIN page staying the PIN not the tutorial, the PIN state machine (attempt cap / expiry / single-use — previously untested, **KI-020**), and the KI-019 throttle (**mutation-checked**: neutering the cooldown fails it). Also boot-tested in `--mock`: `/pair` loopback → 200 tutorial, foreign Host → 403.

## Housekeeping

Recovers the design spec from branch `feat/pairing-tutorial` into `docs/memory/project_pairing-tutorial.md` — it had never been on main.

## Not done

The Windows agent has no PIN pairing at all; untouched. Ships as agent-only (no app release) but `install.sh` is a signed release asset, so shipping needs `release-agent.sh` + `sign-release.sh` + the ets3d `sync-installer.mjs` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)