### PR TITLE
fix(win): upgrading over a running agent silently failed (0.4.1-win)

### DIFF
--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.4.0-win"
+VERSION = "0.4.1-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")

--- a/install.ps1
+++ b/install.ps1
@@ -131,8 +131,30 @@ if (-not (Test-Admin)) {
 function Stop-AgentTask {
     # Stop-ScheduledTask kills a running instance; Unregister does NOT, so an
     # upgrade must stop first or copying over the running files/exe conflicts.
+    #
+    # But Stop-ScheduledTask only ends an instance the TASK still tracks, and a
+    # logon-launched agent routinely outlives that: measured on a real box, the
+    # task read "Ready" while couchside-agent.exe was very much alive. Nothing
+    # was stopped, the .exe stayed locked, and the upgrade died on
+    # "Copy-Item ... because it is being used by another process" -- which Inno
+    # then reported as a successful install. So also stop the process by name,
+    # and WAIT for the handle to drop (process exit is asynchronous, and copying
+    # a millisecond too early fails exactly the same way).
     Stop-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
-    Start-Sleep -Milliseconds 500
+    Get-Process -Name 'couchside-agent' -ErrorAction SilentlyContinue |
+        Stop-Process -Force -ErrorAction SilentlyContinue
+    $exe = Join-Path $InstallDir 'couchside-agent.exe'
+    if (Test-Path $exe) {
+        foreach ($i in 1..20) {           # up to ~5s, then let the copy report
+            try {
+                $fs = [IO.File]::Open($exe, 'Open', 'ReadWrite', 'None')
+                $fs.Close()
+                break
+            } catch { Start-Sleep -Milliseconds 250 }
+        }
+    } else {
+        Start-Sleep -Milliseconds 500
+    }
 }
 
 function Uninstall-Couchside {


### PR DESCRIPTION
Installing `CouchsideSetup.exe` on a box that **already had Couchside running** left the OLD agent in place — while the wizard said *"Setup completed successfully."*

## Root cause (measured on a real box)
The logon-launched agent outlives the scheduled task's tracking: the task reads **`Ready`** while `couchside-agent.exe` is very much alive. So `Stop-ScheduledTask` had no instance to stop, the `.exe` stayed locked, and the upgrade died on:

```
Copy-Item : The process cannot access the file
'...\couchside-agent.exe' because it is being used by another process.
```

`install.ps1` exited **1** — but Inno's `[Run]` does not inspect exit codes, so Setup still reported success. The user "upgrades", sees a green wizard, and keeps running the old agent.

## Fix
`Stop-AgentTask` now also stops the process by name and **waits for the file handle to drop** (process exit is asynchronous — copying a moment too early fails identically) before the copy.

`VERSION` → `0.4.1-win` so existing 0.4.0-win boxes are offered the update that carries this fix. The agent code itself is unchanged.

## Verified on hardware (EMERY-PC), both states observed
| | old agent running → | result |
|---|---|---|
| **before fix** | `install.ps1` exit **1** | box stuck on 0.3.8-win |
| **after fix** | `install.ps1` exit **0** | box upgraded; `/api/ping` reports the new agent |

And the live API after the upgrade — the end-to-end proof of the multi-launcher work from #248:

```
TOTAL=35   steam=32  epic=2  gog=1
epic:Fortnite                        | Fortnite
epic:aa7093efba5b4760ad413c01fbdd0fae | Asphalt Legends
gog:1412601690                        | Diablo
caps.launchers=True
```

## Not fixed here
Inno still reports success on a failed `[Run]`; surfacing that needs a `[Code] Exec()` capturing `ResultCode` (tracked separately). This PR removes the failure that was hiding behind it.

No unit test: `install.ps1` is PowerShell and there is no Windows runner for it — verified against the real reproduction on hardware instead, in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)