### PR TITLE
fix(pad): survive iOS WS keepalive freeze — box PING + input-driven recovery (agent 2.9.53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,15 @@ jobs:
       - name: Unit tests (gamepad handoff)
         run: python3 tests/test_gamepad_handoff.py
 
+      # Box-driven keepalive: the app's own {"t":"ping"} rides a JS setInterval
+      # that iOS FREEZES when the app idles, so the phone sat mute on a live
+      # socket and got idle-reaped at 12s -- dead trackpad, "controller
+      # disconnected", endless reconnect churn. The box now PINGs every session;
+      # the phone OS auto-PONGs below the JS layer, keeping the holder alive.
+      # If the tick ever stops pinging every session, that churn is back.
+      - name: Unit tests (gamepad keepalive)
+        run: python3 tests/test_gamepad_keepalive.py
+
       # The d-pad is a LATCHED absolute axis (DPAD_MAP -> ABS_HAT0X/Y), not an
       # edge-triggered key, and nothing re-zeroes it: no stuck-button watchdog,
       # and the 12s idle reap never fires while the app pings every 5s. ONE

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.52"
+VERSION = "2.9.53"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -10928,14 +10928,26 @@ def ws_send_json(conn, obj):
 GAMEPAD_LOCK = threading.Lock()
 GAMEPAD_HOLDER = None      # the entry that currently owns input devices, or None
 GAMEPAD_SESSIONS = []      # every live entry (holder + waiters)
-# Idle-reap: drop a gamepad session that has sent us NOTHING for this long. The
-# app pings every ~5s, so real silence this long means app->box is dead (a
-# Game-Mode Wi-Fi blip during a Couch Mode switch leaves the socket half-dead —
-# the phone keeps sending but nothing arrives, so the trackpad freezes). Reaping
-# fast + closing cleanly is the ONLY reliable app->box-death signal (a box->app
-# heartbeat can't detect it — it flows regardless and would just mask a dead
-# outbound). Was 60s; 12s is >2x the ping so a healthy client never false-reaps.
+# Idle-reap: drop a gamepad session that has sent us NOTHING for this long. On a
+# healthy client this never fires: the box drives its OWN keepalive now (a WS
+# PING every GAMEPAD_PING_INTERVAL_S, see _gamepad_keepalive_loop), and even a
+# fully idle phone's OS auto-answers with a PONG, so the only way to go silent
+# this long is a genuinely dead app->box path.
+#
+# CORRECTION to what this comment used to say ("a box->app heartbeat can't detect
+# a dead outbound -- it flows regardless"): true of a one-way push, FALSE of a WS
+# PING, whose PONG travels phone->box -- a dead outbound never delivers it, so the
+# reap still fires. That distinction is the whole fix. Field-diagnosed on
+# iOS->Bazzite (2026-07-24): the app's own {"t":"ping"} rides a JS setInterval
+# that iOS FREEZES whenever the app idles, so the phone sat on a live socket
+# sending nothing and got reaped at 12s -- dead trackpad, "controller
+# disconnected", then a reconnect that muted again (endless churn only a
+# force-quit cleared). The OS-level auto-PONG rides no JS timer, so it lands
+# anyway. Was 60s; 12s is >2x the app ping and 3x the box ping.
 GAMEPAD_IDLE_TIMEOUT_S = 12.0
+# Box-driven keepalive interval. Kept well under the reap window above (3 PINGs
+# per window) so a single dropped PONG can't trip a false reap.
+GAMEPAD_PING_INTERVAL_S = 4.0
 
 
 def _wsend_json(entry, obj):
@@ -10966,6 +10978,33 @@ def _gamepad_broadcast(obj):
         entries = list(GAMEPAD_SESSIONS)
     for entry in entries:
         _wsend_json(entry, obj)
+
+
+def _gamepad_keepalive_tick():
+    """Send one WS PING to every live session (holder + waiters). The phone's OS
+    answers with a PONG at the network layer -- below the app's JS runtime -- and
+    that inbound frame resets the recv loop's idle clock. This is what keeps an
+    iOS client alive while its own JS keepalive timer is frozen (see
+    GAMEPAD_IDLE_TIMEOUT_S). Snapshots the session list under the lock, then sends
+    OUTSIDE it (each _wsend_op takes only that socket's slock), so socket I/O
+    never blocks GAMEPAD_LOCK -- same discipline as _gamepad_broadcast. A dead
+    socket is skipped (_wsend_op never raises); the idle-reap, not this, closes
+    it. Split out from the loop so a test can drive one tick deterministically."""
+    with GAMEPAD_LOCK:
+        entries = list(GAMEPAD_SESSIONS)
+    for entry in entries:
+        _wsend_op(entry, WS_OP_PING)
+
+
+def _gamepad_keepalive_loop():
+    """Forever: PING every live session every GAMEPAD_PING_INTERVAL_S. Daemon
+    thread started in main(); never raises, so it can never take the agent down."""
+    while True:
+        time.sleep(GAMEPAD_PING_INTERVAL_S)
+        try:
+            _gamepad_keepalive_tick()
+        except Exception:  # a keepalive must never die on a transient send error
+            pass
 
 
 def _release_devices(entry):
@@ -13768,6 +13807,10 @@ def main():
     server.daemon_threads = True
     threading.Thread(target=_udp_discovery_responder, args=(port,),
                      daemon=True, name="discover").start()
+    # Box-driven gamepad keepalive: PING idle sockets so their OS auto-PONG keeps
+    # the session alive even while the app's own JS keepalive timer is frozen (iOS).
+    threading.Thread(target=_gamepad_keepalive_loop,
+                     daemon=True, name="gp-keepalive").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.3.8-win"
+VERSION = "0.3.9-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -4171,6 +4171,37 @@ def _wsend_op(entry, opcode, payload=b""):
             pass
 
 
+# Box-driven keepalive. Parity with the Linux agent's _gamepad_keepalive_loop:
+# the app's own {"t":"ping"} rides a JS setInterval iOS freezes when the app
+# idles, so the box PINGs each session and the phone OS auto-PONGs below the JS
+# layer, resetting the recv loop's idle clock. The Windows recv loop's idle
+# window is a roomier 60s (vs Linux 12s), so this is defence-in-depth here rather
+# than the acute fix it is on Linux. 4s keeps many pings inside that window.
+GAMEPAD_PING_INTERVAL_S = 4.0
+
+
+def _gamepad_keepalive_tick():
+    """PING every live session; the phone OS auto-PONG keeps the socket's idle
+    clock fresh independent of the app's (freezable) JS keepalive. Snapshots the
+    list under the lock, sends outside it. Never raises (each _wsend_op is
+    self-contained). Split out so a test can drive one tick deterministically."""
+    with GAMEPAD_LOCK:
+        entries = list(GAMEPAD_SESSIONS)
+    for entry in entries:
+        _wsend_op(entry, WS_OP_PING)
+
+
+def _gamepad_keepalive_loop():
+    """Forever: PING every live session every GAMEPAD_PING_INTERVAL_S. Daemon
+    thread started in main(); guarded so it can never take the agent down."""
+    while True:
+        time.sleep(GAMEPAD_PING_INTERVAL_S)
+        try:
+            _gamepad_keepalive_tick()
+        except Exception:  # a keepalive must never die on a transient send error
+            pass
+
+
 def _release_devices(entry):
     """Demote a session that stays connected as a waiter: destroy its gamepad
     (one pad per holder — the new holder brings its own) but KEEP the mouse and
@@ -5454,6 +5485,10 @@ def main():
 
     server = QuietThreadingHTTPServer((args.host, port), Handler)
     server.daemon_threads = True
+    # Box-driven gamepad keepalive: PING idle sockets so their OS auto-PONG keeps
+    # the session alive even while the app's own JS keepalive timer is frozen (iOS).
+    threading.Thread(target=_gamepad_keepalive_loop,
+                     daemon=True, name="gp-keepalive").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.23",
+    "version": "2.9.24",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/lib/__tests__/gamepad.lifecycle.test.ts
+++ b/app/lib/__tests__/gamepad.lifecycle.test.ts
@@ -187,6 +187,61 @@ test('reconnect(): no-op when not active', () => {
   assert.equal(MockWebSocket.instances.length, 0);
 });
 
+// --- foreground-freeze recovery (the "green pill, dead mouse" field case) -----
+// A foreground JS freeze leaves the socket OPEN but silent: no AppState event
+// fires (no background transition), the ping timer + pong watchdog are frozen,
+// and the box now keepalives the TCP so onclose never fires. The user's gesture
+// is the only signal left. These lock the two recovery paths that gesture drives.
+
+test('input-driven recovery: a swipe on a stale OPEN socket rebuilds it', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello(); // connected, lastInbound = NOW
+  NOW += 5_000 * 2.5 + 1; // silent past the watchdog window (frozen, socket still OPEN)
+  c.sendMouseMove(5, 5); // the user swipes
+  assert.equal(
+    MockWebSocket.instances.length,
+    2,
+    'a swipe on a stale-but-OPEN socket must rebuild, not vanish into the void',
+  );
+  c.close();
+});
+
+test('input-driven recovery: a swipe on a FRESH socket just sends (control)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  const ws0 = MockWebSocket.instances[0];
+  ws0.openAndHello(); // lastInbound = NOW (fresh)
+  c.sendMouseMove(5, 5);
+  assert.equal(MockWebSocket.instances.length, 1, 'a live socket is never rebuilt by input');
+  assert.ok(
+    ws0.sent.some((m) => m.includes('"t":"m"')),
+    'the move frame was actually sent on the live socket',
+  );
+  c.close();
+});
+
+test('freshness guard: connect() rebuilds an OPEN-but-stale zombie (tab-focus path)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  // The tab-focus listener calls connect() WITHOUT ensureLive(). Pre-fix it saw
+  // readyState OPEN and no-oped, stranding the zombie. Post-fix, staleness rebuilds.
+  NOW += 5_000 * 2.5 + 1;
+  c.connect(CONN);
+  assert.equal(MockWebSocket.instances.length, 2, 'connect() rebuilds a stale OPEN socket');
+  c.close();
+});
+
+test('freshness guard: connect() still no-ops over a FRESH OPEN socket (control)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  c.connect(CONN); // same conn, socket fresh — must not churn
+  assert.equal(MockWebSocket.instances.length, 1, 'a fresh connected socket is not rebuilt');
+  c.close();
+});
+
 // restore the clock so a leaked reference can't confuse other files
 process.on('exit', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -479,10 +479,19 @@ export class GamepadClient {
     // nothing scheduled to reconnect, every input frame silently dropped, and
     // only a force-quit recovers. So only no-op when the socket is genuinely
     // still CONNECTING or OPEN; otherwise fall through to open() and rebuild it.
+    // A socket that merely reads OPEN is not proof of a usable pipe: the box now
+    // keepalives the TCP (its WS PING draws an OS-level auto-PONG that rides no
+    // JS timer), so a socket orphaned by a foreground JS freeze stays OPEN yet
+    // silent. Treat OPEN as alive only while it is also FRESH — an inbound frame
+    // within the watchdog window — so the tab-focus listener, which fires
+    // connect() WITHOUT ensureLive(), can't no-op over a stale zombie. A
+    // CONNECTING socket is mid-dial and always left alone. Same liveness test as
+    // ensureLive() so the two never disagree.
     const wsAlive =
       this.ws != null &&
-      (this.ws.readyState === 0 /* CONNECTING */ ||
-        this.ws.readyState === 1); /* OPEN */
+      (this.ws.readyState === 0 /* CONNECTING — mid-dial, leave it */ ||
+        (this.ws.readyState === 1 /* OPEN */ &&
+          Date.now() - this.lastInbound < PING_INTERVAL_MS * 2.5));
     if (
       same &&
       this.active &&
@@ -1097,6 +1106,26 @@ export class GamepadClient {
         wsTrace.lastSocketState = wsStateName(ws);
       }
       return;
+    }
+    // Input-driven zombie recovery. The user's gesture is the one liveness
+    // signal that survives an iOS JS freeze: a FOREGROUND stall leaves the ping
+    // timer AND the pong watchdog frozen, and — now that the box keepalives the
+    // TCP — the socket never closes, so onclose/ensureLive never fire either
+    // (AppState 'active' only catches a real background→foreground transition,
+    // not a foreground stall). So when asked to send INPUT on a 'connected'
+    // socket that has heard nothing back for longer than the watchdog window,
+    // rebuild NOW instead of swiping into the void. This is the field case:
+    // green pill, dead mouse, recoverable only by force-quit. Pings are exempt
+    // (they must never trigger a rebuild), and a rebuilt/CONNECTING socket has
+    // status !== 'connected', so this fires at most once per freeze — the very
+    // next frame after the user resumes — not once per frame.
+    if (
+      f.t !== 'ping' &&
+      this.status === 'connected' &&
+      Date.now() - this.lastInbound > PING_INTERVAL_MS * 2.5
+    ) {
+      this.reconnect();
+      return; // can't land on a dead socket; the rebuilt one carries the next frame
     }
     // Note real input (anything but our own keepalive ping) so the watchdog can
     // tighten its dead-socket deadline while the user is actively driving.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,21 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Trackpad WS liveness on iOS: box keepalive + foreground-freeze recovery
+`priority: P1` · `risk: med (input path)` · `affects: agent, win-agent, app/lib/gamepad.ts` ·
+`depends_on: —`
+- Two failure modes behind "trackpad dead after couch-mode switch" (field-diagnosed on
+  iOS→Bazzite, see BUILD_LOG 2026-07-24). NOT the compositor.
+- **Idle churn** — DONE + VERIFIED on box (agent 2.9.53 / win 0.3.9-win): box drives a WS PING
+  every 4s so the phone OS auto-PONGs below the frozen JS timer; holder survives idle instead of
+  being reaped at 12s.
+- **Foreground freeze (green pill, dead mouse)** — app fix written + control-verified (app 2.9.24,
+  `gamepad.ts` input-driven recovery + `connect()` freshness guard; Node lifecycle harness 15/15).
+  **Blocked on:** real-device (TestFlight) confirmation — the simulator can't reproduce an iOS
+  foreground JS freeze. Move to ✅ Completed only after on-device verification.
+- Notes: if on-device shows the input path still can't recover, fall back to an agent-side two-tier
+  reap (reap a socket that OS-PONGs but sends zero app-level frames for ~20-25s).
+
 ## 📋 Planned
 
 ### On-box pairing tutorial (auto-plays after install)

--- a/tests/test_gamepad_keepalive.py
+++ b/tests/test_gamepad_keepalive.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression test for the box-driven gamepad keepalive.
+
+Run: python3 tests/test_gamepad_keepalive.py
+
+Why this exists: on iOS the app's own {"t":"ping"} keepalive rides a JS
+setInterval that the OS FREEZES whenever the app idles. The phone then sits on a
+live socket sending nothing, and the agent idle-reaps the holder at
+GAMEPAD_IDLE_TIMEOUT_S (12s) -- dead trackpad, "controller disconnected", then a
+reconnect that mutes again (an endless churn only a force-quit cleared).
+Field-diagnosed on iPhone -> bazzite.local, 2026-07-24, at the packet level: box
+WS PING out, phone OS auto-PONG back in ~4ms, holder alive 4.5 min idle where it
+previously died at 12s. The OS-level auto-PONG rides no JS timer, so it lands
+even while the app is frozen -- that is the fix.
+
+This locks the box side of it: _gamepad_keepalive_tick() must PING EVERY live
+session (holder AND waiters), with a PING frame (not TEXT/CLOSE), and cadence
+kept well under the reap window. The end-to-end "survives the idle window"
+behaviour was verified on hardware; a pure-stdlib unit test cannot exercise the
+real recv-loop timer plus the OS auto-PONG, so that half is proven on a box and
+cited above, not faked here.
+
+Pure stdlib, no pytest -- same style as test_gamepad_handoff.py so CI just runs it.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# Capture (session-name, opcode) for every raw frame a tick sends, instead of
+# touching a real socket. _gamepad_keepalive_tick looks _wsend_op up as a module
+# global at call time, so replacing it here is enough (same trick as
+# test_gamepad_handoff.py).
+_pings = []
+cs._wsend_op = lambda entry, op, payload=b"": _pings.append((entry["name"], op))
+
+
+def _reset(sessions):
+    _pings.clear()
+    cs.GAMEPAD_SESSIONS[:] = sessions
+
+
+def _entry(name):
+    # slock is never contended here (_wsend_op is stubbed); include it so the
+    # shape matches a real session entry.
+    return {"name": name, "slock": None}
+
+
+def test_pings_every_session():
+    """Holder + every waiter gets exactly one PING per tick."""
+    _reset([_entry("holder"), _entry("waiterA"), _entry("waiterB")])
+    cs._gamepad_keepalive_tick()
+    check("one frame per live session", len(_pings), 3)
+    check("every frame is a WS PING",
+          all(op == cs.WS_OP_PING for _, op in _pings), True)
+    check("the holder was pinged", ("holder", cs.WS_OP_PING) in _pings, True)
+    check("a waiter was pinged", ("waiterB", cs.WS_OP_PING) in _pings, True)
+
+
+def test_no_sessions_is_a_noop():
+    """No live sessions -> nothing sent, no crash (the common idle case)."""
+    _reset([])
+    cs._gamepad_keepalive_tick()
+    check("no sessions -> no pings", _pings, [])
+
+
+def test_cadence_stays_under_the_reap_window():
+    """The box ping must be frequent enough that a single lost PONG can't trip a
+    false reap: at least 3 pings inside GAMEPAD_IDLE_TIMEOUT_S. This is the
+    invariant the whole fix rests on, so assert it rather than trust the literal."""
+    check("ping interval <= 1/3 of the idle-reap window",
+          cs.GAMEPAD_PING_INTERVAL_S <= cs.GAMEPAD_IDLE_TIMEOUT_S / 3.0, True)
+
+
+if __name__ == "__main__":
+    test_pings_every_session()
+    test_no_sessions_is_a_noop()
+    test_cadence_stays_under_the_reap_window()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nAll gamepad-keepalive tests passed.")


### PR DESCRIPTION
Lands the gamepad WS-keepalive work already deployed to the box.

**Agent (2.9.53):** box drives a WS PING every 4s so the phone OS auto-PONGs below the frozen iOS JS timer, feeding the 12s idle-reap independent of the app's (freezable) keepalive — fixes the idle-churn / "controller disconnected" loop. Windows agent gets the same for parity.

**App:** input-driven recovery in gamepad.ts (a swipe on a stale socket rebuilds it) + freshness in the connect() guard.

**Verified:** agent keepalive live-verified on a Bazzite box (tcpdump PING->auto-PONG every 4s; holder survived 4.5min idle vs dying at 12s). Full agent suite 34/34, test_gamepad_keepalive control-verified, app lifecycle tests 15/15, tsc clean. NOT verified: the foreground-freeze end-to-end on a real device (simulator can't reproduce an iOS foreground JS freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)