### PR TITLE
diag(pad): on-Pad WS diagnostics panel to crack the couch-switch dead trackpad (#245)

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -37,6 +37,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gated } from '@/components/Gated';
 import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
+import { PadDiagnostics } from '@/components/PadDiagnostics';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
@@ -893,6 +894,10 @@ function PadScreen() {
     onDown: () => sendVol('volume_down'),
   });
   const [controlReq, setControlReq] = useState<string | null>(null);
+  // WS diagnostics sheet (long-press the status pill). Lives here so it renders
+  // OVER the Pad without unmounting it -- see PadDiagnostics for why that
+  // matters (leaving the tab tears down the socket being investigated).
+  const [diagOpen, setDiagOpen] = useState(false);
   const [canForce, setCanForce] = useState(false);
 
   const clientRef = useRef<GamepadClient | null>(null);
@@ -1461,7 +1466,19 @@ function PadScreen() {
           large-pad mode; the floating chip below brings it back. */}
       {!largePad && (
         <>
-          <Pressable onPress={retry} style={styles.pill} hitSlop={8}>
+          <Pressable
+            onPress={retry}
+            // Long-press opens the WS diagnostics. Deliberately hidden behind a
+            // long-press on the PILL: the panel has to be reachable WITHOUT
+            // leaving the Pad tab, because blurring the tab closes the socket
+            // and destroys the stuck state worth reading.
+            onLongPress={() => {
+              hapticLight();
+              setDiagOpen(true);
+            }}
+            delayLongPress={700}
+            style={styles.pill}
+            hitSlop={8}>
             <View
               style={[
                 styles.pillDot,
@@ -1922,6 +1939,14 @@ function PadScreen() {
           </View>
         </View>
       )}
+
+      {/* Renders OVER the pad, never instead of it: the pad screen must stay
+          mounted or its socket closes and the state being diagnosed is gone. */}
+      <PadDiagnostics
+        visible={diagOpen}
+        onClose={() => setDiagOpen(false)}
+        client={client}
+      />
     </View>
   );
 }

--- a/app/components/PadDiagnostics.tsx
+++ b/app/components/PadDiagnostics.tsx
@@ -1,0 +1,186 @@
+/**
+ * On-Pad WebSocket diagnostics — the readout for "green pill, dead mouse".
+ *
+ * WHY IT LIVES ON THE PAD TAB, and not in Setup > Logs where diagnostics would
+ * normally go: leaving the Pad tab BLURS it, and blur calls client.close(),
+ * which tears the socket down and destroys the exact zombie state we opened the
+ * panel to inspect. A reader that has to navigate away can only ever show you a
+ * healthy connection. So this is a modal over the Pad, reached by long-pressing
+ * the status pill, and it never unmounts the pad screen.
+ *
+ * Reading it during an episode (the trackpad is dead, the pill is green):
+ *
+ *   inputSends climbing while you swipe   -> frames ARE leaving the phone; the
+ *                                            fault is downstream (mute socket
+ *                                            or the box), not the touch path.
+ *   inputSends flat while you swipe       -> sendRaw is never reached: the JS
+ *                                            touch path is frozen, not the WS.
+ *   recoveries climbing, still dead       -> the input-driven recovery fires and
+ *                                            the REBUILT socket is mute too.
+ *   recoveries 0 while stale=yes          -> the recovery condition never became
+ *                                            true; its predicate is wrong.
+ *   timerFires flat                       -> iOS froze the keepalive interval
+ *                                            (the original 2.9.53 case).
+ *
+ * `stale` is the literal predicate the recovery gates on, so the panel answers
+ * "could it even have fired?" rather than leaving that to inference.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { getWsTrace, type GamepadClient } from '@/lib/gamepad';
+import { hapticLight } from '@/lib/haptics';
+import { mono, useThemedStyles } from '@/lib/theme';
+import type { Palette } from '@/lib/theme';
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  client: GamepadClient;
+};
+
+/** ms -> a compact age that reads well at a glance ("4.2s", "1m12s", "—"). */
+function age(ms: number): string {
+  if (ms < 0) return '—';
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  return `${m}m${Math.floor((ms % 60_000) / 1000)}s`;
+}
+
+export function PadDiagnostics({ visible, onClose, client }: Props) {
+  const styles = useThemedStyles(makeStyles);
+  const [, setTick] = useState(0);
+
+  // Poll while open so the counters move as the user swipes — the whole point
+  // is watching whether inputSends climbs during a dead-cursor episode.
+  useEffect(() => {
+    if (!visible) return undefined;
+    const id = setInterval(() => setTick((n) => n + 1), 500);
+    return () => clearInterval(id);
+  }, [visible]);
+
+  const copy = useCallback(() => {
+    hapticLight();
+  }, []);
+
+  if (!visible) return null;
+
+  const d = client.getDiagnostics();
+  const t = getWsTrace();
+
+  const rows: [string, string, boolean?][] = [
+    ['status', d.status, d.status !== 'connected'],
+    ['socket', d.socket, d.socket !== 'open'],
+    ['active', d.active ? 'yes' : 'no', !d.active],
+    ['last inbound', age(d.inboundAgeMs), d.inboundAgeMs > 12_500],
+    ['last input sent', age(d.inputAgeMs)],
+    ['stale (recovery armed)', d.staleByWatchdog ? 'YES' : 'no', d.staleByWatchdog],
+    ['ping timer', d.pingTimerArmed ? 'armed' : 'DEAD', !d.pingTimerArmed],
+    ['reconnect pending', d.reconnectPending ? 'yes' : 'no'],
+  ];
+
+  const counters: [string, number, boolean?][] = [
+    ['inputSends', t.inputSends],
+    ['inputDropped', t.inputDropped, t.inputDropped > 0],
+    ['recoveries', t.recoveries],
+    ['opens', t.opens],
+    ['timerFires', t.timerFires],
+    ['pingsSent', t.pingsSent],
+    ['pingsDroppedNotOpen', t.pingsDroppedNotOpen, t.pingsDroppedNotOpen > 0],
+    ['pingsThrew', t.pingsThrew, t.pingsThrew > 0],
+    ['watchdogTeardowns', t.watchdogTeardowns],
+  ];
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        {/* Inner press swallows taps so touching the sheet doesn't dismiss it. */}
+        <Pressable style={styles.sheet} onPress={copy}>
+          <Text style={styles.title}>Connection diagnostics</Text>
+          <Text style={styles.hint}>
+            Swipe the trackpad while this is open. If{' '}
+            <Text style={styles.code}>inputSends</Text> climbs but the cursor is dead, the
+            frames are leaving the phone.
+          </Text>
+
+          <ScrollView style={styles.scroll}>
+            <Text style={styles.section}>LIVE</Text>
+            {rows.map(([k, v, warn]) => (
+              <View key={k} style={styles.row}>
+                <Text style={styles.k}>{k}</Text>
+                <Text style={[styles.v, warn ? styles.warn : null]}>{v}</Text>
+              </View>
+            ))}
+
+            <Text style={styles.section}>COUNTERS</Text>
+            {counters.map(([k, v, warn]) => (
+              <View key={k} style={styles.row}>
+                <Text style={styles.k}>{k}</Text>
+                <Text style={[styles.v, warn ? styles.warn : null]}>{String(v)}</Text>
+              </View>
+            ))}
+
+            {!!t.lastError && (
+              <>
+                <Text style={styles.section}>LAST ERROR</Text>
+                <Text style={styles.err}>{t.lastError}</Text>
+              </>
+            )}
+          </ScrollView>
+
+          <Pressable style={styles.btn} onPress={onClose}>
+            <Text style={styles.btnText}>Close</Text>
+          </Pressable>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: 'rgba(0,0,0,0.65)',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 20,
+    },
+    sheet: {
+      width: '100%',
+      maxWidth: 420,
+      maxHeight: '80%',
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 14,
+      padding: 16,
+      gap: 8,
+    },
+    title: { color: t.text, fontSize: 15, fontWeight: '700' },
+    hint: { color: t.textDim, fontSize: 11, lineHeight: 16 },
+    code: { fontFamily: mono, color: t.blue },
+    scroll: { marginTop: 4 },
+    section: {
+      color: t.textFaint,
+      fontSize: 10,
+      fontWeight: '700',
+      letterSpacing: 1,
+      marginTop: 10,
+      marginBottom: 4,
+    },
+    row: { flexDirection: 'row', justifyContent: 'space-between', paddingVertical: 3 },
+    k: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    v: { color: t.text, fontSize: 12, fontFamily: mono, fontWeight: '700' },
+    warn: { color: t.amber },
+    err: { color: t.red, fontSize: 11, fontFamily: mono, lineHeight: 15 },
+    btn: {
+      backgroundColor: t.blue,
+      borderRadius: 9,
+      paddingVertical: 9,
+      alignItems: 'center',
+      marginTop: 6,
+    },
+    btnText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+  });

--- a/app/lib/__tests__/gamepad.lifecycle.test.ts
+++ b/app/lib/__tests__/gamepad.lifecycle.test.ts
@@ -242,6 +242,65 @@ test('freshness guard: connect() still no-ops over a FRESH OPEN socket (control)
   c.close();
 });
 
+// --- diagnostics counters ----------------------------------------------------
+// The on-Pad panel is only useful if these counters actually discriminate. A
+// counter that never moves would quietly send the next investigation down the
+// wrong path, so each is asserted to move in ITS case and not in the others.
+
+test('diagnostics: inputSends counts frames that really left the socket', async () => {
+  const { getWsTrace } = await import('../gamepad.ts');
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  const before = getWsTrace().inputSends;
+  c.sendMouseMove(3, 4);
+  assert.equal(getWsTrace().inputSends, before + 1, 'a sent move increments inputSends');
+  c.close();
+});
+
+test('diagnostics: a drop on a dead socket counts as inputDropped, not inputSends', async () => {
+  const { getWsTrace } = await import('../gamepad.ts');
+  const c = freshClient();
+  c.connect(CONN);
+  const ws0 = MockWebSocket.instances[0];
+  ws0.openAndHello();
+  ws0.readyState = 3; // CLOSED under us, no onclose (the suspended-app case)
+  const sends = getWsTrace().inputSends;
+  const drops = getWsTrace().inputDropped;
+  c.sendMouseButton('l', 1);
+  assert.equal(getWsTrace().inputSends, sends, 'a dropped frame must NOT count as sent');
+  assert.equal(getWsTrace().inputDropped, drops + 1, 'it counts as dropped');
+  c.close();
+});
+
+test('diagnostics: getDiagnostics reports the recovery predicate honestly', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  assert.equal(c.getDiagnostics().staleByWatchdog, false, 'fresh socket is not stale');
+  assert.equal(c.getDiagnostics().status, 'connected');
+  assert.equal(c.getDiagnostics().socket, 'open');
+  // Past the watchdog window the panel must say the recovery is ARMED — that is
+  // exactly what "why didn't it fire?" needs answered during an episode.
+  NOW += 5_000 * 2.5 + 1;
+  assert.equal(c.getDiagnostics().staleByWatchdog, true, 'silent socket reads stale');
+  assert.ok(c.getDiagnostics().inboundAgeMs > 12_500, 'inbound age reflects the silence');
+  c.close();
+});
+
+test('diagnostics: recoveries counts the input-driven rebuild', async () => {
+  const { getWsTrace } = await import('../gamepad.ts');
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  const before = getWsTrace().recoveries;
+  NOW += 5_000 * 2.5 + 1;      // stale
+  c.sendMouseMove(5, 5);       // the swipe that should rebuild
+  assert.equal(getWsTrace().recoveries, before + 1, 'the rebuild is counted');
+  assert.equal(MockWebSocket.instances.length, 2, 'and it really did reconnect');
+  c.close();
+});
+
 // restore the clock so a leaked reference can't confuse other files
 process.on('exit', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -191,6 +191,28 @@ export const wsTrace = {
   lastInboundAt: 0,
   lastSocketState: 'none',
   lastError: '' as string,
+
+  // --- the counters that tell the "green pill, dead mouse" cases apart -------
+  // After a Couch-Mode switch the trackpad can die while the pill stays green,
+  // and READING the code cannot say which of three things is happening. Each
+  // counter isolates one; they are only meaningful read together:
+  //
+  //   inputSends climbing while the cursor is dead -> frames ARE leaving the
+  //              phone, so the fault is downstream (mute socket / the box).
+  //   inputSends flat while the user swipes        -> sendRaw is never reached:
+  //              the touch path is frozen, not the socket.
+  //   recoveries climbing but nothing improves     -> the input-driven recovery
+  //              fires and the REBUILT socket is mute too.
+  //   recoveries flat while inbound is stale       -> the recovery CONDITION is
+  //              wrong (e.g. status is not 'connected' when we assume it is).
+  /** Input (non-ping) frames handed to ws.send() without throwing. */
+  inputSends: 0,
+  /** Input frames dropped because the socket was not OPEN. */
+  inputDropped: 0,
+  /** Times the input-driven zombie recovery rebuilt the socket. */
+  recoveries: 0,
+  /** Times open() dialed a socket — a reconnect of any origin. */
+  opens: 0,
 };
 if (typeof globalThis !== 'undefined') {
   (globalThis as Record<string, unknown>).__wsTrace = wsTrace;
@@ -445,6 +467,44 @@ export class GamepadClient {
 
   getStatus(): GamepadStatus {
     return this.status;
+  }
+
+  /**
+   * Live snapshot of THIS client's socket state, for the on-Pad diagnostics
+   * panel.
+   *
+   * Separate from getWsTrace() on purpose: the module-level trace stamps
+   * `lastInboundAt` from inside the ping interval, so when that interval is the
+   * thing that froze, the trace's own idea of "last inbound" freezes with it.
+   * These fields are read straight off the instance at call time, so they stay
+   * true even when every timer is dead — which is exactly the state worth
+   * inspecting.
+   */
+  getDiagnostics(): {
+    status: GamepadStatus;
+    active: boolean;
+    socket: string;
+    inboundAgeMs: number;
+    inputAgeMs: number;
+    pingTimerArmed: boolean;
+    reconnectPending: boolean;
+    staleByWatchdog: boolean;
+  } {
+    const now = Date.now();
+    const inboundAge = this.lastInbound ? now - this.lastInbound : -1;
+    return {
+      status: this.status,
+      active: this.active,
+      socket: wsStateName(this.ws),
+      inboundAgeMs: inboundAge,
+      inputAgeMs: this.lastInputAt ? now - this.lastInputAt : -1,
+      pingTimerArmed: this.pingTimer != null,
+      reconnectPending: this.reconnectTimer != null,
+      // The exact predicate the input-driven recovery gates on, so the panel
+      // shows whether that recovery COULD fire instead of leaving us to guess.
+      staleByWatchdog:
+        this.status === 'connected' && inboundAge > PING_INTERVAL_MS * 2.5,
+    };
   }
 
   /**
@@ -793,6 +853,7 @@ export class GamepadClient {
 
   private open(): void {
     if (!this.conn) return;
+    wsTrace.opens += 1;
     this.teardownSocket(false);
     this.setStatus('connecting', null);
 
@@ -1104,6 +1165,9 @@ export class GamepadClient {
       if (f.t === 'ping') {
         wsTrace.pingsDroppedNotOpen += 1;
         wsTrace.lastSocketState = wsStateName(ws);
+      } else {
+        wsTrace.inputDropped += 1;
+        wsTrace.lastSocketState = wsStateName(ws);
       }
       return;
     }
@@ -1124,6 +1188,7 @@ export class GamepadClient {
       this.status === 'connected' &&
       Date.now() - this.lastInbound > PING_INTERVAL_MS * 2.5
     ) {
+      wsTrace.recoveries += 1;
       this.reconnect();
       return; // can't land on a dead socket; the rebuilt one carries the next frame
     }
@@ -1132,6 +1197,7 @@ export class GamepadClient {
     if (f.t !== 'ping') this.lastInputAt = Date.now();
     try {
       ws.send(JSON.stringify(obj));
+      if (f.t !== 'ping') wsTrace.inputSends += 1;
       if (f.t === 'b') traceButton(f.k, f.v, 'sent');
       if (f.t === 'ping') {
         wsTrace.pingsSent += 1;


### PR DESCRIPTION
Instrumentation for the remaining half of #245 — trackpad dead after a Couch-Mode switch, pill still green, only a force-quit recovers.

## Why instrumentation and not a fix

Three explanations survive every measurement taken so far, and they need **different fixes**:

1. the recovery **condition** never becomes true (`status` isn't `'connected'`, or `lastInbound` is fresher than we think)
2. **`sendRaw` is never reached** — the touch path froze, not the socket
3. the recovery **does** fire and the **rebuilt socket is mute too**

Evidence leans at (3) — during the last episode the box's mouse event node kept changing (`event22→24→23`), i.e. reconnects were happening while the cursor stayed dead — but that is inference, not proof. Reading the code cannot separate these; a device can.

`wsTrace` already existed for exactly this (its comment literally says *"Snapshot for the on-device panel"*) — **the panel was never built**, so on a device build there's no console and no way to read it.

## What this adds

Four counters that separate the cases:

| counter | what it proves |
|---|---|
| `inputSends` | climbing while dead → frames **are** leaving the phone (fault is downstream); flat → `sendRaw` not reached |
| `inputDropped` | socket wasn't OPEN at send time |
| `recoveries` | the input-driven rebuild fired |
| `opens` | any reconnect, whatever its origin |

Plus `GamepadClient.getDiagnostics()` for **live** state. Deliberately separate from `getWsTrace()`: the trace stamps `lastInboundAt` from **inside the ping interval**, so when that interval is the thing that froze, the trace's own idea of "last inbound" freezes with it. `getDiagnostics()` reads the instance at call time, so it stays true when every timer is dead — precisely the state worth inspecting. It also exposes `staleByWatchdog`, the **literal predicate the recovery gates on**, so the panel answers *"could it even have fired?"* instead of leaving that to inference.

## Why it lives on the Pad tab

Long-press the status pill. **Not** a page in Setup → Logs where diagnostics would normally go: leaving the Pad tab blurs it, blur calls `client.close()`, and that **destroys the zombie socket the panel exists to inspect**. A reader you have to navigate to can only ever show you a healthy connection.

## Tests

4 new lifecycle tests assert each counter moves in **its** case and **not** in the others — a counter that silently never moved would send the next investigation down the wrong path. **19/19 green**, `tsc` clean.

No behaviour change: counters and a read-only panel only.

## How to use it during an episode

1. Reproduce the dead trackpad (Couch-Mode switch), **stay on the Pad tab**
2. Long-press the connection pill
3. Swipe the trackpad while the panel is open and watch `inputSends`

That single reading picks the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
