### PR TITLE
feat(win): Epic/GOG/Xbox game launchers + double-click installer polish (0.4.0-win)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,14 @@ jobs:
       - name: Unit tests (no camera in the shipping app)
         run: python3 tests/test_no_camera_in_shipping_app.py
 
+      # Windows non-Steam launchers (Epic / GOG / Xbox). These take a client id,
+      # so the load-bearing gate is allowlist-by-lookup: the id is matched in a
+      # fresh read-only discovery and the argv is REBUILT from the record, never
+      # interpolated. Pins the reject path (unknown/malformed id -> None, nothing
+      # runs) and that the `launchers` capability is wired at all five edit sites.
+      - name: Unit tests (Windows game launchers)
+        run: python3 tests/test_win_launchers.py
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,24 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.53
+
+The trackpad stays alive — and on Windows, your whole game library shows up.
+
+- **No more dead mouse after the phone sits idle.** If the app was in the
+  background (or the phone locked, or you switched to Desktop mode), the
+  connection could go quiet and the box would quietly drop it — you'd come back
+  to a green "connected" dot and a trackpad that moved nothing, and the only fix
+  was force-quitting the app. The box now keeps the link awake itself, and your
+  first swipe rebuilds the connection if it did die. Pointer, keyboard, and
+  controller all recover on their own.
+- **Windows: Epic, GOG, and Xbox / Game Pass games now appear** next to your
+  Steam library, in the same cover grid — tap one and it starts on the TV. The
+  Launch tab also shows up on a PC that has no Steam installed at all.
+- **Windows: a double-click installer.** `CouchsideSetup.exe` sets the service
+  up without pasting anything into PowerShell. Grab it from
+  <https://couchside.tv/windows>.
+
 ## 2.9.52
 
 A smoother first pairing on the box's own screen.

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.3.9-win"
+VERSION = "0.4.0-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -887,7 +887,8 @@ def set_caps(mock):
         # (see the Linux agent). Windows has its own desktop shortcuts (the
         # WIN/ALT-TAB cluster on a ViGEm box), not the Plasma desktop-nav cap.
         CAPS = {k: True for k in
-                ("gamepad", "steam", "media", "tv", "screen", "power_schedule")}
+                ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
+                 "launchers")}
         CAPS["screensaver"] = False
         CAPS["couchmode"] = False
         CAPS["desktop"] = False
@@ -895,6 +896,7 @@ def set_caps(mock):
     CAPS = {
         "gamepad": safe(vigem_available),
         "steam": _steam_root() is not None,
+        "launchers": safe(_any_launcher_source),
         "media": safe(smtc_available),
         "tv": safe(lambda: _tv_hw_backend() is not None or soft_available()),
         "screen": _SCREEN is not None,
@@ -1554,20 +1556,332 @@ def steam_downloads():
         return []
 
 
+# ---------------------------------------------------------------------------
+# Non-Steam game launchers (Epic, GOG Galaxy, Xbox / Game Pass).
+#
+# Same allowlist-by-lookup contract as Steam (CLAUDE.md §3): a client sends an
+# opaque launcher id; the agent RE-DISCOVERS the installed games (read-only),
+# matches the id against that fresh set, and rebuilds the launch argv from the
+# MATCHED RECORD's fields. The client string is never interpolated into a
+# command or URI — an unknown id yields None (the route 404s) and nothing runs.
+# Every discovery is best-effort and degrades closed: any error -> [].
+#
+# id schemes:  epic:<AppName>   gog:<numericGameId>   xbox:<AUMID>
+# Auto-discovered ids are not custom launchers, so they cannot be created or
+# deleted over the network (see _valid_launcher_id and the DELETE guard).
+# ---------------------------------------------------------------------------
+
+_AUTO_LAUNCHER_KINDS = frozenset({"steam", "epic", "gog", "xbox"})
+_ALNUM = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+_AUMID_CHARS = _ALNUM | frozenset("._-")
+
+
+def _alnum_ok(s):
+    """True if s is a non-empty run of ASCII letters/digits. Validates the Epic
+    id components before they are embedded in the launch URI, so nothing but
+    [A-Za-z0-9] can reach it (no ':', '/', '?', '&', spaces, quoting)."""
+    return bool(s) and all(c in _ALNUM for c in s)
+
+
+def _aumid_ok(s):
+    """True if s looks like a UWP AUMID: <PackageFamilyName>!<AppId>, each side a
+    non-empty run of [A-Za-z0-9._-] with exactly one '!'. Embedded in the
+    shell:AppsFolder path handed to explorer, so keep it strict."""
+    if s.count("!") != 1:
+        return False
+    left, right = s.split("!", 1)
+    return (bool(left) and bool(right)
+            and all(c in _AUMID_CHARS for c in left)
+            and all(c in _AUMID_CHARS for c in right))
+
+
+def _explorer_exe():
+    """Full path to explorer.exe, or None. explorer is the argv[0] that fires a
+    registered protocol URI (Epic) or a shell:AppsFolder app (Xbox) without a
+    shell — it hands the single argument to the registered handler."""
+    win = os.environ.get("WINDIR") or r"C:\Windows"
+    exe = os.path.join(win, "explorer.exe")
+    return exe if os.path.isfile(exe) else None
+
+
+# ---- Epic Games -----------------------------------------------------------
+def _epic_manifests_dir():
+    pd = os.environ.get("PROGRAMDATA") or r"C:\ProgramData"
+    return os.path.join(pd, "Epic", "EpicGamesLauncher", "Data", "Manifests")
+
+
+def _epic_games_from_manifests(manifests):
+    """Pure transform: a list of parsed *.item dicts -> launcher records. Keeps
+    the launchable, installed GAMES (not the engine or marketplace plugins)
+    whose URI components are strictly alphanumeric. Deterministic order."""
+    out = {}
+    for m in manifests:
+        if not isinstance(m, dict):
+            continue
+        app = m.get("AppName")
+        ns = m.get("CatalogNamespace")
+        cid = m.get("CatalogItemId")
+        disp = m.get("DisplayName") or app
+        if not (app and ns and cid and disp):
+            continue
+        # These three are interpolated into the launch URI -> require strict
+        # alphanumeric. A game with an unexpected id shape is dropped, not
+        # sanitised (CLAUDE.md §3.6): it simply won't appear.
+        if not (_alnum_ok(app) and _alnum_ok(ns) and _alnum_ok(cid)):
+            continue
+        # Epic tags each app with categories; keep only games (drops "engines",
+        # "plugins", "software"). If the tag is absent, don't guess it out.
+        cats = m.get("AppCategories")
+        if isinstance(cats, list) and cats:
+            if not any(isinstance(c, str) and c.lower() == "games" for c in cats):
+                continue
+        out[app] = {"id": "epic:%s" % app, "label": disp, "kind": "epic",
+                    "namespace": ns, "catalog_item_id": cid, "app_name": app}
+    res = list(out.values())
+    res.sort(key=lambda l: (l["label"].lower(), l["id"]))
+    return res
+
+
+def discover_epic_games():
+    """Installed Epic games as launcher dicts, sorted by name. Read-only,
+    best-effort: any error yields []."""
+    if not IS_WINDOWS:
+        return []
+    try:
+        manifests = []
+        for it in glob.glob(os.path.join(_epic_manifests_dir(), "*.item")):
+            try:
+                with open(it, "r", encoding="utf-8", errors="replace") as f:
+                    manifests.append(json.load(f))
+            except (OSError, ValueError):
+                continue
+            except Exception:
+                continue
+        return _epic_games_from_manifests(manifests)
+    except Exception:
+        return []
+
+
+# ---- GOG Galaxy -----------------------------------------------------------
+def _reg_str(key, name):
+    """QueryValueEx as a stripped str, or None (never raises)."""
+    try:
+        val, _t = winreg.QueryValueEx(key, name)
+    except OSError:
+        return None
+    except Exception:
+        return None
+    if val is None:
+        return None
+    s = str(val).strip()
+    return s or None
+
+
+def _gog_client_exe():
+    """Path to GalaxyClient.exe from the registry, or None."""
+    if not IS_WINDOWS:
+        return None
+    for sub in (r"SOFTWARE\WOW6432Node\GOG.com\GalaxyClient\paths",
+                r"SOFTWARE\GOG.com\GalaxyClient\paths"):
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, sub) as k:
+                d = _reg_str(k, "client")
+        except OSError:
+            continue
+        except Exception:
+            continue
+        if d:
+            exe = os.path.join(d, "GalaxyClient.exe")
+            if os.path.isfile(exe):
+                return exe
+    return None
+
+
+def _gog_games_from_rows(rows):
+    """Pure transform: raw registry rows [{gameID,gameName,path}] -> launcher
+    records. Keeps rows with a numeric id and a name. Deterministic order."""
+    out = {}
+    for r in rows:
+        gid = (r.get("gameID") or "").strip()
+        name = (r.get("gameName") or "").strip()
+        path = (r.get("path") or "").strip()
+        if not (gid.isdigit() and name):
+            continue
+        out[gid] = {"id": "gog:%s" % gid, "label": name, "kind": "gog",
+                    "game_id": gid, "path": path}
+    res = list(out.values())
+    res.sort(key=lambda l: (l["label"].lower(), l["id"]))
+    return res
+
+
+def _gog_registry_rows():
+    r"""Read HKLM\...\GOG.com\Games\<id> subkeys into raw dict rows. Windows
+    only; never raises."""
+    rows = []
+    for base in (r"SOFTWARE\WOW6432Node\GOG.com\Games",
+                 r"SOFTWARE\GOG.com\Games"):
+        try:
+            root = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, base)
+        except OSError:
+            continue
+        except Exception:
+            continue
+        with root:
+            i = 0
+            while True:
+                try:
+                    sub = winreg.EnumKey(root, i)
+                except OSError:
+                    break
+                i += 1
+                try:
+                    with winreg.OpenKey(root, sub) as gk:
+                        rows.append({
+                            "gameID": _reg_str(gk, "gameID") or sub,
+                            "gameName": _reg_str(gk, "gameName"),
+                            "path": _reg_str(gk, "path"),
+                        })
+                except OSError:
+                    continue
+                except Exception:
+                    continue
+        if rows:
+            break
+    return rows
+
+
+def discover_gog_games():
+    """Installed GOG Galaxy games as launcher dicts. Read-only, best-effort."""
+    if not IS_WINDOWS:
+        return []
+    try:
+        return _gog_games_from_rows(_gog_registry_rows())
+    except Exception:
+        return []
+
+
+# ---- Xbox / Game Pass -----------------------------------------------------
+# UWP games are found via Get-AppxPackage: a package is a GAME (not a random
+# Store app) when a MicrosoftGame.config sits in its InstallLocation. The AUMID
+# = "<PackageFamilyName>!<Application Id>"; launch is explorer shell:AppsFolder.
+_XBOX_TIMEOUT = 8
+_XBOX_TTL = 60.0
+_XBOX_CACHE = {"at": 0.0, "val": None}
+_XBOX_LOCK = threading.Lock()
+
+_XBOX_PS = r"""
+$ErrorActionPreference='SilentlyContinue'
+$out = New-Object System.Collections.ArrayList
+foreach ($p in Get-AppxPackage) {
+  if (-not $p.InstallLocation) { continue }
+  if (-not (Test-Path (Join-Path $p.InstallLocation 'MicrosoftGame.config'))) { continue }
+  $man = Get-AppxPackageManifest $p
+  $app = $man.Package.Applications.Application
+  if ($app -is [array]) { $app = $app[0] }
+  $id = $app.Id
+  if (-not $id) { continue }
+  $dn = $man.Package.Properties.DisplayName
+  if (-not $dn -or $dn -like 'ms-resource:*') { $dn = $p.Name }
+  [void]$out.Add([pscustomobject]@{ aumid = "$($p.PackageFamilyName)!$id"; name = "$dn" })
+}
+$out | ConvertTo-Json -Compress
+"""
+
+
+def _xbox_games_from_json(text):
+    """Pure transform: the Get-AppxPackage JSON blob -> launcher records. Accepts
+    either a single object or an array (ConvertTo-Json collapses one item).
+    Drops anything without a well-formed AUMID. Deterministic order."""
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        return []
+    if isinstance(data, dict):
+        data = [data]
+    if not isinstance(data, list):
+        return []
+    out = {}
+    for e in data:
+        if not isinstance(e, dict):
+            continue
+        aumid = (e.get("aumid") or "").strip()
+        name = (e.get("name") or "").strip()
+        if not _aumid_ok(aumid):
+            continue
+        out[aumid] = {"id": "xbox:%s" % aumid, "label": name or aumid,
+                      "kind": "xbox", "aumid": aumid}
+    res = list(out.values())
+    res.sort(key=lambda l: (l["label"].lower(), l["id"]))
+    return res
+
+
+def discover_xbox_games():
+    """Installed Xbox / Game Pass games as launcher dicts. Read-only,
+    best-effort. Cached for _XBOX_TTL because it shells out to PowerShell."""
+    if not IS_WINDOWS:
+        return []
+    now = time.monotonic()
+    with _XBOX_LOCK:
+        if _XBOX_CACHE["val"] is not None and now - _XBOX_CACHE["at"] < _XBOX_TTL:
+            return _XBOX_CACHE["val"]
+    try:
+        out = _run_powershell(_XBOX_PS, _XBOX_TIMEOUT)
+        games = _xbox_games_from_json(out) if out else []
+    except Exception:
+        games = []
+    with _XBOX_LOCK:
+        _XBOX_CACHE["at"] = time.monotonic()
+        _XBOX_CACHE["val"] = games
+    return games
+
+
+def _any_launcher_source():
+    """True if the box has any launcher the app can drive, via CHEAP checks only
+    (no game enumeration, no PowerShell): a configured custom launcher, a Steam
+    or GOG client install, or an Epic manifests dir holding >=1 installed game.
+    Backs the `launchers` capability so the Launch tab appears on Epic/GOG boxes,
+    not only Steam ones. Xbox-only boxes (Game Pass with no other launcher) are
+    intentionally NOT detected here — enumerating them needs the PowerShell
+    bridge, and blocking startup on it would hurt reachability; they surface once
+    any other launcher exists (or on the next restart). Never raises."""
+    try:
+        if LAUNCHERS:
+            return True
+        if _steam_root() is not None:
+            return True
+        if _gog_client_exe() is not None:
+            return True
+        if glob.glob(os.path.join(_epic_manifests_dir(), "*.item")):
+            return True
+    except Exception:
+        return False
+    return False
+
+
 def list_launchers():
-    """All launchers: configured custom launchers first, then Steam games."""
+    """All launchers: configured custom launchers first, then auto-discovered
+    games from each store (Steam, Epic, GOG, Xbox)."""
     customs = [
         {"id": l["id"], "label": l["label"], "kind": "custom"}
         for l in LAUNCHERS
     ]
-    return customs + discover_steam_games()
+    return (customs + discover_steam_games() + discover_epic_games()
+            + discover_gog_games() + discover_xbox_games())
 
 
 def _launcher_argv(launcher_id):
-    """Resolve a KNOWN launcher id to its argv, or None if unknown.
+    r"""Resolve a KNOWN launcher id to its argv, or None if unknown.
 
-    steam:<appid>  -> [steam.exe, "steam://rungameid/<appid>"]
-    custom:<slug>  -> that launcher's stored cmd argv from config
+    Every store branch RE-DISCOVERS (read-only) and matches launcher_id against
+    that fresh set, then rebuilds the argv from the matched RECORD — the client
+    string is never interpolated into the command. An id absent from discovery
+    yields None, the route 404s, and nothing runs.
+
+    steam:<appid> -> [steam.exe, "steam://rungameid/<appid>"]
+    epic:<name>   -> [explorer.exe, "com.epicgames.launcher://apps/<ns>:<cid>:<name>?action=launch"]
+    gog:<id>      -> [GalaxyClient.exe, "/command=runGame", "/gameId=<id>", "/path=<dir>"]
+    xbox:<aumid>  -> [explorer.exe, "shell:AppsFolder\<aumid>"]
+    custom:<slug> -> that launcher's stored cmd argv from config
     """
     if launcher_id.startswith("steam:"):
         appid = launcher_id[len("steam:"):]
@@ -1580,6 +1894,44 @@ def _launcher_argv(launcher_id):
         for game in discover_steam_games():
             if game["id"] == launcher_id:
                 return [exe, "steam://rungameid/%s" % appid]
+        return None
+    if launcher_id.startswith("epic:"):
+        # Cheap shape pre-check; the real gate is membership in discovery below.
+        if not _alnum_ok(launcher_id[len("epic:"):]):
+            return None
+        exe = _explorer_exe()
+        if exe is None:
+            return None
+        for game in discover_epic_games():
+            if game["id"] == launcher_id:
+                uri = ("com.epicgames.launcher://apps/%s:%s:%s?action=launch"
+                       % (game["namespace"], game["catalog_item_id"],
+                          game["app_name"]))
+                return [exe, uri]
+        return None
+    if launcher_id.startswith("gog:"):
+        gid = launcher_id[len("gog:"):]
+        if not gid.isdigit():
+            return None
+        exe = _gog_client_exe()
+        if exe is None:
+            return None
+        for game in discover_gog_games():
+            if game["id"] == launcher_id:
+                argv = [exe, "/command=runGame", "/gameId=%s" % game["game_id"]]
+                if game.get("path"):
+                    argv.append("/path=%s" % game["path"])
+                return argv
+        return None
+    if launcher_id.startswith("xbox:"):
+        if not _aumid_ok(launcher_id[len("xbox:"):]):
+            return None
+        exe = _explorer_exe()
+        if exe is None:
+            return None
+        for game in discover_xbox_games():
+            if game["id"] == launcher_id:
+                return [exe, "shell:AppsFolder\\%s" % game["aumid"]]
         return None
     if _valid_launcher_id(launcher_id):
         for l in LAUNCHERS:
@@ -5006,7 +5358,8 @@ class Handler(BaseHTTPRequestHandler):
             lprefix = "/api/launchers/"
             if path.startswith(lprefix):
                 launcher_id = unquote(path[len(lprefix):])
-                if launcher_id.startswith("steam:"):
+                if launcher_id.split(":", 1)[0] in _AUTO_LAUNCHER_KINDS:
+                    # steam/epic/gog/xbox are auto-discovered, not stored config.
                     self._send(400, {"error": "not deletable"}, started)
                     return
                 if not _valid_launcher_id(launcher_id):

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -32,7 +32,13 @@ export default function TabLayout() {
   // or agent < 2.8.2) leaves both visible — never hide a tab on a guess.
   const caps = activeBox?.caps;
   const hidePad = caps?.gamepad === false;
-  const hideLaunch = caps?.steam === false;
+  // `launchers` (Windows agent >= 0.4.0-win) means "any launcher present"
+  // (Steam/Epic/GOG/custom), so an Epic/GOG/Game Pass box shows the Launch tab
+  // even without Steam. Older agents (and every Linux agent) don't send it, so
+  // fall back to the `steam` cap — never hide the tab on a guess.
+  const hideLaunch =
+    caps?.launchers === false ||
+    (caps?.launchers === undefined && caps?.steam === false);
 
   // On true first run (persisted fleet loaded, but empty) send the user to
   // Setup to pair. Otherwise honour the landing-tab preference.

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -387,7 +387,7 @@ function BoxEditPanel({
           setHost(t);
           setError(null);
         }}
-        placeholder="steamdeck.local · bazzite.local"
+        placeholder="steamdeck.local · gaming-pc · 10.0.0.5"
         placeholderTextColor={t.textFaint}
         autoCapitalize="none"
         autoCorrect={false}
@@ -1132,7 +1132,7 @@ function SetupBody() {
             style={styles.input}
             value={name}
             onChangeText={setName}
-            placeholder="Media center · Steam Deck"
+            placeholder="Media center · Steam Deck · gaming PC"
             placeholderTextColor={t.textFaint}
             autoCapitalize="none"
             autoCorrect={false}
@@ -1144,7 +1144,7 @@ function SetupBody() {
             style={styles.input}
             value={host}
             onChangeText={setHost}
-            placeholder="steamdeck.local · bazzite.local"
+            placeholder="steamdeck.local · gaming-pc · 10.0.0.5"
             placeholderTextColor={t.textFaint}
             autoCapitalize="none"
             autoCorrect={false}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -142,6 +142,14 @@ export type BoxCaps = {
    * undefined reads as "unknown, probe" — only an explicit false skips it.
    */
   streamhost?: boolean;
+  /**
+   * Any game launcher the box can drive — Steam, Epic, GOG Galaxy, or a custom
+   * launcher (Windows agent >= 0.4.0-win). Gates the Launch tab in place of
+   * `steam` alone, so an Epic/GOG/Game Pass box shows its games too. Optional:
+   * absent on older agents and every Linux agent, so undefined falls back to
+   * `steam` for the tab decision — never hides on a guess.
+   */
+  launchers?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -880,7 +888,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.gaming === b.gaming &&
     a.streamhost === b.streamhost &&
     a.steammenus === b.steammenus &&
-    a.boxbattery === b.boxbattery
+    a.boxbattery === b.boxbattery &&
+    a.launchers === b.launchers
   );
 }
 

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -246,10 +246,15 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // boxbattery arrived with agent 2.9.40 — same optional-cap drop trap. A box
   // with no battery reports false, which is a real answer, not "unknown".
   const boxbattery = bool('boxbattery');
+  // launchers arrived with the Windows agent 0.4.0-win (multi-launcher: Epic/
+  // GOG/Xbox) — same optional-cap drop trap: omit it here (and from capsEqual)
+  // and the cap never persists, so the Launch tab re-decides from `steam` every
+  // launch. undefined stays undefined = "fall back to steam".
+  const launchers = bool('launchers');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
-    boxbattery,
+    boxbattery, launchers,
   };
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -42,7 +42,10 @@ param(
     [switch]$NoFirewall,
     [switch]$NoGamepad,      # skip the ViGEmBus virtual-controller install
     [switch]$KeepHibernate,  # skip `powercfg /hibernate off`
-    [string]$Ref = 'main'    # git ref to download the agent from
+    [string]$Ref = 'main',   # git ref to download the agent from
+    [switch]$FromInstaller   # set by CouchsideSetup.exe: the elevated relaunch must
+                             # WAIT (so Inno's waituntilterminated tracks the real
+                             # install) and must NOT keep a -NoExit window open
 )
 
 $ErrorActionPreference = 'Stop'
@@ -89,17 +92,37 @@ if (-not (Test-Admin)) {
     if ($NoFirewall)     { $fwd += '-NoFirewall' }
     if ($NoGamepad)      { $fwd += '-NoGamepad' }
     if ($KeepHibernate)  { $fwd += '-KeepHibernate' }
+    if ($FromInstaller)  { $fwd += '-FromInstaller' }
     $fwd += "-Port $Port"; $fwd += "-Ref $Ref"
+    # A human running this directly wants -NoExit so the elevated window stays up to
+    # read. The Inno installer wants the opposite: no leftover window, AND the outer
+    # (non-elevated) process must block on the elevated child so waituntilterminated
+    # sees real completion instead of the async RunAs handoff returning instantly.
+    $base = @('-NoProfile','-ExecutionPolicy','Bypass')
+    if (-not $FromInstaller) { $base += '-NoExit' }
     if ($PSCommandPath) {
         # Run from a file: relaunch that same file elevated.
-        $a = @('-NoProfile','-ExecutionPolicy','Bypass','-NoExit','-File',"`"$PSCommandPath`"") + $fwd
+        $a = $base + @('-File',"`"$PSCommandPath`"") + $fwd
     } else {
         # Piped from the web: re-fetch and run in the elevated window, carrying
         # the resolved params through a scriptblock so options aren't lost.
         $inner = "& ([scriptblock]::Create((irm $SelfUrl))) $($fwd -join ' ')"
-        $a = @('-NoProfile','-ExecutionPolicy','Bypass','-NoExit','-Command',$inner)
+        $a = $base + @('-Command',$inner)
     }
-    try { Start-Process powershell -Verb RunAs -ArgumentList $a }
+    try {
+        if ($FromInstaller) {
+            # -Wait blocks the outer process so the caller sees the install finish
+            # rather than the async RunAs handoff returning instantly; -PassThru
+            # lets us mirror the child's exit code outward.
+            # NOTE: Inno's [Run] with waituntilterminated does NOT inspect exit
+            # codes, so today this code is only observable to a caller that reads
+            # it -- the wizard still reports success either way. Surfacing a failed
+            # install in the wizard needs a [Code] Exec() that checks ResultCode.
+            $child = Start-Process powershell -Verb RunAs -ArgumentList $a -Wait -PassThru
+            exit $child.ExitCode
+        }
+        Start-Process powershell -Verb RunAs -ArgumentList $a
+    }
     catch { throw 'Elevation was declined. Re-run from an elevated PowerShell (Run as administrator).' }
     return
 }

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -183,5 +183,14 @@
       "steammenus",
       "streamhost"
     ]
+  },
+  "windowsOnlyCapabilities": {
+    "_doc": "Windows-only TODAY. `launchers` means 'this box can drive at least one game launcher' (Steam, Epic, GOG Galaxy, or a configured custom launcher) and exists because the Windows agent discovers non-Steam stores, so a PC with only Epic/GOG/Game Pass still has a Launch tab worth showing -- the older `steam` cap alone would hide it. Portable in principle and simply NOT ported to Linux yet, so it is recorded here as a decision rather than rediscovered as a surprise. The app treats a MISSING cap as unknown (not false) and falls back to `steam` for the tab decision, so a Linux box is unaffected.",
+    "platforms": [
+      "windows"
+    ],
+    "keys": [
+      "launchers"
+    ]
   }
 }

--- a/tests/test_protocol_parity.py
+++ b/tests/test_protocol_parity.py
@@ -179,7 +179,7 @@ def _ts_union(name):
     return set(re.findall(r"'([^']+)'", m.group(1)))
 
 
-CAP_GROUPS = ("capabilities", "linuxOnlyCapabilities")
+CAP_GROUPS = ("capabilities", "linuxOnlyCapabilities", "windowsOnlyCapabilities")
 
 APP_UNIONS = {
     "buttons": "ButtonKey",
@@ -276,7 +276,8 @@ def test_capabilities():
                 check(not leaked, "%s: %s correctly absent (leaked: %s)"
                       % (plat, gname, leaked or "none"))
     # No agent may declare a cap the spec has never heard of.
-    declared = set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+    declared = (set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+                | set(group("windowsOnlyCapabilities")[0]))
     for plat, mod in AGENTS.items():
         extra = sorted(_agent_caps(mod) - declared)
         check(not extra, "%s: no undeclared caps (extra: %s)" % (plat, extra or "none"))
@@ -291,7 +292,8 @@ def test_app_knows_every_capability():
     silent one: BoxCaps and capsEqual can agree while normalizeCaps quietly drops
     a key, and the only symptom is a cap that never persists."""
     print("capabilities: all three app edit sites carry every cap")
-    declared = set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+    declared = (set(group("capabilities")[0]) | set(group("linuxOnlyCapabilities")[0])
+                | set(group("windowsOnlyCapabilities")[0]))
     for site, have in _app_caps_sites().items():
         check(have, "app: %s parsed something at all" % site)
         missing = sorted(declared - have)

--- a/tests/test_win_launchers.py
+++ b/tests/test_win_launchers.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Tests for the Windows agent's non-Steam game launchers (Epic, GOG, Xbox).
+
+Run: python3 tests/test_win_launchers.py
+
+These launchers take a client-supplied id, so per CLAUDE.md §3/§6 the load-bearing
+property is allowlist-by-lookup: an id is looked up in a fresh, read-only
+discovery and the launch argv is REBUILT from the matched record — the client
+string is never interpolated into a command or URI. The security assertions here
+prove the reject path (unknown / malformed id -> None -> the route 404s and
+NOTHING runs) and that the argv comes from the record, not the id.
+
+The pure transforms (_epic_games_from_manifests / _gog_games_from_rows /
+_xbox_games_from_json) are tested with fixtures shaped like the real files, so
+they run cross-platform (the agent module imports fine on macOS; winreg + the
+PowerShell bridge are guarded). Live GOG/Xbox enumeration is Windows-only and is
+verified on a real box separately; here we test their pure transforms + resolver.
+
+Also asserts the `launchers` capability is wired at all five edit sites
+(CLAUDE.md §4): the two agent sites here, plus the three app sites by reading the
+app source — a missing app site is the classic silent "cap never persists" bug.
+
+Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import json
+import os
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "win", "couchsided-win.py")
+spec = importlib.util.spec_from_file_location("couchsided_win", AGENT)
+cw = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cw)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+# --------------------------------------------------------------------------
+# Epic
+# --------------------------------------------------------------------------
+def test_epic_transform():
+    print("epic: manifest -> records (games only, strict ids)")
+    manifests = [
+        {"AppName": "Fortnite", "DisplayName": "Fortnite",
+         "CatalogNamespace": "fn", "CatalogItemId": "abc123",
+         "AppCategories": ["public", "games"]},
+        # engine: has categories but no "games" -> dropped
+        {"AppName": "UnrealEngine", "DisplayName": "Unreal Engine",
+         "CatalogNamespace": "ue", "CatalogItemId": "def",
+         "AppCategories": ["public", "engines"]},
+        # non-alphanumeric AppName -> dropped (would be unsafe in the URI)
+        {"AppName": "bad name", "DisplayName": "Bad", "CatalogNamespace": "x",
+         "CatalogItemId": "y", "AppCategories": ["games"]},
+        # colon in the namespace -> dropped (URI-injection shape)
+        {"AppName": "Hostile", "DisplayName": "Hostile",
+         "CatalogNamespace": "a:b", "CatalogItemId": "z",
+         "AppCategories": ["games"]},
+        # no categories at all -> kept (don't guess a game out)
+        {"AppName": "NoCat", "DisplayName": "No Category Game",
+         "CatalogNamespace": "nc", "CatalogItemId": "z9"},
+        # missing required field -> dropped
+        {"AppName": "MissingNs", "DisplayName": "x", "CatalogItemId": "q"},
+    ]
+    got = [g["id"] for g in cw._epic_games_from_manifests(manifests)]
+    check(got == ["epic:Fortnite", "epic:NoCat"], "keeps only real games: %r" % got)
+
+
+def test_epic_discovery_reads_files():
+    print("epic: discover_epic_games globs + parses *.item on disk")
+    o_win, o_dir = cw.IS_WINDOWS, cw._epic_manifests_dir
+    try:
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "a.item"), "w", encoding="utf-8") as f:
+                json.dump({"AppName": "Alpha", "DisplayName": "Alpha Game",
+                           "CatalogNamespace": "ns1", "CatalogItemId": "cid1",
+                           "AppCategories": ["games"]}, f)
+            # malformed JSON: skipped, not fatal (degrade closed)
+            with open(os.path.join(d, "broken.item"), "w", encoding="utf-8") as f:
+                f.write("{ not json")
+            cw.IS_WINDOWS = True
+            cw._epic_manifests_dir = lambda: d
+            games = cw.discover_epic_games()
+            check([g["id"] for g in games] == ["epic:Alpha"],
+                  "found the good manifest, skipped the broken one")
+    finally:
+        cw.IS_WINDOWS, cw._epic_manifests_dir = o_win, o_dir
+
+
+def test_epic_resolver_and_reject():
+    print("epic: resolve rebuilds URI from the RECORD; unknown/malformed -> None")
+    o_win, o_disc, o_exe = cw.IS_WINDOWS, cw.discover_epic_games, cw._explorer_exe
+    try:
+        cw.IS_WINDOWS = True
+        cw._explorer_exe = lambda: r"C:\Windows\explorer.exe"
+        # namespace/cid live ONLY in the record — the client id carries neither,
+        # so a correct URI proves it was rebuilt from the record, not the id.
+        cw.discover_epic_games = lambda: [
+            {"id": "epic:Alpha", "label": "Alpha", "kind": "epic",
+             "namespace": "REALNS", "catalog_item_id": "REALCID",
+             "app_name": "Alpha"}]
+        argv = cw._launcher_argv("epic:Alpha")
+        want = [r"C:\Windows\explorer.exe",
+                "com.epicgames.launcher://apps/REALNS:REALCID:Alpha?action=launch"]
+        check(argv == want, "known id -> exact URI from record: %r" % argv)
+        check("REALNS" in argv[1] and "REALCID" in argv[1],
+              "URI components came from the record, not the client id")
+        check(cw._launcher_argv("epic:NotInstalled") is None,
+              "id absent from discovery -> None (nothing runs)")
+        check(cw._launcher_argv("epic:Alpha:../../evil") is None,
+              "malformed id (colons/dots) -> None, never sanitised")
+        check(cw._launcher_argv("epic:") is None, "empty name -> None")
+    finally:
+        cw.IS_WINDOWS, cw.discover_epic_games, cw._explorer_exe = o_win, o_disc, o_exe
+
+
+# --------------------------------------------------------------------------
+# GOG
+# --------------------------------------------------------------------------
+def test_gog_transform():
+    print("gog: registry rows -> records (numeric id + name required)")
+    rows = [
+        {"gameID": "1207658924", "gameName": "The Witcher 3",
+         "path": r"D:\Games\Witcher3"},
+        {"gameID": "notnumeric", "gameName": "Bad", "path": "x"},   # dropped
+        {"gameID": "55", "gameName": "", "path": "y"},              # dropped
+    ]
+    got = [(g["id"], g["path"]) for g in cw._gog_games_from_rows(rows)]
+    check(got == [("gog:1207658924", r"D:\Games\Witcher3")],
+          "keeps only rows with a numeric id + name: %r" % got)
+
+
+def test_gog_resolver_and_reject():
+    print("gog: resolve rebuilds GalaxyClient argv; unknown/non-numeric -> None")
+    o_win, o_disc, o_exe = cw.IS_WINDOWS, cw.discover_gog_games, cw._gog_client_exe
+    try:
+        cw.IS_WINDOWS = True
+        cw._gog_client_exe = lambda: r"C:\GOG\GalaxyClient.exe"
+        cw.discover_gog_games = lambda: [
+            {"id": "gog:1207658924", "label": "W3", "kind": "gog",
+             "game_id": "1207658924", "path": r"D:\Games\Witcher3"}]
+        argv = cw._launcher_argv("gog:1207658924")
+        want = [r"C:\GOG\GalaxyClient.exe", "/command=runGame",
+                "/gameId=1207658924", r"/path=D:\Games\Witcher3"]
+        check(argv == want, "known id -> exact Galaxy argv: %r" % argv)
+        check(cw._launcher_argv("gog:999") is None, "unknown id -> None")
+        check(cw._launcher_argv("gog:abc") is None, "non-numeric id -> None")
+        # a game with no stored path drops the /path arg (never an empty one)
+        cw.discover_gog_games = lambda: [
+            {"id": "gog:1", "label": "P", "kind": "gog", "game_id": "1",
+             "path": ""}]
+        check(cw._launcher_argv("gog:1") ==
+              [r"C:\GOG\GalaxyClient.exe", "/command=runGame", "/gameId=1"],
+              "empty path -> no /path argument")
+    finally:
+        cw.IS_WINDOWS, cw.discover_gog_games, cw._gog_client_exe = o_win, o_disc, o_exe
+
+
+# --------------------------------------------------------------------------
+# Xbox
+# --------------------------------------------------------------------------
+def test_xbox_transform():
+    print("xbox: Get-AppxPackage JSON -> records (well-formed AUMID only)")
+    blob = json.dumps([
+        {"aumid": "Microsoft.MinecraftUWP_8wekyb3d8bbwe!App", "name": "Minecraft"},
+        {"aumid": "noseparator", "name": "Bad"},           # dropped: no '!'
+        {"aumid": "a_b!App!Extra", "name": "BadToo"},      # dropped: two '!'
+        {"aumid": "evil path!x", "name": "Spacey"},        # dropped: space
+    ])
+    got = [g["id"] for g in cw._xbox_games_from_json(blob)]
+    check(got == ["xbox:Microsoft.MinecraftUWP_8wekyb3d8bbwe!App"],
+          "keeps only the well-formed AUMID: %r" % got)
+    # ConvertTo-Json collapses a single item to an object, not an array
+    solo = cw._xbox_games_from_json(json.dumps({"aumid": "A_b!App", "name": "Solo"}))
+    check([g["id"] for g in solo] == ["xbox:A_b!App"],
+          "single-object JSON is accepted (not just arrays)")
+    check(cw._xbox_games_from_json("not json") == [], "garbage JSON -> []")
+
+
+def test_xbox_resolver_and_reject():
+    print("xbox: resolve rebuilds shell:AppsFolder; unknown/malformed -> None")
+    o_win, o_disc, o_exe = cw.IS_WINDOWS, cw.discover_xbox_games, cw._explorer_exe
+    try:
+        cw.IS_WINDOWS = True
+        cw._explorer_exe = lambda: r"C:\Windows\explorer.exe"
+        aumid = "Microsoft.MinecraftUWP_8wekyb3d8bbwe!App"
+        cw.discover_xbox_games = lambda: [
+            {"id": "xbox:" + aumid, "label": "Minecraft", "kind": "xbox",
+             "aumid": aumid}]
+        argv = cw._launcher_argv("xbox:" + aumid)
+        check(argv == [r"C:\Windows\explorer.exe",
+                       "shell:AppsFolder\\" + aumid],
+              "known id -> exact shell:AppsFolder argv: %r" % argv)
+        check(cw._launcher_argv("xbox:Not_Installed!App") is None,
+              "unknown AUMID -> None")
+        check(cw._launcher_argv("xbox:evil path!x") is None,
+              "malformed AUMID (space) -> None")
+    finally:
+        cw.IS_WINDOWS, cw.discover_xbox_games, cw._explorer_exe = o_win, o_disc, o_exe
+
+
+def test_validators_reject_injection():
+    print("id validators reject anything but the strict charset")
+    for bad in ("a:b", "a/b", "a b", "a?x", "..", "a\\b", ""):
+        check(not cw._alnum_ok(bad), "_alnum_ok rejects %r" % bad)
+    for bad in ("nobang", "a!b!c", "a b!x", "!x", "x!", "a/b!c"):
+        check(not cw._aumid_ok(bad), "_aumid_ok rejects %r" % bad)
+    check(cw._alnum_ok("Fortnite123"), "_alnum_ok accepts a clean id")
+    check(cw._aumid_ok("Pkg.Name_hash13!App"), "_aumid_ok accepts a real AUMID")
+
+
+# --------------------------------------------------------------------------
+# Merge + delete guard + capability wiring
+# --------------------------------------------------------------------------
+def test_list_launchers_merges_all_stores():
+    print("list_launchers merges customs + steam + epic + gog + xbox in order")
+    saved = (cw.LAUNCHERS, cw.discover_steam_games, cw.discover_epic_games,
+             cw.discover_gog_games, cw.discover_xbox_games)
+    try:
+        cw.LAUNCHERS = [{"id": "custom:c", "label": "C", "cmd": ["x"]}]
+        cw.discover_steam_games = lambda: [{"id": "steam:1", "label": "S", "kind": "steam"}]
+        cw.discover_epic_games = lambda: [{"id": "epic:E", "label": "E", "kind": "epic"}]
+        cw.discover_gog_games = lambda: [{"id": "gog:2", "label": "G", "kind": "gog"}]
+        cw.discover_xbox_games = lambda: [{"id": "xbox:X!A", "label": "X", "kind": "xbox"}]
+        ids = [l["id"] for l in cw.list_launchers()]
+        check(ids == ["custom:c", "steam:1", "epic:E", "gog:2", "xbox:X!A"],
+              "merge order is custom, steam, epic, gog, xbox: %r" % ids)
+    finally:
+        (cw.LAUNCHERS, cw.discover_steam_games, cw.discover_epic_games,
+         cw.discover_gog_games, cw.discover_xbox_games) = saved
+
+
+def test_auto_ids_not_creatable_or_deletable():
+    print("auto-discovered ids are never custom (can't be created/deleted)")
+    check(cw._AUTO_LAUNCHER_KINDS == frozenset({"steam", "epic", "gog", "xbox"}),
+          "the delete guard covers all four auto kinds")
+    for lid in ("steam:1", "epic:E", "gog:2", "xbox:X!A"):
+        check(not cw._valid_launcher_id(lid),
+              "%s is not a valid custom id (POST create refuses it)" % lid)
+        check(lid.split(":", 1)[0] in cw._AUTO_LAUNCHER_KINDS,
+              "%s hits the 'not deletable' DELETE guard" % lid)
+
+
+def test_launchers_cap_five_sites():
+    print("`launchers` capability wired at all five edit sites (CLAUDE.md §4)")
+    # Agent site 1: mock CAPS
+    cw.set_caps(mock=True)
+    check(cw.CAPS.get("launchers") is True, "agent mock CAPS carries launchers")
+    # Agent site 2: real CAPS predicate, both directions
+    o = (cw.IS_WINDOWS, cw.LAUNCHERS, cw._steam_root, cw._gog_client_exe,
+         cw._epic_manifests_dir)
+    try:
+        cw.IS_WINDOWS = True
+        cw.LAUNCHERS = []
+        cw._steam_root = lambda: None
+        cw._gog_client_exe = lambda: None
+        cw._epic_manifests_dir = lambda: os.path.join(tempfile.gettempdir(), "no-epic-here")
+        check(cw._any_launcher_source() is False, "no launcher -> cap False")
+        cw._steam_root = lambda: r"C:\Steam"
+        check(cw._any_launcher_source() is True, "steam present -> cap True")
+    finally:
+        (cw.IS_WINDOWS, cw.LAUNCHERS, cw._steam_root, cw._gog_client_exe,
+         cw._epic_manifests_dir) = o
+    # App sites 3-5: read the app source and assert `launchers` is present in
+    # each. A missing site is the silent "cap never persists / re-probes" bug.
+    app = os.path.join(HERE, "..", "app")
+    api = open(os.path.join(app, "lib", "api.ts"), encoding="utf-8").read()
+    settings = open(os.path.join(app, "lib", "settings.ts"), encoding="utf-8").read()
+    layout = open(os.path.join(app, "app", "(tabs)", "_layout.tsx"), encoding="utf-8").read()
+    check("launchers?: boolean" in api, "app BoxCaps type declares launchers")
+    check("a.launchers === b.launchers" in api, "app capsEqual compares launchers")
+    check("bool('launchers')" in settings and "launchers," in settings,
+          "app normalizeCaps parses + returns launchers")
+    check("caps?.launchers" in layout, "app _layout gates the Launch tab on launchers")
+
+
+if __name__ == "__main__":
+    test_epic_transform()
+    test_epic_discovery_reads_files()
+    test_epic_resolver_and_reject()
+    test_gog_transform()
+    test_gog_resolver_and_reject()
+    test_xbox_transform()
+    test_xbox_resolver_and_reject()
+    test_validators_reject_injection()
+    test_list_launchers_merges_all_stores()
+    test_auto_ids_not_creatable_or_deletable()
+    test_launchers_cap_five_sites()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all Windows launcher tests passed")


### PR DESCRIPTION
Windows boxes could only launch **Steam** games — a PC whose library lives in Epic, GOG, or Game Pass got an empty (or hidden) Launch tab. The Windows agent now discovers all four stores.

## Agent — 0.4.0-win
- `discover_epic_games()` — `ProgramData\Epic\...\Manifests\*.item`, games only (drops engines/plugins)
- `discover_gog_games()` — `HKLM\...\GOG.com\Games`, numeric ids only
- `discover_xbox_games()` — `Get-AppxPackage` + `MicrosoftGame.config`, launched by AUMID (cached 60s; it shells out to PowerShell)
- `list_launchers()` merges custom → steam → epic → gog → xbox

## Allowlist (CLAUDE.md §3)
Every store branch of `_launcher_argv` **re-discovers read-only, matches the client id in that fresh set, and rebuilds the argv from the matched RECORD**. The client string is never interpolated into a command, URI, or path. An id absent from discovery returns `None` → the route 404s → nothing runs. Ids that would be unsafe in the launch URI are **rejected, not sanitised** (`_alnum_ok` / `_aumid_ok`). Every discovery degrades closed to `[]`. Auto-discovered ids are not custom ids, so they can be neither created nor deleted over the network (the DELETE guard now covers all four kinds).

## New `launchers` capability
"This box can drive at least one launcher" — so an Epic/GOG-only PC shows the Launch tab that the `steam` cap alone would hide. Wired at all five edit sites **plus** `protocol/protocol.json` as a new `windowsOnlyCapabilities` group.

**Backwards compatible:** the app falls back to `steam` when the cap is absent, so older agents and every Linux agent are unaffected. Startup detection is cheap-checks only (no PowerShell, no game enumeration) to protect reachability.

## Installer
`install.ps1` gains `-FromInstaller`: the UAC self-elevation now **waits** for the elevated child and drops `-NoExit`, so `CouchsideSetup.exe`'s `waituntilterminated` tracks the real install instead of the async `RunAs` handoff — and no stray PowerShell window is left behind.

## Drive-by unblock
`agent/CHANGELOG.md` gains the **2.9.53** section. `release-agent.sh` *refuses to publish* without a section matching the Linux agent VERSION, and main has shipped 2.9.53 with none — so the next agent release was already blocked before this PR. Also neutralizes the Linux-only host placeholders in the app's setup screen.

## Verified
- 35 agent test files + decky shell test + `tsc` + 23 app tests — all pass
- New `tests/test_win_launchers.py` (40+ assertions): pins the reject path, proves the argv is built from the record rather than the id, asserts the cap at all five sites
- `test_protocol_parity` caught the missing spec entry (that's the test doing its job) and now enforces `launchers` is Windows-only
- **Runtime-verified on real hardware** (EMERY-PC, over tailscale): Epic **2** games, GOG **1**, Steam **32** discovered, `list_launchers`=35, `caps.launchers`=True, Xbox PowerShell probe runs clean
- Adversarial pre-ship review across 5 dimensions (security / cap-BC / installer / tests / release): **no security findings**; its release-blocker and comment-accuracy findings are fixed in this PR

## NOT verified
- Firing an actual Epic/GOG/Xbox **launch** on hardware — the argv is unit-proven only
- The **non-elevated double-click** UAC handoff (needs a human at the keyboard)
- Xbox **AUMID** discovery against a real Game Pass install (the test box has none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)