### PR TITLE
Desktop no longer shows a peripheral's charge as its own battery (agent 2.9.49)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,13 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.49
+
+Desktop PCs no longer show a phantom battery. If you had a wireless controller
+paired, its charge could appear as the machine's own battery — a desktop
+reading "On battery 15%" when it has no battery at all. The box now only reports
+its own pack, never a controller, mouse, or headset.
+
 ## 2.9.48
 
 The first-pairing screen now helps you get the app, and it opens reliably from

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.48"
+VERSION = "2.9.49"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -10002,6 +10002,26 @@ def read_box_battery():
         u = _uevent(os.path.join(_POWER_SUPPLY_DIR, name, "uevent"))
         kind = u.get("POWER_SUPPLY_TYPE")
         if kind == "Battery" and batt is None:
+            # A PERIPHERAL's battery -- a wireless controller, mouse, keyboard, or
+            # headset -- also appears here as TYPE=Battery. The kernel's HID
+            # battery driver marks those POWER_SUPPLY_SCOPE=Device; the machine's
+            # OWN pack is System, and every handheld/laptop measured (the Legion
+            # Go S BAT0 above) emits NO SCOPE line at all -- default System. A
+            # mains DESKTOP with a paired gamepad at 15% would otherwise report
+            # "On battery 15%" for the box (a real TestFlight bug, 2026-07-23).
+            # Skipping Device scope also fixes a latent mis-pick on handhelds: a
+            # MAC-named controller node can sort BEFORE BAT0 and be taken first
+            # (hence `continue`, not `break` -- a peripheral must never suppress
+            # the real pack). Degrade closed -- Device is never the machine's own
+            # battery. This mirrors UPower. Verified against kernel source
+            # (adversarial pass 2026-07-23): no in-tree main-battery driver (ACPI
+            # battery.c, sbs-battery, axp20x, bq27xxx, macsmc) emits a SCOPE line,
+            # so System/no-scope packs are always kept. Do NOT gate on a name
+            # allowlist like ^BAT instead: it would wrongly drop macsmc-battery
+            # (Apple Silicon / Asahi) and sbs-* (Chromebooks), breaking the
+            # "any systemd machine" promise. Scope is the principled signal.
+            if u.get("POWER_SUPPLY_SCOPE") == "Device":
+                continue
             # PRESENT=0 means a bay with no pack in it -- not this machine's
             # battery, and reporting 0% for it would be a lie.
             if u.get("POWER_SUPPLY_PRESENT") == "0":

--- a/tests/test_box_battery.py
+++ b/tests/test_box_battery.py
@@ -85,6 +85,27 @@ POWER_SUPPLY_TYPE=USB
 POWER_SUPPLY_ONLINE=0
 """
 
+# A wireless PERIPHERAL -- gamepad / mouse / headset -- ALSO shows up here as
+# TYPE=Battery. The kernel's HID battery driver marks it POWER_SUPPLY_SCOPE=Device,
+# which is the field that separates it from the machine's own pack. This is the
+# case a DESKTOP tester hit (TestFlight 2026-07-23): a non-laptop PC with a paired
+# controller at 15% reported "On battery 15%" for the box itself.
+#
+# Representative of the hid-input battery format (the discriminating line is
+# POWER_SUPPLY_SCOPE=Device); the NAME leads with a digit on purpose, so it sorts
+# BEFORE "BAT0" -- proving the SCOPE filter, not sort-order luck, is what keeps a
+# handheld reading its own pack when a controller is paired.
+HID_CONTROLLER = """DEVTYPE=power_supply
+POWER_SUPPLY_NAME=0005:054C:0CE6.0009-battery
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_SCOPE=Device
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_CAPACITY=15
+POWER_SUPPLY_CAPACITY_LEVEL=Normal
+POWER_SUPPLY_MODEL_NAME=Wireless Controller
+"""
+
 
 class Supplies:
     """A fake /sys/class/power_supply the REAL reader walks."""
@@ -332,6 +353,48 @@ POWER_SUPPLY_CAPACITY=%s
             s.close()
 
 
+def test_desktop_with_paired_controller_is_not_on_battery():
+    """THE reported bug: a mains DESKTOP with a wireless controller paired showed
+    "On battery 15%". The controller is TYPE=Battery but SCOPE=Device -- a
+    peripheral, not the machine's pack. The box has no battery of its own, so the
+    reading (and the whole card) must be absent, not the controller's 15%."""
+    print("test_desktop_with_paired_controller_is_not_on_battery")
+    s = Supplies({"0005:054C:0CE6.0009-battery": HID_CONTROLLER, "ACAD": ACAD_ONLINE})
+    try:
+        check("no box battery reported", cs.read_box_battery(), {})
+        check("cap is false on a desktop", cs.box_battery_available(), False)
+    finally:
+        s.close()
+
+
+def test_device_scope_alone_degrades_closed():
+    """A box whose ONLY battery-typed node is a peripheral has no own battery."""
+    print("test_device_scope_alone_degrades_closed")
+    s = Supplies({"0005:054C:0CE6.0009-battery": HID_CONTROLLER})
+    try:
+        check("device-scope peripheral ignored", cs.read_box_battery(), {})
+    finally:
+        s.close()
+
+
+def test_handheld_with_paired_controller_reads_its_own_pack():
+    """Control -- must NOT regress the hardware-verified handheld. With a paired
+    controller (SCOPE=Device, named to sort BEFORE BAT0) AND the real BAT0
+    (System, no SCOPE line) both present, the reader returns the machine's 58%,
+    never the controller's 15%. The old code took the first Battery node in sort
+    order, so the digit-leading controller name would have won."""
+    print("test_handheld_with_paired_controller_reads_its_own_pack")
+    s = Supplies({"0005:054C:0CE6.0009-battery": HID_CONTROLLER,
+                  "BAT0": BAT0, "ACAD": ACAD_OFFLINE})
+    try:
+        got = cs.read_box_battery()
+        check("its own pack, not the controller", got.get("pct"), 58)
+        check("its own status", got.get("status"), "Discharging")
+        check("cap is true on a handheld", cs.box_battery_available(), True)
+    finally:
+        s.close()
+
+
 if __name__ == "__main__":
     for fn in (test_real_handheld,
                test_watts_from_power_now,
@@ -347,7 +410,10 @@ if __name__ == "__main__":
                test_full_on_the_charger_reports_no_time_to_full,
                test_charging_reports_no_time_left,
                test_empty_bay_is_not_a_battery,
-               test_garbage_capacity_rejected):
+               test_garbage_capacity_rejected,
+               test_desktop_with_paired_controller_is_not_on_battery,
+               test_device_scope_alone_degrades_closed,
+               test_handheld_with_paired_controller_reads_its_own_pack):
         fn()
     if FAILURES:
         print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))


### PR DESCRIPTION
## The bug (TestFlight, 2026-07-23)
A mains **desktop** PC reported **"On battery 15%"** — it has no battery. The 15% was a paired wireless controller's charge, mistaken for the machine's own pack.

## Root cause
`read_box_battery` walked `/sys/class/power_supply` and took the **first** `POWER_SUPPLY_TYPE=Battery` node with no filter on `POWER_SUPPLY_SCOPE`. A wireless controller/mouse/headset surfaces there as `TYPE=Battery` too, marked `SCOPE=Device` by the kernel's HID battery drivers. The machine's own pack is `System`-scope or (on every handheld/laptop measured — the verbatim Legion Go S `BAT0`) emits **no SCOPE line at all**. So the peripheral leaked in. Worse: HID node names (`MAC:…-battery`) sort **before** `BAT0`, so on a handheld a paired controller could even **mask the real pack**.

## Fix
Skip `POWER_SUPPLY_SCOPE=Device` nodes (`continue`, not `break` — a peripheral must never suppress the real pack). Mirrors what UPower does.

## Verified
- **Reproduced** the exact bug: pre-fix returns `{'pct': 15, 'status': 'Discharging', 'on_ac': True}` for a desktop+controller fixture; post-fix returns `{}`.
- **Control:** the hardware-verified Legion Go S still reads its own **58%** with a controller paired (proves no regression + fixes the latent mis-pick).
- **Adversarial kernel-source review** (3 independent lenses + synthesis): no in-tree main-battery driver (ACPI `battery.c`, `sbs-battery`, `axp20x`, `bq27xxx`, `macsmc`) emits a SCOPE line → real packs always kept; only HID peripheral drivers set `Device`. A `^BAT` name allowlist was considered and **rejected as harmful** — it would drop `macsmc-battery` (Asahi) and `sbs-*` (Chromebooks). One theoretical residual (an out-of-tree driver omitting SCOPE) logged as KI-032; no live occurrence.
- Full `test_box_battery.py` suite (18 checks) green.

## Constraints
Degrade-closed area — a box with no readable **own** battery returns `{}` (no card), never a fabricated reading. No client input. App side unchanged (the card is status-driven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
