### PR TITLE
feat(launchers): let the phone launch non-Steam shortcuts (Netflix, Hulu, EmuDeck)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,13 @@ jobs:
       - name: Unit tests (steam link / remote play)
         run: python3 tests/test_steamlink.py
 
+      # Non-Steam shortcuts are how EVERYTHING that is not a Steam game reaches
+      # the TV on SteamOS/Bazzite. This id ends in a subprocess call, so the
+      # rejection cases (non-numeric, unregistered, injection shapes) are the
+      # point of the suite, not a bonus.
+      - name: Unit tests (non-Steam shortcut launchers)
+        run: python3 tests/test_steam_shortcuts.py
+
       # Stream-host liveness (the `online` field). remoteclients.vdf lists every
       # host ever streamed from and says nothing about which are ON, so picking a
       # game from a sleeping PC makes Steam offer a multi-GB install instead.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3787,6 +3787,117 @@ def _is_steam_tool(appid, name):
     return False
 
 
+# ---------------------------------------------------------------------------
+# Non-Steam shortcuts (shortcuts.vdf)
+#
+# On SteamOS/Bazzite this is how EVERYTHING that is not a Steam game reaches the
+# TV: Bazzite's own `ujust get-media-app` registers Netflix, Hulu, Disney+, Max,
+# Prime Video and friends here, EmuDeck registers its launchers here, and this
+# agent registers its own pairing and screensaver tiles here. Until this existed
+# the app listed only installed Steam games — MEASURED on the maintainer's box
+# 2026-07-26: 5 Steam games listed, while shortcuts.vdf held 32 entries the
+# phone could not launch, including every streaming service on the machine.
+#
+# Read-only and best-effort. The parse is anchored on the same b"\x02appid\x00"
+# field _ss_appid() already uses; this walks every occurrence instead of one.
+# ---------------------------------------------------------------------------
+
+MAX_SHORTCUTS = 200        # cap enumeration; a corrupt vdf can't spin the agent
+# Our OWN tiles are filtered out of the launcher list: the pairing tile and the
+# screensaver have dedicated UI, and offering them as generic launchers would
+# invite someone to "launch" the pairing screen over whatever is playing.
+_SHORTCUT_SELF_EXE = ("couchside-pair", "couchside-screensaver", "Couchside")
+
+
+def _shortcut_entries():
+    """[(appid:int, name:str)] for every non-Steam shortcut, or [] on any error.
+
+    Best-effort by design (degrade closed): a missing, truncated or unreadable
+    shortcuts.vdf yields an empty list, which makes the shortcuts simply not
+    appear rather than breaking the whole launcher route.
+    """
+    out = []
+    seen = set()
+    try:
+        paths = sorted(glob.glob(os.path.expanduser(
+            "~/.steam/steam/userdata/*/config/shortcuts.vdf")))
+    except Exception:
+        return []
+    for p in paths:
+        try:
+            with open(p, "rb") as f:
+                data = f.read()
+        except OSError:
+            continue
+        pos = 0
+        while len(out) < MAX_SHORTCUTS:
+            i = data.find(b"\x02appid\x00", pos)
+            if i < 0:
+                break
+            pos = i + 7
+            if pos + 4 > len(data):
+                break
+            try:
+                appid = struct.unpack("<I", data[pos:pos + 4])[0]
+            except struct.error:
+                break
+            if appid == 0 or appid in seen:
+                continue
+            # AppName and Exe both follow the appid within the same entry; cap
+            # the window so a truncated record can't borrow the next one's name.
+            tail = data[pos:pos + 600]
+            name = _vdf_str(tail, b"appname")
+            exe = _vdf_str(tail, b"exe")
+            if not name:
+                continue
+            if any(s in exe for s in _SHORTCUT_SELF_EXE):
+                continue
+            seen.add(appid)
+            out.append((appid, name))
+    return out
+
+
+def _shortcut_appids():
+    """The set of appids currently registered as non-Steam shortcuts."""
+    return {a for a, _ in _shortcut_entries()}
+
+
+def _vdf_str(buf, key):
+    """Value of a binary-VDF string field (\\x01<key>\\x00<value>\\x00), or "".
+
+    Case-insensitive on the key because Steam has written both "AppName" and
+    "appname" over the years. Never raises.
+    """
+    try:
+        low = buf.lower()
+        i = low.find(b"\x01" + key + b"\x00")
+        if i < 0:
+            return ""
+        start = i + 1 + len(key) + 1
+        end = buf.find(b"\x00", start)
+        if end < 0:
+            return ""
+        return buf[start:end].decode("utf-8", "replace").strip().strip('"')
+    except Exception:
+        return ""
+
+
+def discover_steam_shortcuts():
+    """Non-Steam shortcuts as Launcher dicts, sorted by label.
+
+    kind="shortcut" is deliberately NOT "custom": custom launchers come from
+    this agent's own config and the app offers a delete control for them, which
+    would do nothing here — these live in Steam's file, not ours.
+    """
+    try:
+        return sorted(
+            ({"id": "shortcut:%d" % appid, "label": name, "kind": "shortcut"}
+             for appid, name in _shortcut_entries()),
+            key=lambda e: e["label"].lower())
+    except Exception:
+        return []
+
+
 def discover_steam_games():
     """Return auto-discovered Steam games as Launcher dicts, sorted by name.
 
@@ -4538,6 +4649,16 @@ MOCK_STEAM_GAMES = [
     (440, "Team Fortress 2", None),
 ]
 
+# Non-Steam shortcuts for --mock. Names match what Bazzite's `ujust
+# get-media-app` actually registers, so the harness shows the real thing.
+MOCK_SHORTCUTS = [
+    (3266446485, "Netflix"),
+    (2282431590, "Hulu"),
+    (2190596466, "Disney+"),
+    (3486690682, "Max"),
+    (3168132873, "YouTube"),
+]
+
 
 def _png(width, height, rgb):
     """A minimal solid-colour PNG. Mock only -- real covers are files on disk.
@@ -4567,16 +4688,26 @@ def mock_launchers():
         if art:
             e["art"] = art
         out.append(e)
+    # Non-Steam shortcuts, so the web harness renders the streaming tiles that
+    # dominate a real SteamOS box (these are the actual names Bazzite's
+    # `ujust get-media-app` registers).
+    for appid, label in MOCK_SHORTCUTS:
+        out.append({"id": "shortcut:%d" % appid, "label": label,
+                    "kind": "shortcut"})
     return out
 
 
 def list_launchers():
-    """All launchers: configured custom launchers first, then Steam games."""
+    """All launchers: custom, then Steam games, then non-Steam shortcuts.
+
+    Shortcuts go LAST so the ordering every existing user already knows is
+    untouched — a box with no shortcuts returns exactly what it did before.
+    """
     customs = [
         {"id": l["id"], "label": l["label"], "kind": "custom"}
         for l in LAUNCHERS
     ]
-    return customs + discover_steam_games()
+    return customs + discover_steam_games() + discover_steam_shortcuts()
 
 
 def _launcher_argv(launcher_id):
@@ -4614,6 +4745,19 @@ def _launcher_argv(launcher_id):
         # offers it is online; if not, the rungameid is a harmless no-op.
         if appid in _streamable_appids():
             return ["steam", "steam://rungameid/%s" % appid]
+        return None
+    if launcher_id.startswith("shortcut:"):
+        appid = launcher_id[len("shortcut:"):]
+        if not appid.isdigit():
+            return None
+        # Re-read shortcuts.vdf and require the appid to still be registered.
+        # The client's id NEVER reaches the command line: it selects a record,
+        # and the argv below is rebuilt from the agent's own constant plus the
+        # integer we just validated. The shortcut's Exe -- an arbitrary path
+        # Steam stores -- is deliberately never executed directly; Steam runs
+        # it, exactly as it would if you picked the tile with a controller.
+        if int(appid) in _shortcut_appids():
+            return ["steam", "steam://rungameid/%d" % _ss_gameid(int(appid))]
         return None
     if _valid_launcher_id(launcher_id):
         for l in LAUNCHERS:

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -345,7 +345,14 @@ export type Journal = {
 export type Launcher = {
   id: string;
   label: string;
-  kind: 'steam' | 'custom';
+  /** "shortcut" = a non-Steam shortcut from Steam's shortcuts.vdf (agent
+   *  >= 2.9.57). On SteamOS that is how Netflix/Hulu/Disney+/EmuDeck and the
+   *  rest reach the TV. It is deliberately not "custom": custom launchers come
+   *  from the agent's own config and offer a delete control, which would do
+   *  nothing for a shortcut that lives in Steam's file. An older app build
+   *  receiving this value degrades cleanly — it renders the generic rocket
+   *  tile and offers no delete, which is exactly right. */
+  kind: 'steam' | 'custom' | 'shortcut';
   /** Steam appid, present for kind "steam": used for library cover art. */
   appid?: number;
   /** Which SHAPE of cover art the box has locally (agent >= 2.9.41).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -111,6 +111,26 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   around, not fixed). Worth reading that before designing — a reinstall button that papers
   over a known root cause is worse than fixing the cause.
 
+### Launch non-Steam shortcuts from the phone (Netflix, Hulu, EmuDeck, …)
+- **priority:** P1 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- **SHIPPED 2026-07-26** — kept here as the record of what it fixed.
+- On SteamOS/Bazzite, `shortcuts.vdf` is how EVERYTHING that is not a Steam game
+  reaches the TV: Bazzite's own `ujust get-media-app` registers Netflix/Hulu/Disney+/
+  Max/Prime Video there, EmuDeck registers its launchers there, and this agent
+  registers its own pairing and screensaver tiles there.
+- **MEASURED on the maintainer's Bazzite box:** `/api/launchers` returned **5** entries
+  (all installed Steam games) while `shortcuts.vdf` held **32**. Every streaming service
+  on the machine was unlaunchable from the phone. After the change: **36 launchers,
+  5 steam + 31 shortcut**, and a live `POST /api/launchers/shortcut:<appid>` put Netflix
+  on the TV.
+- **Allowlist shape:** `shortcut:<appid>` must be all digits AND still present in
+  shortcuts.vdf; argv is rebuilt as `["steam", "steam://rungameid/<gameid>"]` from the
+  agent's own constants plus the validated integer, using the non-Steam encoding
+  `(appid << 32) | 0x02000000`. The shortcut's stored Exe — an arbitrary path Steam
+  holds — is NEVER executed directly; Steam runs it, exactly as pressing the tile would.
+- The agent's own tiles are filtered out, and proven unlaunchable rather than merely
+  unlisted.
+
 ### Media seek buttons (-10s / +10s) on the now-playing card
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
 - **Requested by u/Most-Bet2021 (r/SteamOS, 2026-07-26):** "a button that fast forwards media

--- a/tests/test_steam_shortcuts.py
+++ b/tests/test_steam_shortcuts.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Tests for non-Steam shortcut launchers (shortcuts.vdf).
+
+Run: python3 tests/test_steam_shortcuts.py
+
+WHY THIS EXISTS: on SteamOS/Bazzite, shortcuts.vdf is how everything that is
+not a Steam game reaches the TV. Bazzite's own `ujust get-media-app` registers
+Netflix/Hulu/Disney+/Max/Prime Video there; EmuDeck registers its launchers
+there. MEASURED on the maintainer's Bazzite box 2026-07-26: /api/launchers
+returned 5 entries (all installed Steam games) while shortcuts.vdf held 32,
+including every streaming service on the machine. The phone could not launch
+any of them.
+
+The fixture below is BUILT FROM THAT REAL FILE's layout: a b"\\x02appid\\x00"
+field followed by a little-endian uint32, with \\x01AppName\\x00 and \\x01Exe\\x00
+string fields in the same record. The appids and names are the ones actually
+observed on that box.
+
+SECURITY: this adds a client-selectable id that ends in a subprocess call, which
+is exactly the shape CLAUDE.md §3 governs. The id is looked up, never
+interpolated: `shortcut:<appid>` must be a digit string AND still present in
+shortcuts.vdf, and the argv is rebuilt from the agent's own constants plus the
+validated integer. The shortcut's stored Exe -- an arbitrary path -- is never
+executed directly; Steam runs it. The rejection tests are the ones to keep if
+this file is ever trimmed.
+"""
+import importlib.util
+import os
+import struct
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def entry(appid, name, exe):
+    """One shortcuts.vdf record, in the real binary-VDF field layout."""
+    return (b"\x00" + b"0" + b"\x00"
+            + b"\x02appid\x00" + struct.pack("<I", appid)
+            + b"\x01AppName\x00" + name.encode("utf-8") + b"\x00"
+            + b"\x01Exe\x00" + exe.encode("utf-8") + b"\x00"
+            + b"\x08\x08")
+
+
+class FakeSteam:
+    """A real shortcuts.vdf on disk, at the path the agent globs."""
+
+    def __init__(self, records):
+        self.tmp = tempfile.mkdtemp()
+        d = os.path.join(self.tmp, ".steam", "steam", "userdata",
+                         "92324858", "config")
+        os.makedirs(d)
+        with open(os.path.join(d, "shortcuts.vdf"), "wb") as f:
+            f.write(b"\x00shortcuts\x00" + b"".join(records) + b"\x08\x08")
+        self._home = os.environ.get("HOME")
+        os.environ["HOME"] = self.tmp
+
+    def close(self):
+        if self._home is not None:
+            os.environ["HOME"] = self._home
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+
+REAL = [
+    entry(3266446485, "Netflix", '"/usr/bin/flatpak"'),
+    entry(2282431590, "Hulu", '"/usr/bin/flatpak"'),
+    entry(2190596466, "Disney+", '"/usr/bin/flatpak"'),
+    # The agent's OWN tiles, which must NOT be offered as launchers.
+    entry(2456487056, "Couchside — Pair Phone",
+          "/home/deck/.local/opt/couchside/couchside-pair"),
+]
+
+
+def main():
+    print("shortcuts.vdf enumeration")
+    fake = FakeSteam(REAL)
+    try:
+        got = cs.discover_steam_shortcuts()
+        labels = [e["label"] for e in got]
+        check("lists the registered shortcuts", labels,
+              ["Disney+", "Hulu", "Netflix"])          # sorted by label
+        check("id is the shortcut: namespace", got[2]["id"],
+              "shortcut:3266446485")
+        check("kind is 'shortcut', not 'custom'", got[0]["kind"], "shortcut")
+        # Both states of the self-filter: our tile is absent, others present.
+        check("the agent's own pair tile is filtered out",
+              any("Couchside" in l for l in labels), False)
+        check("...while a normal tile in the same file is kept",
+              "Netflix" in labels, True)
+
+        print("appid -> rungameid encoding")
+        # Non-Steam shortcuts use (appid << 32) | 0x02000000, not the raw appid.
+        check("uses the non-Steam gameid encoding",
+              cs._ss_gameid(3266446485), 14029280827242708992)
+
+        print("launch resolution (the allowlist)")
+        argv = cs._launcher_argv("shortcut:3266446485")
+        check("a registered shortcut resolves to a steam:// argv LIST",
+              argv, ["steam", "steam://rungameid/14029280827242708992"])
+        check("argv is a list, never a shell string", isinstance(argv, list), True)
+
+        print("rejections — an id that is not in the file is not a launcher")
+        check("unregistered appid -> None",
+              cs._launcher_argv("shortcut:999999999"), None)
+        check("non-numeric id -> None",
+              cs._launcher_argv("shortcut:netflix"), None)
+        check("empty id -> None", cs._launcher_argv("shortcut:"), None)
+        # These are the injection shapes: none may reach a command line.
+        for bad in ("shortcut:1;reboot", "shortcut:$(id)", "shortcut:../../x",
+                    "shortcut:1 2", "shortcut:0x10", "shortcut:-1"):
+            check("rejects %r" % bad, cs._launcher_argv(bad), None)
+        # The filtered-out tile must also be unlaunchable, not merely unlisted.
+        check("a filtered self-tile cannot be launched either",
+              cs._launcher_argv("shortcut:2456487056"), None)
+    finally:
+        fake.close()
+
+    print("degrade closed")
+    empty = FakeSteam([])
+    try:
+        check("no shortcuts -> empty list, not an error",
+              cs.discover_steam_shortcuts(), [])
+    finally:
+        empty.close()
+
+    missing = tempfile.mkdtemp()
+    home = os.environ.get("HOME")
+    os.environ["HOME"] = missing
+    try:
+        check("absent shortcuts.vdf -> empty list",
+              cs.discover_steam_shortcuts(), [])
+        check("...and nothing is launchable from it",
+              cs._launcher_argv("shortcut:3266446485"), None)
+    finally:
+        os.environ["HOME"] = home
+        import shutil
+        shutil.rmtree(missing, ignore_errors=True)
+
+    print("truncated file does not raise")
+    trunc = tempfile.mkdtemp()
+    d = os.path.join(trunc, ".steam", "steam", "userdata", "1", "config")
+    os.makedirs(d)
+    with open(os.path.join(d, "shortcuts.vdf"), "wb") as f:
+        f.write(b"\x00shortcuts\x00\x02appid\x00\x01\x02")   # appid cut short
+    os.environ["HOME"] = trunc
+    try:
+        check("truncated record -> empty list", cs.discover_steam_shortcuts(), [])
+    finally:
+        os.environ["HOME"] = home
+        import shutil
+        shutil.rmtree(trunc, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        return 1
+    print("all shortcut-launcher tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
On SteamOS/Bazzite, `shortcuts.vdf` is how **everything that is not a Steam game** reaches the TV — Bazzite's own `ujust get-media-app` registers Netflix/Hulu/Disney+/Max/Prime Video there, EmuDeck registers its launchers there, and this agent registers its own tiles there.

**Measured on a real Bazzite box:** `/api/launchers` returned **5** entries (all installed Steam games) while `shortcuts.vdf` held **32**. Every streaming service on the machine was unlaunchable from the phone.

After this change, same box: **36 launchers (5 steam + 31 shortcut)**, and a live `POST /api/launchers/shortcut:3773274584` put Netflix on the TV.

### Allowlist
`shortcut:<appid>` is **looked up, never interpolated** — all digits AND still present in a fresh read of `shortcuts.vdf`, so a well-formed but unregistered id is a 404. argv is rebuilt as `["steam", "steam://rungameid/<gameid>"]` from agent constants plus the validated integer, using the non-Steam encoding `(appid << 32) | 0x02000000` that the screensaver tile already proved on hardware.

**The shortcut's stored `Exe` — an arbitrary path Steam holds — is never executed directly.** Steam runs it, exactly as picking the tile with a controller would.

`kind="shortcut"` not `"custom"`: custom launchers come from the agent's config and the app offers a delete control, which would do nothing for a record in Steam's file. An older app build degrades correctly — generic tile, no delete, no art. Shortcuts append **last**, so a box with none returns exactly what it did before.

### Verified
- **22 unit tests**: injection shapes (`1;reboot`, `$(id)`, `../../x`, `0x10`, `-1`), non-numeric/unregistered ids, truncated vdf, absent vdf, self-filter in both directions.
- **Live on hardware**: 5 → 36 launchers; Netflix launched (confirmed by the running `StreamingServiceLauncher --appname=netflix` process *and* a screen capture); unregistered appid → **404**; no token → **401**.

### Not verified
That input reaches a *browser* under gamescope — Chrome launched outside Steam never gets focus, so the related input test exercised the Steam UI (0 px idle vs 155,515 px after two uinput KEY_RIGHT, selection moved exactly two tiles).