### PR TITLE
fix(pad): reliable two-finger right-click + no click leak on scroll

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,6 @@ jobs:
       # leaks the 5s ping setInterval and would otherwise keep the run alive until
       # the job times out. Force-exit makes a failure exit promptly (and report)
       # instead of hanging. Passing runs close every client and exit on their own.
-      - name: Gamepad client lifecycle tests
-        run: node --experimental-strip-types --test --test-force-exit lib/__tests__/*.test.ts
+      - name: Input-path unit tests (gamepad lifecycle + trackpad gestures)
+        run: node --experimental-strip-types --test --test-force-exit lib/__tests__/*.test.ts hooks/__tests__/*.test.ts
         working-directory: app

--- a/app/hooks/__tests__/trackpadGesture.test.ts
+++ b/app/hooks/__tests__/trackpadGesture.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Trackpad gesture-classification tests (CLAUDE.md §4 — input path). The logic
+ * lives in a pure module because useTrackpad.ts imports react-native's
+ * PanResponder (not node-loadable) and RN-Web emits mouse, not touch events, so
+ * the harness can't exercise these gestures. Run:
+ *   node --experimental-strip-types --test --test-force-exit hooks/__tests__/*.test.ts
+ *
+ * The two cases the tester reported (right-click flaky, two-finger scroll leaks a
+ * click) are pinned as BUG1 / BUG2 below. Pre-fix, a motionless two-finger tap
+ * classified as a left-click, and a short two-finger stroke as a right-click.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const { classifyRelease, TP_TAP_MS } = await import('../trackpadGesture.ts');
+
+test('one-finger quick still tap -> left-click', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 1, moved: false, scrolled: false, elapsedMs: 100 }),
+    'left-click',
+  );
+});
+
+test('one-finger drag -> none (pointer move, not a click)', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 1, moved: true, scrolled: false, elapsedMs: 100 }),
+    'none',
+  );
+});
+
+test('one-finger slow press -> none', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 1, moved: false, scrolled: false, elapsedMs: 400 }),
+    'none',
+  );
+});
+
+test('BUG1: motionless two-finger tap -> right-click (was misfiring as left)', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 2, moved: false, scrolled: false, elapsedMs: 120 }),
+    'right-click',
+  );
+});
+
+test('BUG2: short two-finger scroll -> none (no spurious right-click)', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 2, moved: false, scrolled: true, elapsedMs: 150 }),
+    'none',
+  );
+});
+
+test('two-finger gesture never falls through to a left-click', () => {
+  // classifies on `scrolled`, not the one-finger `moved` slop: a quick still
+  // two-finger release is a right-click, and it is NEVER a left-click.
+  for (const moved of [false, true]) {
+    const a = classifyRelease({ maxTouches: 2, moved, scrolled: false, elapsedMs: 100 });
+    assert.notEqual(a, 'left-click', `maxTouches=2 moved=${moved} must not left-click`);
+    assert.equal(a, 'right-click');
+  }
+});
+
+test('two-finger slow press -> none', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 2, moved: false, scrolled: false, elapsedMs: 400 }),
+    'none',
+  );
+});
+
+test('boundary: elapsed exactly TP_TAP_MS is too slow -> none', () => {
+  assert.equal(
+    classifyRelease({ maxTouches: 1, moved: false, scrolled: false, elapsedMs: TP_TAP_MS }),
+    'none',
+  );
+});

--- a/app/hooks/trackpadGesture.ts
+++ b/app/hooks/trackpadGesture.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure trackpad-gesture decision logic, split out of useTrackpad.ts so it can be
+ * unit-tested. useTrackpad.ts owns the PanResponder + mutable ref state and
+ * imports react-native (so it can't be loaded standalone), and RN-Web emits
+ * mouse events, not touch — so the classifier is the only place these gestures
+ * can be verified without a physical device. Keep this file react-native-free.
+ */
+
+/** Movement under this (px) still counts as a one-finger tap/click. */
+export const TP_TAP_SLOP = 8;
+/** Two-finger travel over this (px) is a scroll, not a right-click tap. Tighter
+ *  than TP_TAP_SLOP and well below the scroll-notch step, so the ambiguous band
+ *  between "moved a little" and "emitted a notch" resolves to scroll — the fix
+ *  for a short two-finger stroke leaking a spurious right-click. */
+export const TP_TWO_FINGER_SLOP = 6;
+/** Touches longer than this aren't taps. */
+export const TP_TAP_MS = 350;
+/** Screen px of two-finger drag per wheel notch. */
+export const TP_SCROLL_STEP = 18;
+
+export type ReleaseAction = 'left-click' | 'right-click' | 'none';
+
+/** State a release is classified from. */
+export type ReleaseState = {
+  /** Highest concurrent touch count seen this gesture (from onStart, live). */
+  maxTouches: number;
+  /** One-finger net travel exceeded TP_TAP_SLOP. */
+  moved: boolean;
+  /** A two-finger scroll actually happened (travel > TP_TWO_FINGER_SLOP). */
+  scrolled: boolean;
+  /** ms from first touch to release. */
+  elapsedMs: number;
+};
+
+/**
+ * Decide what a lifted trackpad gesture was. Pure.
+ *
+ *  - too slow (> TP_TAP_MS)        -> 'none' (a press/hold, not a tap)
+ *  - two fingers, scrolled         -> 'none' (it was a scroll — never a click)
+ *  - two fingers, quick + still    -> 'right-click' (independent of one-finger
+ *                                     slop: a two-finger tap classifies on
+ *                                     `scrolled`, which is what the misfires were)
+ *  - one finger, quick, not moved  -> 'left-click'
+ *  - one finger, moved             -> 'none' (a pointer drag)
+ *
+ * A ≥2-finger gesture NEVER falls through to a left-click, and a scroll never
+ * yields any click — the two reported bugs.
+ */
+export function classifyRelease(s: ReleaseState): ReleaseAction {
+  if (s.elapsedMs >= TP_TAP_MS) return 'none';
+  if (s.maxTouches >= 2) return s.scrolled ? 'none' : 'right-click';
+  return s.moved ? 'none' : 'left-click';
+}

--- a/app/hooks/useTrackpad.ts
+++ b/app/hooks/useTrackpad.ts
@@ -22,10 +22,13 @@ import { PanResponder, PanResponderInstance } from 'react-native';
 
 import { usePref } from '@/lib/prefs';
 
-/** Movement under this (px) still counts as a tap/click. */
-const TP_TAP_SLOP = 8;
-/** Touches longer than this aren't taps. */
-const TP_TAP_MS = 350;
+import {
+  classifyRelease,
+  TP_SCROLL_STEP,
+  TP_TAP_SLOP,
+  TP_TWO_FINGER_SLOP,
+} from './trackpadGesture';
+
 /**
  * Max gap between the first tap's release and the second touch's start for the
  * pair to read as a double-tap (which, if the second touch then drags, arms a
@@ -38,8 +41,6 @@ const TP_DOUBLE_TAP_MS = 300;
  */
 const TP_BASE = 1.1;
 const TP_GAIN = 0.05;
-/** Screen px of two-finger drag per wheel notch. */
-const TP_SCROLL_STEP = 18;
 
 export type TrackpadCallbacks = {
   onMove: (dx: number, dy: number) => void;
@@ -67,6 +68,7 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
     lastY: 0,
     lastT: 0,
     moved: false,
+    scrolled: false,
     t0: 0,
     maxTouches: 1,
     scrollAccum: 0,
@@ -102,6 +104,7 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
           lastY: 0,
           lastT: now,
           moved: false,
+          scrolled: false,
           t0: now,
           maxTouches: touches,
           scrollAccum: 0,
@@ -111,6 +114,15 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
           dragging: false,
         };
       },
+      // Fires on EVERY touch start, movement or not — so a motionless two-finger
+      // tap (which emits no move event) still records maxTouches = 2 and reads as
+      // a right-click. Sampling touches only in onPanResponderMove missed that:
+      // the second finger seldom lands in the same frame as the first, so a still
+      // two-finger tap stayed at 1 and misfired as a left-click.
+      onPanResponderStart: (_evt, g) => {
+        const s = st.current;
+        if (g.numberActiveTouches > s.maxTouches) s.maxTouches = g.numberActiveTouches;
+      },
       onPanResponderMove: (evt, g) => {
         const s = st.current;
         const touches = evt.nativeEvent.touches.length;
@@ -118,6 +130,12 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
         if (!s.moved && Math.hypot(g.dx, g.dy) > TP_TAP_SLOP) s.moved = true;
 
         if (s.maxTouches >= 2) {
+          // Any real two-finger travel is a scroll, not a right-click tap —
+          // latched at a tighter slop than the notch step so even a short stroke
+          // that never emits a notch still suppresses the click on release.
+          if (!s.scrolled && Math.hypot(g.dx, g.dy) > TP_TWO_FINGER_SLOP) {
+            s.scrolled = true;
+          }
           // Two-finger drag -> vertical scroll. g.dy is cumulative from grant.
           const delta = g.dy - s.scrollLastY;
           s.scrollAccum += delta;
@@ -160,16 +178,19 @@ export function useTrackpad(cbs: TrackpadCallbacks): PanResponderInstance {
           cb.current.onDragEnd?.();
           return;
         }
-        const wasTap = !s.moved && now - s.t0 < TP_TAP_MS;
-        if (wasTap) {
-          if (s.maxTouches >= 2) {
-            cb.current.onRightClick();
-            s.lastTapEndT = 0; // two-finger tap doesn't start a marquee
-          } else {
-            cb.current.onLeftClick();
-            // Record the tap so a quick follow-up touch+drag becomes a marquee.
-            s.lastTapEndT = now;
-          }
+        const action = classifyRelease({
+          maxTouches: s.maxTouches,
+          moved: s.moved,
+          scrolled: s.scrolled,
+          elapsedMs: now - s.t0,
+        });
+        if (action === 'right-click') {
+          cb.current.onRightClick();
+          s.lastTapEndT = 0; // two-finger tap doesn't start a marquee
+        } else if (action === 'left-click') {
+          cb.current.onLeftClick();
+          // Record the tap so a quick follow-up touch+drag becomes a marquee.
+          s.lastTapEndT = now;
         } else {
           s.lastTapEndT = 0;
         }


### PR DESCRIPTION
## What

Trackpad triage item **B** (likwidtek: *right-click flaky — several tries to register*; *two-finger scroll also sends a click that hits random stuff*). Both are gesture-classification faults in `useTrackpad.ts`:

- **Right-click flaky** — `maxTouches` was sampled **only in `onPanResponderMove`**, so a *motionless* two-finger tap (which emits no move event) stayed at 1 and fired a **left**-click. Fix: `onPanResponderStart` (fires on every touch start) bumps it from `gestureState.numberActiveTouches`, so a still two-finger tap reliably reads as 2 → right-click.
- **Scroll leaks a click** — release decided tap-vs-not from the one-finger 8px slop and never checked whether a scroll happened, so a short (<8px) two-finger stroke with `maxTouches===2` fired a **spurious right-click**. Fix: a `scrolled` flag latches once two-finger travel passes a tighter **6px** slop, and the release gates the right-click on `!scrolled`. A ≥2-finger gesture also **never** falls through to a left-click.

## Testable-by-design

`useTrackpad` imports `PanResponder` (not node-loadable) and RN-Web emits mouse, not touch — so neither node nor the harness can drive these gestures. The decision logic is extracted to a pure, **react-native-free** module `hooks/trackpadGesture.ts` (`classifyRelease`), which *is* unit-testable.

- **8 classifier tests** (`hooks/__tests__/trackpadGesture.test.ts`): one/two-finger, still/moved/scrolled/slow, boundary.
- **Control-verified (§11):** the BUG2 scroll-leak test **fails** when the `scrolled` gate is removed.
- CI `app-input` job now runs `hooks/__tests__` alongside `lib/__tests__`.

The `onPanResponderStart` half is RN-callback plumbing feeding the tested classifier — verified by code review + the RN PanResponder API (per-touch start with a live `numberActiveTouches`). The classification it produces IS tested.

## Scope
- Shared hook → fixes both the Pad trackpad and RemoteView's nav-circle trackpad. **No interface change**, no other consumer affected.
- Pure app-side; no agent surface.

## Verified
19/19 input-path unit tests (11 gamepad + 8 trackpad); tsc clean; web harness mounts the refactored surface with no console errors (touch gestures themselves are RN-Web-untestable — hence the pure-module tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
