### PR TITLE
chore(release): app 2.9.23 (iOS build 77 / vc 60)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "76",
+      "buildNumber": "77",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 59
+      "versionCode": 60
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.22",
+    "version": "2.9.23",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,8 +1,6 @@
-New in 2.9.22
+New in 2.9.23
 
-• Update your box from your phone — Flatpak apps and the OS (SteamOS/Bazzite), together or one at a time. Turn it on once at the box.
-• A fresh install now walks you through pairing on the box's own screen.
-• Search your Preferences by typing.
-• Check for an app update in Setup › Account — it asks your store directly, sends nothing about you.
-• Closing the running game from your phone now actually works.
-• Swipe traces draw a clean glowing line.
+• Bigger trackpad — a one-tap corner button expands the Mouse and Swipe surfaces for easier scrolling.
+• Steadier connection — if the app was backgrounded and the pointer stopped responding, it now reconnects on its own instead of a force-quit.
+• Honest status — the connection dot turns amber the moment input stops getting through; tap to reconnect.
+• Reliable right-click — two-finger tap registers every time; two-finger scrolling no longer fires stray clicks.


### PR DESCRIPTION
Marketing version 2.9.23; autoIncrement set iOS build 77 / vc 60. Ships the four trackpad PRs (#239 large-pad, #240 WS zombie, #241 pill, #242 gestures).

**Released while this was open:**
- Android **live on Play production** (vc60) + listing copy refreshed (licensing fixed + TV control/Fleet/etc.) + notes + couchside.tv app-version.json → 2.9.23.
- iOS **submitted to App Store review** (build 77, AFTER_APPROVAL) + refreshed copy + 7 iPhone + 5 iPad screenshots + notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)