### PR TITLE
fix(pair): raise the on-box pairing popup in front + one store QR (agent 2.9.52)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,19 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.52
+
+A smoother first pairing on the box's own screen.
+
+- **The pairing screen now comes up in front.** On a desktop (non–Game Mode)
+  install it could open *behind* the terminal window, leaving you staring at the
+  install log instead of the QR. It now raises itself to the front so the code
+  and the 6-digit PIN are right there.
+- **One code to get the app, not two.** The "get Couchside on your phone" step
+  shows a single QR that opens the download page for both the App Store and
+  Google Play — scan it and pick your store on the phone, instead of aiming the
+  camera at the right one of two codes.
+
 ## 2.9.51
 
 Updating the box from your phone now finishes on its own — and tells you if it

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -11538,10 +11538,11 @@ def render_pair_page(token, port):
         "justify-content:center;}"
         ".step b{font-size:min(3vmin,20px);font-weight:600;color:#e8ecf3;}"
         ".step span{display:block;color:#9aa4b2;font-size:min(2.4vmin,15px);margin-top:.3vmin;}"
-        # The two store QR codes under step 1 (App Store + Google Play). Small
-        # white cards -- a phone reads them up close, so they can be compact and
-        # still fit the one-screen budget. image-rendering:pixelated keeps the
-        # modules crisp when CSS scales the canvas.
+        # The single store QR under step 1 (a couchside.tv link carrying both
+        # store badges). A small white card -- a phone reads it up close, so it
+        # can be compact and still fit the one-screen budget. image-rendering:
+        # pixelated keeps the modules crisp when CSS scales the canvas. .stores
+        # stays a flex row so a second card could return without a reflow.
         ".stores{display:flex;gap:min(2.6vmin,18px);margin-top:1.2vmin;}"
         ".store{display:flex;flex-direction:column;align-items:center;gap:.5vmin;}"
         ".sqr{background:#fff;border-radius:9px;padding:min(1.1vmin,7px);line-height:0;}"

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.51"
+VERSION = "2.9.52"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -11501,12 +11501,13 @@ def render_pair_page(token, port):
     url_js = json.dumps(pair_url)          # safe JS string literal
     url_html = (pair_url.replace("&", "&amp;").replace("<", "&lt;")
                         .replace(">", "&gt;"))  # safe HTML text
-    # Store links for the "get the app first" QR codes. A fresh installer who
-    # does not have Couchside yet scans one of these to install; the big QR
-    # above is for someone who already has it. Both are static, public URLs.
-    ios_js = json.dumps("https://apps.apple.com/app/id6786884115")
-    play_js = json.dumps(
-        "https://play.google.com/store/apps/details?id=com.ets3d.rescueremote")
+    # One "get the app first" QR for a fresh installer who doesn't have
+    # Couchside yet. It points at couchside.tv, whose hero already carries BOTH
+    # store badges, so the phone picks its own store instead of the box making
+    # someone aim a camera at the right one of two codes. A single small canvas
+    # also leaves the one-screen layout roomier. The big QR above stays the
+    # pairing deep link for someone who already has the app.
+    get_js = json.dumps("https://couchside.tv/#get")
     return (
         "<!doctype html><html lang=\"en\"><head>"
         "<meta charset=\"utf-8\">"
@@ -11601,14 +11602,12 @@ def render_pair_page(token, port):
         "<div class=\"steps\">"
         "<div class=\"step\"><div class=\"num\">1</div><div>"
         "<b>Get Couchside on your phone</b>"
-        "<span>Don&rsquo;t have it? Scan a store code to install &mdash; free.</span>"
+        "<span>Don&rsquo;t have it? Scan to install on iOS or Android "
+        "&mdash; free.</span>"
         "<div class=\"stores\">"
         "<div class=\"store\">"
-        "<div class=\"sqr\"><canvas id=\"qr-ios\" width=\"104\" height=\"104\"></canvas></div>"
-        "<div class=\"slabel\">App Store</div></div>"
-        "<div class=\"store\">"
-        "<div class=\"sqr\"><canvas id=\"qr-play\" width=\"104\" height=\"104\"></canvas></div>"
-        "<div class=\"slabel\">Google Play</div></div>"
+        "<div class=\"sqr\"><canvas id=\"qr-get\" width=\"104\" height=\"104\"></canvas></div>"
+        "<div class=\"slabel\">App Store &amp; Google Play</div></div>"
         "</div></div></div>"
         "<div class=\"step\"><div class=\"num\">2</div><div>"
         "<b>Setup tab &rarr; Scan for boxes</b>"
@@ -11628,8 +11627,7 @@ def render_pair_page(token, port):
         "<script>\n" + PAIR_QR_JS + "\n"
         "(function(){\n"
         "  var url = " + url_js + ";\n"
-        "  var iosUrl = " + ios_js + ";\n"
-        "  var playUrl = " + play_js + ";\n"
+        "  var getUrl = " + get_js + ";\n"
         "  function drawQR(id, text, box, minpx){\n"
         "    var canvas = document.getElementById(id);\n"
         "    if (!canvas) return;\n"
@@ -11646,8 +11644,7 @@ def render_pair_page(token, port):
         "  }\n"
         "  try {\n"
         "    drawQR('qr', url, 300, 4);\n"
-        "    drawQR('qr-ios', iosUrl, 108, 2);\n"
-        "    drawQR('qr-play', playUrl, 108, 2);\n"
+        "    drawQR('qr-get', getUrl, 108, 2);\n"
         "  } catch (e) {\n"
         "    document.getElementById('err').textContent = 'Could not render QR: ' + e;\n"
         "  }\n"

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -294,6 +294,24 @@ recommendation was wrong, not merely superseded.
 
 ## ✅ Completed
 
+### 2026-07-23 — Pairing popup: raise it in front + one store QR, not two (agent 2.9.52)
+Two fixes to the on-box pairing tutorial, both VERIFIED LIVE on a real Bazzite box (Plasma
+**Wayland**, desktop mode), screenshot before/after. **Popup was behind the terminal:** on a fresh
+desktop install `couchside-pair` is launched detached (`setsid`), so KWin's focus-stealing
+prevention drops the new full-screen browser to the BOTTOM of the stack — behind (even below) the
+Konsole the install ran in. On Wayland a client cannot reorder itself; only the compositor can.
+`couchside-pair` now runs a background KWin-scripting raiser (`qdbus org.kde.KWin /Scripting`,
+`loadScript`/`run`/`unloadScript`) that finds our own page by title ("Couchside" in every `/pair`
+`<title>`, never by browser name, so an unrelated browser is never yanked) and pulls it to the
+front, retrying ~18s while the browser cold-starts. Best-effort + KDE-only: no KWin (Game Mode →
+`steam://openurl`, another WM, or SSH-no-display) and every step no-ops. **MEASURED:** `keepAbove`
+alone does NOT reliably raise a full-screen window here; `minimized=true→false` (un-minimize forces
+a restack) + `keepAbove` + `activeWindow` does — the raiser uses all three. **Two store QRs → one:**
+step 1 now carries a single QR to `https://couchside.tv/#get` (whose hero already holds both store
+badges) instead of separate App Store + Google Play codes — the phone picks its own store, one less
+code to aim a camera at, roomier one-screen layout. New-page render proven on the box's own browser
+at 4K. `tests/test_pair_page.py` updated. See [[pairing-tutorial-on-box]].
+
 ### 2026-07-23 — Pairing page: store QR codes + reliable desktop-mode open (agent 2.9.48)
 Two follow-ups to the on-box pairing tutorial. **Store QR codes on `/pair`:** a fresh installer
 standing at the box can now scan an App Store or Google Play code to DOWNLOAD the app, not just

--- a/install.sh
+++ b/install.sh
@@ -1093,17 +1093,23 @@ _raise_pair_window_bg() {
 
     local js
     js="$(mktemp)" || return 0
-    # Match our own page by title (every /pair page's <title> carries
-    # "Couchside"), never by browser name -- so we never yank an unrelated
-    # browser window the user happens to have open. min->unmin forces a restack
-    # even where keepAbove alone won't; keepAbove + activeWindow then hold it.
+    # Match our OWN pairing page by its window title -- never by browser name, so
+    # an unrelated browser window the user has open is left alone. min->unmin
+    # forces a restack even where keepAbove alone won't; keepAbove + activeWindow
+    # then hold it in front. Works across KWin versions (Plasma 6 windowList /
+    # activeWindow, Plasma 5 clientList / activeClient -- the Steam Deck desktop).
     cat > "$js" <<'KWINJS'
-var W = (typeof workspace.windowList === "function")
-        ? workspace.windowList() : (workspace.stackingOrder || []);
+var W = (typeof workspace.windowList === "function") ? workspace.windowList()
+      : (typeof workspace.clientList === "function") ? workspace.clientList()
+      : (workspace.stackingOrder || []);
 for (var i = 0; i < (W ? W.length : 0); i++) {
     var w = W[i];
     if (!w || !w.normalWindow) continue;
-    if (((w.caption || "") + "").toLowerCase().indexOf("couchside") === -1) continue;
+    // Both states of our page carry BOTH tokens -- "Pair Couchside" (idle
+    // tutorial) and "Couchside pairing" (live PIN). Requiring both avoids
+    // grabbing an unrelated tab that merely has couchside.tv or the repo open.
+    var cap = ((w.caption || "") + "").toLowerCase();
+    if (cap.indexOf("couchside") === -1 || cap.indexOf("pair") === -1) continue;
     w.minimized = true;
     w.minimized = false;
     w.keepAbove = true;

--- a/install.sh
+++ b/install.sh
@@ -1075,15 +1075,74 @@ PYEOF
 )"
 URL="http://localhost:${PORT}/pair"
 echo "Opening ${URL} full-screen…"
+
+# Pull the pairing window in front of the terminal the install ran in. When the
+# installer launches this script detached on a fresh desktop box, KDE's KWin
+# applies focus-stealing prevention and drops the new full-screen browser to the
+# BOTTOM of the stack -- behind (even below) the Konsole that's still focused.
+# On Wayland a client cannot reorder itself; only the compositor can, so we ask
+# KWin over its scripting DBus to raise our own page. Runs in the background
+# alongside the browser, retrying while it cold-starts. Best-effort and
+# KDE-only: no KWin (Game Mode, another WM, or an SSH install with no display)
+# means every step below no-ops and the browser is left exactly as it was.
+_raise_pair_window_bg() {
+    local qd
+    qd="$(command -v qdbus || command -v qdbus6 || command -v qdbus-qt6 || true)"
+    [ -n "$qd" ] || return 0
+    "$qd" org.kde.KWin /Scripting >/dev/null 2>&1 || return 0   # no KWin session
+
+    local js
+    js="$(mktemp)" || return 0
+    # Match our own page by title (every /pair page's <title> carries
+    # "Couchside"), never by browser name -- so we never yank an unrelated
+    # browser window the user happens to have open. min->unmin forces a restack
+    # even where keepAbove alone won't; keepAbove + activeWindow then hold it.
+    cat > "$js" <<'KWINJS'
+var W = (typeof workspace.windowList === "function")
+        ? workspace.windowList() : (workspace.stackingOrder || []);
+for (var i = 0; i < (W ? W.length : 0); i++) {
+    var w = W[i];
+    if (!w || !w.normalWindow) continue;
+    if (((w.caption || "") + "").toLowerCase().indexOf("couchside") === -1) continue;
+    w.minimized = true;
+    w.minimized = false;
+    w.keepAbove = true;
+    if ("activeWindow" in workspace) { workspace.activeWindow = w; }
+    else { workspace.activeClient = w; }
+}
+KWINJS
+    # The browser cold-starts and its title lands a moment later, so retry for
+    # ~18s until the window exists to be raised. Each pass loads, runs, and
+    # unloads a uniquely-named script so nothing accumulates in KWin.
+    local k id
+    for k in 1 2 3 4 5 6 7 8 9 10 11 12; do
+        sleep 1.5
+        id="$("$qd" org.kde.KWin /Scripting org.kde.kwin.Scripting.loadScript \
+              "$js" "couchsidepair$k" 2>/dev/null)"
+        [ -n "$id" ] || continue
+        "$qd" org.kde.KWin "/Scripting/Script${id}" org.kde.kwin.Script.run \
+              >/dev/null 2>&1
+        sleep 0.4
+        "$qd" org.kde.KWin /Scripting org.kde.kwin.Scripting.unloadScript \
+              "couchsidepair$k" >/dev/null 2>&1
+    done
+    rm -f "$js"
+}
+
 # Game Mode (gamescope session): there's no desktop browser, but Steam's own
 # built-in browser renders the page: steam://openurl works from a non-Steam
 # shortcut tile. This is what makes the "Pair Phone" tile work on stock
-# SteamOS with no Chrome/Chromium installed.
+# SteamOS with no Chrome/Chromium installed. Steam's overlay owns the screen
+# here, so no window-raising is needed (or possible) -- skip straight to it.
 if [ "${XDG_CURRENT_DESKTOP:-}" = "gamescope" ] \
    || pgrep -x gamescope-session >/dev/null 2>&1 \
    || pgrep -x gamescope >/dev/null 2>&1; then
     exec steam -ifrunning "steam://openurl/${URL}"
 fi
+
+# Desktop mode: raise our window once it maps (background), then launch the
+# browser. The raiser outlives this shell's exec into the browser.
+_raise_pair_window_bg &
 
 # Desktop mode: open a real browser DIRECTLY, full-screen. We deliberately do
 # NOT lean on xdg-open here — on SteamOS/KDE it routes through kfmclient, which

--- a/tests/test_pair_page.py
+++ b/tests/test_pair_page.py
@@ -98,25 +98,25 @@ def test_idle_page_has_the_tutorial():
     check("inline svg present", "<svg" in html and "</svg>" in html, True)
 
 
-def test_idle_page_has_store_qr_codes():
-    """A fresh installer without the app needs to install it first. The page
-    carries an App Store and a Google Play QR — the exact store URLs, on their
-    own canvases, drawn by the same offline generator as the pairing QR."""
-    print("test_idle_page_has_store_qr_codes")
+def test_idle_page_has_store_qr_code():
+    """A fresh installer without the app needs to install it first. Rather than
+    make them aim a camera at the right one of two store codes, the page carries
+    ONE code to couchside.tv, whose hero holds both store badges — the phone
+    then picks its own store. Drawn by the same offline generator as the
+    pairing QR."""
+    print("test_idle_page_has_store_qr_code")
     html = cs.render_pair_page("a" * 64, 8787)
-    check("App Store QR canvas present", 'id="qr-ios"' in html, True)
-    check("Google Play QR canvas present", 'id="qr-play"' in html, True)
-    check("App Store URL encoded",
-          "https://apps.apple.com/app/id6786884115" in html, True)
-    check("Google Play URL encoded",
-          "https://play.google.com/store/apps/details?id=com.ets3d.rescueremote"
-          in html, True)
-    check("store labels present",
+    check("store QR canvas present", 'id="qr-get"' in html, True)
+    check("store URL points at couchside.tv/#get",
+          "https://couchside.tv/#get" in html, True)
+    check("store label names both stores",
           "App Store" in html and "Google Play" in html, True)
-    # All three QRs go through one generator — assert the store canvases are
-    # actually wired into a draw call, not just empty elements.
-    check("store canvases are drawn",
-          "drawQR('qr-ios'" in html and "drawQR('qr-play'" in html, True)
+    # The store canvas goes through the same generator as the pairing QR —
+    # assert it is actually wired into a draw call, not just an empty element.
+    check("store canvas is drawn", "drawQR('qr-get'" in html, True)
+    # The old two-code layout is gone: no stray per-store canvases left behind.
+    check("no legacy store canvases",
+          'id="qr-ios"' not in html and 'id="qr-play"' not in html, True)
 
 
 def test_idle_page_hands_off():
@@ -235,7 +235,7 @@ if __name__ == "__main__":
     for fn in (test_loopback_gate,
                test_host_header_gate,
                test_idle_page_has_the_tutorial,
-               test_idle_page_has_store_qr_codes,
+               test_idle_page_has_store_qr_code,
                test_idle_page_hands_off,
                test_live_pin_page_is_the_pin_not_the_tutorial,
                test_pin_start_is_debounced_and_marks_fresh,


### PR DESCRIPTION
## What

Two fixes to the on-box pairing tutorial, both **verified live on a real Bazzite box** (Plasma **Wayland**, desktop mode), screenshotted before/after.

### 1. The pairing popup opened *behind* the terminal (the reported bug)
On a fresh desktop install, `couchside-pair` is launched detached (`setsid`), so KDE's KWin applies **focus-stealing prevention** and drops the new full-screen browser to the **bottom** of the stack — behind, even *below*, the Konsole the install ran in. On Wayland a client cannot reorder itself; only the compositor can (wmctrl/xdotool are X11-only and can't touch Wayland windows).

`couchside-pair` now runs a background **KWin-scripting raiser** (`qdbus org.kde.KWin /Scripting` → `loadScript`/`run`/`unloadScript`) that:
- finds **our own** page by title — every `/pair` `<title>` contains `Couchside`, so we match on caption, never on browser name, and never yank an unrelated browser window;
- pulls it to the front and holds it there;
- retries ~18s while the browser cold-starts.

**Best-effort and KDE-only:** no KWin (Game Mode → `steam://openurl`, another WM, or an SSH install with no display) means every step no-ops and the browser is left exactly as it was.

**Measured on the box (load-bearing):** `keepAbove = true` alone does **not** reliably raise a full-screen window here. What works deterministically is `minimized = true; minimized = false` (un-minimize forces a restack) **plus** `keepAbove` **plus** `activeWindow` — the raiser sets all three.

### 2. Two store QR codes → one
Step 1 carried two small QRs (App Store + Google Play). It now carries **one** QR to `https://couchside.tv/#get`, whose hero already holds both store badges. The phone picks its own store, there's one less code to aim a camera at, and the one-screen layout is roomier. (No website change needed — the `#get` anchor already exists.)

## Verification

Real Bazzite box, Plasma Wayland desktop, `spectacle` screen capture:

- **Raiser** — reproduced the bug (Konsole on top, detached full-screen Firefox hidden behind it), then ran the **exact** shipped raiser JS: the "Pair your phone" page came fully to the front, Konsole gone. Both states observed.
- **New page** — ran the edited agent on a spare port and opened `/pair` in the box's own browser at 4K: single store QR labelled "App Store & Google Play", clean one-screen layout.
- `tests/test_pair_page.py` updated and passing.

## Not verified
- Steam CEF (Game Mode) is unaffected by the raiser (it takes the `steam://openurl` branch, which was already fine).
- Real-phone scan of the new `couchside.tv/#get` QR (the target page's store badges are already live and unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)