### PR TITLE
fix(win): PIN pairing + fail the build without ViGEmClient.dll (0.4.2-win)

### DIFF
--- a/agent/win/build.ps1
+++ b/agent/win/build.ps1
@@ -3,9 +3,16 @@
 #
 #   powershell -ExecutionPolicy Bypass -File build.ps1
 #
-# Output: dist\couchside-agent.exe. Drop it (optionally with ViGEmClient.dll)
-# next to this script in agent\win\ — the root install.ps1 finds an exe there
-# and installs it instead of downloading the Python agent.
+# Output: dist\couchside-agent.exe. Drop it next to this script in agent\win\ —
+# the root install.ps1 finds an exe there and installs it instead of downloading
+# the Python agent.
+#
+# ViGEmClient.dll MUST be next to this script: without it the built agent cannot
+# create a virtual pad, reports caps.gamepad=false, and the app hides the Pad tab
+# (issue #255). Use -NoGamepad only if you deliberately want a build with no
+# controller support.
+
+param([switch]$NoGamepad)
 
 $ErrorActionPreference = 'Stop'
 $here = Split-Path -Parent $MyInvocation.MyCommand.Path
@@ -19,9 +26,9 @@ $qrPath = $here
 if (-not (Test-Path (Join-Path $here 'qr.py'))) { $qrPath = Split-Path $here -Parent }
 
 # --noconsole would swallow the log prints; keep the console build and let the
-# scheduled task hide the window instead. qr.py is bundled as a module; the
-# ViGEmClient.dll (if present next to this script) is bundled as data so the
-# _MEIPASS lookup in _load_vigem finds it.
+# scheduled task hide the window instead. qr.py is bundled as a module;
+# ViGEmClient.dll is bundled below (required -- see the block after $piArgs) so
+# the _MEIPASS lookup in _load_vigem finds it.
 $piArgs = @(
     '--onefile',
     '--name', 'couchside-agent',
@@ -34,11 +41,48 @@ $piArgs = @(
     '--workpath', (Join-Path $here 'build'),
     '--specpath', $here
 )
+# ViGEmClient.dll is REQUIRED, and its absence is a hard error rather than a
+# quiet skip. vigem_available() is a DLL-load check, so an agent built without
+# this file reports caps.gamepad=false and the app HIDES THE PAD TAB -- the
+# headline feature -- on every install made from that build. That shipped: a
+# user on 0.4.1-win had ViGEmBus.sys installed and working, no ViGEmClient.dll
+# anywhere, and no Pad tab, because this used to be
+#     if (Test-Path $dll) { ... }
+# which succeeds silently when the file is missing. A build that cannot do
+# gamepad must fail loudly here, not surprise someone on their couch.
 $dll = Join-Path $here 'ViGEmClient.dll'
-if (Test-Path $dll) { $piArgs += @('--add-binary', "$dll;.") }
+if ($NoGamepad) {
+    Write-Host 'NOTE: -NoGamepad given; building WITHOUT ViGEmClient.dll.' -ForegroundColor Yellow
+    Write-Host '      This agent will report caps.gamepad=false and the app will hide the Pad tab.'
+} elseif (-not (Test-Path $dll)) {
+    Write-Host ''
+    Write-Host 'ERROR: ViGEmClient.dll not found next to build.ps1.' -ForegroundColor Red
+    Write-Host ''
+    Write-Host '  Without it the built agent reports caps.gamepad=false and the'
+    Write-Host '  phone app hides the Pad tab entirely (see issue #255).'
+    Write-Host ''
+    Write-Host '  Get it from the ViGEm client release and drop it in:'
+    Write-Host '    https://github.com/nefarius/ViGEmClient/releases'
+    Write-Host "    -> $dll"
+    Write-Host ''
+    Write-Host '  To build a deliberately gamepad-less agent anyway, pass -NoGamepad.'
+    throw 'ViGEmClient.dll missing (see message above)'
+}
+if (-not $NoGamepad) { $piArgs += @('--add-binary', "$dll;.") }
 $piArgs += (Join-Path $here 'couchsided-win.py')
 
 python -m PyInstaller @piArgs
+if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed with exit code $LASTEXITCODE" }
+
+# Prove the DLL actually made it in, rather than trusting the flag. PyInstaller
+# can succeed while dropping a binary it could not resolve.
+$exe = Join-Path $here 'dist\couchside-agent.exe'
+if (-not (Test-Path $exe)) { throw "build reported success but $exe does not exist" }
+if ((-not $NoGamepad) -and -not (Select-String -Path $exe -Pattern 'ViGEmClient\.dll' -Encoding Byte -Quiet -ErrorAction SilentlyContinue)) {
+    Write-Host 'WARNING: could not confirm ViGEmClient.dll inside the exe.' -ForegroundColor Yellow
+    Write-Host '         Run the agent and check that /api/status reports caps.gamepad=true.'
+}
 
 Write-Host ''
-Write-Host "Built: $(Join-Path $here 'dist\couchside-agent.exe')"
+Write-Host "Built: $exe"
+Write-Host 'Verify before shipping: start it, then GET /api/status and confirm caps.gamepad = true.'

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.4.1-win"
+VERSION = "0.4.2-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")
@@ -4647,6 +4647,112 @@ def _pair_lan_ip():
         return None
 
 
+# ---------------------------------------------------------------------------
+# PIN pairing (POST /api/pair/start, /api/pair/finish) — parity with the Linux
+# agent. These are the only UNAUTHENTICATED POST routes, because a phone that
+# has just discovered this box has no token yet; the box proves consent by
+# showing a PIN on ITS OWN screen, which only someone who can see that screen
+# can read.
+#
+# Before this existed the Windows agent had no PIN flow at all, so the app's
+# "Scan for boxes -> tap the box" path hit the bearer gate and answered
+# 401 unauthorized. Pairing a Windows box was only possible via the QR page or
+# by typing the token by hand (issue #256).
+#
+# The bounds below are what make an unauthenticated endpoint safe and are
+# copied deliberately from the Linux agent — do not relax them:
+#   TTL             a PIN dies on its own
+#   MAX_ATTEMPTS    a wrong PIN burns the session, so it cannot be brute-forced
+#                   (5 tries against 1e6 PINs)
+#   START_DEBOUNCE  a repeat /start cannot spam the screen or reroll the number
+#                   the user is currently reading
+PAIR_PIN_TTL = 120           # seconds a displayed PIN stays valid
+PAIR_PIN_MAX_ATTEMPTS = 5    # wrong PINs before the session is burned
+PAIR_PIN_START_DEBOUNCE = 3  # min seconds between /start (anti on-screen spam)
+PAIR_PIN_LOCK = threading.Lock()
+PAIR_PIN = None              # {pin, expires, attempts, started} or None
+
+
+def pair_pin_start():
+    """Mint a fresh PIN + session (replacing any prior one) and return
+    (pin, ttl, fresh). Debounced: within PAIR_PIN_START_DEBOUNCE of the last
+    start the LIVE pin is returned unchanged, so a double-tap doesn't reroll the
+    number already on screen. `fresh` is True only when a NEW PIN was minted, so
+    the caller pops the box screen only then."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        now = time.monotonic()
+        s = PAIR_PIN
+        if s and now <= s["expires"] and now - s["started"] < PAIR_PIN_START_DEBOUNCE:
+            return s["pin"], int(s["expires"] - now), False
+        pin = "%06d" % (int.from_bytes(os.urandom(3), "big") % 1000000)
+        PAIR_PIN = {"pin": pin, "expires": now + PAIR_PIN_TTL,
+                    "attempts": 0, "started": now}
+        return pin, PAIR_PIN_TTL, True
+
+
+def pair_pin_active():
+    """The current PIN if a session is live (for /pair to render), else None."""
+    with PAIR_PIN_LOCK:
+        if PAIR_PIN and time.monotonic() <= PAIR_PIN["expires"]:
+            return PAIR_PIN["pin"]
+        return None
+
+
+def pair_pin_check(pin):
+    """Validate a submitted PIN. True (and burns the session) on match; raises
+    ValueError with a user-facing reason on no-session / expired / locked /
+    wrong. A wrong guess counts toward the attempt cap."""
+    global PAIR_PIN
+    with PAIR_PIN_LOCK:
+        s = PAIR_PIN
+        if not s or time.monotonic() > s["expires"]:
+            PAIR_PIN = None
+            raise ValueError("no active pairing - start it again from the app")
+        if s["attempts"] >= PAIR_PIN_MAX_ATTEMPTS:
+            PAIR_PIN = None
+            raise ValueError("too many wrong PINs - start again")
+        if (pin or "").strip() != s["pin"]:
+            s["attempts"] += 1
+            raise ValueError("wrong PIN")
+        PAIR_PIN = None                       # consume on success
+        return True
+
+
+_BOX_POP_LOCK = threading.Lock()
+_BOX_POP_AT = [0.0]                 # monotonic time of the last box-screen pop
+_BOX_POP_COOLDOWN = 5.0             # hard floor between pops
+
+
+def pair_show_on_box(port):
+    """Open the loopback /pair page on THIS machine's screen so the PIN is
+    visible there. Best-effort and detached: pairing must never fail because a
+    browser would not open. Rate-limited so a retry storm cannot throw windows
+    at the user."""
+    with _BOX_POP_LOCK:
+        now = time.monotonic()
+        if now - _BOX_POP_AT[0] < _BOX_POP_COOLDOWN:
+            return
+        _BOX_POP_AT[0] = now
+    url = "http://localhost:%d/pair" % port
+
+    def go():
+        try:
+            # os.startfile is the Windows "open with the default handler" call;
+            # it returns immediately and does not need a shell.
+            os.startfile(url)          # noqa: S606  (Windows-only, fixed URL)
+        except Exception:
+            try:
+                subprocess.Popen(["cmd", "/c", "start", "", url],
+                                 stdin=subprocess.DEVNULL,
+                                 stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL,
+                                 creationflags=_DETACH_FLAGS)
+            except Exception:
+                pass
+    threading.Thread(target=go, daemon=True).start()
+
+
 def build_pair_url(token, port):
     """The Couchside pairing link (same format as the Linux agent: params ride
     the URL #FRAGMENT so browsers never send the token to any server)."""
@@ -4657,6 +4763,39 @@ def build_pair_url(token, port):
     if ip:
         url += "&ip=" + quote(ip, safe="")
     return url
+
+
+def render_pin_page(pin):
+    """Full-screen dark page showing the pairing PIN, sized to be read from a
+    couch. Served ONLY on loopback (the /pair gates), so the PIN is visible only
+    to someone physically at this PC — that is the whole consent mechanism.
+
+    Polls /api/pair/status and clears itself once the session ends (paired or
+    expired) rather than leaving a stale number on screen. A fetch error leaves
+    the page untouched: an agent restart must never paint an error here."""
+    return (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        "<title>Pair Couchside</title><style>"
+        "html,body{height:100%;margin:0;background:#0b1220;color:#e6edf3;"
+        "font-family:system-ui,Segoe UI,sans-serif;display:flex;align-items:center;"
+        "justify-content:center;text-align:center}"
+        ".w{padding:24px}h1{font-size:1.4rem;font-weight:600;color:#9fb0c0;margin:0 0 18px}"
+        ".pin{font-size:22vw;line-height:1;letter-spacing:.12em;font-weight:700;"
+        "font-variant-numeric:tabular-nums;color:#34d399}"
+        ".sub{margin-top:20px;color:#7d8da0;font-size:1rem}"
+        ".done{font-size:2rem;color:#9fb0c0}"
+        "</style></head><body><div class=\"w\">"
+        "<h1>Enter this PIN on your phone</h1>"
+        "<div class=\"pin\" id=\"pin\">" + pin + "</div>"
+        "<div class=\"sub\" id=\"sub\">Couchside &middot; pairing expires in 2 minutes</div>"
+        "</div><script>(function(){var gone=false;setInterval(function(){"
+        "fetch('/api/pair/status').then(function(r){return r.json()})"
+        ".then(function(d){if(d&&d.active===false&&!gone){gone=true;"
+        "document.getElementById('pin').outerHTML="
+        "'<div class=\"done\">Pairing finished &mdash; you can close this.</div>';"
+        "document.getElementById('sub').textContent='';}}).catch(function(){});"
+        "},3000);})();</script></body></html>")
 
 
 def render_pair_page(token, port):
@@ -4882,8 +5021,23 @@ class Handler(BaseHTTPRequestHandler):
                 if not self._is_loopback() or not self._host_header_is_local():
                     self._send(403, {"error": "forbidden"}, started)
                     return
-                html = render_pair_page(self._current_token(), self.port)
+                # While a PIN-pairing session is live, this page IS the
+                # physical-presence proof: show the big PIN (loopback-only, so
+                # only someone at this PC sees it). Otherwise the usual token QR.
+                pin = pair_pin_active()
+                html = (render_pin_page(pin) if pin
+                        else render_pair_page(self._current_token(), self.port))
                 self._send_html(200, html, started)
+                return
+
+            if path == "/api/pair/status":
+                # Loopback-only: the on-screen PIN page polls this to learn when
+                # its session ended (paired or expired) so it can clear itself.
+                # Reveals only a boolean — never the PIN, never the token.
+                if not self._is_loopback():
+                    self._send(403, {"error": "forbidden"}, started)
+                    return
+                self._send(200, {"active": pair_pin_active() is not None}, started)
                 return
 
             if path == "/api/ping":
@@ -5057,6 +5211,43 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 self._read_body()
                 self._send(404, {"error": "not found"}, started)
+                return
+
+            # UNAUTHENTICATED PIN pairing (the only unauthenticated POSTs): a
+            # phone that discovered this box enrolls via a PIN shown on the
+            # box's own screen. Bounded: /start is debounced + displays the PIN
+            # locally; /finish is TTL + attempt-capped and only returns the token
+            # for the correct PIN. Handled here, BEFORE the bearer-token gate —
+            # a phone that has no token yet cannot present one, which is why the
+            # gate used to answer 401 and made scan-and-pair impossible on
+            # Windows (issue #256).
+            if path in ("/api/pair/start", "/api/pair/finish"):
+                if self._body_too_large():
+                    self.close_connection = True
+                    self._send(413, {"error": "request body too large"}, started)
+                    return
+                pair_body = self._read_body()
+                if path == "/api/pair/start":
+                    _pin, ttl, fresh = pair_pin_start()
+                    # Pop the box screen ONLY on a fresh mint: a repeat /start
+                    # inside the debounce window returns the same PIN and must
+                    # not throw another window at whoever is at the PC.
+                    if fresh:
+                        pair_show_on_box(self.port)
+                    self._send(200, {"ok": True, "ttl": ttl}, started)
+                    return
+                try:
+                    req = json.loads(pair_body.decode("utf-8")) if pair_body else {}
+                    submitted = req.get("pin")
+                except (ValueError, UnicodeDecodeError):
+                    submitted = None
+                try:
+                    pair_pin_check(submitted)
+                except ValueError as e:
+                    self._send(403, {"ok": False, "error": str(e)}, started)
+                    return
+                self._send(200, {"ok": True, "token": self._current_token(),
+                                 "port": self.port}, started)
                 return
 
             # Authorize BEFORE reading the body: an unauthenticated client must


### PR DESCRIPTION
Closes #256 and #255 — two bugs a user hit on a fresh `.exe` install: **couldn't re-pair the box**, and the **Pad tab was missing**.

## 1. PIN pairing (#256)

The Windows agent had **no PIN-pairing endpoints at all**, so the app's *Scan for boxes → tap the box* flow hit the bearer gate:

```
POST /api/pair/start  ->  401 {"error": "unauthorized"}     (verified on the user's box)
```

`/api/pair/start` and `/api/pair/finish` are the only **unauthenticated** POSTs by design — a phone that has just discovered a box has no token to present; that *is* the point. Linux exempts them before the gate (`couchsided.py:12634`); Windows' `do_POST` went straight to `_authorized()`. So scan-and-pair has **never** worked on Windows — only the QR page or typing the token by hand.

Ported with the **same bounds**, deliberately unchanged, because they're what makes an unauthenticated endpoint safe:

| Bound | Value |
|---|---|
| PIN TTL | 120s |
| Wrong PINs before the session burns | 5 (against 1e6 PINs) |
| `/start` debounce | 3s (can't spam the screen or reroll the number being read) |
| Consent proof | PIN shown on the box's **own** screen via loopback-only `/pair` |

Also adds `render_pin_page` and the loopback-only `/api/pair/status` the page polls to clear itself.

## 2. ViGEmClient.dll (#255)

Pad tab missing because the box reported `caps.gamepad=false`. On the machine: **`ViGEmBus.sys` installed and fine, `ViGEmClient.dll` absent everywhere.** `vigem_available()` is a **DLL-load** check, and `build.ps1` bundled it like this:

```powershell
if (Test-Path $dll) { $piArgs += @('--add-binary', "$dll;.") }
```

The DLL isn't in the repo, so any build made without someone manually dropping it next to the script produced a **gamepad-less agent and said nothing**. Every `.exe` install then silently loses the Pad tab — the app's headline feature, and the `.exe` is the install method the changelog points people at.

Now: fails loudly with instructions, **verifies the DLL actually landed in the exe** rather than trusting the flag, and offers `-NoGamepad` for a deliberate build.

## Verified on the user's Windows box (EMERY-PC)

```
before:  POST /api/pair/start  ->  401
after :  POST /api/pair/start  ->  200 {"ok": true, "ttl": 120}    (0.4.2-win)
```

PIN state machine exercised directly — 6 digits; debounce returns the same PIN; wrong rejected; correct **consumed** (no replay); and after the attempt cap even the **correct** PIN is refused. `py_compile` clean.

## NOT verified

- The end-to-end phone→box pairing **tap** (needs the app against a box running 0.4.2-win).
- A rebuilt `.exe` actually reporting `caps.gamepad=true` — needs a Windows build with the DLL present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
