### PR TITLE
feat(media): −/+ skip buttons on the now-playing card, with tap and hold amounts

### DIFF
--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -170,9 +170,6 @@ function ConsoleScreen() {
         {/* Gaming card (probe-and-appear; hidden when the box has no Steam) */}
         <GamingCard />
 
-        {/* Send a file to the box (probe-and-appear; agent >= 2.9.54) */}
-        <FileDropCard />
-
         {s && (
           <>
             <View style={styles.row}>
@@ -334,6 +331,12 @@ function ConsoleScreen() {
             </Text>
           </Card>
         )}
+
+        {/* Send a file to the box (probe-and-appear; agent >= 2.9.54).
+            LAST on purpose: sending a file is a deliberate errand you go
+            looking for, not something you monitor, so it does not earn space
+            above the vitals you opened this tab to read. */}
+        <FileDropCard />
         </Screen>
       </ScrollView>
     </View>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -49,6 +49,12 @@ import {
   type KeepAwakeTimeoutMin,
 } from '@/lib/keepAwake';
 import { navigateAfterPair } from '@/lib/postPair';
+import {
+  MEDIA_HOLD_SKIP_SECS,
+  MEDIA_SKIP_SECS,
+  type MediaHoldSkipSec,
+  type MediaSkipSec,
+} from '@/lib/mediaSeek';
 import { setPref, usePref } from '@/lib/prefs';
 import { buy, getProduct, restore } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
@@ -766,6 +772,9 @@ function SetupBody() {
   const hapticsOn = useHapticsEnabled();
   const keepAwakeOn = useKeepAwakeEnabled();
   const keepAwakeTimeout = useKeepAwakeTimeoutMin();
+  const mediaSkipSec = usePref('mediaSkipSec');
+  const mediaHoldSkip = usePref('mediaHoldSkip');
+  const mediaHoldSkipSec = usePref('mediaHoldSkipSec');
   const themeMode = useThemeMode();
   const accent = useAccent();
   const scheme = useResolvedScheme();
@@ -1380,6 +1389,41 @@ function SetupBody() {
                 </View>
               </View>
               </PrefFilterable>
+            </View>
+
+            <View style={prefCardGroupStyle}>
+              <CardHeader icon="musical-notes-outline" label="MEDIA" />
+              <SegPref
+                label="Skip by"
+                sub="How far the skip buttons on the Now Playing card jump when you tap them."
+                options={MEDIA_SKIP_SECS.map((n) => ({ value: n, label: `${n}s` }))}
+                value={mediaSkipSec}
+                onSelect={(v) => {
+                  void setPref('mediaSkipSec', v as MediaSkipSec);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Hold to skip further"
+                sub="Holding a skip button jumps by a larger amount instead. Off makes the buttons a single amount, so a resting thumb can't trigger a big jump."
+                value={mediaHoldSkip}
+                onValueChange={(v) => {
+                  void setPref('mediaHoldSkip', v);
+                  hapticSelection();
+                }}
+              />
+              {mediaHoldSkip && (
+                <SegPref
+                  label="Hold skips by"
+                  sub="How far a held skip button jumps."
+                  options={MEDIA_HOLD_SKIP_SECS.map((n) => ({ value: n, label: `${n}s` }))}
+                  value={mediaHoldSkipSec}
+                  onSelect={(v) => {
+                    void setPref('mediaHoldSkipSec', v as MediaHoldSkipSec);
+                    hapticSelection();
+                  }}
+                />
+              )}
             </View>
 
             <View style={prefCardGroupStyle}>

--- a/app/components/NowPlayingCard.tsx
+++ b/app/components/NowPlayingCard.tsx
@@ -10,8 +10,10 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Image, LayoutChangeEvent, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
+import { MEDIA_HOLD_MS, nextSeekPosition } from '@/lib/mediaSeek';
+import { usePref } from '@/lib/prefs';
 import { api, hostKey, Media, MediaOp, MediaPlayer, mediaArtSource } from '@/lib/api';
-import { hapticLight, hapticMedium } from '@/lib/haptics';
+import { hapticHeavy, hapticLight, hapticMedium } from '@/lib/haptics';
 import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -28,6 +30,9 @@ export function NowPlayingCard() {
   const styles = useThemedStyles(makeStyles);
   const { Card } = useSkinKit();
   const { settings, ready } = useSettings();
+  const skipSec = usePref('mediaSkipSec');
+  const holdEnabled = usePref('mediaHoldSkip');
+  const holdSkipSec = usePref('mediaHoldSkipSec');
   const configured = !!settings.host && !!settings.token;
 
   const poll = usePoll<Media | null>(
@@ -110,6 +115,44 @@ export function NowPlayingCard() {
     [active, barWidth, send],
   );
 
+  /**
+   * Jump by a relative offset. Requested on r/SteamOS: "a button that fast
+   * forwards media or goes back like 10+ seconds".
+   *
+   * The scrub bar above can already reach any position, but only via a precise
+   * tap on a thin target — which is the wrong instrument from a couch, and the
+   * wrong one for "what did they just say". This is that gesture.
+   *
+   * Uses displayedMs, not active.position_ms: displayedMs interpolates playback
+   * since the last poll, so "back 10s" means 10s from where the track actually
+   * is, not from a reading up to a poll-interval stale. Off by that interval
+   * otherwise, which on a 5s poll is a visibly wrong jump.
+   *
+   * Note this is gated ONLY on can_seek, unlike the bar, which also requires
+   * length_ms > 0. The bar needs a known length to map a tap fraction to a
+   * position; a relative offset does not. Live streams and players that report
+   * no duration can still skip. The agent clamps to the track length itself
+   * when it knows one, and falls back to a relative MPRIS Seek when the player
+   * rejects SetPosition.
+   */
+  const seekBy = useCallback(
+    (deltaMs: number, long = false) => {
+      if (!active || !active.can_seek) return;
+      // A hold is a bigger, blind jump, so it gets a heavier confirmation than
+      // the tap's — you should be able to feel which one you got without
+      // watching the timecode.
+      if (long) hapticHeavy();
+      send('seek', {
+        position_ms: nextSeekPosition({
+          currentMs: displayedMs,
+          deltaMs,
+          lengthMs: active.length_ms,
+        }),
+      });
+    },
+    [active, displayedMs, send],
+  );
+
   if (!active) return null;
 
   const pct =
@@ -175,17 +218,44 @@ export function NowPlayingCard() {
         <TransportButton
           icon="play-skip-back"
           disabled={!active.can_go_previous}
+          accessibilityLabel="Previous track"
           onPress={() => send('previous')}
+        />
+        <TransportButton
+          icon="play-back"
+          label={String(skipSec)}
+          disabled={!active.can_seek}
+          accessibilityLabel={`Back ${skipSec} seconds`}
+          accessibilityHint={
+            holdEnabled ? `Hold to go back ${holdSkipSec} seconds` : undefined
+          }
+          onPress={() => seekBy(-skipSec * 1000)}
+          onLongPress={holdEnabled ? () => seekBy(-holdSkipSec * 1000, true) : undefined}
+          delayLongPress={MEDIA_HOLD_MS}
         />
         <TransportButton
           icon={playing ? 'pause' : 'play'}
           primary
           disabled={playing ? !active.can_pause : !active.can_play}
+          accessibilityLabel={playing ? 'Pause' : 'Play'}
           onPress={() => send('play_pause')}
+        />
+        <TransportButton
+          icon="play-forward"
+          label={String(skipSec)}
+          disabled={!active.can_seek}
+          accessibilityLabel={`Forward ${skipSec} seconds`}
+          accessibilityHint={
+            holdEnabled ? `Hold to jump forward ${holdSkipSec} seconds` : undefined
+          }
+          onPress={() => seekBy(skipSec * 1000)}
+          onLongPress={holdEnabled ? () => seekBy(holdSkipSec * 1000, true) : undefined}
+          delayLongPress={MEDIA_HOLD_MS}
         />
         <TransportButton
           icon="play-skip-forward"
           disabled={!active.can_go_next}
+          accessibilityLabel="Next track"
           onPress={() => send('next')}
         />
       </View>
@@ -210,34 +280,50 @@ function ArtImage({ uri }: { uri: string }) {
   );
 }
 
+
 function TransportButton({
   icon,
   onPress,
   disabled,
   primary,
+  label,
+  accessibilityLabel,
+  accessibilityHint,
+  onLongPress,
+  delayLongPress,
 }: {
   icon: keyof typeof Ionicons.glyphMap;
   onPress: () => void;
   disabled?: boolean;
   primary?: boolean;
+  onLongPress?: () => void;
+  delayLongPress?: number;
+  accessibilityHint?: string;
+  /** Small digits over the glyph — "10" on the skip buttons, so the amount is
+   * stated rather than left to a bare ⏪/⏩ the user has to guess at. */
+  label?: string;
+  accessibilityLabel?: string;
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const color = disabled ? t.textFaint : primary ? t.bg : t.text;
   return (
     <Pressable
       onPress={onPress}
+      onLongPress={onLongPress}
+      delayLongPress={delayLongPress}
       disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityHint={accessibilityHint}
       style={({ pressed }) => [
         styles.tBtn,
         primary && styles.tBtnPrimary,
         pressed && styles.tBtnPressed,
         disabled && styles.tBtnDisabled,
       ]}>
-      <Ionicons
-        name={icon}
-        size={primary ? 26 : 22}
-        color={disabled ? t.textFaint : primary ? t.bg : t.text}
-      />
+      <Ionicons name={icon} size={primary ? 26 : 22} color={color} />
+      {!!label && <Text style={[styles.tBtnLabel, { color }]}>{label}</Text>}
     </Pressable>
   );
 }
@@ -298,6 +384,13 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   times: { flexDirection: 'row', justifyContent: 'space-between', marginTop: 6 },
   time: { color: t.textDim, fontSize: 11, ...numeric },
 
+  tBtnLabel: {
+    // Digits sit tight under the glyph inside the same round button, so the
+    // control reads as one unit rather than an icon with a caption.
+    fontSize: 9,
+    fontWeight: '700',
+    marginTop: -2,
+  },
   transport: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/lib/__tests__/mediaSeek.test.ts
+++ b/app/lib/__tests__/mediaSeek.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Relative-seek arithmetic — lib/mediaSeek.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * (Node >= 22.6). Picked up by the existing CI `app-input` job's glob.
+ *
+ * These exist because the web harness CANNOT test this. Its mock player
+ * advances position by a flat 3000ms per GET and ignores seeks entirely
+ * (agent `_MOCK_MPRIS_POS`), so pressing the button there proves a well-formed
+ * request goes out and nothing about whether the offset was correct. Confirmed
+ * the hard way: an early "verified +10s" reading was arithmetic against that
+ * synthetic counter and meant nothing.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MEDIA_HOLD_SKIP_SECS,
+  MEDIA_SKIP_SECS,
+  nextSeekPosition,
+} from '../mediaSeek.ts';
+
+const LEN = 214_000; // the mock track's length, and a realistic one
+
+test('forward and back move by exactly the requested offset', () => {
+  // Both directions of the same rule.
+  assert.equal(
+    nextSeekPosition({ currentMs: 60_000, deltaMs: 10_000, lengthMs: LEN }),
+    70_000,
+  );
+  assert.equal(
+    nextSeekPosition({ currentMs: 60_000, deltaMs: -10_000, lengthMs: LEN }),
+    50_000,
+  );
+});
+
+test('clamps to the start instead of going negative', () => {
+  // The agent 400s a negative position_ms, so this must never emit one.
+  assert.equal(nextSeekPosition({ currentMs: 3_000, deltaMs: -10_000, lengthMs: LEN }), 0);
+  assert.equal(nextSeekPosition({ currentMs: 0, deltaMs: -30_000, lengthMs: LEN }), 0);
+  // Control: comfortably inside the track is untouched.
+  assert.equal(nextSeekPosition({ currentMs: 30_000, deltaMs: -10_000, lengthMs: LEN }), 20_000);
+});
+
+test('clamps to the track end when a length is known', () => {
+  assert.equal(nextSeekPosition({ currentMs: LEN - 2_000, deltaMs: 30_000, lengthMs: LEN }), LEN);
+  // Control: the same jump earlier in the track is not clamped.
+  assert.equal(nextSeekPosition({ currentMs: 100_000, deltaMs: 30_000, lengthMs: LEN }), 130_000);
+});
+
+test('an unknown length (0) still allows a skip, bounded only at the start', () => {
+  // Live streams and players that report no duration. The bar refuses these
+  // because it needs a length to map a tap; a relative offset does not.
+  assert.equal(nextSeekPosition({ currentMs: 40_000, deltaMs: 30_000, lengthMs: 0 }), 70_000);
+  assert.equal(nextSeekPosition({ currentMs: 5_000, deltaMs: -30_000, lengthMs: 0 }), 0);
+});
+
+test('always returns an integer — the agent rejects a non-int position_ms', () => {
+  // displayedMs is interpolated from Date.now() and a playback rate, so it is
+  // routinely fractional. Route 400s on `int(req.get("position_ms"))` failing.
+  for (const cur of [1234.5678, 0.1, 99_999.99]) {
+    for (const d of [10_000, -10_000, 30_000]) {
+      const v = nextSeekPosition({ currentMs: cur, deltaMs: d, lengthMs: LEN });
+      assert.equal(Number.isInteger(v), true, `${cur}+${d} produced ${v}`);
+      assert.equal(v >= 0, true);
+    }
+  }
+});
+
+test('every offered skip amount stays in range from anywhere in the track', () => {
+  const amounts = [...MEDIA_SKIP_SECS, ...MEDIA_HOLD_SKIP_SECS];
+  assert.ok(amounts.length >= 4, 'expected both option sets to be non-empty');
+  for (const sec of amounts) {
+    for (const cur of [0, 1_000, LEN / 2, LEN - 1_000, LEN]) {
+      for (const sign of [1, -1]) {
+        const v = nextSeekPosition({ currentMs: cur, deltaMs: sign * sec * 1000, lengthMs: LEN });
+        assert.ok(v >= 0 && v <= LEN, `${sec}s from ${cur} gave ${v}, outside [0, ${LEN}]`);
+      }
+    }
+  }
+});
+
+test('the offered amounts are distinct and ordered small-to-large', () => {
+  // A hold that jumps the same distance as a tap is a pointless gesture; guard
+  // the option tables so that stays true if someone edits them.
+  assert.ok(Math.min(...MEDIA_HOLD_SKIP_SECS) >= Math.max(...MEDIA_SKIP_SECS));
+  assert.equal(new Set(MEDIA_SKIP_SECS).size, MEDIA_SKIP_SECS.length);
+  assert.equal(new Set(MEDIA_HOLD_SKIP_SECS).size, MEDIA_HOLD_SKIP_SECS.length);
+});

--- a/app/lib/mediaSeek.ts
+++ b/app/lib/mediaSeek.ts
@@ -1,0 +1,50 @@
+/**
+ * Relative-seek arithmetic for the now-playing card, with ZERO runtime imports.
+ *
+ * Split out so it can be unit-tested on bare Node like lib/gamepad.ts and
+ * lib/keepAwakeRules.ts (see the `app-input` CI job). That matters here more
+ * than usual: the web harness CANNOT verify this. Its mock player advances
+ * position by a fixed 3000ms per GET and ignores seeks entirely
+ * (agent/couchsided.py `_MOCK_MPRIS_POS`), so the harness can only show that a
+ * request fires with a well-formed body — never that the offset was right.
+ * The arithmetic is therefore tested here or not at all.
+ *
+ * Keep this file import-free. Adding one breaks the standalone test job.
+ */
+
+/** Tap-to-skip amounts offered in Settings, in seconds. */
+export const MEDIA_SKIP_SECS = [10, 30] as const;
+export type MediaSkipSec = (typeof MEDIA_SKIP_SECS)[number];
+
+/** Hold-to-skip amounts offered in Settings, in seconds. */
+export const MEDIA_HOLD_SKIP_SECS = [30, 60] as const;
+export type MediaHoldSkipSec = (typeof MEDIA_HOLD_SKIP_SECS)[number];
+
+/**
+ * Hold threshold. RN's default is 500ms — too eager here, where a slightly slow
+ * tap should still mean the small skip, not a surprise long one.
+ */
+export const MEDIA_HOLD_MS = 1500;
+
+/**
+ * Where a relative skip should land.
+ *
+ * `lengthMs <= 0` means the player reports no duration (live streams, and some
+ * browser players). That is NOT a reason to refuse: a relative offset does not
+ * need a known length, unlike the scrub bar, which must map a tap fraction onto
+ * one. In that case only the lower bound is enforced and the agent decides what
+ * the player can actually do — it clamps to the real track length when it knows
+ * one, and falls back to a relative MPRIS Seek when SetPosition is rejected.
+ *
+ * Returns an integer: the agent requires position_ms to be an int and 400s a
+ * body that is not.
+ */
+export function nextSeekPosition(o: {
+  currentMs: number;
+  deltaMs: number;
+  lengthMs: number;
+}): number {
+  let next = o.currentMs + o.deltaMs;
+  if (o.lengthMs > 0) next = Math.min(next, o.lengthMs);
+  return Math.max(0, Math.round(next));
+}

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -12,6 +12,12 @@ import * as SecureStore from 'expo-secure-store';
 import { useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 
+import {
+  MEDIA_HOLD_SKIP_SECS,
+  MEDIA_SKIP_SECS,
+  type MediaHoldSkipSec,
+  type MediaSkipSec,
+} from './mediaSeek';
 import { PadMode } from './settings';
 
 /** Tabs the app can open on. Values are the expo-router route names ('index' is
@@ -158,6 +164,22 @@ export type Prefs = {
       default: it emits a mark every 45ms, which is pure noise outside a
       recording. */
   traceDrags: boolean;
+  /** How far the now-playing card's skip buttons jump on a TAP, in seconds.
+   *
+   *  Requested on r/SteamOS as "fast forwards media or goes back like 10+
+   *  seconds". 10s is the podcast/video convention and the default; 30s suits
+   *  people who mostly skip ad breaks and intros. */
+  mediaSkipSec: MediaSkipSec;
+  /** Whether HOLDING a skip button jumps by mediaHoldSkipSec instead.
+   *
+   *  On by default, but switchable: a hold-to-do-something-bigger gesture is
+   *  invisible until discovered, and on a control you press repeatedly it can
+   *  fire by accident when someone rests a thumb. Off makes the buttons
+   *  strictly one-amount. */
+  mediaHoldSkip: boolean;
+  /** How far a HELD skip button jumps, in seconds. Ignored when mediaHoldSkip
+   *  is off. */
+  mediaHoldSkipSec: MediaHoldSkipSec;
 };
 
 export const DEFAULTS: Prefs = {
@@ -192,6 +214,9 @@ export const DEFAULTS: Prefs = {
   hideTvVolume: false,
   showTaps: false,
   traceDrags: false,
+  mediaSkipSec: 10,
+  mediaHoldSkip: true,
+  mediaHoldSkipSec: 30,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -293,6 +318,16 @@ function normalize(raw: unknown): Prefs {
     hideTvVolume: bool(o.hideTvVolume, DEFAULTS.hideTvVolume),
     showTaps: bool(o.showTaps, DEFAULTS.showTaps),
     traceDrags: bool(o.traceDrags, DEFAULTS.traceDrags),
+    // Validated against the offered sets, not clamped: these become a
+    // position_ms the agent is asked to seek to, so a corrupted blob must fall
+    // back to a known-good amount rather than invent one.
+    mediaSkipSec: num(o.mediaSkipSec, MEDIA_SKIP_SECS, DEFAULTS.mediaSkipSec) as MediaSkipSec,
+    mediaHoldSkip: bool(o.mediaHoldSkip, DEFAULTS.mediaHoldSkip),
+    mediaHoldSkipSec: num(
+      o.mediaHoldSkipSec,
+      MEDIA_HOLD_SKIP_SECS,
+      DEFAULTS.mediaHoldSkipSec,
+    ) as MediaHoldSkipSec,
   };
 }
 


### PR DESCRIPTION
Requested on r/SteamOS: *"a button that fast forwards media or goes back like 10+ seconds"*.

**App-only.** The agent has supported this all along — `POST /api/media/<player>/seek` with `{"position_ms"}`, `"seek"` already in `MPRIS_OPS`, and `_mpris_seek` preferring `SetPosition` with a relative `Seek` fallback. The snapshot already returns `position_ms`, `length_ms`, `can_seek`. No allowlist, capability, or endpoint work.

### Behavior
- **Tap** skips by `mediaSkipSec` (10s default), **hold** by `mediaHoldSkipSec` (30s), and the hold can be **switched off** — a hold-to-do-more gesture is invisible until discovered and can fire from a resting thumb, so it is a preference, not a fact.
- Hold threshold is 1500ms rather than RN's 500ms default, so a slow tap still means the small skip. RN does not fire `onPress` once a long press fires, so they cannot both run.
- Seeks from `displayedMs` (interpolated) not `position_ms`, so "back 10s" is 10s from where the track actually is, not from a reading up to a poll stale.
- Gated only on `can_seek`, unlike the bar which also needs `length_ms > 0` — the bar must map a tap fraction onto a length, a relative offset need not, so live streams still skip.

Also **moves the file-drop card to the bottom of Console** — sending a file is a deliberate errand, not something you monitor.

### Why the arithmetic is unit-tested rather than harness-tested
The harness **cannot** verify it. Its mock player advances position a flat 3000ms per GET and ignores seeks entirely (`_MOCK_MPRIS_POS`), so pressing the button there proves a well-formed request goes out and nothing about the offset. An early "verified +10s" reading of mine was arithmetic against that synthetic counter and meant nothing — caught by reading the mock instead of trusting the number. So the math lives in an import-free `lib/mediaSeek.ts` with 7 tests: both directions, clamping at both ends, unknown length, integer output (the route 400s a non-int, and `displayedMs` is fractional), and every offered amount from every point in a track.

### Verified
42/42 app tests, typecheck clean. Harness, pressing controls: all three prefs render with correct defaults; "Skip by" 10s→30s moves the segment **and** retitles the card buttons to "Back/Forward 30 seconds"; turning the hold off **removes** the "Hold skips by" row and the hold hints; file card confirmed last in DOM order.

### Not verified
An actual seek landing in a real player — the mock ignores seeks and no live Game Mode player has been seeked yet.