### PR TITLE
chore(agent): 2.9.57 — non-Steam shortcut launchers

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,22 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.57
+
+Your streaming apps now show up in the phone's Launch tab.
+
+- **Netflix, Hulu, Disney+, Prime Video, Max — and anything else you have added
+  to Steam yourself.** Until now the Launch tab only listed games you had
+  installed through Steam, which on a SteamOS or Bazzite box leaves out almost
+  everything you actually watch. Streaming services, EmuDeck's launchers, a
+  browser shortcut, Waydroid — all of those are "non-Steam shortcuts", and the
+  phone could not see any of them. On the box this was tested on, that was 5
+  things listed out of 36 that were really there.
+- Tap one and it opens on the TV exactly as it would if you had picked the tile
+  with a controller — same app, same window, so you stay signed in.
+- Nothing to set up. If you have no shortcuts, the Launch tab looks exactly as
+  it did before.
+
 ## 2.9.56
 
 Send files to the box from your phone — and the screen preview works again.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.56"
+VERSION = "2.9.57"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 


### PR DESCRIPTION
Prepares the next agent release so the shortcut feature ([#274](https://github.com/emerytech/couchside/pull/274)) actually reaches boxes.

- `VERSION` 2.9.56 → **2.9.57**
- `agent/CHANGELOG.md` gains a matching `## 2.9.57` section — `release-agent.sh` **refuses to publish** without one, and I verified the match before committing.

The notes lead with the measurement that makes the change legible to a user: on the box this was tested on, the Launch tab listed **5 things out of 36** that were really there.

### Back-compat
No API shape changed — `list_launchers()` appends a new *entry* kind, and shortcuts go **last**, so a box with none returns exactly what it did before. The shipped app (2.9.29) predates the `kind: 'shortcut'` type widening but handles the value correctly at runtime: generic rocket tile, no delete control, no cover-art lookup. So agent 2.9.57 + app 2.9.29 is fine.

### Still to do (not in this PR)
Publishing is a separate, signed step: `scripts/release-agent.sh <tag>` run locally with the offline key. Flagging it because that is what actually puts the agent in front of boxes.