### PR TITLE
Update fast-path gates on service-active, not Decky-absent (agent 2.9.51)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,18 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.51
+
+Updating the box from your phone now finishes on its own — and tells you if it
+doesn't.
+
+- **The box's update screen shows when an update didn't finish**, instead of
+  spinning forever. It says the box is still on the old version and how to retry.
+- **App-triggered updates now restart the service cleanly** on boxes installed as
+  a system service — including boxes that also have Decky installed, which the
+  first version of this fix missed. On an existing box, re-run the installer once
+  (in a terminal) to enable it; after that, phone updates finish on their own.
+
 ## 2.9.50
 
 Two fixes for updating the box from your phone.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.50"
+VERSION = "2.9.51"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/install.sh
+++ b/install.sh
@@ -609,15 +609,22 @@ fi
 # already replaced above (signature-verified). So when we have no way to run the
 # privileged setup, don't barrel into a sudo we can't answer: reload the new
 # binary by restarting the service via the exactly-argument NOPASSWD grant, and
-# finish. Decky boxes are excluded (the plugin owns the service).
+# finish.
+#
+# Gate on couchside.service being ACTIVE -- i.e. it IS the live system agent, so
+# restarting it reloads the binary we just replaced. That holds even when Decky
+# is ALSO installed (the reported Legion Go S ran couchside.service active AND had
+# Decky) -- so DON'T gate on "Decky absent", which wrongly skipped exactly that
+# box. A pure Decky setup leaves couchside.service INACTIVE (the plugin runs its
+# own copy), so is-active is false there and the fast-path correctly stands down.
 CAN_PRIVILEGE=0
 if sudo -n true 2>/dev/null; then
     CAN_PRIVILEGE=1                       # passwordless sudo (e.g. a fresh Deck)
 elif { true < /dev/tty; } 2>/dev/null; then
     CAN_PRIVILEGE=1                       # a terminal we can prompt on
 fi
-if [ "$CAN_PRIVILEGE" -eq 0 ] && [ -s "$TOKEN_FILE" ] && [ -f "$UNIT_DST" ] \
-   && { [ "$NO_DECKY" -eq 1 ] || ! decky_installed; }; then
+if [ "$CAN_PRIVILEGE" -eq 0 ] && [ -s "$TOKEN_FILE" ] \
+   && systemctl is-active --quiet couchside.service 2>/dev/null; then
     if sudo -n systemctl restart --no-block couchside.service 2>/dev/null; then
         say "Updated the agent and restarted couchside.service (no password needed)."
         note "Quick update: agent binary only. If the service file or sudo grants"

--- a/tests/test_update_grant.py
+++ b/tests/test_update_grant.py
@@ -85,12 +85,15 @@ def test_restart_is_no_block():
 def test_fastpath_is_gated_and_short_circuits_before_root_setup():
     print("test_fastpath_is_gated_and_short_circuits_before_root_setup")
     # Gated: only when we cannot get root (CAN_PRIVILEGE=0), on an existing
-    # install (token present + unit present), and NOT on a Decky box.
+    # install (token present), and only when couchside.service is the LIVE system
+    # agent (is-active) -- so restarting it reloads the new binary. Gating on
+    # is-active (NOT "Decky absent") is deliberate: the reported box ran
+    # couchside.service active WITH Decky installed, and a "! decky_installed"
+    # gate wrongly skipped it. A pure/dormant Decky setup is inactive -> skipped.
     check("CAN_PRIVILEGE gate present", "CAN_PRIVILEGE" in SRC, True)
     check("requires an existing token", '[ -s "$TOKEN_FILE" ]' in SRC, True)
-    check("requires the unit present", '[ -f "$UNIT_DST" ]' in SRC, True)
-    check("excludes Decky boxes", "decky_installed" in SRC
-          and "NO_DECKY" in SRC, True)
+    check("gated on couchside.service being active",
+          "systemctl is-active --quiet couchside.service" in SRC, True)
     # It must short-circuit (exit 0) BEFORE the first general-root command,
     # `sudo mkdir -p "$ETC_DIR"`. Otherwise `set -e` aborts there exactly as the
     # bug did. Assert ordering by source position.


### PR DESCRIPTION
The 2.9.50 detached-update fast-path excluded any box with Decky installed. But the reported Legion Go S runs **couchside.service active** as a system service **and** has Decky installed — so the exclusion skipped exactly the box the fix was for, and the update fell through to the sudo wall again (verified: PID unchanged, no restart).

**Fix:** gate on `systemctl is-active --quiet couchside.service` instead of `! decky_installed`. The fast-path fires when couchside.service is the *live* system agent (true here even with Decky present); a pure/dormant Decky setup leaves it inactive, so it stands down there.

**Proven end-to-end on the actual box** (Decky present, service active): a detached, no-tty install.sh run hit the fast-path, restarted via the NOPASSWD `--no-block` grant with no password, PID changed 2463767 → 2464513, no stall. The old gate left the PID unchanged (reproduced the miss).

Grant shape unchanged (exact, wildcard-free, no privilege gain). `test_update_grant.py` updated to pin the is-active gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)