### PR TITLE
feat(drop): "Show on box" opens the drop folder + instant-upload feedback (agent 2.9.55)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.54"
+VERSION = "2.9.55"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1420,6 +1420,63 @@ def _drop_dir():
             or os.path.join(os.path.expanduser("~"), "Downloads", "Couchside"))
     os.makedirs(base, exist_ok=True)
     return os.path.realpath(base)
+
+
+def drop_dir_reveal():
+    """Open the drop dir in the box's file manager (POST /api/upload/reveal).
+
+    A file that lands invisibly is a file the user has to go hunting for, so the
+    app offers a "Show on box" tap after a successful drop.
+
+    DESKTOP ONLY, deliberately. In Game Mode there is no file manager to raise —
+    gamescope shows only what Steam surfaces, so a spawned Dolphin window would
+    either do nothing visible or land behind the session. Reports an honest
+    skip-with-reason there rather than claiming success (a dead button costs more
+    trust than a missing one).
+
+    SECURITY: takes NO client input. The path is this module's own `_drop_dir()`
+    constant and the program comes from the frozen list below, so a caller can
+    only ever ask for "the drop dir" — there is nothing to point somewhere else.
+
+    Names the file manager instead of delegating to xdg-open. MEASURED on a live
+    Bazzite box: `xdg-mime query default inode/directory` returned
+    `de.leopoldluley.Clapgrep.desktop` — a text-search app — so xdg-open opened a
+    grep tool over the folder and then HUNG until the timeout (exit 124). Any
+    installed app can claim inode/directory, so asking the desktop to guess is
+    how "Show on box" silently does the wrong thing. xdg-open stays only as a
+    last resort when no known manager exists."""
+    if not desktop_available():
+        return {"opened": False,
+                "reason": "the box is in Game Mode; switch to the desktop first"}
+    path = _drop_dir()
+    # Frozen preference order: KDE first (SteamOS/Bazzite ship Plasma), then the
+    # common GTK managers. Chosen by the agent; never by the client.
+    cmd = None
+    for prog in ("dolphin", "nautilus", "nemo", "thunar", "pcmanfm"):
+        if shutil.which(prog):
+            cmd = [prog, path]
+            break
+    if cmd is None:
+        if not shutil.which("xdg-open"):
+            return {"opened": False, "reason": "no file manager on this box"}
+        cmd = ["xdg-open", path]
+    # Popen, not run(): a file manager runs for as long as its window is open, so
+    # waiting on it would pin a thread for that whole time (and xdg-open can hang
+    # outright, as measured above). Detached so it outlives this request.
+    #
+    # _session_env(), not _user_env(): a GUI app needs DISPLAY / WAYLAND_DISPLAY,
+    # and _user_env() sets only XDG_RUNTIME_DIR. Measured on the box — with the
+    # bare user env dolphin started and exited immediately (a <defunct> child and
+    # no window); the session env is what the launcher path already uses.
+    try:
+        subprocess.Popen(cmd, env=_session_env(), stdin=subprocess.DEVNULL,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                         start_new_session=True)
+    except Exception as e:
+        return {"opened": False,
+                "reason": "could not start %s on the box" % cmd[0],
+                "detail": e.__class__.__name__}
+    return {"opened": True, "path": path, "with": cmd[0]}
 
 
 # ---------------------------------------------------------------------------
@@ -12501,6 +12558,16 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(413, {"error": "request body too large"}, started)
                 return
             body = self._read_body()
+
+            # POST /api/upload/reveal — open the drop dir in the box's file
+            # manager after a drop. Takes NO body and NO parameters: the path is
+            # the agent's own _drop_dir(), so there is nothing a client can point
+            # elsewhere. Always 200 with {opened: bool} — Game Mode reports an
+            # honest opened:false + reason rather than a fake success.
+            if path == "/api/upload/reveal":
+                self._send(200, (({"opened": True, "path": "/home/deck/Downloads/Couchside"})
+                                 if self.mock else drop_dir_reveal()), started)
+                return
 
             # POST /api/steam/menus {"id": "<panel>"}: open one Steam settings
             # page on the box's screen. 404 on an id that is not on the frozen

--- a/app/components/FileDropCard.tsx
+++ b/app/components/FileDropCard.tsx
@@ -13,7 +13,7 @@
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import * as DocumentPicker from 'expo-document-picker';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api } from '@/lib/api';
@@ -24,6 +24,11 @@ import type { Palette } from '@/lib/theme';
 
 type Phase = 'idle' | 'uploading' | 'done' | 'error';
 
+/** How long the "✓ Sent …" confirmation stays before the card resets itself.
+ *  Long enough to read it and still tap "Show on box"; short enough that the
+ *  card isn't still naming a file you sent ten minutes ago. */
+const DONE_LINGER_MS = 12_000;
+
 export function FileDropCard() {
   const { settings } = useSettings();
   const styles = useThemedStyles(makeStyles);
@@ -33,6 +38,24 @@ export function FileDropCard() {
   const [detail, setDetail] = useState('');
   const [bytes, setBytes] = useState(0);
   const [revealMsg, setRevealMsg] = useState('');
+
+  // The ✓ line used to sit there with the filename until the next upload, so the
+  // card kept advertising a file you sent minutes ago. Clear back to the neutral
+  // prompt after a beat — long enough to read the confirmation and still tap
+  // "Show on box", short enough that the card doesn't become a stale receipt.
+  // Only the SUCCESS state auto-clears: an error has to stay until it's read.
+  useEffect(() => {
+    if (phase !== 'done') return undefined;
+    const id = setTimeout(() => {
+      setPhase('idle');
+      setFileName('');
+      setBytes(0);
+      setDetail('');
+      setRevealMsg('');
+      setProgress(0);
+    }, DONE_LINGER_MS);
+    return () => clearTimeout(id);
+  }, [phase]);
 
   const send = useCallback(async () => {
     try {

--- a/app/components/FileDropCard.tsx
+++ b/app/components/FileDropCard.tsx
@@ -17,7 +17,7 @@ import { useCallback, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { api } from '@/lib/api';
-import { hapticLight } from '@/lib/haptics';
+import { hapticLight, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
@@ -31,6 +31,8 @@ export function FileDropCard() {
   const [fileName, setFileName] = useState('');
   const [progress, setProgress] = useState(0);
   const [detail, setDetail] = useState('');
+  const [bytes, setBytes] = useState(0);
+  const [revealMsg, setRevealMsg] = useState('');
 
   const send = useCallback(async () => {
     try {
@@ -49,10 +51,31 @@ export function FileDropCard() {
       hapticLight();
       const result = await api.uploadFile(settings, asset.uri, name, setProgress);
       setDetail(result.path || '');
+      setBytes(result.bytes || asset.size || 0);
       setPhase('done');
+      // A LAN drop of a document is often over before the progress bar paints a
+      // single frame, so "it worked" has to be felt as well as seen: a success
+      // haptic fires here and the ✓ row below stays put until the next action.
+      // Deliberately NOT slowing the upload down to show a bar — a fake delay
+      // would make the feature worse to use in exchange for a nicer animation.
+      hapticSuccess();
     } catch (e) {
       setDetail(e instanceof Error ? e.message : 'Upload failed');
       setPhase('error');
+    }
+  }, [settings]);
+
+  // "Show on box": raise the drop folder in the box's file manager. Desktop-only
+  // on the agent side; in Game Mode it answers opened:false + a reason, which we
+  // surface verbatim rather than silently doing nothing.
+  const reveal = useCallback(async () => {
+    hapticLight();
+    setRevealMsg('');
+    try {
+      const r = await api.revealDrop(settings);
+      if (!r.opened) setRevealMsg(r.reason || 'Could not open the folder on the box.');
+    } catch {
+      setRevealMsg('Could not open the folder on the box.');
     }
   }, [settings]);
 
@@ -70,7 +93,13 @@ export function FileDropCard() {
       </View>
 
       {phase === 'done' ? (
-        <Text style={styles.ok}>✓ Sent {fileName}</Text>
+        // Size included on purpose: a LAN drop is usually instant, so "✓ Sent"
+        // alone can read as "did anything happen?". The byte count is the
+        // box's OWN reported number, i.e. proof of what actually landed.
+        <Text style={styles.ok}>
+          ✓ Sent {fileName}
+          {bytes > 0 ? ` · ${formatBytes(bytes)}` : ''}
+        </Text>
       ) : phase === 'error' ? (
         <Text style={styles.err}>{detail}</Text>
       ) : (
@@ -88,6 +117,7 @@ export function FileDropCard() {
         </View>
       )}
       {phase === 'done' && !!detail && <Text style={styles.pathHint}>{detail}</Text>}
+      {!!revealMsg && <Text style={styles.revealMsg}>{revealMsg}</Text>}
 
       <Pressable
         style={({ pressed }) => [styles.btn, pressed && styles.btnPressed, uploading && styles.btnDisabled]}
@@ -97,8 +127,27 @@ export function FileDropCard() {
           {uploading ? `Sending ${fileName}…` : phase === 'done' ? 'Send another file' : 'Choose a file…'}
         </Text>
       </Pressable>
+
+      {/* "Show on box" — only after a successful drop, and only when the box is
+          on the DESKTOP (caps.desktop flips per session switch). Game Mode has
+          no file manager to raise, so offering it there would be a dead button. */}
+      {phase === 'done' && settings.caps?.desktop === true && (
+        <Pressable
+          style={({ pressed }) => [styles.btnGhost, pressed && styles.btnPressed]}
+          onPress={reveal}>
+          <Text style={styles.btnGhostText}>Show on box</Text>
+        </Pressable>
+      )}
     </View>
   );
+}
+
+/** Human-readable size for the ✓ line (1 decimal past KB, matching the Console). */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(1)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(1)} GB`;
 }
 
 const makeStyles = (t: Palette) =>
@@ -134,4 +183,15 @@ const makeStyles = (t: Palette) =>
     btnPressed: { opacity: 0.85 },
     btnDisabled: { opacity: 0.6 },
     btnText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+    // Secondary action: outlined, so it reads as "optional extra" next to the
+    // filled primary button rather than competing with it.
+    btnGhost: {
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 9,
+      paddingVertical: 8,
+      alignItems: 'center',
+    },
+    btnGhostText: { color: t.text, fontSize: 12, fontWeight: '600' },
+    revealMsg: { color: t.amber, fontSize: 11, lineHeight: 15 },
   });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -904,6 +904,10 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
 /** Result of a successful POST /api/upload (agent >= 2.9.54). */
 export type UploadResult = { ok: boolean; name: string; bytes: number; path: string };
 
+/** Result of POST /api/upload/reveal (agent >= 2.9.55). `opened` is false with a
+ *  human-readable `reason` when the box can't raise a file manager (Game Mode). */
+export type RevealResult = { opened: boolean; path?: string; reason?: string };
+
 /**
  * Upload a local file to the box's drop dir (POST /api/upload, agent >= 2.9.54).
  *
@@ -1979,6 +1983,17 @@ export const api = {
   /** Exit Couch Mode: return the box to its desktop session. */
   desktopMode(settings: ConnSettings): Promise<{ ok: boolean }> {
     return request(settings, '/api/desktop-mode', { method: 'POST' });
+  },
+
+  /**
+   * Open the box's drop dir in its file manager after a file drop
+   * (agent >= 2.9.55). Desktop-only on the box side: in Game Mode it answers
+   * 200 with {opened:false, reason} rather than pretending, so the caller can
+   * show the reason instead of a lie. Takes no arguments — the agent opens its
+   * OWN drop dir, nothing client-supplied.
+   */
+  revealDrop(settings: ConnSettings): Promise<RevealResult> {
+    return request(settings, '/api/upload/reveal', { method: 'POST' });
   },
 
   /**

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -17,6 +17,7 @@ plus the capability wiring on the agent side (file_upload in mock + real CAPS).
 Pure stdlib, no pytest — same style as the other agent tests.
 """
 import http.client
+import json
 import importlib.util
 import os
 import tempfile
@@ -130,11 +131,44 @@ def test_capability_wired():
     check("file_upload" in cs.CAPS, "real caps compute file_upload")
 
 
+def test_reveal_requires_auth_and_gates_on_desktop():
+    """POST /api/upload/reveal — "Show on box" after a drop.
+
+    Three properties matter: it is bearer-gated like every other state-changing
+    route; it takes NO client input (so there is nothing to point at another
+    directory); and it degrades HONESTLY in Game Mode (opened:false + a reason)
+    instead of claiming it raised a file manager that isn't there.
+    """
+    print("reveal: auth-gated, no client input, honest Game-Mode skip")
+    srv, port, drop, _ = _server()
+    real_desktop = cs.desktop_available
+    try:
+        status, _ = _post(port, "/api/upload/reveal", b"", token=None)
+        check(status == 401, "no bearer -> 401")
+
+        # Game Mode (or any non-desktop box): must NOT claim success.
+        cs.desktop_available = lambda: False
+        status, data = _post(port, "/api/upload/reveal", b"")
+        body = json.loads(data.decode("utf-8"))
+        check(status == 200, "authed -> 200")
+        check(body.get("opened") is False, "Game Mode -> opened:false")
+        check(bool(body.get("reason")), "Game Mode -> says why")
+
+        # The function is the whole surface: it accepts no arguments at all, so a
+        # client cannot steer WHICH directory is opened.
+        check(cs.drop_dir_reveal.__code__.co_argcount == 0,
+              "reveal takes no client-supplied arguments")
+    finally:
+        cs.desktop_available = real_desktop
+        srv.shutdown()
+
+
 if __name__ == "__main__":
     test_happy_path()
     test_auth_failure()
     test_reject_bad_names()
     test_capability_wired()
+    test_reveal_requires_auth_and_gates_on_desktop()
     if _fail:
         print("\n%d check(s) failed" % len(_fail))
         raise SystemExit(1)


### PR DESCRIPTION
Follow-up to #246. Two things a real drop made obvious.

## "Show on box"
A file that lands invisibly is a file you have to go hunting for. After a successful drop the card offers **Show on box**, which raises the drop folder in the box's file manager.

- **Desktop-only.** Game Mode has no file manager to raise, so the agent returns `{opened:false, reason}` and the button is hidden behind `caps.desktop` — no dead control.
- **`POST /api/upload/reveal` takes NO client input.** The path is the agent's own `_drop_dir()`; the program comes from a frozen list. A caller can only ever say "the drop dir".

## Instant-upload feedback
A LAN drop is usually over before the progress bar paints a frame, so it read as "did anything happen?". **Deliberately not slowing the upload down** for a nicer animation — instead the success line carries the box's own reported byte count, and a success haptic fires.

## Two bugs caught by testing on hardware, not trusting the 200
1. **`xdg-open` is not safe for a directory.** On a live Bazzite box `xdg-mime query default inode/directory` was `de.leopoldluley.Clapgrep.desktop` — a text-search app. `xdg-open` ran a grep tool over the folder and hung until timeout (exit 124). Any app can claim `inode/directory`, so the agent now names the manager (dolphin first — Plasma is the SteamOS/Bazzite desktop) and only falls back to `xdg-open`.
2. **Wrong env killed the window.** `_user_env()` sets only `XDG_RUNTIME_DIR`, so dolphin started and exited instantly (`<defunct>`, no window). Now uses `_session_env()` — the same env the launcher path already uses — which supplies `DISPLAY`/`WAYLAND_DISPLAY`.

## Verification
- **Live on a Bazzite box, both states:** Game Mode → `opened:false` + reason; desktop → `opened:true` **and dolphin actually RUNNING** (pid alive, not defunct; 0 dolphin processes before the call).
- `tests/test_upload.py` extended: reveal is 401 without a bearer, reports an honest `opened:false` off-desktop, and takes zero client-supplied arguments.
- Agent suite **36/36**, `tsc` clean.

## NOT verified
The **app-side button** has not been pressed on a device — the agent endpoint is hardware-verified, the card wiring is compile-verified only. Needs a TestFlight build to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
