### PR TITLE
feat(pad): pill shows amber "no response" over a half-dead socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,6 +441,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+      # --test-force-exit: a FAILING test throws before its client.close(), which
+      # leaks the 5s ping setInterval and would otherwise keep the run alive until
+      # the job times out. Force-exit makes a failure exit promptly (and report)
+      # instead of hanging. Passing runs close every client and exit on their own.
       - name: Gamepad client lifecycle tests
-        run: node --experimental-strip-types --test lib/__tests__/*.test.ts
+        run: node --experimental-strip-types --test --test-force-exit lib/__tests__/*.test.ts
         working-directory: app

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -854,6 +854,10 @@ function PadScreen() {
   // has nothing to drive. Fall back rather than render sticks that go nowhere.
   const mode: PadMode = keyboardMode && rawMode === 'gamepad' ? 'swipe' : rawMode;
   const [status, setStatus] = useState<GamepadStatus>('closed');
+  // True when status is 'connected' but the socket has gone silent (half-dead):
+  // polled from the client, it turns the pill amber + tap-to-retry live BEFORE
+  // the pong watchdog acts, instead of showing a green pill over a dead pipe.
+  const [stale, setStale] = useState(false);
   const [dev, setDev] = useState<string | null>(null);
   // Non-null when the box is refusing input injection (locked / not the active
   // desktop / an elevated window has focus); the string is the hint to show.
@@ -1043,8 +1047,22 @@ function PadScreen() {
     return () => clearTimeout(t);
   }, [status]);
 
+  // Poll the client's liveness while it believes it's connected: a socket can be
+  // OPEN yet silently dropping frames, so the pill must not just trust the
+  // latched 'connected'. One check per second is plenty against a 5s ping. Off
+  // whenever we're not connected (the status itself already tells the truth then).
+  useEffect(() => {
+    if (status !== 'connected') {
+      setStale(false);
+      return;
+    }
+    setStale(client.isStale());
+    const id = setInterval(() => setStale(client.isStale()), 1000);
+    return () => clearInterval(id);
+  }, [status, client]);
+
   // The status pill's tap does the right thing per state: request/force control
-  // during a handoff, otherwise reconnect.
+  // during a handoff, reconnect a stale socket, otherwise reconnect.
   const retry = useCallback(() => {
     haptic();
     if (status === 'released') {
@@ -1058,8 +1076,12 @@ function PadScreen() {
         deviceName: DEVICE_LABEL,
         noPad: keyboardMode,
       });
+    } else if (stale) {
+      // Connected on paper but the socket has gone silent: force a fresh one.
+      // connect() would no-op here (its guard sees the still-OPEN socket).
+      client.reconnect();
     }
-  }, [client, settings, status, canForce, askToSwitch]);
+  }, [client, settings, status, stale, canForce, askToSwitch, keyboardMode]);
 
   const btn = useCallback(
     (k: ButtonKey) => ({
@@ -1440,11 +1462,18 @@ function PadScreen() {
       {!largePad && (
         <>
           <Pressable onPress={retry} style={styles.pill} hitSlop={8}>
-            <View style={[styles.pillDot, { backgroundColor: STATUS_COLOR[status] }]} />
+            <View
+              style={[
+                styles.pillDot,
+                { backgroundColor: stale ? t.amber : STATUS_COLOR[status] },
+              ]}
+            />
             <Text style={styles.pillText} numberOfLines={1}>
-              {status === 'waiting' && canForce
-                ? 'no response · tap to take control'
-                : statusLabel(status, dev)}
+              {stale
+                ? 'no response · tap to retry'
+                : status === 'waiting' && canForce
+                  ? 'no response · tap to take control'
+                  : statusLabel(status, dev)}
             </Text>
           </Pressable>
           <View style={styles.modeToggle}>

--- a/app/lib/__tests__/gamepad.lifecycle.test.ts
+++ b/app/lib/__tests__/gamepad.lifecycle.test.ts
@@ -150,6 +150,43 @@ test('normal background→foreground still reconnects (close then connect)', () 
   c.close();
 });
 
+test('isStale(): false on a fresh connection, true once the socket goes silent', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello(); // lastInbound = NOW
+  assert.equal(c.isStale(), false, 'a fresh connection is not stale');
+  NOW += 5_000 * 1.3 + 1; // past 1.3 ping intervals with no inbound frame
+  assert.equal(c.isStale(), true, 'a silent OPEN socket reads stale');
+  c.close();
+});
+
+test('isStale(): false whenever not connected', () => {
+  const c = freshClient();
+  assert.equal(c.isStale(), false, 'never connected');
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  c.close();
+  assert.equal(c.isStale(), false, 'after close');
+});
+
+test('reconnect(): forces a fresh socket even while still OPEN (pill tap-to-retry)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  // Still OPEN and only mildly stale (1.4 intervals): connect()/ensureLive would
+  // no-op, but an explicit user tap must rebuild the socket.
+  NOW += 5_000 * 1.4;
+  c.reconnect();
+  assert.equal(MockWebSocket.instances.length, 2, 'reconnect() opens a fresh socket');
+  c.close();
+});
+
+test('reconnect(): no-op when not active', () => {
+  const c = freshClient();
+  c.reconnect();
+  assert.equal(MockWebSocket.instances.length, 0);
+});
+
 // restore the clock so a leaked reference can't confuse other files
 process.on('exit', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -536,6 +536,38 @@ export class GamepadClient {
     this.open(); // tears the stale socket down + sets status 'connecting'
   }
 
+  /**
+   * We believe we're 'connected', but no inbound frame (pong or server message)
+   * has arrived for longer than ~1.3 ping intervals — a pong was missed, so the
+   * pipe is probably half-dead even though readyState still says OPEN. Lets the
+   * UI degrade the status pill from green to amber ("no response") BEFORE the
+   * pong watchdog gives up (1.4–2.5 intervals), instead of showing a live-green
+   * pill over a dead socket. The 1.3× floor stays above one whole interval so a
+   * healthy socket between pongs is never flagged. Read on a poll — the client
+   * does not push a frame for this.
+   */
+  isStale(): boolean {
+    return (
+      this.status === 'connected' &&
+      this.ws != null &&
+      Date.now() - this.lastInbound > PING_INTERVAL_MS * 1.3
+    );
+  }
+
+  /**
+   * Force a fresh socket now — the status pill's tap-to-retry when a 'connected'
+   * socket has gone stale. Unlike ensureLive() (conservative, auto-fired on
+   * foreground) this does not second-guess: an explicit user tap means rebuild,
+   * even inside the watchdog's grace window. connect() alone can't do this — its
+   * guard sees the still-OPEN socket and no-ops.
+   */
+  reconnect(): void {
+    if (!this.active) return;
+    this.attempt = 0;
+    this.clearReconnect();
+    this.open();
+  }
+
   sendButton(k: ButtonKey, v: 0 | 1): void {
     this.sendRaw({ t: 'b', k, v });
   }


### PR DESCRIPTION
## What

The pill polish deferred from #240. Even with the WS zombie fixed, a socket can be **OPEN but silently dropping frames** for a few seconds before the pong watchdog acts — and the pill stayed **green**, hiding a dead pointer. Now it degrades to **amber "no response · tap to retry"**, and the tap forces a fresh socket.

## Changes
- **`gamepad.ts`**
  - `isStale()` — `status === 'connected'` but no inbound frame for `> 1.3 × ping interval` (a missed pong). The 1.3× floor stays above one whole interval so a healthy socket between pongs is never flagged; below the watchdog's 1.4–2.5× so the pill warns *before* teardown.
  - `reconnect()` — force a fresh socket now (the pill's tap). `connect()`/`ensureLive()` deliberately no-op over a still-OPEN socket, so an explicit user tap needs its own path.
- **`pad.tsx`** — poll `isStale()` once a second while connected; pill dot → amber + label "no response · tap to retry" when stale; `retry()` calls `reconnect()` in that state. (Also fixes a latent missing `keyboardMode` dep on the retry callback.)

## Tests (CLAUDE.md §4)
4 new cases in `gamepad.lifecycle.test.ts` (isStale fresh/stale/disconnected; reconnect force/inactive) → **11/11**. **Control-verified:** the `isStale` test fails when the 1.3-interval threshold is neutered.

CI now passes **`--test-force-exit`** — a failing test throws before `client.close()`, leaking the 5s ping `setInterval`; force-exit makes a failure exit promptly instead of hanging out the job timeout. Passing runs close every client and exit on their own (verified 11/11 identical with and without the flag).

## Verified
- 11/11 lifecycle tests; tsc clean.
- Web harness: pill renders correctly (amber "connecting…"), no console errors, no regression. The stale-**amber** path needs a real connected-then-silent socket the harness proxy can't provide (it can't route `/ws/gamepad`), so that path is covered by the unit test, not the harness.

## Depends on
Built on `main` (has #240's `ensureLive`). Trackpad triage: **A** done (#240), **this** = the pill polish, **B** (gesture misfires) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
