### PR TITLE
fix(win): the ViGEmClient.dll check threw instead of verifying, and pointed nowhere real

### DIFF
--- a/agent/win/build.ps1
+++ b/agent/win/build.ps1
@@ -61,9 +61,15 @@ if ($NoGamepad) {
     Write-Host '  Without it the built agent reports caps.gamepad=false and the'
     Write-Host '  phone app hides the Pad tab entirely (see issue #255).'
     Write-Host ''
-    Write-Host '  Get it from the ViGEm client release and drop it in:'
-    Write-Host '    https://github.com/nefarius/ViGEmClient/releases'
-    Write-Host "    -> $dll"
+    Write-Host '  There is NO prebuilt download. Verified 2026-07-25: the'
+    Write-Host '  ViGEmClient GitHub releases are SOURCE ONLY (no assets), and both'
+    Write-Host '  NuGet packages ship MANAGED .NET assemblies, which ctypes cannot'
+    Write-Host '  load. Build the native DLL from source:'
+    Write-Host '    git clone --depth 1 https://github.com/nefarius/ViGEmClient.git'
+    Write-Host '    msbuild src\ViGEmClient.vcxproj /p:Configuration=Release_DLL /p:Platform=x64'
+    Write-Host '    (config is Release_DLL, NOT Release -- plain Release does not exist)'
+    Write-Host '    -> bin\release\x64\ViGEmClient.dll'
+    Write-Host "  Then copy it to:  $dll"
     Write-Host ''
     Write-Host '  To build a deliberately gamepad-less agent anyway, pass -NoGamepad.'
     throw 'ViGEmClient.dll missing (see message above)'
@@ -78,9 +84,28 @@ if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed with exit code $LASTEXITCOD
 # can succeed while dropping a binary it could not resolve.
 $exe = Join-Path $here 'dist\couchside-agent.exe'
 if (-not (Test-Path $exe)) { throw "build reported success but $exe does not exist" }
-if ((-not $NoGamepad) -and -not (Select-String -Path $exe -Pattern 'ViGEmClient\.dll' -Encoding Byte -Quiet -ErrorAction SilentlyContinue)) {
-    Write-Host 'WARNING: could not confirm ViGEmClient.dll inside the exe.' -ForegroundColor Yellow
-    Write-Host '         Run the agent and check that /api/status reports caps.gamepad=true.'
+# Byte scan, NOT Select-String: `-Encoding Byte` is a Get-Content parameter and
+# Select-String REJECTS it on Windows PowerShell 5.1 ("does not belong to the
+# set"), so this check threw instead of verifying on its first real run.
+if (-not $NoGamepad) {
+    $needle = [System.Text.Encoding]::ASCII.GetBytes('ViGEmClient.dll')
+    $hay = [System.IO.File]::ReadAllBytes($exe)
+    $found = $false
+    $last = $hay.Length - $needle.Length
+    for ($i = 0; $i -le $last -and -not $found; $i++) {
+        if ($hay[$i] -ne $needle[0]) { continue }
+        $ok = $true
+        for ($j = 1; $j -lt $needle.Length; $j++) {
+            if ($hay[$i + $j] -ne $needle[$j]) { $ok = $false; break }
+        }
+        if ($ok) { $found = $true }
+    }
+    if ($found) {
+        Write-Host 'Verified: ViGEmClient.dll is bundled inside the exe.' -ForegroundColor Green
+    } else {
+        Write-Host 'WARNING: could not confirm ViGEmClient.dll inside the exe.' -ForegroundColor Yellow
+        Write-Host '         Run the agent and check /api/status reports caps.gamepad=true.'
+    }
 }
 
 Write-Host ''


### PR DESCRIPTION
Two defects in the `build.ps1` guard added by #257 — both found by **running it for real** on a Windows box rather than reading it.

## 1. The verification threw instead of verifying

```
Select-String -Path $exe -Pattern 'ViGEmClient\.dll' -Encoding Byte -Quiet
```

`-Encoding Byte` is a **`Get-Content`** parameter; `Select-String` rejects it on Windows PowerShell 5.1:

```
Cannot validate argument on parameter 'Encoding'. The argument "Byte" does not
belong to the set "unicode,utf7,utf8,utf32,ascii,bigendianunicode,default,oem"
```

So the step whose entire job is to **prove the DLL landed in the exe** blew up on its first real run. Replaced with a plain byte scan, which now also prints an explicit green **`Verified: ViGEmClient.dll is bundled inside the exe.`**

## 2. The error message pointed somewhere with no DLL

It told people to grab `ViGEmClient.dll` from the ViGEmClient GitHub releases. **Verified 2026-07-25:** those releases are **source-only and attach no assets at all**. NuGet is a dead end too — both `nefarius.vigemclient` and `Nefarius.ViGEm.Client` ship **managed .NET assemblies** (`lib/net452`, `lib/netstandard2.0`), which `ctypes.CDLL` cannot load. The agent needs the **native C** DLL.

**There is no prebuilt download.** The message now gives the real recipe, including the trap that the config is **`Release_DLL`, not `Release`** — plain `Release|x64` doesn't exist in the project and MSBuild fails with `MSB8013`.

## Verified end to end on EMERY-PC

Built the DLL from source with VS Build Tools 2019, then:

| Check | Result |
|---|---|
| PE machine type | `0x8664` (native x64) |
| `ctypes.CDLL` load | **LOADED ok**, `vigem_alloc` + `vigem_connect` present |
| This script | printed the green **Verified** line |
| Agent over the LAN | `version = 0.4.2-win` |
| | `caps.gamepad = True` — was `False`, **Pad tab is back** (#255) |
| | `POST /api/pair/start = 200` — was `401`, **scan-and-pair works** (#256) |

`PARSE OK` under Windows PowerShell 5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
