### PR TITLE
fix(pad): recover the WS instead of stranding a green-pill zombie

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,3 +426,21 @@ jobs:
           PY
 
           echo "smoke OK"
+
+  # App-side WebSocket input-path lifecycle (CLAUDE.md §4 — the most bug-prone
+  # code in the project). lib/gamepad.ts is runtime-import-free (only a global
+  # WebSocket + Date/timers), so the lifecycle test runs standalone on Node's
+  # built-in type stripping + test runner: no npm install, no Metro, no bundler.
+  # Guards the "green pill, dead mouse, force-quit to recover" zombie —
+  # connect()/ensureLive() must never leave a torn-down socket behind over a
+  # stale 'connected' status.
+  app-input:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Gamepad client lifecycle tests
+        run: node --experimental-strip-types --test lib/__tests__/*.test.ts
+        working-directory: app

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -966,8 +966,15 @@ function PadScreen() {
     const offFocus = navigation.addListener('focus', connect);
     const offBlur = navigation.addListener('blur', disconnect);
     const appSub = AppState.addEventListener('change', (state) => {
-      if (state === 'active') connect();
-      else disconnect();
+      if (state === 'active') {
+        connect();
+        // connect() refreshes settings and rebuilds a null/closed socket, but a
+        // socket left OPEN-but-half-dead (a backgrounded suspend or Wi-Fi blip)
+        // still looks connected to it. ensureLive() forces a reconnect for that
+        // case, so foregrounding always restores input instead of needing a
+        // force-quit — the exact "green pill, dead mouse" the field hit.
+        client.ensureLive();
+      } else disconnect();
     });
 
     // Baseline: connect on mount. Focus/blur listeners above refine this when

--- a/app/lib/__tests__/gamepad.lifecycle.test.ts
+++ b/app/lib/__tests__/gamepad.lifecycle.test.ts
@@ -1,0 +1,157 @@
+/**
+ * GamepadClient socket-lifecycle tests — the safety-critical input path
+ * (CLAUDE.md §4). No RN, no bundler: gamepad.ts only touches a global
+ * `WebSocket` and Date/timers, so we mock WebSocket + a controllable clock and
+ * drive the client directly.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * (Node >= 22.6). Wired into CI as the "gamepad-lifecycle" job.
+ *
+ * Regression under test: a torn-down socket (this.ws === null) must NOT be left
+ * behind by connect()/ensureLive() over a stale 'connected' status — that was
+ * the "green pill, dead mouse, force-quit to recover" zombie.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// ---- controllable clock (ensureLive/watchdog compare Date.now to lastInbound)
+let NOW = 1_000_000;
+const realDateNow = Date.now;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(Date as any).now = () => NOW;
+
+// ---- mock WebSocket -------------------------------------------------------
+type Handler = ((ev: unknown) => void) | null;
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  readyState = 0; // CONNECTING
+  onopen: Handler = null;
+  onmessage: Handler = null;
+  onerror: Handler = null;
+  onclose: Handler = null;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+  send(data: string) {
+    this.sent.push(data);
+  }
+  close() {
+    if (this.readyState === 3) return;
+    this.readyState = 3;
+    if (this.onclose) this.onclose({});
+  }
+  /** Simulate the real open + `hello` handshake that drives status→connected. */
+  openAndHello(dev = 'mock pad') {
+    this.readyState = 1; // OPEN
+    if (this.onopen) this.onopen({});
+    if (this.onmessage) this.onmessage({ data: JSON.stringify({ t: 'hello', dev }) });
+  }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).WebSocket = MockWebSocket;
+
+// Import AFTER the WebSocket global is installed.
+const { GamepadClient } = await import('../gamepad.ts');
+
+const CONN = { host: 'box.local', port: 8787, token: 'tok', lastIp: '10.0.0.5' };
+
+function freshClient() {
+  MockWebSocket.reset();
+  NOW = 1_000_000;
+  return new GamepadClient();
+}
+
+test('connect() drives to connected via the hello handshake', () => {
+  const c = freshClient();
+  c.connect(CONN, { deviceName: 'phone' });
+  assert.equal(MockWebSocket.instances.length, 1, 'one socket opened');
+  MockWebSocket.instances[0].openAndHello();
+  assert.equal(c.getStatus(), 'connected');
+  c.close();
+});
+
+test('ZOMBIE FIX: connect() rebuilds a torn-down socket instead of no-oping', () => {
+  const c = freshClient();
+  c.connect(CONN, { deviceName: 'phone' });
+  MockWebSocket.instances[0].openAndHello();
+  assert.equal(c.getStatus(), 'connected');
+
+  // The noPad toggle calls teardownSocket(false) (nulls this.ws) but leaves
+  // status 'connected'. Pre-fix, the connect() guard saw 'connected' and
+  // returned WITHOUT opening — a null-socket zombie. Post-fix, wsAlive is false
+  // so it falls through to open().
+  c.connect(CONN, { noPad: true });
+  assert.equal(
+    MockWebSocket.instances.length,
+    2,
+    'connect() must open a new socket over the torn-down one, not no-op',
+  );
+  c.close();
+});
+
+test('ensureLive(): no-op on a fresh OPEN socket', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  c.ensureLive();
+  assert.equal(MockWebSocket.instances.length, 1, 'a live socket is left alone');
+  c.close();
+});
+
+test('ensureLive(): reconnects an OPEN-but-stale (half-dead) socket', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello(); // lastInbound = NOW
+  // Socket still says OPEN, but no inbound frame for > 2.5 ping intervals: the
+  // pipe is half-dead. connect() can't see this (readyState OPEN); ensureLive can.
+  NOW += 5_000 * 2.5 + 1;
+  c.ensureLive();
+  assert.equal(MockWebSocket.instances.length, 2, 'stale OPEN socket is rebuilt');
+  c.close();
+});
+
+test('ensureLive(): reconnects when the socket has closed under us', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  const ws0 = MockWebSocket.instances[0];
+  ws0.openAndHello();
+  ws0.readyState = 3; // CLOSED, without an onclose (e.g. app was suspended)
+  c.ensureLive();
+  assert.equal(MockWebSocket.instances.length, 2, 'a CLOSED socket is rebuilt');
+  c.close();
+});
+
+test('ensureLive(): no-op when not active (never connected / after close)', () => {
+  const c = freshClient();
+  c.ensureLive(); // active === false
+  assert.equal(MockWebSocket.instances.length, 0, 'no socket opened while inactive');
+});
+
+test('normal background→foreground still reconnects (close then connect)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  c.close(); // background
+  assert.equal(c.getStatus(), 'closed');
+  c.connect(CONN); // foreground
+  assert.equal(MockWebSocket.instances.length, 2, 'foreground opens a fresh socket');
+  c.close();
+});
+
+// restore the clock so a leaked reference can't confuse other files
+process.on('exit', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (Date as any).now = realDateNow;
+});

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -24,7 +24,7 @@
  *   The hello `text` field advertises how much of a typed string the agent can
  *   deliver; sendText() strips non-typeable chars when it is not "unicode".
  */
-import { Settings } from './settings';
+import type { Settings } from './settings';
 
 export type GamepadStatus =
   | 'connecting'
@@ -471,9 +471,22 @@ export class GamepadClient {
     // Always take the latest conn (a refreshed lastIp must be visible to
     // future reconnects), but never tear down a healthy socket for it.
     this.conn = conn;
+    // A latched 'connected'/'connecting' status is NOT proof of a usable socket.
+    // teardownSocket(false) nulls this.ws WITHOUT resetting status (the noPad
+    // branch above does exactly this), and a missed/coalesced background event
+    // can leave status stuck 'connected' over a socket that has since closed.
+    // If we no-op on status alone we strand a zombie: null socket, ping stopped,
+    // nothing scheduled to reconnect, every input frame silently dropped, and
+    // only a force-quit recovers. So only no-op when the socket is genuinely
+    // still CONNECTING or OPEN; otherwise fall through to open() and rebuild it.
+    const wsAlive =
+      this.ws != null &&
+      (this.ws.readyState === 0 /* CONNECTING */ ||
+        this.ws.readyState === 1); /* OPEN */
     if (
       same &&
       this.active &&
+      wsAlive &&
       (this.status === 'connected' || this.status === 'connecting')
     ) {
       return;
@@ -493,6 +506,34 @@ export class GamepadClient {
     this.releaseAll();
     this.teardownSocket(true);
     this.setStatus('closed', null);
+  }
+
+  /**
+   * Force a live socket when the app returns to the foreground. The AppState
+   * handler also calls connect(), but connect() is idempotent and (correctly)
+   * will not rebuild a socket that is CONNECTING or OPEN. A socket can be OPEN
+   * yet half-dead — iOS keeps buffering our sends without erroring after a
+   * Wi-Fi blip or a backgrounded suspend, so every frame vanishes while
+   * readyState still says OPEN. The pong watchdog only catches that after
+   * ~2.5 idle intervals, and only while it is still running (a backgrounded
+   * app freezes the timer). So on foreground: if the socket is not provably
+   * live — null, not OPEN, or silent longer than the watchdog deadline —
+   * reconnect NOW instead of waiting the watchdog out (or forever). A socket
+   * still CONNECTING is left alone: a just-fired connect() is mid-dial, not
+   * dead, and tearing it down here would double-open.
+   */
+  ensureLive(): void {
+    if (!this.active) return;
+    const ws = this.ws;
+    const live =
+      ws != null &&
+      (ws.readyState === 0 /* CONNECTING — mid-dial, leave it */ ||
+        (ws.readyState === 1 /* OPEN */ &&
+          Date.now() - this.lastInbound < PING_INTERVAL_MS * 2.5));
+    if (live) return;
+    this.attempt = 0;
+    this.clearReconnect();
+    this.open(); // tears the stale socket down + sets status 'connecting'
   }
 
   sendButton(k: ButtonKey, v: 0 | 1): void {

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -174,6 +174,26 @@ This is the strongest convention in the repo; a new test file without one is inc
 ```
 (`.github/workflows/ci.yml:36-43`; see also `:45-50`, `:66-72`, `:74-82`, `:93-101`)
 
+### App-side lifecycle tests (TypeScript, no bundler, no new dependency)
+
+The safety-critical WS input path (`app/lib/gamepad.ts`, CLAUDE.md §4) has real unit
+tests despite the app having **no jest/vitest**. The trick: keep the module
+**runtime-import-free** (`gamepad.ts` imports only `import type { Settings }` — erased —
+and touches only a global `WebSocket` + `Date`/timers), so a test can load it standalone
+and run on **Node's built-ins**:
+
+```
+node --experimental-strip-types --test app/lib/__tests__/*.test.ts   # Node >= 22.6
+```
+
+`app/lib/__tests__/gamepad.lifecycle.test.ts` installs a mock `WebSocket` on `globalThis`
++ a controllable `Date.now`, then drives `GamepadClient` through connect → hello → teardown
+→ reconnect / `ensureLive`. It is **control-verified**: the "ZOMBIE FIX" case FAILS if the
+`connect()` guard's `wsAlive` requirement is removed (§11 — see it fire AND not fire). CI job
+`app-input` runs it with **no `npm install`** (the module needs no node_modules). Adding a
+bundler-dependent test would have meant a whole toolchain; this needs none. If you make the
+tested module import a real dependency, this standalone path breaks — keep it import-free.
+
 CI is two jobs: `compile` (`py_compile` on all three entrypoints, then the unit tests) and `smoke`
 (boots the agent `--mock` on a spare port and proves auth: `/api/ping` 200, `/api/status` 401
 without a token, 200 with one) — `.github/workflows/ci.yml:103-186`.


### PR DESCRIPTION
## What

Fixes the **"green pill, dead mouse + paste, force-quit to recover"** zombie — triage item **A**, the highest-impact of the trackpad-feedback bugs (likwidtek).

`teardownSocket(false)` nulls `this.ws` **without** resetting `status`, so `connect()`'s idempotent guard saw a stale `'connected'` and returned **without** reopening. The noPad/keyboard-mode toggle hits this path directly (`connect` → `teardownSocket(false)` → guard), and a missed/coalesced background event does too. The pong watchdog would normally rebuild a half-dead socket — but it's stopped in that state, so nothing reconnects. Result: null socket, ping stopped, pill still green, every input frame silently dropped, only a force-quit recovers.

## Changes
- **`gamepad.ts` — guard requires a live socket.** `connect()` no-ops only when `this.ws != null && readyState ∈ {CONNECTING, OPEN}`; a null/closed socket falls through to `open()`. Kills the permanent zombie.
- **`gamepad.ts` — new `ensureLive()`.** On foreground, reconnect if the socket isn't provably live (null | not OPEN | silent > 2.5 ping intervals) — so an OPEN-but-half-dead socket (backgrounded suspend / Wi-Fi blip) recovers *now* instead of after the watchdog, or never. A `CONNECTING` socket is left alone so a just-fired `connect()` isn't double-opened.
- **`pad.tsx`** — AppState `'active'` calls `client.ensureLive()` after `connect()`.
- **`gamepad.ts`** — `import type { Settings }` (runtime-import-free, so the test can load it standalone).

## Tests (CLAUDE.md §4)

`app/lib/__tests__/gamepad.lifecycle.test.ts` — mock `WebSocket` + a controllable clock, driving connect → hello → teardown → reconnect / `ensureLive` (7 cases: the zombie rebuild, `ensureLive` on fresh/stale/closed/inactive, normal background→foreground).

**Control-verified (§11):** the `ZOMBIE FIX` test **fails** when the guard's `wsAlive` check is removed, and passes with it — confirmed by reverting the fix and re-running.

The app has no jest/vitest; this runs on **Node's built-ins** (`node --experimental-strip-types --test`, Node ≥ 22.6) with **no new dependency and no `npm install`** — new CI job `app-input`. Convention recorded in `docs/memory/CONVENTIONS.md`.

## NOT in this PR
- The pill still reads green during the brief pre-recovery window; turning it **amber-when-stale** is a follow-up. The recovery itself no longer needs it (foreground/watchdog now rebuild the socket).
- Gesture bugs (right-click / scroll-click) = triage item **B**, separate PR.

## Verified
- 7/7 lifecycle tests pass; control-fail confirmed. `tsc --noEmit` clean. Web harness: app loads + runs with no console errors (the harness proxy doesn't route `/ws/gamepad`, so the pad WS can't be exercised there — hence the mock-WS unit test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
