### PR TITLE
docs(install): the -FromInstaller exit code is now load-bearing

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -44,7 +44,7 @@ param(
     [switch]$KeepHibernate,  # skip `powercfg /hibernate off`
     [string]$Ref = 'main',   # git ref to download the agent from
     [switch]$FromInstaller   # set by CouchsideSetup.exe: the elevated relaunch must
-                             # WAIT (so Inno's waituntilterminated tracks the real
+                             # WAIT (so the installer's Exec() tracks the real
                              # install) and must NOT keep a -NoExit window open
 )
 
@@ -114,10 +114,12 @@ if (-not (Test-Admin)) {
             # -Wait blocks the outer process so the caller sees the install finish
             # rather than the async RunAs handoff returning instantly; -PassThru
             # lets us mirror the child's exit code outward.
-            # NOTE: Inno's [Run] with waituntilterminated does NOT inspect exit
-            # codes, so today this code is only observable to a caller that reads
-            # it -- the wizard still reports success either way. Surfacing a failed
-            # install in the wizard needs a [Code] Exec() that checks ResultCode.
+            # This exit code is LOAD-BEARING as of couchside-windows 896d4be:
+            # CouchsideSetup.exe runs this script from Inno's PrepareToInstall and
+            # aborts the wizard (exit code 7, error on screen, nothing installed)
+            # when it is non-zero. Before that it ran from a [Run] entry, which
+            # never inspects exit codes -- a failed install still showed "Setup
+            # completed successfully". So do not swallow a failure here.
             $child = Start-Process powershell -Verb RunAs -ArgumentList $a -Wait -PassThru
             exit $child.ExitCode
         }


### PR DESCRIPTION
Comments only, no behaviour change.

`install.ps1` carried this NOTE next to the `-FromInstaller` elevation branch:

> Inno's [Run] with waituntilterminated does NOT inspect exit codes, so today this code is only observable to a caller that reads it -- the wizard still reports success either way.

That was accurate when written and is now wrong. emerytech/couchside-windows@896d4be moved the handoff out of the passive `[Run]` entry and into Inno's `PrepareToInstall`, which reads `ResultCode` and aborts Setup — exit code 7, error text on screen, nothing installed — whenever this script exits non-zero.

So the `exit $child.ExitCode` line is now load-bearing: it is the only thing carrying a failure out of the UAC-elevated child and into the wizard. The comment now says so, so nobody "simplifies" the `-Wait -PassThru` mirroring away. The stale `waituntilterminated` reference in the `-FromInstaller` param docs is corrected too.

Context: with the old `[Run]` entry, a real upgrade failure (`install.ps1` exited 1 — `Process exit code: 1` in the Inno log) still showed "Setup completed successfully", and `runhidden` kept the error invisible. A user upgraded, saw a green wizard, and kept running the old agent.

`install.ps1` mirrors into emerytech/couchside-windows via the daily sync, which is why this correction has to land here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)