### PR TITLE
chore(release): 2.9.29 store notes

### DIFF
--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,6 +1,5 @@
-New in 2.9.23
+New in 2.9.29
 
-• Bigger trackpad — a one-tap corner button expands the Mouse and Swipe surfaces for easier scrolling.
-• Steadier connection — if the app was backgrounded and the pointer stopped responding, it now reconnects on its own instead of a force-quit.
-• Honest status — the connection dot turns amber the moment input stops getting through; tap to reconnect.
-• Reliable right-click — two-finger tap registers every time; two-finger scrolling no longer fires stray clicks.
+• Skip buttons on Now Playing — tap to jump back or forward 10 seconds, hold for 30. Both amounts are adjustable in Settings, and the hold can be turned off.
+• Screen-awake timeout — the Pad can now let your phone sleep after 5, 10, 30 or 60 minutes with no input, instead of holding the display on the whole time.
+• Send a file moved to the bottom of the Console tab, so your box's vitals come first.


### PR DESCRIPTION
The changelog still said **"New in 2.9.23"** while 2.9.29 was going out — exactly the stale-notes trap the house rules call out (the script publishes it and exits 0).

Rewritten for what actually shipped. 416/500 chars, used for **both** stores: `play-release-notes.py` read it for Play (verified by reading the release back from the API — "2.9.29", `completed`, vc 62) and `asc-submit.py` set it as the App Store `whatsNew`.

Also appends the release entry to BUILD_LOG.