### PR TITLE
chore(app): 2.9.28 / build 89 — diagnostics-panel TestFlight build

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.27",
+    "version": "2.9.28",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "85",
+      "buildNumber": "89",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Version bump so the on-Pad WS diagnostics panel (#260) can reach TestFlight. Build 89 is clear of 88 (in App Store review) and 86 (TestFlight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)