### PR TITLE
chore(app): reconcile build numbers from the 2.9.29 artifacts (iOS 92 / vc 62)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "89",
+      "buildNumber": "92",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 60
+      "versionCode": 62
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Read off the built artifacts, not the log (CONVENTIONS §5).

**This one caught a real collision.** `app.json` still said `versionCode: 60` after 2.9.27 shipped at **vc 61** — the reconcile after that release never landed. So `autoIncrement` read 60 and produced **61 again** for 2.9.29. Play already has 61 on the production track (release "2.9.27", status `completed` — confirmed against the Play Android Publisher API; uploaded bundles `[7, 22, 54, 55, 59, 60, 61]`), so that build would have been **rejected at submit**.

iOS had the mirror problem: `app.json` said 89 while 2.9.28 had already used build **91**, so the bump produced 90 — going backwards.

Both builds were cancelled and re-cut at **iOS 92 / vc 62**. Committing the real numbers here is what stops the next release inheriting the same drift.