### PR TITLE
Auto-bump couchside.tv/app-version.json on each Play release

### DIFF
--- a/scripts/play-release-notes.py
+++ b/scripts/play-release-notes.py
@@ -26,6 +26,7 @@ Requires `cryptography` (already used by the ASC tooling) — no google SDK.
 import argparse
 import json
 import os
+import subprocess
 import sys
 import time
 import urllib.error
@@ -135,6 +136,22 @@ def main() -> None:
         {"track": a.track, "releases": releases})
     api(token, "POST", f"/edits/{edit_id}:commit")
     print(f"OK: release notes set for versionCode {a.version_code} on '{a.track}' and committed.")
+
+    # Keep couchside.tv/app-version.json (the Android update-check source) in step
+    # with this release. Best-effort and non-fatal: the notes are already
+    # committed, so a missing ets3d checkout or a deploy hiccup must WARN, never
+    # unwind the release. Skipped for non-production tracks (only the live
+    # listing feeds the in-app check).
+    if a.track == "production":
+        pub = os.path.join(REPO_ROOT, "scripts", "publish-app-version.py")
+        try:
+            print("==> updating couchside.tv/app-version.json for the Android update check")
+            subprocess.run([sys.executable, pub, "--version-code", str(a.version_code)],
+                           check=True)
+        except Exception as e:  # noqa: BLE001 - best-effort, must not fail the release
+            print(f"WARNING: could not update app-version.json ({e}). Run manually:\n"
+                  f"         scripts/publish-app-version.py --version-code {a.version_code}",
+                  file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/publish-app-version.py
+++ b/scripts/publish-app-version.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""publish-app-version.py — keep couchside.tv/app-version.json in step with a Play release.
+
+The app's "check for app update" reads this file ONLY on Android (iOS asks Apple
+directly). So on every Play release the manifest's android.versionCode has to be
+bumped, or Android users get a stale answer forever. This automates that: it
+rewrites the manifest in the ets3d site repo, commits, and deploys.
+
+    scripts/publish-app-version.py                 # versions from app/app.json
+    scripts/publish-app-version.py --version-code 59 --version 2.9.22
+    scripts/publish-app-version.py --no-deploy     # write + commit only
+
+The ets3d checkout is found via --site-dir, then $COUCHSIDE_SITE_DIR, then
+~/Developer/ets3d. iOS needs nothing here.
+
+play-release-notes.py calls this automatically after setting the Play notes
+(best-effort — a failure warns, it does not undo the notes).
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_JSON = os.path.join(REPO_ROOT, "app", "app.json")
+MANIFEST_REL = os.path.join("couchside", "app-version.json")
+
+
+def app_json_versions():
+    """(marketing_version, android_version_code) from app/app.json."""
+    d = json.load(open(APP_JSON, encoding="utf-8"))["expo"]
+    return d["version"], int(d["android"]["versionCode"])
+
+
+def find_site_dir(explicit):
+    for cand in (explicit, os.environ.get("COUCHSIDE_SITE_DIR"),
+                 os.path.expanduser("~/Developer/ets3d")):
+        if cand and os.path.isdir(os.path.join(cand, "couchside")):
+            return cand
+    return None
+
+
+def main():
+    ver_default, vc_default = app_json_versions()
+    p = argparse.ArgumentParser()
+    p.add_argument("--version", default=ver_default,
+                   help="marketing version shown to users (default: app/app.json)")
+    p.add_argument("--version-code", type=int, default=vc_default,
+                   help="Android versionCode that just went live (default: app/app.json)")
+    p.add_argument("--site-dir", default=None,
+                   help="ets3d site checkout (default: $COUCHSIDE_SITE_DIR or ~/Developer/ets3d)")
+    p.add_argument("--no-deploy", action="store_true",
+                   help="write + commit the manifest but do not push/deploy")
+    a = p.parse_args()
+
+    site = find_site_dir(a.site_dir)
+    if not site:
+        sys.exit("error: ets3d site checkout not found. Pass --site-dir or set "
+                 "$COUCHSIDE_SITE_DIR (needs a couchside/ subdir).")
+    manifest = os.path.join(site, MANIFEST_REL)
+    if not os.path.isfile(manifest):
+        sys.exit(f"error: manifest missing: {manifest}")
+
+    d = json.load(open(manifest, encoding="utf-8"))
+    android = d.setdefault("android", {})
+    if android.get("versionCode") == a.version_code and android.get("version") == a.version:
+        print(f"already current: android {a.version} / vc {a.version_code} — nothing to do.")
+        return
+    android["versionCode"] = a.version_code
+    android["version"] = a.version
+    android.setdefault(
+        "url", "https://play.google.com/store/apps/details?id=com.ets3d.rescueremote")
+    with open(manifest, "w", encoding="utf-8") as f:
+        json.dump(d, f, indent=2)
+        f.write("\n")
+    print(f"==> {MANIFEST_REL}: android -> {a.version} / vc {a.version_code}")
+
+    def git(*args):
+        subprocess.run(["git", "-C", site, *args], check=True)
+
+    git("add", MANIFEST_REL)
+    git("commit", "-m",
+        f"couchside: app-version.json android {a.version} / vc {a.version_code} (Play release)")
+    if a.no_deploy:
+        print(f"--no-deploy: committed. To publish:  cd {site} && git push && npm run deploy")
+        return
+    git("push")
+    print("==> npm run deploy (production)")
+    subprocess.run(["npm", "run", "deploy"], cwd=site, check=True)
+    print("OK: manifest bumped and couchside.tv deployed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automates the one manual follow-up from the app-update-check work: keeping `couchside.tv/app-version.json` (the **Android** update-check source) in step with Play.

- **`scripts/publish-app-version.py`** — rewrites the ets3d manifest's `android.versionCode` + `version` (defaults from `app/app.json`), commits, and `npm run deploy`s. Idempotent (no-op when already current). Finds the ets3d checkout via `--site-dir` / `$COUCHSIDE_SITE_DIR` / `~/Developer/ets3d`. `--no-deploy` stops at the commit.
- **`play-release-notes.py`** calls it after committing the Play notes — **production track only**, and **best-effort**: the notes are already live, so a missing checkout or deploy hiccup *warns* with the manual command, it never unwinds the release.

iOS needs nothing — the app queries Apple's App Store lookup directly and never reads this file.

**Verified:** idempotent no-op on the live vc55; the write+commit path on a throwaway vc (then reset the ets3d tree). `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)