### PR TITLE
chore(release): reword 2.9.29 notes to the house voice

### DIFF
--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,5 @@
 New in 2.9.29
 
-• Skip buttons on Now Playing — tap to jump back or forward 10 seconds, hold for 30. Both amounts are adjustable in Settings, and the hold can be turned off.
-• Screen-awake timeout — the Pad can now let your phone sleep after 5, 10, 30 or 60 minutes with no input, instead of holding the display on the whole time.
-• Send a file moved to the bottom of the Console tab, so your box's vitals come first.
+• Skip 10 or 30 seconds — new arrows on Now Playing jump back or forward 10 seconds; hold one for 30. Change either amount in Settings, or switch the hold off.
+• Kinder to your battery — the Pad no longer holds your screen on indefinitely. Let it sleep after 5, 10, 30 or 60 idle minutes, or keep it always on.
+• Vitals first — the file-sending card moved to the bottom of the Console tab.


### PR DESCRIPTION
Rewritten to match how the 2.9.23 notes read — benefit-first label, em dash, plain language contrasting with the old behavior ("Bigger trackpad", "Steadier connection") — rather than naming the feature and describing the mechanism.

Already live on **both** stores: Play notes reset for vc 62, App Store `whatsNew` PATCHed in place.

Worth recording for next time: the App Store localization **accepted the edit at `appStoreState=WAITING_FOR_REVIEW` and returned 200** — the version did *not* need pulling from review, so no queue position was lost. Previous notes assumed a pull-and-resubmit was required to change anything post-submission; for `whatsNew` at least, it is not.

404/500 chars.