### PR TITLE
feat(pad): large-trackpad toggle for edge-to-edge scrolling

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -11,7 +11,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { hapticLight, hapticSelection } from '@/lib/haptics';
 import { getKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
-import { getPref, usePref } from '@/lib/prefs';
+import { getPref, setPref, usePref } from '@/lib/prefs';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNavigation } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -1124,6 +1124,11 @@ function PadScreen() {
   const showDesktopNav = usePref('padDesktopNav');
   const showWinShortcuts = usePref('padWinShortcuts');
   const showKeyboardBar = usePref('padKeyboardBar');
+  const trackpadLarge = usePref('padTrackpadLarge');
+  // Large-pad mode is meaningful only on the trackpad surface: it collapses the
+  // pill + mode tabs + button/keyboard rows so the pad fills the pane for
+  // edge-to-edge scrolling. A floating chip restores the chrome.
+  const largePad = trackpadLarge && mode === 'trackpad';
   // Auto-raise the phone keyboard when the box raises its own. The counter is
   // what KeyboardBar watches; the ref lets the (memoised) socket callback read
   // the current pref without re-subscribing.
@@ -1396,29 +1401,34 @@ function PadScreen() {
         styles.screen,
         { paddingTop: 10, paddingBottom: Math.max(insets.bottom, 10) },
       ]}>
-      {/* Header: status pill + input-mode toggle (all modes) */}
-      <Pressable onPress={retry} style={styles.pill} hitSlop={8}>
-        <View style={[styles.pillDot, { backgroundColor: STATUS_COLOR[status] }]} />
-        <Text style={styles.pillText} numberOfLines={1}>
-          {status === 'waiting' && canForce
-            ? 'no response · tap to take control'
-            : statusLabel(status, dev)}
-        </Text>
-      </Pressable>
-      <View style={styles.modeToggle}>
-        {modes.map((m) => (
-          <Pressable
-            key={m.key}
-            onPress={() => setMode(m.key)}
-            style={[styles.modeSeg, mode === m.key && styles.modeSegActive]}>
-            <Text
-              numberOfLines={1}
-              style={[styles.modeSegText, mode === m.key && styles.modeSegTextActive]}>
-              {m.label}
+      {/* Header: status pill + input-mode toggle (all modes). Hidden in
+          large-pad mode; the floating chip below brings it back. */}
+      {!largePad && (
+        <>
+          <Pressable onPress={retry} style={styles.pill} hitSlop={8}>
+            <View style={[styles.pillDot, { backgroundColor: STATUS_COLOR[status] }]} />
+            <Text style={styles.pillText} numberOfLines={1}>
+              {status === 'waiting' && canForce
+                ? 'no response · tap to take control'
+                : statusLabel(status, dev)}
             </Text>
           </Pressable>
-        ))}
-      </View>
+          <View style={styles.modeToggle}>
+            {modes.map((m) => (
+              <Pressable
+                key={m.key}
+                onPress={() => setMode(m.key)}
+                style={[styles.modeSeg, mode === m.key && styles.modeSegActive]}>
+                <Text
+                  numberOfLines={1}
+                  style={[styles.modeSegText, mode === m.key && styles.modeSegTextActive]}>
+                  {m.label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+        </>
+      )}
 
       {inputBlocked != null && status === 'connected' && (
         <View style={styles.inputBlockedBar}>
@@ -1538,7 +1548,22 @@ function PadScreen() {
             onDragStart={tpDragStart}
             onDragEnd={tpDragEnd}
           />
-          {(showMouseRow || showSteamRow) && (
+          {/* Large-pad escape hatch: the pill + mode tabs are hidden in this
+              mode, so this floating chip is the only way back to the normal
+              layout. Rendered only while large-pad is active. */}
+          {largePad && (
+            <Pressable
+              onPress={() => {
+                setPref('padTrackpadLarge', false);
+                hapticSelection();
+              }}
+              style={styles.exitLargeChip}
+              hitSlop={12}
+              accessibilityLabel="Exit large trackpad">
+              <Ionicons name="contract-outline" size={16} color={t.text} />
+            </Pressable>
+          )}
+          {!largePad && (showMouseRow || showSteamRow) && (
             <View style={styles.swipeBtnRow}>
               {showMouseRow && (
                 <>
@@ -1605,7 +1630,7 @@ function PadScreen() {
             </View>
           )}
           {/* Plasma desktop nav — SteamOS/Bazzite boxes on the desktop only. */}
-          {hasDesktop && showDesktopNav && (
+          {!largePad && hasDesktop && showDesktopNav && (
             <View style={styles.swipeBtnRow}>
               <PadButton label="START" onDown={desk('meta')} onUp={NOOP}
                 style={[styles.tpBtn, styles.tpBtnWide]} fontSize={11} />
@@ -1616,7 +1641,7 @@ function PadScreen() {
             </View>
           )}
           {/* Windows desktop shortcuts — one-shot chords, ViGEm boxes only. */}
-          {isWindows && showWinShortcuts && (
+          {!largePad && isWindows && showWinShortcuts && (
             <View style={styles.swipeBtnRow}>
               <PadButton label="⊞ WIN" onDown={sys('win')} onUp={NOOP}
                 style={[styles.tpBtn, styles.tpBtnWide]} fontSize={12} />
@@ -1628,7 +1653,7 @@ function PadScreen() {
                 style={styles.tpBtn} fontSize={11} />
             </View>
           )}
-          {keyboardBar}
+          {!largePad && keyboardBar}
         </>
       ) : landscape ? (
         // ---------- Landscape gamepad: real-controller spread ----------
@@ -1854,6 +1879,23 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     backgroundColor: t.bg,
     paddingHorizontal: 12,
     justifyContent: 'space-between',
+  },
+
+  // Floating "exit large trackpad" chip — top-right, overlays the pad corner.
+  // The only way out of large-pad mode (pill + mode tabs are hidden there).
+  exitLargeChip: {
+    position: 'absolute',
+    top: 6,
+    right: 6,
+    width: 34,
+    height: 34,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
+    borderWidth: 1,
+    borderRadius: 999,
+    zIndex: 10,
   },
 
   // "Another phone has control" takeover. Covers the input surfaces (which are

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1126,10 +1126,12 @@ function PadScreen() {
   const showKeyboardBar = usePref('padKeyboardBar');
   const trackpadLarge = usePref('padTrackpadLarge');
   const padLargeToggle = usePref('padLargeToggle');
-  // Large-pad mode is meaningful only on the trackpad surface: it collapses the
-  // pill + mode tabs + button/keyboard rows so the pad fills the pane for
-  // edge-to-edge scrolling. A floating chip restores the chrome.
-  const largePad = trackpadLarge && mode === 'trackpad';
+  // Large-pad mode applies to the two big drag surfaces (trackpad + swipe): it
+  // collapses the pill + mode tabs + button/keyboard rows so the surface fills
+  // the pane. A floating chip restores the chrome. Not meaningful for the
+  // menus/remote/gamepad modes, which have no full-pane drag surface.
+  const largePad =
+    trackpadLarge && (mode === 'trackpad' || mode === 'swipe');
   // Auto-raise the phone keyboard when the box raises its own. The counter is
   // what KeyboardBar watches; the ref lets the (memoised) socket callback read
   // the current pref without re-subscribing.
@@ -1396,6 +1398,30 @@ function PadScreen() {
     />
   ) : null;
 
+  // One corner chip toggles large mode in a single tap, shared by the trackpad
+  // and swipe surfaces. In large mode it ALWAYS shows (the CONTRACT/exit
+  // affordance — the pill + tabs are hidden, so it is the only way back); in
+  // normal mode it shows the EXPAND affordance only when padLargeToggle is on.
+  // Rendered INSIDE each surface's wrapper (styles.tpWrap) so it sits on the
+  // pad's own corner in both modes rather than over the header.
+  const padToggleChip =
+    trackpadLarge || padLargeToggle ? (
+      <Pressable
+        onPress={() => {
+          setPref('padTrackpadLarge', !trackpadLarge);
+          hapticSelection();
+        }}
+        style={styles.tpToggleChip}
+        hitSlop={12}
+        accessibilityLabel={trackpadLarge ? 'Exit large pad' : 'Enlarge pad'}>
+        <Ionicons
+          name={trackpadLarge ? 'contract-outline' : 'expand-outline'}
+          size={16}
+          color={t.text}
+        />
+      </Pressable>
+    ) : null;
+
   return (
     <View
       style={[
@@ -1500,7 +1526,11 @@ function PadScreen() {
       ) : mode === 'swipe' ? (
         <>
           {/* Apple-TV-remote style: big swipe/tap surface + three big buttons */}
-          <SwipeSurface onStep={dpadStep} onStepEnd={dpadRelease} onSelect={selectTap} />
+          <View style={styles.tpWrap}>
+            <SwipeSurface onStep={dpadStep} onStepEnd={dpadRelease} onSelect={selectTap} />
+            {padToggleChip}
+          </View>
+          {!largePad && (
           <View style={styles.swipeBtnRow}>
             <PadButton
               label="‹ BACK"
@@ -1536,7 +1566,8 @@ function PadScreen() {
               </>
             )}
           </View>
-          {keyboardBar}
+          )}
+          {!largePad && keyboardBar}
         </>
       ) : mode === 'trackpad' ? (
         <>
@@ -1550,28 +1581,7 @@ function PadScreen() {
               onDragStart={tpDragStart}
               onDragEnd={tpDragEnd}
             />
-            {/* One corner chip toggles large mode in a single tap. In large mode
-                it ALWAYS shows (the CONTRACT/exit affordance — the pill + tabs
-                are hidden, so it's the only way back). In normal mode it shows
-                the EXPAND affordance only when padLargeToggle is on. It lives
-                inside this surface wrapper, so it sits on the pad's own corner
-                in both modes rather than over the header. */}
-            {(trackpadLarge || padLargeToggle) && (
-              <Pressable
-                onPress={() => {
-                  setPref('padTrackpadLarge', !trackpadLarge);
-                  hapticSelection();
-                }}
-                style={styles.tpToggleChip}
-                hitSlop={12}
-                accessibilityLabel={trackpadLarge ? 'Exit large trackpad' : 'Enlarge trackpad'}>
-                <Ionicons
-                  name={trackpadLarge ? 'contract-outline' : 'expand-outline'}
-                  size={16}
-                  color={t.text}
-                />
-              </Pressable>
-            )}
+            {padToggleChip}
           </View>
           {!largePad && (showMouseRow || showSteamRow) && (
             <View style={styles.swipeBtnRow}>

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1125,6 +1125,7 @@ function PadScreen() {
   const showWinShortcuts = usePref('padWinShortcuts');
   const showKeyboardBar = usePref('padKeyboardBar');
   const trackpadLarge = usePref('padTrackpadLarge');
+  const padLargeToggle = usePref('padLargeToggle');
   // Large-pad mode is meaningful only on the trackpad surface: it collapses the
   // pill + mode tabs + button/keyboard rows so the pad fills the pane for
   // edge-to-edge scrolling. A floating chip restores the chrome.
@@ -1540,29 +1541,38 @@ function PadScreen() {
       ) : mode === 'trackpad' ? (
         <>
           {/* Relative-mouse surface + a mouse-button row + keyboard */}
-          <Trackpad
-            onMove={tpMove}
-            onLeftClick={tpLeft}
-            onRightClick={tpRight}
-            onScroll={tpScroll}
-            onDragStart={tpDragStart}
-            onDragEnd={tpDragEnd}
-          />
-          {/* Large-pad escape hatch: the pill + mode tabs are hidden in this
-              mode, so this floating chip is the only way back to the normal
-              layout. Rendered only while large-pad is active. */}
-          {largePad && (
-            <Pressable
-              onPress={() => {
-                setPref('padTrackpadLarge', false);
-                hapticSelection();
-              }}
-              style={styles.exitLargeChip}
-              hitSlop={12}
-              accessibilityLabel="Exit large trackpad">
-              <Ionicons name="contract-outline" size={16} color={t.text} />
-            </Pressable>
-          )}
+          <View style={styles.tpWrap}>
+            <Trackpad
+              onMove={tpMove}
+              onLeftClick={tpLeft}
+              onRightClick={tpRight}
+              onScroll={tpScroll}
+              onDragStart={tpDragStart}
+              onDragEnd={tpDragEnd}
+            />
+            {/* One corner chip toggles large mode in a single tap. In large mode
+                it ALWAYS shows (the CONTRACT/exit affordance — the pill + tabs
+                are hidden, so it's the only way back). In normal mode it shows
+                the EXPAND affordance only when padLargeToggle is on. It lives
+                inside this surface wrapper, so it sits on the pad's own corner
+                in both modes rather than over the header. */}
+            {(trackpadLarge || padLargeToggle) && (
+              <Pressable
+                onPress={() => {
+                  setPref('padTrackpadLarge', !trackpadLarge);
+                  hapticSelection();
+                }}
+                style={styles.tpToggleChip}
+                hitSlop={12}
+                accessibilityLabel={trackpadLarge ? 'Exit large trackpad' : 'Enlarge trackpad'}>
+                <Ionicons
+                  name={trackpadLarge ? 'contract-outline' : 'expand-outline'}
+                  size={16}
+                  color={t.text}
+                />
+              </Pressable>
+            )}
+          </View>
           {!largePad && (showMouseRow || showSteamRow) && (
             <View style={styles.swipeBtnRow}>
               {showMouseRow && (
@@ -1881,12 +1891,18 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     justifyContent: 'space-between',
   },
 
-  // Floating "exit large trackpad" chip — top-right, overlays the pad corner.
-  // The only way out of large-pad mode (pill + mode tabs are hidden there).
-  exitLargeChip: {
+  // The trackpad surface wrapper: holds the pad + its corner toggle chip so the
+  // chip anchors to the pad's own corner (not the screen header) in both normal
+  // and large modes. flex:1 so the pad still fills the leftover space.
+  tpWrap: {
+    flex: 1,
+    position: 'relative',
+  },
+  // Corner chip that toggles large-pad mode (expand <-> contract) in one tap.
+  tpToggleChip: {
     position: 'absolute',
-    top: 6,
-    right: 6,
+    top: 8,
+    right: 8,
     width: 34,
     height: 34,
     alignItems: 'center',

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -777,6 +777,7 @@ function SetupBody() {
   const padWinShortcuts = usePref('padWinShortcuts');
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
+  const padTrackpadLarge = usePref('padTrackpadLarge');
   const askToSwitchControl = usePref('askToSwitchControl');
   const keyboardMode = usePref('keyboardMode');
   const searchButtonSide = usePref('searchButtonSide');
@@ -1525,6 +1526,15 @@ function SetupBody() {
                 value={padHints}
                 onValueChange={(v) => {
                   void setPref('padHints', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Large trackpad"
+                sub="Hide the status bar, mode tabs, and button rows on the MOUSE surface for edge-to-edge scrolling. A corner chip brings them back."
+                value={padTrackpadLarge}
+                onValueChange={(v) => {
+                  void setPref('padTrackpadLarge', v);
                   hapticSelection();
                 }}
               />

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1532,7 +1532,7 @@ function SetupBody() {
               />
               <TogglePref
                 label="Large trackpad"
-                sub="Hide the status bar, mode tabs, and button rows on the MOUSE surface for edge-to-edge scrolling. A corner chip brings them back."
+                sub="Hide the status bar, mode tabs, and button rows on the MOUSE and SWIPE surfaces for edge-to-edge use. A corner chip brings them back."
                 value={padTrackpadLarge}
                 onValueChange={(v) => {
                   void setPref('padTrackpadLarge', v);
@@ -1541,7 +1541,7 @@ function SetupBody() {
               />
               <TogglePref
                 label="Large-pad corner button"
-                sub="Show a one-tap chip in the corner of the MOUSE surface to enter large mode. The exit chip always shows in large mode."
+                sub="Show a one-tap chip in the corner of the MOUSE and SWIPE surfaces to enter large mode. The exit chip always shows in large mode."
                 value={padLargeToggle}
                 onValueChange={(v) => {
                   void setPref('padLargeToggle', v);

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -778,6 +778,7 @@ function SetupBody() {
   const padKeyboardBar = usePref('padKeyboardBar');
   const padHints = usePref('padHints');
   const padTrackpadLarge = usePref('padTrackpadLarge');
+  const padLargeToggle = usePref('padLargeToggle');
   const askToSwitchControl = usePref('askToSwitchControl');
   const keyboardMode = usePref('keyboardMode');
   const searchButtonSide = usePref('searchButtonSide');
@@ -1535,6 +1536,15 @@ function SetupBody() {
                 value={padTrackpadLarge}
                 onValueChange={(v) => {
                   void setPref('padTrackpadLarge', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Large-pad corner button"
+                sub="Show a one-tap chip in the corner of the MOUSE surface to enter large mode. The exit chip always shows in large mode."
+                value={padLargeToggle}
+                onValueChange={(v) => {
+                  void setPref('padLargeToggle', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -107,6 +107,10 @@ export type Prefs = {
   padKeyboardBar: boolean;
   /** Gesture hint text on the swipe/trackpad surfaces. */
   padHints: boolean;
+  /** Collapse the pill + mode tabs + button/keyboard rows so the trackpad
+   *  surface fills the pane for edge-to-edge scrolling. Trackpad mode only;
+   *  a floating chip restores the chrome. */
+  padTrackpadLarge: boolean;
   /** When another phone joins a box you're controlling, ask before handing
       over (true) vs let it grab control immediately (false). Agent >= 2.9.2. */
   askToSwitchControl: boolean;
@@ -173,6 +177,7 @@ export const DEFAULTS: Prefs = {
   padWinShortcuts: true,
   padKeyboardBar: true,
   padHints: true,
+  padTrackpadLarge: false,
   askToSwitchControl: true,
   // Android intercepts the keycode cleanly (no HUD); iOS can't, so it stays off
   // until the user opts in.
@@ -274,6 +279,7 @@ function normalize(raw: unknown): Prefs {
     padWinShortcuts: bool(o.padWinShortcuts, DEFAULTS.padWinShortcuts),
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
+    padTrackpadLarge: bool(o.padTrackpadLarge, DEFAULTS.padTrackpadLarge),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
     hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -111,6 +111,10 @@ export type Prefs = {
    *  surface fills the pane for edge-to-edge scrolling. Trackpad mode only;
    *  a floating chip restores the chrome. */
   padTrackpadLarge: boolean;
+  /** Show the corner chip on the trackpad that toggles large mode in one tap.
+   *  Off hides the ENTER chip (large mode still shows the EXIT chip so you're
+   *  never stranded); the Setup toggle always works. */
+  padLargeToggle: boolean;
   /** When another phone joins a box you're controlling, ask before handing
       over (true) vs let it grab control immediately (false). Agent >= 2.9.2. */
   askToSwitchControl: boolean;
@@ -178,6 +182,7 @@ export const DEFAULTS: Prefs = {
   padKeyboardBar: true,
   padHints: true,
   padTrackpadLarge: false,
+  padLargeToggle: true,
   askToSwitchControl: true,
   // Android intercepts the keycode cleanly (no HUD); iOS can't, so it stays off
   // until the user opts in.
@@ -280,6 +285,7 @@ function normalize(raw: unknown): Prefs {
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
     padTrackpadLarge: bool(o.padTrackpadLarge, DEFAULTS.padTrackpadLarge),
+    padLargeToggle: bool(o.padLargeToggle, DEFAULTS.padLargeToggle),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
     hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,42 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Large trackpad toggle — edge-to-edge scrolling surface
+- **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
+- Tester ask (likwidtek): the trackpad is cramped for "mindless scrolling." A
+  `padTrackpadLarge` pref (Setup → PAD LAYOUT) collapses the status pill, mode tabs,
+  button rows, and keyboard bar in MOUSE/trackpad mode so the pad fills the pane; a
+  floating corner chip is the escape hatch (the only affordance left once the mode
+  tabs hide). **Not** OS-fullscreen — the bottom tab bar stays (hiding it is a
+  navigator-level change, follow-up only if asked).
+- **PR #239.** Verified in the web harness (collapse + exit chip both pressed, not
+  just rendered); tsc clean. Awaiting merge — mark Complete once merged.
+
 ## 📋 Planned
+
+### Trackpad reliability — "green pill but dead" zombie + gesture misfires
+- **priority:** P1 · **risk:** MED (safety-critical input path, CLAUDE.md §4) · **affects:** app only · **depends_on:** none
+- From the tester triage (items A + B; C shipped as PR #239). Root-caused in code —
+  see BUILD_LOG 2026-07-23 and the workflow findings; do not re-derive.
+- **A — WS zombie (the force-quit bug).** The connection pill is a *latched* self-report
+  with no liveness input, so a half-dead socket stays green forever; `connect()`'s
+  idempotent guard early-returns whenever it *thinks* it is connected, stranding a client
+  whose socket was nulled + ping stopped and never reconnects (mouse **and** paste dead
+  until force-quit). The existing foreground-reconnect (`pad.tsx:968`) no-ops for the same
+  reason. Fix: require a live socket in the guard (`ws && ws.readyState===1`) at
+  `lib/gamepad.ts:~474`; add `wake()/ensureLive()` on AppState `active` that reconnects
+  unconditionally + probes immediately (don't wait ~12s for the watchdog); drive the pill
+  color off `lastInbound`/`readyState`, which also re-enables tap-to-retry. **Needs §4
+  device-lifecycle tests.** Highest-impact of the three.
+- **B — gesture misfires.** Two-finger tap (right-click) uses `maxTouches` sampled only
+  during *move*, so a motionless two-finger tap stays count 1 → left-click; and a sub-8px
+  two-finger stroke leaks a right-click because `moved` (8px net) is decoupled from the
+  scroll notch (18px). Fix in `hooks/useTrackpad.ts`: track live count via
+  `onPanResponderStart`/`gestureState.numberActiveTouches`; latch an explicit `scrolled`
+  flag and gate the right-click on `!scrolled`. One file covers Pad + RemoteView.
+- Recommended split: **A solo** (risk isolation + lifecycle tests), **B** on its own.
+
+
 
 ### On-box pairing tutorial (auto-plays after install)
 - **priority:** P1 · **risk:** low · **affects:** agent + installer · **depends_on:** none


### PR DESCRIPTION
## What

Adds a **Large trackpad** toggle (Setup → PAD LAYOUT). In MOUSE/trackpad mode it
collapses the status pill, mode tabs, button rows, and keyboard bar so the pad
surface fills the pane — the "mindless scrolling" surface a tester asked for.
A floating corner chip (the only affordance left once the mode tabs are hidden)
restores the chrome.

From the tester triage (item C of 4). The pad already grows to fill leftover
vertical space (`flex:1`), so "bigger" = "reclaim the chrome above and below,"
which this does behind one pref.

## Changes
- `lib/prefs.ts` — `padTrackpadLarge` boolean (type + DEFAULTS false + normalize), mirroring the existing `padMouseRow`/`padHints` pad-layout prefs.
- `app/(tabs)/pad.tsx` — `largePad = padTrackpadLarge && mode === 'trackpad'`; gate the pill, mode toggle, all three button rows, and the keyboard bar on `!largePad`; render a floating `exitLargeChip` (calls `setPref('padTrackpadLarge', false)`) only in that state.
- `app/(tabs)/setup.tsx` — one `TogglePref` row in the PAD LAYOUT card.

## Not in scope
- **Not OS-fullscreen** — the bottom tab bar stays. Hiding it is a navigator-level change (`tabBarStyle` conditioned on route/state), higher risk; left as a follow-up.
- Only affects trackpad mode (the conjunction guards it); PAD/SWIPE/REMOTE are untouched.

## Verified (web harness, mock agent — pressed, not just rendered)
- Toggle renders in Setup → PAD LAYOUT and is found via the settings search.
- Toggle ON → trackpad mode collapses pill + tabs + button rows + keyboard bar; the pad fills the pane; the exit chip appears top-right.
- Press the exit chip → full chrome returns (baseline restored).
- `tsc --noEmit` clean.

Screenshots (collapsed vs. restored) captured during verification.

## Safety
Pure app-side layout + one pref. No agent surface, no allowlist, no WS/gesture logic touched (those are triage items A/B, separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
