### PR TITLE
feat(pad): inactivity timeout for "keep screen awake", with a battery note

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -10,7 +10,13 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { hapticLight, hapticSelection } from '@/lib/haptics';
-import { getKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
+import {
+  getKeepAwakeEnabled,
+  getKeepAwakeTimeoutMin,
+  shouldHoldWakeLock,
+  useKeepAwakeEnabled,
+  useKeepAwakeTimeoutMin,
+} from '@/lib/keepAwake';
 import { getPref, setPref, usePref } from '@/lib/prefs';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNavigation } from 'expo-router';
@@ -45,13 +51,25 @@ import type { SteamMenus } from '@/lib/api';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status } from '@/lib/api';
-import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, SpecialKey, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
+import { ButtonKey, DesktopKey, GamepadClient, GamepadStatus, getWsTrace, SpecialKey, StickKey, SystemChord, TriggerKey } from '@/lib/gamepad';
 import { PadMode } from '@/lib/settings';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 
 const KEEP_AWAKE_TAG = 'rescue-remote-pad';
+
+/**
+ * How often the wake-lock timer re-checks for activity.
+ *
+ * Activity is read from wsTrace.inputSends rather than hooked into the touch
+ * handlers ON PURPOSE: the input path is the most timing-sensitive code in the
+ * app, and a counter that already increments on every outbound frame gives the
+ * same signal for free. Polling a number costs nothing; adding work per touch
+ * move does not. 10s only bounds how late the release can be — the shortest
+ * selectable timeout is 5 minutes.
+ */
+const WAKE_POLL_MS = 10_000;
 
 // All Pad haptics (swipe steps, taps, buttons, sticks, mode switch) route
 // through the app-wide gated emitter so the Settings toggle governs them.
@@ -917,6 +935,40 @@ function PadScreen() {
   // below can (de)acquire the wake lock when the pref loads or is toggled.
   const focusedRef = useRef(false);
   const keepAwakeOn = useKeepAwakeEnabled();
+  const keepAwakeTimeout = useKeepAwakeTimeoutMin();
+
+  // Wake-lock state. wakeHeldRef mirrors what we last told expo-keep-awake so
+  // the poll is a no-op in the steady state instead of re-issuing a native call
+  // every 10s. lastSendsRef is the previous inputSends reading; a change in it
+  // is what "activity" means here.
+  const lastActivityRef = useRef(Date.now());
+  const lastSendsRef = useRef(0);
+  const wakeHeldRef = useRef(false);
+
+  const noteActivity = useCallback(() => {
+    lastActivityRef.current = Date.now();
+  }, []);
+
+  /** Acquire/release the lock, but only on an actual edge. */
+  const applyWakeLock = useCallback((hold: boolean) => {
+    if (Platform.OS === 'web') return;
+    if (hold === wakeHeldRef.current) return;
+    wakeHeldRef.current = hold;
+    if (hold) activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => {});
+    else deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
+  }, []);
+
+  /** Ask the shared (tested) predicate what the lock should be, then apply it. */
+  const evaluateWakeLock = useCallback(() => {
+    applyWakeLock(
+      shouldHoldWakeLock({
+        enabled: getKeepAwakeEnabled(),
+        timeoutMin: getKeepAwakeTimeoutMin(),
+        focused: focusedRef.current,
+        msSinceActivity: Date.now() - lastActivityRef.current,
+      }),
+    );
+  }, [applyWakeLock]);
 
   // Manage the connection off the screen's mount lifecycle (reliable on web
   // and native) rather than useFocusEffect, whose callback-body timing is
@@ -954,22 +1006,17 @@ function PadScreen() {
         deviceName: DEVICE_LABEL,
         noPad: keyboardModeRef.current,
       });
-      if (Platform.OS !== 'web') {
-        // Honor the "keep screen awake on Pad" pref; if it was turned off while
-        // focused, this re-connect path also releases a prior lock.
-        if (getKeepAwakeEnabled()) {
-          activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => {});
-        } else {
-          deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
-        }
-      }
+      // Arriving on the Pad IS activity: start the inactivity clock now, so a
+      // stale timestamp from a previous visit can't release the lock instantly.
+      noteActivity();
+      evaluateWakeLock();
     };
     const disconnect = () => {
       focusedRef.current = false;
       client.close();
-      if (Platform.OS !== 'web') {
-        deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
-      }
+      // evaluateWakeLock would also release (focused=false), but call it
+      // directly: leaving the Pad must never depend on the poll running.
+      applyWakeLock(false);
     };
 
     const offFocus = navigation.addListener('focus', connect);
@@ -1004,18 +1051,32 @@ function PadScreen() {
     // identity only; settingsRef carries the rest without re-running.
   }, [client, ready, settings.host, settings.port, settings.token, navigation]);
 
-  // Re-apply the wake lock when the keep-awake pref loads or is toggled. The
-  // pref loads asynchronously, so on a cold start straight onto the Pad tab the
-  // first connect() can read the default (on) before a user's "off" resolves;
-  // this corrects the lock once the real value arrives (and on later toggles).
+  // Drive the wake lock, and run the inactivity timer that releases it.
+  //
+  // Re-runs when either pref loads or changes. Both load asynchronously, so on
+  // a cold start straight onto the Pad the first connect() can read the
+  // defaults before the user's stored values resolve; this corrects the lock
+  // once the real values arrive (and on every later change).
   useEffect(() => {
-    if (Platform.OS === 'web') return;
-    if (focusedRef.current && keepAwakeOn) {
-      activateKeepAwakeAsync(KEEP_AWAKE_TAG).catch(() => {});
-    } else {
-      deactivateKeepAwake(KEEP_AWAKE_TAG).catch(() => {});
-    }
-  }, [keepAwakeOn]);
+    if (Platform.OS === 'web') return undefined;
+    // Changing the pref is itself an interaction — don't let a countdown that
+    // started before the user opened Settings expire the moment they return.
+    noteActivity();
+    lastSendsRef.current = getWsTrace().inputSends;
+    evaluateWakeLock();
+    // "Always" needs no timer, and neither does a disabled pref: in both cases
+    // the answer can only change when a pref does, which re-runs this effect.
+    if (!keepAwakeOn || keepAwakeTimeout <= 0) return undefined;
+    const id = setInterval(() => {
+      const sends = getWsTrace().inputSends;
+      if (sends !== lastSendsRef.current) {
+        lastSendsRef.current = sends;
+        noteActivity();
+      }
+      evaluateWakeLock();
+    }, WAKE_POLL_MS);
+    return () => clearInterval(id);
+  }, [keepAwakeOn, keepAwakeTimeout, noteActivity, evaluateWakeLock, applyWakeLock]);
 
   // Toggling keyboard mode has to RE-HANDSHAKE: whether the agent creates a
   // virtual pad is decided once, from the connect URL. Without this, turning the

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -41,7 +41,13 @@ import {
   setHapticsEnabled,
   useHapticsEnabled,
 } from '@/lib/haptics';
-import { setKeepAwakeEnabled, useKeepAwakeEnabled } from '@/lib/keepAwake';
+import {
+  setKeepAwakeEnabled,
+  setKeepAwakeTimeoutMin,
+  useKeepAwakeEnabled,
+  useKeepAwakeTimeoutMin,
+  type KeepAwakeTimeoutMin,
+} from '@/lib/keepAwake';
 import { navigateAfterPair } from '@/lib/postPair';
 import { setPref, usePref } from '@/lib/prefs';
 import { buy, getProduct, restore } from '@/lib/purchase';
@@ -759,6 +765,7 @@ function SetupBody() {
   const status = useBoxOnlineStatus(boxes, { active: true, intervalMs: 10000 });
   const hapticsOn = useHapticsEnabled();
   const keepAwakeOn = useKeepAwakeEnabled();
+  const keepAwakeTimeout = useKeepAwakeTimeoutMin();
   const themeMode = useThemeMode();
   const accent = useAccent();
   const scheme = useResolvedScheme();
@@ -1400,6 +1407,24 @@ function SetupBody() {
                 />
               </View>
               </PrefFilterable>
+              {keepAwakeOn && (
+                <SegPref
+                  label="Let the screen sleep after"
+                  sub="Inactivity timer: it only counts down while you're not touching the Pad, and any input resets it — so it won't fire mid-session. Leaving your phone sitting on the Pad tab with the display held on will drain the battery; a timeout caps that. 'Always' never lets the screen sleep."
+                  options={[
+                    { value: 5, label: '5m' },
+                    { value: 10, label: '10m' },
+                    { value: 30, label: '30m' },
+                    { value: 60, label: '1h' },
+                    { value: 0, label: 'Always' },
+                  ]}
+                  value={keepAwakeTimeout}
+                  onSelect={(v) => {
+                    void setKeepAwakeTimeoutMin(v as KeepAwakeTimeoutMin);
+                    hapticSelection();
+                  }}
+                />
+              )}
               <SegPref
                 label="Open on"
                 sub="The tab the app starts on. Pairing wins on first run — with no box paired you still land on Setup."

--- a/app/lib/__tests__/keepAwake.rules.test.ts
+++ b/app/lib/__tests__/keepAwake.rules.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Wake-lock arbitration tests — lib/keepAwakeRules.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * (Node >= 22.6). Picked up by the existing CI `app-input` job's glob.
+ *
+ * Both states are asserted for every rule (CLAUDE.md §11): a timeout that can
+ * only ever be observed expiring, or only ever observed holding, is an
+ * unverified timeout. The two failures this guards are opposite and both bad —
+ * a lock stranded on forever (the battery complaint that motivated the setting)
+ * and a screen that sleeps mid-session (worse than having no setting at all).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  KEEP_AWAKE_TIMEOUTS,
+  KEEP_AWAKE_TIMEOUT_DEFAULT,
+  isKeepAwakeTimeout,
+  shouldHoldWakeLock,
+} from '../keepAwakeRules.ts';
+
+const MIN = 60_000;
+/** Defaults describing an active session; each test overrides one thing. */
+const ACTIVE = { enabled: true, timeoutMin: 30, focused: true, msSinceActivity: 0 };
+
+test('held while active, released once idle past the timeout', () => {
+  // Both states of the SAME rule, which is the point.
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, msSinceActivity: 29 * MIN }), true);
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, msSinceActivity: 31 * MIN }), false);
+});
+
+test('the boundary is exclusive: exactly at the timeout releases', () => {
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, msSinceActivity: 30 * MIN - 1 }), true);
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, msSinceActivity: 30 * MIN }), false);
+});
+
+test('"Always" (0) never releases, no matter how long idle', () => {
+  const a = { ...ACTIVE, timeoutMin: 0 };
+  assert.equal(shouldHoldWakeLock({ ...a, msSinceActivity: 0 }), true);
+  // A full day idle. This is the historical behavior and must stay reachable.
+  assert.equal(shouldHoldWakeLock({ ...a, msSinceActivity: 24 * 60 * MIN }), true);
+});
+
+test('the pref off always wins, even with fresh activity', () => {
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, enabled: false }), false);
+  // ...including under "Always", where the timeout would otherwise short-circuit.
+  assert.equal(
+    shouldHoldWakeLock({ ...ACTIVE, enabled: false, timeoutMin: 0 }),
+    false,
+  );
+});
+
+test('unfocused never holds — a missed blur cannot strand the lock', () => {
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, focused: false }), false);
+  assert.equal(
+    shouldHoldWakeLock({ ...ACTIVE, focused: false, timeoutMin: 0 }),
+    false,
+  );
+  // Control: the only difference from the held case is `focused`.
+  assert.equal(shouldHoldWakeLock({ ...ACTIVE, focused: true }), true);
+});
+
+test('every offered timeout holds just under and releases just over', () => {
+  for (const m of KEEP_AWAKE_TIMEOUTS) {
+    if (m === 0) continue; // covered by the "Always" test
+    const o = { ...ACTIVE, timeoutMin: m };
+    assert.equal(
+      shouldHoldWakeLock({ ...o, msSinceActivity: m * MIN - 1000 }),
+      true,
+      `${m}m should still be held 1s before expiry`,
+    );
+    assert.equal(
+      shouldHoldWakeLock({ ...o, msSinceActivity: m * MIN + 1000 }),
+      false,
+      `${m}m should be released 1s after expiry`,
+    );
+  }
+});
+
+test('timeout values are validated, not clamped', () => {
+  // Positive control: everything we actually offer is accepted.
+  for (const m of KEEP_AWAKE_TIMEOUTS) assert.equal(isKeepAwakeTimeout(m), true);
+  // Negative control: plausible-but-unoffered values are rejected outright,
+  // so a corrupted stored pref falls back to the default instead of silently
+  // becoming some other duration.
+  for (const bad of [1, 15, 45, 90, -30, 0.5, NaN, Infinity]) {
+    assert.equal(isKeepAwakeTimeout(bad), false, `${bad} must not be accepted`);
+  }
+});
+
+test('the default is a real offered option and is not "Always"', () => {
+  assert.equal(isKeepAwakeTimeout(KEEP_AWAKE_TIMEOUT_DEFAULT), true);
+  // Upgraders inherit this default. If it were 0 the feature would ship inert,
+  // which is the exact failure mode of "add a setting nobody changes".
+  assert.notEqual(KEEP_AWAKE_TIMEOUT_DEFAULT, 0);
+});

--- a/app/lib/keepAwake.ts
+++ b/app/lib/keepAwake.ts
@@ -1,17 +1,42 @@
 /**
- * "Keep the screen awake on the Pad" preference, as a single persisted flag.
+ * "Keep the screen awake on the Pad" preference: an on/off flag plus an
+ * inactivity timeout.
  *
  * The Pad holds the phone awake while it's focused so a controller session
  * doesn't dim out mid-game. Some users only tap in for one button and would
  * rather save the battery, so this gates that behavior. Same external-store
  * shape as haptics.ts: a `<Switch>` reads/writes it and re-renders live via
  * useKeepAwakeEnabled(); the Pad reads it with getKeepAwakeEnabled().
+ *
+ * WHY A TIMEOUT EXISTS: the flag alone is all-or-nothing, and the expensive
+ * case is not an active session — it is a phone left sitting on the Pad tab,
+ * screen lit, for hours. So the timeout is an INACTIVITY timer, not a session
+ * cap: it only counts down while no input is being sent, and any input resets
+ * it. During real use it never fires, which is why a non-zero default is safe.
+ * 0 means "never release", the historical behavior.
  */
 import * as SecureStore from 'expo-secure-store';
 import { useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 
 const KEY = 'couchside.keepAwake.v1';
+const TIMEOUT_KEY = 'couchside.keepAwake.timeoutMin.v1';
+
+// The decision logic lives in an import-free module so it can be unit-tested on
+// bare Node (this file cannot: expo-secure-store + react-native). Re-exported
+// here so callers still have one import site for the whole preference.
+export {
+  KEEP_AWAKE_TIMEOUTS,
+  KEEP_AWAKE_TIMEOUT_DEFAULT,
+  isKeepAwakeTimeout,
+  shouldHoldWakeLock,
+  type KeepAwakeTimeoutMin,
+} from './keepAwakeRules';
+import {
+  KEEP_AWAKE_TIMEOUT_DEFAULT,
+  isKeepAwakeTimeout,
+  type KeepAwakeTimeoutMin,
+} from './keepAwakeRules';
 
 // ---------- persistence (SecureStore native / localStorage web) ----------
 
@@ -45,6 +70,7 @@ async function storageSet(key: string, value: string): Promise<void> {
 // ---------- external store ----------
 
 let enabled = true; // default ON: keep the screen awake on the Pad
+let timeoutMin: KeepAwakeTimeoutMin = KEEP_AWAKE_TIMEOUT_DEFAULT;
 const listeners = new Set<() => void>();
 
 function emitChange(): void {
@@ -52,15 +78,27 @@ function emitChange(): void {
 }
 
 let loadStarted = false;
-/** Load the persisted preference once. Safe to call repeatedly. */
+/** Load the persisted preferences once. Safe to call repeatedly. */
 export async function loadKeepAwakePref(): Promise<void> {
   if (loadStarted) return;
   loadStarted = true;
+  let dirty = false;
   const v = await storageGet(KEY);
   if (v === '0' && enabled) {
     enabled = false;
-    emitChange();
+    dirty = true;
   }
+  // An absent/garbage value keeps the default. Upgraders have no stored value,
+  // so they land on KEEP_AWAKE_TIMEOUT_DEFAULT rather than the old "never".
+  const t = await storageGet(TIMEOUT_KEY);
+  if (t !== null) {
+    const n = Number(t);
+    if (Number.isFinite(n) && isKeepAwakeTimeout(n) && n !== timeoutMin) {
+      timeoutMin = n;
+      dirty = true;
+    }
+  }
+  if (dirty) emitChange();
 }
 // Kick the load off at import so the pref is ready by the time the Pad mounts.
 void loadKeepAwakePref();
@@ -76,6 +114,17 @@ export async function setKeepAwakeEnabled(next: boolean): Promise<void> {
   await storageSet(KEY, next ? '1' : '0');
 }
 
+export function getKeepAwakeTimeoutMin(): KeepAwakeTimeoutMin {
+  return timeoutMin;
+}
+
+export async function setKeepAwakeTimeoutMin(next: KeepAwakeTimeoutMin): Promise<void> {
+  if (next === timeoutMin || !isKeepAwakeTimeout(next)) return;
+  timeoutMin = next;
+  emitChange();
+  await storageSet(TIMEOUT_KEY, String(next));
+}
+
 function subscribe(cb: () => void): () => void {
   listeners.add(cb);
   return () => {
@@ -86,4 +135,9 @@ function subscribe(cb: () => void): () => void {
 /** React hook: live boolean of the keep-awake preference (for the Settings switch). */
 export function useKeepAwakeEnabled(): boolean {
   return useSyncExternalStore(subscribe, getKeepAwakeEnabled, getKeepAwakeEnabled);
+}
+
+/** React hook: live inactivity timeout in minutes (0 = never release). */
+export function useKeepAwakeTimeoutMin(): KeepAwakeTimeoutMin {
+  return useSyncExternalStore(subscribe, getKeepAwakeTimeoutMin, getKeepAwakeTimeoutMin);
 }

--- a/app/lib/keepAwakeRules.ts
+++ b/app/lib/keepAwakeRules.ts
@@ -1,0 +1,49 @@
+/**
+ * Wake-lock arbitration for the Pad, with ZERO runtime imports.
+ *
+ * Split out of keepAwake.ts so it can be unit-tested on bare Node the same way
+ * lib/gamepad.ts is (see .github/workflows/ci.yml, job `app-input`): keepAwake.ts
+ * itself pulls in expo-secure-store and react-native, neither of which resolves
+ * without a bundler. The decision is the part worth testing — "is the lock held
+ * right now" is exactly where a battery bug or a screen that sleeps mid-game
+ * would live — so it lives here and keepAwake.ts re-exports it.
+ *
+ * Keep this file import-free. Adding one breaks the standalone test job.
+ */
+
+/** Selectable inactivity timeouts, in minutes. 0 = never release the lock. */
+export const KEEP_AWAKE_TIMEOUTS = [0, 5, 10, 30, 60] as const;
+export type KeepAwakeTimeoutMin = (typeof KEEP_AWAKE_TIMEOUTS)[number];
+
+/**
+ * Default for everyone, including users upgrading from the flag-only build.
+ *
+ * 30 minutes is chosen so it cannot fire mid-session — the timer resets on
+ * every input frame — while still capping a phone left face-up on the couch.
+ * Upgraders have no stored value, so they land here rather than on the old
+ * unbounded behavior; that is a deliberate behavior change, not an oversight.
+ */
+export const KEEP_AWAKE_TIMEOUT_DEFAULT: KeepAwakeTimeoutMin = 30;
+
+/** Is `n` one of the offered timeouts? Anything else is rejected, not clamped. */
+export function isKeepAwakeTimeout(n: number): n is KeepAwakeTimeoutMin {
+  return (KEEP_AWAKE_TIMEOUTS as readonly number[]).includes(n);
+}
+
+/**
+ * Should the wake lock be held right now?
+ *
+ * Deliberately returns false when the Pad is not focused. Releasing on blur is
+ * the caller's job too, but encoding it here means a missed blur event cannot
+ * strand a lock held forever — the worst outcome for a battery setting.
+ */
+export function shouldHoldWakeLock(o: {
+  enabled: boolean;
+  timeoutMin: number;
+  focused: boolean;
+  msSinceActivity: number;
+}): boolean {
+  if (!o.enabled || !o.focused) return false;
+  if (o.timeoutMin <= 0) return true; // "Always"
+  return o.msSinceActivity < o.timeoutMin * 60_000;
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -21,6 +21,7 @@
         "expo-font": "~57.0.0",
         "expo-haptics": "~57.0.0",
         "expo-iap": "^4.3.6",
+        "expo-keep-awake": "~57.0.1",
         "expo-linking": "~57.0.1",
         "expo-network": "~57.0.1",
         "expo-router": "~57.0.2",
@@ -3905,9 +3906,9 @@
       }
     },
     "node_modules/expo-keep-awake": {
-      "version": "57.0.0",
-      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.0.tgz",
-      "integrity": "sha512-WqEoyDNSmUeAI9Gu7UaWKDjOhfaV+jGcms7N0hh/EAr7sqJrI2s0HpLSC3P9cWfXFUZCL1zZjd22m/NbsJYCKg==",
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
+      "integrity": "sha512-28lkFImeXTS+bhAjuCFV7w7tW5bXg27BJVrxv+nC/nyYa86qEa0oFeHwqol6ha5k4pdVDQgBF09GM4A1k76Ssg==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*",

--- a/app/package.json
+++ b/app/package.json
@@ -16,6 +16,7 @@
     "expo-font": "~57.0.0",
     "expo-haptics": "~57.0.0",
     "expo-iap": "^4.3.6",
+    "expo-keep-awake": "~57.0.1",
     "expo-linking": "~57.0.1",
     "expo-network": "~57.0.1",
     "expo-router": "~57.0.2",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,6 +111,33 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   around, not fixed). Worth reading that before designing — a reinstall button that papers
   over a known root cause is worse than fixing the cause.
 
+### Media seek buttons (-10s / +10s) on the now-playing card
+- **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
+- **Requested by u/Most-Bet2021 (r/SteamOS, 2026-07-26):** "a button that fast forwards media
+  or goes back like 10+ seconds".
+- **The agent side already exists in full — this is an app-only change.** Verified by reading
+  the source, not grepping for absence: `POST /api/media/<player>/seek` with
+  `{"position_ms": int}` is live (agent ~13034), `"seek"` is already in `MPRIS_OPS`
+  (agent 7672), and `_mpris_seek` (agent 7888) prefers `SetPosition` with the current trackid
+  and falls back to a relative `Seek` delta for players that reject it. The GET snapshot
+  already returns `position_ms`, `length_ms` and `can_seek` (agent 7850-7853), which is
+  everything the app needs to compute an offset. The app's `MediaOp` union already includes
+  `'seek'` (api.ts:517).
+- **So the work is:** two buttons in the transport row of `NowPlayingCard.tsx`, reusing the
+  `send('seek', { position_ms })` path the scrub bar already uses (NowPlayingCard.tsx:105-108).
+  Clamp to `[0, length_ms]`, gate on `can_seek` exactly as the bar does.
+- **Why it is worth doing even though the scrub bar exists:** the bar needs a precise tap on a
+  thin target from the couch. Discrete ±10s is the "what did they just say" / "skip the intro"
+  gesture, and it is the one the request actually named.
+- **No allowlist, capability, or endpoint work.** Nothing new reaches D-Bus: the op is still
+  looked up in the closed `MPRIS_OPS` table and the player name is re-validated against a
+  fresh `ListNames` before use.
+- **Unverified:** whether a seek actually lands on the players people use in Game Mode. On
+  bazzite.local `playerctl` is NOT installed (only `mpris-proxy`, which is BlueZ's AVRCP
+  bridge, not a player) — the agent shells `busctl` instead, which IS present. Needs a live
+  test with Chrome/Firefox/Plex/Kodi flatpaks actually playing, and `can_seek` observed both
+  true and false.
+
 ### Two-way clipboard (box <-> phone)
 - **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
 - **Requested by likwidtek (Discord, 2026-07-22).** **Half of this does NOT exist**, contrary


### PR DESCRIPTION
The keep-awake flag was all-or-nothing, and the case that actually costs battery is not an active session — it is a phone left sitting on the Pad tab with the display held on. So the pref gains a timeout: **5m / 10m / 30m / 1h / Always**, with the battery note in the setting's own sub-text.

### It is an inactivity timer, not a session cap
It only counts down while no input is being sent, and any input resets it — so it cannot fire mid-session. That is what makes a non-zero default safe: upgraders have no stored value and land on **30m** rather than the old unbounded behavior. Deliberate behavior change, called out here rather than buried.

### Not touching the input path
Activity is read from `wsTrace.inputSends` (already incremented per outbound frame, gamepad.ts:1200) on a 10s poll, rather than hooked into the touch handlers. The input path is the most timing-sensitive code in the app (CLAUDE.md §4) and this needs **zero** per-touch work.

The three scattered activate/deactivate sites collapse into one arbiter: `shouldHoldWakeLock()` decides, `applyWakeLock()` applies only on an edge, so the steady state issues no repeat native calls.

`shouldHoldWakeLock` lives in a new import-free `lib/keepAwakeRules.ts` so it is unit-testable on bare Node exactly like `lib/gamepad.ts` — `keepAwake.ts` itself pulls in expo-secure-store and react-native, which need a bundler. `keepAwake.ts` re-exports it, so callers keep one import site.

Also declares `expo-keep-awake`: pad.tsx imported it directly while it only resolved transitively through `expo`. It worked, but nothing pinned it.

### Tests
9 cases in `lib/__tests__/keepAwake.rules.test.ts`, picked up by the existing `app-input` CI glob. Every rule asserts **both** states (CLAUDE.md §11) — a timeout only ever observed holding, or only ever observed expiring, is an unverified timeout. Covers the exclusive boundary, "Always" over a full day idle, off-wins, unfocused-never-holds, every offered value just under and just over expiry, and that unoffered values are rejected rather than clamped.

### Verified
Web harness, pressing the control rather than rendering it (CLAUDE.md §6):
- default lands on **30m**
- pressing **10m** writes `"10"` to storage AND moves the active segment
- survives a reload (exercises the load path upgraders hit)
- turning the pref **off hides the picker** ("No settings match") while preserving the choice
- turning it back **on restores 10m**
- settings-search finds the new control; no console errors

31/31 input-path tests pass; CI's exact typecheck exits 0.

### Not verified
Real battery impact, and the native lock actually releasing on a device — the wake lock is `Platform.OS !== 'web'` gated, so the harness exercises the preference and the UI but never the lock itself. Needs a device build.