### PR TITLE
Stall-aware update page + detached updates that finish (agent 2.9.50)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,25 @@ jobs:
       - name: Unit tests (pairing page)
         run: python3 tests/test_pair_page.py
 
+      # The on-box UPDATE progress page. It polls /api/ping across the agent's
+      # own restart and must express THREE outcomes, not one: version changed
+      # (updated), unreachable a while (restarting), and reachable-but-unchanged
+      # for a long time (STALLED — the installer died before restarting, so the
+      # old agent keeps answering). The stall branch is the fix for a real box
+      # that span forever; this pins all three so a refactor cannot drop them.
+      - name: Unit tests (update page)
+        run: python3 tests/test_update_page.py
+
+      # The app-triggered-update sudo grant + detached fast-path (§3). A phone
+      # update on a system-service box stalled because the detached installer
+      # could not restart the service without a password. The fix adds ONE
+      # NOPASSWD grant — so its SHAPE is pinned here: exactly-argument (fixed unit
+      # + --no-block, no wildcard that could restart any unit), and the fast-path
+      # is gated (existing install, not Decky) and exits BEFORE the general-root
+      # setup it cannot do. A grant in the sudo path is where §3 bites hardest.
+      - name: Unit tests (update grant)
+        run: python3 tests/test_update_grant.py
+
       # The flatpak slice of the update hub. Asserts the SECURITY SHAPE (§3):
       # the update functions take zero client-reachable arguments, the elevated
       # argv is exactly the fixed root-owned wrapper (never raw flatpak, whose

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,20 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.50
+
+Two fixes for updating the box from your phone.
+
+- **The box's update screen now tells you if an update didn't finish**, instead
+  of spinning forever. If it stalls, it says the box is still on the old version
+  and how to retry.
+- **App-triggered updates now finish on more boxes.** On a box installed as a
+  system service, an update could quietly stop after downloading the new agent —
+  leaving the old one running — because it had no way to restart the service
+  without a password. It now restarts cleanly. On an existing box, re-run the
+  installer once (in a terminal) to enable this; after that, phone updates finish
+  on their own.
+
 ## 2.9.49
 
 Desktop PCs no longer show a phantom battery. If you had a wireless controller

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.49"
+VERSION = "2.9.50"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1538,26 +1538,64 @@ def render_update_page():
 <h1 id="t">Updating Couchside</h1>
 <p id="s">Keep the box powered on. This takes about a minute.</p>
 <p class="dots" id="d"><span>&#9679;</span><span>&#9679;</span><span>&#9679;</span></p>
+<p id="hint" style="display:none;font-size:.95rem;color:#6b7a90;margin-top:1.4rem"></p>
 </div><script>
-var was=null, misses=0;
+/* Poll /api/ping (the one pre-auth endpoint) until the version CHANGES.
+   Three outcomes, not one:
+     - version changes            -> Updated (success).
+     - unreachable for a while     -> the service is restarting (expected).
+     - reachable, SAME version,    -> the update STALLED. The installer copies
+       for a long time                the new file first, then restarts; if it
+                                       dies in between (e.g. it needed a sudo
+                                       password it could not get in the detached
+                                       run), the OLD agent keeps answering the
+                                       same version forever. Without this branch
+                                       the page spins forever for that case,
+                                       telling the user it was still working
+                                       when it was not.
+   A genuine restart shows up as MISSES (unreachable), which reset the stall
+   clock -- so `same` only climbs while the old agent stays healthy, which is
+   exactly the stalled case. */
+var was=null, misses=0, same=0;
+var STALL=90;   /* ~3 min of reachable + unchanged version -> call it stalled */
+function stalled(){
+  document.getElementById('t').textContent='Update didn\u2019t finish';
+  document.getElementById('t').style.color='#f0b232';
+  document.getElementById('s').textContent='The box is still running '+was+'.';
+  document.getElementById('d').style.display='none';
+  var h=document.getElementById('hint');
+  h.style.display='block';
+  h.innerHTML='Try Update again from the app. If it keeps stopping here, open a '
+    +'terminal on the box and run:<br><br>'
+    +'<code style="color:#9fb3cc">curl -fsSL https://couchside.tv/install.sh | bash</code>';
+}
 function tick(){
   fetch('/api/ping',{cache:'no-store'}).then(function(r){return r.json()}).then(function(j){
+    misses=0;
     if(was===null){ was=j.version; }
     else if(j.version!==was){
       document.getElementById('t').textContent='Updated';
       document.getElementById('t').className='ok';
       document.getElementById('s').textContent='Now running '+j.version+'.';
       document.getElementById('d').style.display='none';
-      return;                                  /* stop polling */
+      document.getElementById('hint').style.display='none';
+      return;                                  /* stop polling: success */
+    } else {
+      /* reachable, same version: normal for the download/install phase */
+      same++;
+      if(same===20){ document.getElementById('s').textContent=
+        'Still working\u2026 downloading and installing.'; }
+      if(same>=STALL){ stalled(); return; }    /* stop polling: stalled */
     }
-    misses=0;
     setTimeout(tick,2000);
   }).catch(function(){
     /* The agent restarts mid-update, so a failed poll is EXPECTED, not an
-       error. Only say something after it has been gone a while. */
-    misses++;
+       error. A restart also means we are NOT stalled -- reset that clock. */
+    misses++; same=0;
     if(misses>8){ document.getElementById('s').textContent=
       'Restarting the service\u2026'; }
+    if(misses>150){ document.getElementById('s').textContent=
+      'Taking longer than usual. If the screen stays here, reboot the box.'; }
     setTimeout(tick,2000);
   });
 }

--- a/install.sh
+++ b/install.sh
@@ -595,6 +595,45 @@ if [ -f "$WORK_DIR/qr.py" ] && python3 -m py_compile "$WORK_DIR/qr.py" 2>/dev/nu
 fi
 
 # ---------------------------------------------------------------------------
+# (c2) Detached update fast-path — restart without a password, or finish clean
+# ---------------------------------------------------------------------------
+# Everything from here down needs GENERAL root (mkdir /etc/couchside, install
+# wrappers, write sudoers, install the unit). The phone's app-triggered update
+# runs this installer DETACHED (no controlling terminal), so it can neither type
+# a sudo password nor, on a box whose 'deck'/user has a password set, get root at
+# all -- and `set -e` then aborts right here, BEFORE the service restart, leaving
+# the freshly-downloaded agent on disk but the OLD one still running. That is the
+# stall a real Legion Go S hit (2026-07-23).
+#
+# On an EXISTING install only the agent BINARY normally changes, and it is
+# already replaced above (signature-verified). So when we have no way to run the
+# privileged setup, don't barrel into a sudo we can't answer: reload the new
+# binary by restarting the service via the exactly-argument NOPASSWD grant, and
+# finish. Decky boxes are excluded (the plugin owns the service).
+CAN_PRIVILEGE=0
+if sudo -n true 2>/dev/null; then
+    CAN_PRIVILEGE=1                       # passwordless sudo (e.g. a fresh Deck)
+elif { true < /dev/tty; } 2>/dev/null; then
+    CAN_PRIVILEGE=1                       # a terminal we can prompt on
+fi
+if [ "$CAN_PRIVILEGE" -eq 0 ] && [ -s "$TOKEN_FILE" ] && [ -f "$UNIT_DST" ] \
+   && { [ "$NO_DECKY" -eq 1 ] || ! decky_installed; }; then
+    if sudo -n systemctl restart --no-block couchside.service 2>/dev/null; then
+        say "Updated the agent and restarted couchside.service (no password needed)."
+        note "Quick update: agent binary only. If the service file or sudo grants"
+        note "also changed, re-run this installer from a terminal to apply those."
+        exit 0
+    fi
+    # No restart grant yet (installed before this build). The new agent is on
+    # disk; the running one is stale and we can't reload it without a password.
+    note "The agent was downloaded, but reloading it needs a password this"
+    note "detached update doesn't have. Run this once in a terminal on the box:"
+    note "  curl -fsSL https://couchside.tv/install.sh | bash"
+    note "After that, updates from the phone finish on their own."
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
 # (d) Token: /etc/couchside/token (sudo from here on)
 # ---------------------------------------------------------------------------
 say "Setting up $ETC_DIR (sudo may prompt for your password)"
@@ -774,6 +813,18 @@ $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl suspend
 # nonexistent unit is a no-op — while a box that gains Decky later would
 # otherwise need install.sh re-run before the recovery action could appear.
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart plugin_loader
+# App-triggered updates: the phone can fire the signed installer to update the
+# box. On a system-service install that update must RESTART couchside.service to
+# load the new agent, but it runs DETACHED with no terminal to type a sudo
+# password into -- so without this it downloads the new agent and never reloads
+# it (the box keeps running the old version, its update screen spins forever).
+# This grant is EXACTLY-argument (fixed unit, fixed --no-block) and adds NO
+# privilege: couchside.service already runs $USER_NAME's OWN code as $USER_NAME,
+# so restarting it only reloads code the user already fully controls -- never
+# anything as root. --no-block is load-bearing: the detached updater lives inside
+# this very unit's cgroup, so a blocking restart would SIGTERM the updater
+# mid-wait; --no-block enqueues the job and returns before the stop begins.
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart --no-block couchside.service
 # System-journal reads go through a fixed-argument, root-owned wrapper that
 # validates the unit + line count and calls journalctl with a locked-down
 # option set. Granting the wrapper (never journalctl itself) is the only way to

--- a/tests/test_update_grant.py
+++ b/tests/test_update_grant.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Security-shape tests for the app-triggered-update sudo grant + fast-path.
+
+Run: python3 tests/test_update_grant.py
+
+WHY THIS EXISTS (CLAUDE.md §3). A real box (Legion Go S, system-service install,
+2026-07-23) took a phone-triggered update that downloaded the new agent and then
+STALLED: the detached installer had no terminal to type a sudo password into, so
+it never restarted the service and the old version kept running.
+
+The fix adds ONE NOPASSWD grant so the detached update can restart the service —
+and a grant in the sudo path is exactly where this project's zero-tolerance rule
+applies. These assertions pin the grant's SHAPE so a future edit can't widen it:
+
+  * it is EXACTLY-argument (fixed unit, fixed --no-block) — no wildcard, no bare
+    `systemctl` that would let any unit be restarted;
+  * it adds no privilege (couchside.service runs the user's own code as the
+    user), which is why restarting it is safe to grant;
+  * the detached fast-path is gated (existing install, token present, not Decky)
+    and short-circuits BEFORE the general-root setup it cannot perform.
+
+This reads install.sh as text — the grant lives in a heredoc, and the point is
+the literal rule that lands in /etc/sudoers.d, so text is the right level.
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC = open(os.path.join(ROOT, "install.sh"), encoding="utf-8").read()
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _sudoers_block():
+    """The couchside-sudoers heredoc body (the rules that become the file)."""
+    m = re.search(r'cat > "\$WORK_DIR/couchside-sudoers" <<SUDOERS\n(.*?)\nSUDOERS\n',
+                  SRC, re.S)
+    assert m, "could not find the couchside-sudoers heredoc"
+    return m.group(1)
+
+
+def test_restart_grant_is_present_and_exact():
+    print("test_restart_grant_is_present_and_exact")
+    block = _sudoers_block()
+    grant = "$USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart --no-block couchside.service"
+    check("exact restart grant present", grant in block, True)
+    # Absolute binary path (never a bare `systemctl` sudo could resolve loosely).
+    check("grant uses the absolute systemctl path",
+          "/usr/bin/systemctl restart --no-block couchside.service" in block, True)
+
+
+def test_no_wildcard_in_any_couchside_grant():
+    """A wildcard on systemctl (e.g. `restart *`) would let ANY unit be
+    restarted as root. Every couchside command grant must be fixed-argument."""
+    print("test_no_wildcard_in_any_couchside_grant")
+    block = _sudoers_block()
+    cmd_lines = [ln for ln in block.splitlines()
+                 if "NOPASSWD:" in ln and not ln.lstrip().startswith("#")]
+    check("there are command grants to check", len(cmd_lines) >= 5, True)
+    # The command is everything after 'NOPASSWD:'. None may contain a glob.
+    offenders = [ln for ln in cmd_lines if "*" in ln.split("NOPASSWD:", 1)[1]]
+    check("no '*' in any granted command", offenders, [])
+
+
+def test_restart_is_no_block():
+    """The detached updater lives in couchside.service's OWN cgroup; a blocking
+    restart would SIGTERM it mid-wait. The grant AND the call must be --no-block,
+    and they must match (sudoers matches the full argv)."""
+    print("test_restart_is_no_block")
+    check("grant carries --no-block",
+          "systemctl restart --no-block couchside.service" in _sudoers_block(), True)
+    check("the fast-path calls exactly that",
+          "sudo -n systemctl restart --no-block couchside.service" in SRC, True)
+
+
+def test_fastpath_is_gated_and_short_circuits_before_root_setup():
+    print("test_fastpath_is_gated_and_short_circuits_before_root_setup")
+    # Gated: only when we cannot get root (CAN_PRIVILEGE=0), on an existing
+    # install (token present + unit present), and NOT on a Decky box.
+    check("CAN_PRIVILEGE gate present", "CAN_PRIVILEGE" in SRC, True)
+    check("requires an existing token", '[ -s "$TOKEN_FILE" ]' in SRC, True)
+    check("requires the unit present", '[ -f "$UNIT_DST" ]' in SRC, True)
+    check("excludes Decky boxes", "decky_installed" in SRC
+          and "NO_DECKY" in SRC, True)
+    # It must short-circuit (exit 0) BEFORE the first general-root command,
+    # `sudo mkdir -p "$ETC_DIR"`. Otherwise `set -e` aborts there exactly as the
+    # bug did. Assert ordering by source position.
+    i_fastpath = SRC.index("restart --no-block couchside.service 2>/dev/null")
+    i_mkdir = SRC.index('sudo mkdir -p "$ETC_DIR"')
+    check("fast-path restart comes before the sudo mkdir", i_fastpath < i_mkdir, True)
+    # And there is an `exit 0` between the fast-path and that mkdir.
+    between = SRC[i_fastpath:i_mkdir]
+    check("fast-path exits before the root setup", "exit 0" in between, True)
+
+
+if __name__ == "__main__":
+    for fn in (test_restart_grant_is_present_and_exact,
+               test_no_wildcard_in_any_couchside_grant,
+               test_restart_is_no_block,
+               test_fastpath_is_gated_and_short_circuits_before_root_setup):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")

--- a/tests/test_update_page.py
+++ b/tests/test_update_page.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Tests for the on-box update progress page (render_update_page).
+
+Run: python3 tests/test_update_page.py
+
+WHY THIS EXISTS. The page is served ONCE and then keeps polling /api/ping across
+the agent's own restart, watching for the version to change. The original page
+had only ONE outcome — success (version changed) — and otherwise spun forever.
+
+A real box (Legion Go S, system-service install, 2026-07-23) hit the failure the
+page could not express: the detached installer copied the new agent file but
+died at a password `sudo` before restarting the service, so the OLD agent kept
+answering the SAME version. The page span its loader indefinitely, telling the
+user it was "still working" when it had stalled. This asserts the three-outcome
+logic is present so a refactor cannot silently regress to the one-outcome page.
+
+The page is a JS string (no JS engine here), so these are STRUCTURAL assertions —
+the same approach test_pair_page uses for the handoff. They pin the branches, not
+the pixels; the on-box render itself is proven live.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def test_self_contained_and_polls_preauth_ping():
+    print("test_self_contained_and_polls_preauth_ping")
+    html = cs.render_update_page()
+    # No external assets: the box may have no network route mid-update, so a
+    # spinner that 404s is worse than none.
+    check("no external src/href", "src=\"http" not in html and "href=\"http" not in html, True)
+    # It watches the ONE pre-auth endpoint (it cannot send the token across a
+    # restart), cache-busted.
+    check("polls /api/ping", "/api/ping" in html, True)
+    check("cache-busted", "no-store" in html, True)
+
+
+def test_success_outcome_present():
+    """Version changes -> Updated. This is the happy path and must survive."""
+    print("test_success_outcome_present")
+    html = cs.render_update_page()
+    check("compares against first-seen version", "j.version!==was" in html, True)
+    check("announces the new version", "Now running" in html, True)
+
+
+def test_restart_outcome_present():
+    """Unreachable for a while == the service is restarting (expected), and a
+    failed poll must NOT be treated as an error immediately."""
+    print("test_restart_outcome_present")
+    html = cs.render_update_page()
+    check("has a catch/miss branch", ".catch(" in html and "misses" in html, True)
+    check("says 'Restarting'", "Restarting the service" in html, True)
+
+
+def test_stall_outcome_present():
+    """THE fix: reachable + SAME version for a long time == stalled, not working.
+    Must stop the spinner, say the box is still on the old version, and give a
+    recovery path — never spin forever."""
+    print("test_stall_outcome_present")
+    html = cs.render_update_page()
+    check("tracks consecutive same-version polls", "same++" in html, True)
+    check("has a stall threshold", "STALL" in html and "same>=STALL" in html, True)
+    check("stall message present", "Update didn" in html, True)
+    check("offers a recovery command", "install.sh | bash" in html, True)
+    # A restart resets the stall clock — a genuine restart (unreachable) must not
+    # be mistaken for a stall.
+    check("restart resets the stall clock", "same=0" in html, True)
+
+
+if __name__ == "__main__":
+    for fn in (test_self_contained_and_polls_preauth_ping,
+               test_success_outcome_present,
+               test_restart_outcome_present,
+               test_stall_outcome_present):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
## The bug (root-caused live on a Legion Go S, 2026-07-23)
A phone-triggered agent update on a **system-service** box downloaded the new agent, then **stalled** — the box kept running the old version, and its on-screen update page **spun forever**.

Two independent problems:

### 1. The update page couldn't express failure
`render_update_page` polled `/api/ping` and only stopped when the version **changed**. When the update dies before the service restarts, the *old* agent keeps answering the same version → infinite spinner, no failure state. Now three outcomes: **updated** / **restarting** (unreachable a while) / **stalled** (reachable + unchanged ~3 min → stops, says the box is still on the old version + how to retry). A restart resets the stall clock so a genuine restart isn't mistaken for a stall.

### 2. The detached update couldn't restart the service
The app runs `install.sh` **detached** (no tty). On a box whose user has a sudo password, it hit `sudo mkdir /etc/couchside` with no way to authenticate, and `set -e` aborted **before the restart** — new agent on disk, unloaded. (On a *fresh* Deck it only works because `deck` has no password.)

**Fix:**
- One **exactly-argument** NOPASSWD grant: `/usr/bin/systemctl restart --no-block couchside.service`. Adds **no privilege** — the unit already runs the user's own code as the user, so restarting it just reloads code they fully control. `--no-block` is load-bearing: the detached updater lives in that unit's cgroup, so a blocking restart would SIGTERM it mid-wait.
- A detached **fast-path**: when root is unavailable (no passwordless sudo, no terminal) on an existing non-Decky install, reload the already-replaced *signature-verified* agent via that grant and finish — instead of barreling into a sudo it can't answer. If the grant isn't present yet (older box), exit cleanly with the file updated + a one-line "re-run the installer in a terminal once" message.

## Constraints (§3)
The grant is the sensitive part. It's fixed-argument (no wildcard), adds no privilege, and the fast-path is gated (existing install, token present, **not Decky**) and short-circuits **before** the general-root setup it can't do. `tests/test_update_grant.py` pins all of that; `tests/test_update_page.py` pins the three page outcomes. Both in CI.

## Verified
- Root-caused + recovered the actual box live (now on 2.9.49; its update page correctly flipped to "Updated — Now running 2.9.49" once the version changed).
- All agent suites green; `install.sh` syntax OK; grant is exact + wildcard-free.
- **NOT yet verified (needs the box):** the end-to-end detached fast-path after an interactive install activates the grant — owner will confirm on the Legion Go S.

Existing boxes need **one interactive install** to gain the grant; after that, phone updates finish on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
