### PR TITLE
Pairing page: store QR codes + reliable desktop-mode open (agent 2.9.48)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,19 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.48
+
+The first-pairing screen now helps you get the app, and it opens reliably from
+Desktop Mode.
+
+- **The pairing screen shows App Store and Google Play QR codes** — if you don't
+  have Couchside on your phone yet, scan one to install it, then scan the big
+  code to pair. No hunting through a store.
+- **The guide now actually opens after a Desktop-Mode install.** On SteamOS's
+  KDE desktop it was silently failing to launch a browser, so nothing appeared;
+  it now opens a real browser full-screen (Firefox, Chrome, Chromium, Brave, or
+  Edge — whichever you have).
+
 ## 2.9.47
 
 Update your whole box from the couch, plus a friendlier first pairing.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.47"
+VERSION = "2.9.48"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -11443,6 +11443,12 @@ def render_pair_page(token, port):
     url_js = json.dumps(pair_url)          # safe JS string literal
     url_html = (pair_url.replace("&", "&amp;").replace("<", "&lt;")
                         .replace(">", "&gt;"))  # safe HTML text
+    # Store links for the "get the app first" QR codes. A fresh installer who
+    # does not have Couchside yet scans one of these to install; the big QR
+    # above is for someone who already has it. Both are static, public URLs.
+    ios_js = json.dumps("https://apps.apple.com/app/id6786884115")
+    play_js = json.dumps(
+        "https://play.google.com/store/apps/details?id=com.ets3d.rescueremote")
     return (
         "<!doctype html><html lang=\"en\"><head>"
         "<meta charset=\"utf-8\">"
@@ -11473,6 +11479,16 @@ def render_pair_page(token, port):
         "justify-content:center;}"
         ".step b{font-size:min(3vmin,20px);font-weight:600;color:#e8ecf3;}"
         ".step span{display:block;color:#9aa4b2;font-size:min(2.4vmin,15px);margin-top:.3vmin;}"
+        # The two store QR codes under step 1 (App Store + Google Play). Small
+        # white cards -- a phone reads them up close, so they can be compact and
+        # still fit the one-screen budget. image-rendering:pixelated keeps the
+        # modules crisp when CSS scales the canvas.
+        ".stores{display:flex;gap:min(2.6vmin,18px);margin-top:1.2vmin;}"
+        ".store{display:flex;flex-direction:column;align-items:center;gap:.5vmin;}"
+        ".sqr{background:#fff;border-radius:9px;padding:min(1.1vmin,7px);line-height:0;}"
+        ".sqr canvas{display:block;image-rendering:pixelated;"
+        "width:min(15vmin,104px);height:min(15vmin,104px);}"
+        ".slabel{color:#9aa4b2;font-size:min(2.1vmin,12px);font-weight:600;}"
         # The QR keeps its white card exactly as before -- do not restyle it, the
         # camera has to read it.
         ".card{background:#fff;border-radius:20px;padding:min(3.4vmin,28px);"
@@ -11526,8 +11542,16 @@ def render_pair_page(token, port):
         "fill=\"#7dd3fc\"/></g></svg>"
         "<div class=\"steps\">"
         "<div class=\"step\"><div class=\"num\">1</div><div>"
-        "<b>Open Couchside on your phone</b>"
-        "<span>Free on the App Store &amp; Google Play.</span></div></div>"
+        "<b>Get Couchside on your phone</b>"
+        "<span>Don&rsquo;t have it? Scan a store code to install &mdash; free.</span>"
+        "<div class=\"stores\">"
+        "<div class=\"store\">"
+        "<div class=\"sqr\"><canvas id=\"qr-ios\" width=\"104\" height=\"104\"></canvas></div>"
+        "<div class=\"slabel\">App Store</div></div>"
+        "<div class=\"store\">"
+        "<div class=\"sqr\"><canvas id=\"qr-play\" width=\"104\" height=\"104\"></canvas></div>"
+        "<div class=\"slabel\">Google Play</div></div>"
+        "</div></div></div>"
         "<div class=\"step\"><div class=\"num\">2</div><div>"
         "<b>Setup tab &rarr; Scan for boxes</b>"
         "<span>Then tap this box in the list.</span></div></div>"
@@ -11546,18 +11570,26 @@ def render_pair_page(token, port):
         "<script>\n" + PAIR_QR_JS + "\n"
         "(function(){\n"
         "  var url = " + url_js + ";\n"
-        "  try {\n"
-        "    var qr = qrcode(0); qr.addData(url); qr.make();\n"
+        "  var iosUrl = " + ios_js + ";\n"
+        "  var playUrl = " + play_js + ";\n"
+        "  function drawQR(id, text, box, minpx){\n"
+        "    var canvas = document.getElementById(id);\n"
+        "    if (!canvas) return;\n"
+        "    var qr = qrcode(0); qr.addData(text); qr.make();\n"
         "    var n = qr.getModuleCount();\n"
         "    var quiet = 4, total = n + quiet*2;\n"
-        "    var canvas = document.getElementById('qr');\n"
-        "    var px = Math.max(4, Math.floor(300/total));\n"
+        "    var px = Math.max(minpx, Math.floor(box/total));\n"
         "    var size = total*px; canvas.width = size; canvas.height = size;\n"
         "    var ctx = canvas.getContext('2d');\n"
         "    ctx.fillStyle = '#ffffff'; ctx.fillRect(0,0,size,size);\n"
         "    ctx.fillStyle = '#000000';\n"
         "    for (var r=0;r<n;r++){ for (var c=0;c<n;c++){ if (qr.isDark(r,c)) {\n"
         "      ctx.fillRect((c+quiet)*px,(r+quiet)*px,px,px); } } }\n"
+        "  }\n"
+        "  try {\n"
+        "    drawQR('qr', url, 300, 4);\n"
+        "    drawQR('qr-ios', iosUrl, 108, 2);\n"
+        "    drawQR('qr-play', playUrl, 108, 2);\n"
         "  } catch (e) {\n"
         "    document.getElementById('err').textContent = 'Could not render QR: ' + e;\n"
         "  }\n"

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "75",
+      "buildNumber": "76",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 58
+      "versionCode": 59
     },
     "web": {
       "bundler": "metro",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -294,6 +294,22 @@ recommendation was wrong, not merely superseded.
 
 ## ✅ Completed
 
+### 2026-07-23 — Pairing page: store QR codes + reliable desktop-mode open (agent 2.9.48)
+Two follow-ups to the on-box pairing tutorial. **Store QR codes on `/pair`:** a fresh installer
+standing at the box can now scan an App Store or Google Play code to DOWNLOAD the app, not just
+pair — two compact QRs under step 1, drawn by the same offline `PAIR_QR_JS` canvas generator (no
+new asset, no network, static public URLs). Encoding of both store URLs proven through the real
+generator (iOS 29 modules, Play 37 — the longer Play URL still fits). **Desktop-mode open fixed:**
+`couchside-pair`'s desktop chain fell to `xdg-open`, which on SteamOS/KDE routes through
+`kfmclient` (not shipped) and fails silently — MEASURED LIVE on a Deck OLED in Desktop Mode
+2026-07-23. The chain now launches a real browser DIRECTLY with its own full-screen flag
+(Chrome/Chromium/Brave/Edge `--app --start-fullscreen`, Firefox `--kiosk`), Flatpak first then
+native, and only falls to kde-open5/gio (xdg-open LAST) then Steam CEF. **Rejected** auto-switching
+to Game Mode (owner floated it): a session switch tears down the desktop + install terminal.
+**NOT a bug:** the auto-open staying quiet on `couchside update` — it's `FRESH_TOKEN`-gated by
+design. Owner's live check still owed: on-box CEF render of the store QRs + a real-phone scan.
+See [[pairing-tutorial-on-box]].
+
 ### 2026-07-22 — Drag trail is a real stroke, verified on a device (#224)
 The 2.9.17 "Trace drags" pref drew a fading DOT every 20px; each shrank on appearance, so a
 fast drag pulled apart into beads. #224 replaced it with abutting rotated-View segments

--- a/install.sh
+++ b/install.sh
@@ -1026,18 +1026,39 @@ if [ "${XDG_CURRENT_DESKTOP:-}" = "gamescope" ] \
    || pgrep -x gamescope >/dev/null 2>&1; then
     exec steam -ifrunning "steam://openurl/${URL}"
 fi
-if command -v flatpak >/dev/null 2>&1 && flatpak info com.google.Chrome >/dev/null 2>&1; then
-    exec flatpak run com.google.Chrome --app="$URL" --start-fullscreen
-elif command -v flatpak >/dev/null 2>&1 && flatpak info org.chromium.Chromium >/dev/null 2>&1; then
-    exec flatpak run org.chromium.Chromium --app="$URL" --start-fullscreen
-elif command -v xdg-open >/dev/null 2>&1; then
-    exec xdg-open "$URL"
-elif command -v steam >/dev/null 2>&1; then
-    exec steam -ifrunning "steam://openurl/${URL}"
-else
-    echo "No browser launcher found. Open this URL on the box:"
-    echo "  $URL"
+
+# Desktop mode: open a real browser DIRECTLY, full-screen. We deliberately do
+# NOT lean on xdg-open here — on SteamOS/KDE it routes through kfmclient, which
+# is not installed, so it fails silently and the pairing page never appears.
+# Each browser gets its own full-screen flag: Chrome/Chromium/Brave/Edge take
+# --app + --start-fullscreen; Firefox takes --kiosk. Flatpak first (SteamOS
+# ships Flatpak and that's where its browsers live), then native binaries.
+if command -v flatpak >/dev/null 2>&1; then
+    if   flatpak info com.google.Chrome      >/dev/null 2>&1; then exec flatpak run com.google.Chrome      --app="$URL" --start-fullscreen
+    elif flatpak info org.chromium.Chromium  >/dev/null 2>&1; then exec flatpak run org.chromium.Chromium  --app="$URL" --start-fullscreen
+    elif flatpak info com.brave.Browser      >/dev/null 2>&1; then exec flatpak run com.brave.Browser      --app="$URL" --start-fullscreen
+    elif flatpak info com.microsoft.Edge     >/dev/null 2>&1; then exec flatpak run com.microsoft.Edge     --app="$URL" --start-fullscreen
+    elif flatpak info org.mozilla.firefox    >/dev/null 2>&1; then exec flatpak run org.mozilla.firefox    --kiosk "$URL"
+    fi
 fi
+for b in google-chrome-stable google-chrome chromium chromium-browser brave-browser microsoft-edge; do
+    if command -v "$b" >/dev/null 2>&1; then exec "$b" --app="$URL" --start-fullscreen; fi
+done
+if command -v firefox >/dev/null 2>&1; then exec firefox --kiosk "$URL"; fi
+
+# No fullscreen-capable browser found. A plain window beats nothing — but pick a
+# working opener: kde-open5 / gio, then xdg-open LAST (it's the one that breaks
+# on KDE). Steam's built-in browser is the final fallback.
+for opener in kde-open5 gio xdg-open; do
+    if command -v "$opener" >/dev/null 2>&1; then
+        if [ "$opener" = "gio" ]; then exec gio open "$URL"; else exec "$opener" "$URL"; fi
+    fi
+done
+if command -v steam >/dev/null 2>&1; then
+    exec steam -ifrunning "steam://openurl/${URL}"
+fi
+echo "No browser launcher found. Open this URL on the box:"
+echo "  $URL"
 PAIREOF
 chmod +x "$PAIR_SCRIPT"
 note "wrote $PAIR_SCRIPT"

--- a/tests/test_pair_page.py
+++ b/tests/test_pair_page.py
@@ -88,7 +88,7 @@ def test_host_header_gate():
 def test_idle_page_has_the_tutorial():
     print("test_idle_page_has_the_tutorial")
     html = cs.render_pair_page("a" * 64, 8787)
-    check("step 1 present", "Open Couchside on your phone" in html, True)
+    check("step 1 present", "Get Couchside on your phone" in html, True)
     check("step 2 present", "Scan for boxes" in html, True)
     check("step 3 present", "6-digit PIN appears here" in html, True)
     # The QR must survive — the Steam tile's documented job is re-showing it.
@@ -96,6 +96,27 @@ def test_idle_page_has_the_tutorial():
     # CSS animation, not JS — the phone mock cross-fades on @keyframes.
     check("keyframe animation present", "@keyframes cs" in html, True)
     check("inline svg present", "<svg" in html and "</svg>" in html, True)
+
+
+def test_idle_page_has_store_qr_codes():
+    """A fresh installer without the app needs to install it first. The page
+    carries an App Store and a Google Play QR — the exact store URLs, on their
+    own canvases, drawn by the same offline generator as the pairing QR."""
+    print("test_idle_page_has_store_qr_codes")
+    html = cs.render_pair_page("a" * 64, 8787)
+    check("App Store QR canvas present", 'id="qr-ios"' in html, True)
+    check("Google Play QR canvas present", 'id="qr-play"' in html, True)
+    check("App Store URL encoded",
+          "https://apps.apple.com/app/id6786884115" in html, True)
+    check("Google Play URL encoded",
+          "https://play.google.com/store/apps/details?id=com.ets3d.rescueremote"
+          in html, True)
+    check("store labels present",
+          "App Store" in html and "Google Play" in html, True)
+    # All three QRs go through one generator — assert the store canvases are
+    # actually wired into a draw call, not just empty elements.
+    check("store canvases are drawn",
+          "drawQR('qr-ios'" in html and "drawQR('qr-play'" in html, True)
 
 
 def test_idle_page_hands_off():
@@ -116,7 +137,7 @@ def test_live_pin_page_is_the_pin_not_the_tutorial():
     pin_html = cs.render_pin_page("123456")
     check("shows the PIN prompt", "ENTER THIS PIN IN THE APP" in pin_html, True)
     check("no tutorial steps on the PIN page",
-          "Open Couchside on your phone" not in pin_html, True)
+          "Get Couchside on your phone" not in pin_html, True)
     check("no QR on the PIN page", "qrcode(0)" not in pin_html, True)
 
 
@@ -214,6 +235,7 @@ if __name__ == "__main__":
     for fn in (test_loopback_gate,
                test_host_header_gate,
                test_idle_page_has_the_tutorial,
+               test_idle_page_has_store_qr_codes,
                test_idle_page_hands_off,
                test_live_pin_page_is_the_pin_not_the_tutorial,
                test_pin_start_is_debounced_and_marks_fresh,


### PR DESCRIPTION
Two follow-ups to the on-box pairing tutorial (agent **2.9.48**), plus recording the shipped 2.9.22 app build numbers.

## Store QR codes on \`/pair\`
A fresh installer standing at the box can now scan an **App Store** or **Google Play** QR to *download* the app, not just to pair. Two compact codes under step 1, drawn by the same offline \`PAIR_QR_JS\` canvas generator (refactored into a shared \`drawQR\` helper) from static public store URLs — no new asset, no network, no client input.

## Reliable open in Desktop Mode
\`couchside-pair\`'s desktop chain fell to \`xdg-open\`, which on SteamOS/KDE routes through \`kfmclient\` (not shipped) and fails silently — so the tutorial **never opened after a Desktop-Mode install**. Confirmed live on a Steam Deck OLED 2026-07-23 (`kfmclient: command not found`). The chain now launches a real browser **directly** with its own full-screen flag (Chrome/Chromium/Brave/Edge \`--app --start-fullscreen\`, Firefox \`--kiosk\`), Flatpak first then native, only then \`kde-open5\`/\`gio\` (xdg-open last) and Steam CEF.

**Rejected** auto-switching to Game Mode (a session switch tears down the desktop + install terminal). The "didn't launch on \`couchside update\`" report is **not a bug** — the auto-open is \`FRESH_TOKEN\`-gated by design.

## Allowlist / constraints
- Store URLs are hardcoded constants — no client input.
- Launcher is installer-side — no client input.
- \`/pair\` stays double-gated (loopback + Host header), unchanged.

## Verified
- All 3 QRs encode through the real generator (iOS 29 modules, Play 37 — longer Play URL still fits).
- \`tests/test_pair_page.py\` extended: store QRs + exact URLs present and wired to \`drawQR\`. Full pair/flatpak/os agent suites pass.
- **NOT yet verified (owner's live check):** on-box CEF render of the store QRs + a real-phone scan of each store code.

Also commits the post-build autoIncrement numbers for the already-submitted 2.9.22 (Android vc59 / iOS build 76).

🤖 Generated with [Claude Code](https://claude.com/claude-code)