### PR TITLE
Release 2.9.22 — agent 2.9.47 span notes + app version bump + whatsnew

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -20,10 +20,19 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.47
 
-Update your box's operating system from the phone too, on SteamOS and Bazzite.
-Same one-time opt-in as app updates (`couchside allow-system-updates on`). An
-OS update is staged and applies on the next reboot — the app tells you that
-plainly rather than pretending it finished.
+Update your whole box from the couch, plus a friendlier first pairing.
+
+- **Update your Flatpak apps and your operating system from the phone** (SteamOS
+  and Bazzite), together or one at a time. Since system updates need root, it's
+  a one-time opt-in you turn on at the box — `couchside allow-system-updates on`
+  — which spells out exactly what it grants. An OS update is staged and applies
+  on the next reboot; the app says so plainly instead of pretending it finished.
+- **A fresh install now shows a short guide right on the box's screen** — open
+  the app, scan, tap this box — that turns into the pairing PIN the moment you
+  start. And a device on your network can no longer pop that pairing screen onto
+  your TV over and over.
+- **Closing the running game from your phone actually closes it now** — the
+  button used to report success while the game kept running.
 
 ## 2.9.46
 

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.21",
+    "version": "2.9.22",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,9 +1,8 @@
-New in 2.9.21
+New in 2.9.22
 
-• Game cover art now shows on Android — it never did before.
-• Search your games on the Launch tab, and fold away Stream from PC.
-• Close the running game from your phone.
-• New Steam search button: opens search on the box and brings up your keyboard.
-• Storage now reports how full drives really are, and shows game drives like SD cards.
-• Handhelds show battery draw, power profile, and time until full.
-• Watch what your box is doing while it updates.
+• Update your box from your phone — Flatpak apps and the OS (SteamOS/Bazzite), together or one at a time. Turn it on once at the box.
+• A fresh install now walks you through pairing on the box's own screen.
+• Search your Preferences by typing.
+• Check for an app update in Setup › Account — it asks your store directly, sends nothing about you.
+• Closing the running game from your phone now actually works.
+• Swipe traces draw a clean glowing line.


### PR DESCRIPTION
Release-prep for the 2.9.22 / agent 2.9.47 chain.

- **agent/CHANGELOG 2.9.47** rewritten to cover the whole **2.9.44→2.9.47** span (update hub, pairing tutorial + KI-019, Close Game fix) — release-agent.sh publishes only the newest section and boxes skip versions.
- **app.json 2.9.21 → 2.9.22**; EAS autoIncrement handles build numbers (floors vc≥56 / iOS≥76).
- **whatsnew-en-US.txt** for 2.9.22 (483/500, under Play's cap).

Docs/config only. Merge → tag v2.9.22 → release-agent.sh + EAS builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)