### PR TITLE
chore(app): 2.9.29

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.28",
+    "version": "2.9.29",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",


### PR DESCRIPTION
Version bump for the 2.9.29 store release.

Contents since v2.9.27 (the last *store* release — 2.9.28 was TestFlight-only, for the diagnostics panel):
- on-Pad WS diagnostics panel (#260)
- keep-awake inactivity timeout, 5m/10m/30m/1h/Always, 30m default (#266)
- media −/+ skip buttons with tap and hold amounts, file-drop card moved to the bottom of Console (#267)
- Windows agent work (0.4.3-win, already released separately) and the brand icon

`buildNumber`/`versionCode` deliberately untouched — EAS `autoIncrement` owns them and they get reconciled back from the artifacts, not the log (CONVENTIONS §5).