### PR TITLE
feat(pad): TV mode — swipe drives the cursor in tile-sized jumps

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -18,6 +18,7 @@ import {
   useKeepAwakeTimeoutMin,
 } from '@/lib/keepAwake';
 import { getPref, setPref, usePref } from '@/lib/prefs';
+import { tvStepDelta } from '@/lib/tvNav';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNavigation } from 'expo-router';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -827,6 +828,11 @@ const MODES: { key: PadMode; label: string }[] = [
   // "MOUSE", not "TRACK": the surface IS a mouse — drag moves the pointer, tap
   // clicks. "Track" named the mechanism and left people guessing at the effect.
   { key: 'trackpad', label: 'MOUSE' },
+  // Same swipe gesture as SWIPE, but each step nudges the POINTER instead of
+  // sending an arrow key — for browser-based streaming apps, where arrow keys
+  // only scroll the page. Sits next to MOUSE because it IS the mouse, driven
+  // in tile-sized jumps.
+  { key: 'tvnav', label: 'TV' },
   { key: 'remote', label: 'REMOTE' },
   // Sits AFTER remote on purpose: it is one swipe further from the surface you
   // reach for most. Conditional -- see `modes` below; a box without Steam menus
@@ -1423,6 +1429,26 @@ function PadScreen() {
     [client],
   );
 
+  // ---- TV mode: swipe steps drive the POINTER, tap clicks ----
+  // Reuses SwipeSurface verbatim (same discrete stepping, same haptic
+  // rate-limit, same gesture-termination safety) and only changes what a step
+  // SENDS. Nothing is held between steps, so unlike the d-pad path there is no
+  // latched axis to release — onStepEnd is a no-op by design, not by omission.
+  const tvStep = useCallback(
+    (k: DpadKey) => {
+      const { dx, dy } = tvStepDelta(k, getPref('tvStepPx'));
+      client.sendMouseMove(dx, dy);
+    },
+    [client],
+  );
+  const tvClick = useCallback(() => {
+    haptic();
+    // Same press/release shape the trackpad tap uses: the 40ms gap is what
+    // makes the click register — a same-tick down+up was not reliably seen.
+    client.sendMouseButton('l', 1);
+    setTimeout(() => client.sendMouseButton('l', 0), 40);
+  }, [client]);
+
   const selectTap = useCallback(() => {
     haptic();
     if (keyboardMode) {
@@ -1635,6 +1661,14 @@ function PadScreen() {
       ) : mode === 'remote' ? (
         <>
           <RemoteView client={client} settings={settings} />
+          {keyboardBar}
+        </>
+      ) : mode === 'tvnav' ? (
+        <>
+          <View style={styles.tpWrap}>
+            <SwipeSurface onStep={tvStep} onStepEnd={NOOP} onSelect={tvClick} />
+            {padToggleChip}
+          </View>
           {keyboardBar}
         </>
       ) : mode === 'swipe' ? (

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -49,6 +49,7 @@ import {
   type KeepAwakeTimeoutMin,
 } from '@/lib/keepAwake';
 import { navigateAfterPair } from '@/lib/postPair';
+import { TV_STEPS, type TvStepPx } from '@/lib/tvNav';
 import {
   MEDIA_HOLD_SKIP_SECS,
   MEDIA_SKIP_SECS,
@@ -775,6 +776,7 @@ function SetupBody() {
   const mediaSkipSec = usePref('mediaSkipSec');
   const mediaHoldSkip = usePref('mediaHoldSkip');
   const mediaHoldSkipSec = usePref('mediaHoldSkipSec');
+  const tvStepPx = usePref('tvStepPx');
   const themeMode = useThemeMode();
   const accent = useAccent();
   const scheme = useResolvedScheme();
@@ -1469,6 +1471,19 @@ function SetupBody() {
                   }}
                 />
               )}
+              <SegPref
+                label="TV mode step size"
+                sub="How far one swipe step moves the pointer in TV mode. TV mode drives the cursor in tile-sized jumps for streaming apps, where arrow keys only scroll the page. Bigger steps cross a row faster; smaller ones land on dense grids more reliably."
+                options={TV_STEPS.map((n) => ({
+                  value: n,
+                  label: n === 160 ? 'Small' : n === 260 ? 'Medium' : 'Large',
+                }))}
+                value={tvStepPx}
+                onSelect={(v) => {
+                  void setPref('tvStepPx', v as TvStepPx);
+                  hapticSelection();
+                }}
+              />
               <SegPref
                 label="Open on"
                 sub="The tab the app starts on. Pairing wins on first run — with no box paired you still land on Setup."

--- a/app/lib/__tests__/tvNav.test.ts
+++ b/app/lib/__tests__/tvNav.test.ts
@@ -1,0 +1,81 @@
+/**
+ * TV-mode cursor stepping — lib/tvNav.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the existing CI `app-input` job's glob.
+ *
+ * This is input-path arithmetic (CLAUDE.md §4), and the failure it guards is
+ * quiet rather than loud: a wrong sign sends the cursor the opposite way from
+ * the swipe, and a fractional delta truncates on the wire so repeated steps
+ * drift off the tile row instead of tracking it. Both directions of every axis
+ * are asserted for that reason.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TV_STEPS, TV_STEP_DEFAULT, isTvStep, tvStepDelta } from '../tvNav.ts';
+
+test('each direction moves the pointer the right way', () => {
+  // Both directions of both axes — a sign flip is the whole bug class here.
+  assert.deepEqual(tvStepDelta('dr', 260), { dx: 260, dy: 0 });
+  assert.deepEqual(tvStepDelta('dl', 260), { dx: -260, dy: 0 });
+  assert.deepEqual(tvStepDelta('dd', 260), { dx: 0, dy: 260 });
+  assert.deepEqual(tvStepDelta('du', 260), { dx: 0, dy: -260 });
+});
+
+test('a step moves exactly one axis', () => {
+  for (const d of ['du', 'dd', 'dl', 'dr'] as const) {
+    const { dx, dy } = tvStepDelta(d, 260);
+    assert.equal(dx === 0 || dy === 0, true, `${d} moved diagonally`);
+    assert.notEqual(dx === 0 && dy === 0, true, `${d} moved nothing`);
+  }
+});
+
+test('deltas are always integers — the wire format truncates', () => {
+  for (const px of [160.4, 259.6, 380.5, 0.2]) {
+    for (const d of ['du', 'dd', 'dl', 'dr'] as const) {
+      const { dx, dy } = tvStepDelta(d, px);
+      assert.equal(Number.isInteger(dx), true, `${d}@${px} dx=${dx}`);
+      assert.equal(Number.isInteger(dy), true, `${d}@${px} dy=${dy}`);
+    }
+  }
+});
+
+test('a step is never zero, however small the setting', () => {
+  // A zero delta is dropped by sendMouseMove, so the swipe would feel dead.
+  for (const px of [0, -5, 0.1]) {
+    const { dx } = tvStepDelta('dr', px);
+    assert.equal(dx >= 1, true, `${px} produced dx=${dx}`);
+  }
+});
+
+test('opposite directions cancel exactly', () => {
+  // Swipe right then left must land back where it started, or the cursor
+  // walks away from the row over a session.
+  for (const px of TV_STEPS) {
+    const r = tvStepDelta('dr', px);
+    const l = tvStepDelta('dl', px);
+    assert.equal(r.dx + l.dx, 0, `${px} did not cancel on x`);
+    const d = tvStepDelta('dd', px);
+    const u = tvStepDelta('du', px);
+    assert.equal(d.dy + u.dy, 0, `${px} did not cancel on y`);
+  }
+});
+
+test('every offered step size is usable and distinct', () => {
+  assert.equal(new Set(TV_STEPS).size, TV_STEPS.length);
+  for (const px of TV_STEPS) {
+    assert.equal(isTvStep(px), true);
+    assert.equal(tvStepDelta('dr', px).dx, px);
+  }
+  // Ordered small-to-large, so the Settings labels stay truthful.
+  assert.deepEqual([...TV_STEPS].sort((a, b) => a - b), [...TV_STEPS]);
+});
+
+test('the default is an offered size', () => {
+  assert.equal(isTvStep(TV_STEP_DEFAULT), true);
+  // Rejected rather than clamped, so a corrupt stored pref falls back.
+  for (const bad of [0, 100, 200, 500, -260, NaN]) {
+    assert.equal(isTvStep(bad), false, `${bad} must not be accepted`);
+  }
+});

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -12,6 +12,7 @@ import * as SecureStore from 'expo-secure-store';
 import { useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 
+import { TV_STEPS, TV_STEP_DEFAULT, type TvStepPx } from './tvNav';
 import {
   MEDIA_HOLD_SKIP_SECS,
   MEDIA_SKIP_SECS,
@@ -180,6 +181,13 @@ export type Prefs = {
   /** How far a HELD skip button jumps, in seconds. Ignored when mediaHoldSkip
    *  is off. */
   mediaHoldSkipSec: MediaHoldSkipSec;
+  /** How far one TV-mode swipe step moves the pointer, in box pixels.
+   *
+   *  A preference rather than a constant because "one tile" is not a fixed
+   *  distance: it depends on the service's grid density and the screen it is
+   *  drawn on. Too small and a row takes many swipes; too large and it skips
+   *  tiles. */
+  tvStepPx: TvStepPx;
 };
 
 export const DEFAULTS: Prefs = {
@@ -217,6 +225,7 @@ export const DEFAULTS: Prefs = {
   mediaSkipSec: 10,
   mediaHoldSkip: true,
   mediaHoldSkipSec: 30,
+  tvStepPx: TV_STEP_DEFAULT,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -328,6 +337,7 @@ function normalize(raw: unknown): Prefs {
       MEDIA_HOLD_SKIP_SECS,
       DEFAULTS.mediaHoldSkipSec,
     ) as MediaHoldSkipSec,
+    tvStepPx: num(o.tvStepPx, TV_STEPS, DEFAULTS.tvStepPx) as TvStepPx,
   };
 }
 

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -15,7 +15,7 @@ import type { BoxCaps } from './api';
  * menus (agent >= 2.9.31). Pad filters it out otherwise rather than offering a
  * mode that would open an empty panel.
  */
-export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus';
+export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus' | 'tvnav';
 
 /**
  * A single paired box (Bazzite media center, Steam Deck, ...). The app manages
@@ -200,6 +200,10 @@ function normalizePadMode(v: unknown): PadMode {
   // A box persisted on 'menus' that later loses the capability is bounced back
   // by the Pad screen; accepting it here keeps the round-trip lossless.
   if (v === 'menus') return 'menus';
+  // TV mode: swipe drives the POINTER in tile-sized jumps, for browser-based
+  // streaming apps where arrow keys only scroll. Accepted here so a box saved
+  // on it round-trips losslessly, same as 'menus'.
+  if (v === 'tvnav') return 'tvnav';
   return 'swipe';
 }
 

--- a/app/lib/tvNav.ts
+++ b/app/lib/tvNav.ts
@@ -1,0 +1,59 @@
+/**
+ * TV-mode cursor stepping, with ZERO runtime imports.
+ *
+ * WHY THIS MODE EXISTS: on SteamOS the streaming services people actually watch
+ * are web pages in a browser. Arrow keys do NOT navigate them — Chromium has no
+ * spatial navigation by default (its own flag breaks on any page that calls
+ * Element.focus(), which Netflix does), and Firefox removed the feature
+ * entirely. MEASURED 2026-07-26: arrow keys sent to the box moved Steam's own
+ * selection, but a browser tile grid only scrolls. So the SWIPE mode that drives
+ * Steam beautifully does nothing useful on Netflix.
+ *
+ * Every shipping Linux TV product converged on the same answer — drive a
+ * CURSOR, not a focus ring (KDE's purpose-built Aura browser ships
+ * `navMode: "vMouse"`). This mode does that, but in tile-sized jumps with a
+ * haptic per step, so it FEELS like a d-pad while being a pointer underneath.
+ * It therefore works on every service, including the ones with no TV UI at all.
+ *
+ * Split out and import-free so the arithmetic is unit-testable on bare Node,
+ * like lib/gamepad.ts and lib/mediaSeek.ts (CI job `app-input`).
+ */
+
+/** Jump sizes offered in Settings, in pixels of box-screen travel per step. */
+export const TV_STEPS = [160, 260, 380] as const;
+export type TvStepPx = (typeof TV_STEPS)[number];
+
+/**
+ * Default. A 1080p tile row on Netflix/Disney+ runs roughly six tiles wide, so
+ * ~260px lands about one tile per swipe-step at that size. Smaller screens and
+ * denser grids are why this is a preference rather than a constant.
+ */
+export const TV_STEP_DEFAULT: TvStepPx = 260;
+
+export function isTvStep(n: number): n is TvStepPx {
+  return (TV_STEPS as readonly number[]).includes(n);
+}
+
+/** The four directions the swipe surface emits. */
+export type TvDir = 'du' | 'dd' | 'dl' | 'dr';
+
+/**
+ * Relative pointer delta for one step in `dir`.
+ *
+ * Returns integers because the wire format is an int32 pair and the agent's
+ * uinput write rounds anyway — emitting a fraction would silently truncate and
+ * make repeated steps drift off the row.
+ */
+export function tvStepDelta(dir: TvDir, stepPx: number): { dx: number; dy: number } {
+  const n = Math.max(1, Math.round(stepPx));
+  switch (dir) {
+    case 'dl':
+      return { dx: -n, dy: 0 };
+    case 'dr':
+      return { dx: n, dy: 0 };
+    case 'du':
+      return { dx: 0, dy: -n };
+    case 'dd':
+      return { dx: 0, dy: n };
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,6 +131,28 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - The agent's own tiles are filtered out, and proven unlaunchable rather than merely
   unlisted.
 
+### TV pad mode — swipe drives the cursor in tile-sized jumps
+- **priority:** P1 · **risk:** low · **affects:** app only · **depends_on:** none
+- **SHIPPED 2026-07-26.** Kept as the record of why it exists.
+- **The problem, measured:** on SteamOS the streaming services people actually watch are
+  web pages. Arrow keys do NOT navigate them — Chromium has no spatial navigation by
+  default, its `--enable-spatial-navigation` flag is documented to break on any page
+  calling `Element.focus()` (Netflix does), and Firefox removed the feature entirely.
+  Verified on the box: uinput arrow keys moved Steam's own selection (0 px idle vs
+  155,515 px, selection moved exactly two tiles) but a browser tile grid only scrolls.
+- Every shipping Linux TV product converged on driving a CURSOR instead of a focus ring —
+  KDE's purpose-built Aura browser ships `navMode: "vMouse"`. This mode does that, but in
+  tile-sized jumps with a haptic per step, so it FEELS like a d-pad while being a pointer.
+  It therefore works on every service, including the ones with no TV UI at all.
+- **App-only.** Reuses `SwipeSurface` verbatim — same discrete stepping, same haptic
+  rate-limit, same gesture-termination safety — and only changes what a step SENDS.
+  Nothing is held between steps, so there is no latched axis to release.
+- Step size is a preference (Small/Medium/Large = 160/260/380 px) because "one tile" is
+  not a fixed distance: it depends on the service's grid density and the screen.
+- **Still unproven:** that uinput pointer motion reaches a browser under gamescope.
+  Keyboard is verified; the mouse test was inconclusive (injected moves produced no pixel
+  change on a static profile picker). Worth a live check with this mode on a real phone.
+
 ### Packaged media shortcuts, installable from the phone
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** shortcut
   launching (shipped 2026-07-26)
@@ -170,10 +192,14 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - Leaning Chrome for adoption-friendliness; needs a decision, not a coin flip.
 
 #### Hard constraints already measured
-- **shortcuts.vdf must be written with Steam DOWN.** Steam rewrites it from memory on
-  exit, so an edit made while it runs is silently clobbered. Verified: `steam -shutdown`,
-  wait for the process to go, edit, let gamescope-session respawn it. A helper that
-  forgets this will appear to work and then quietly undo itself.
+- **File-level edits to shortcuts.vdf DO NOT STICK — not even with Steam down.**
+  CORRECTED 2026-07-26 after testing: a prune (32 -> 27 entries) and a separate
+  LaunchOptions edit were both applied with Steam shut down, verified on disk, and both
+  were REVERTED after Steam restarted — the deleted tiles came back and the added flag
+  was gone. Steam holds an authoritative copy (cloud sync is the likely mechanism) and
+  rewrites the file from it. So any shortcut management must go through Steam's own
+  mechanism (`steamos-add-to-steam`), and REMOVAL may not be reachable from the agent at
+  all — it may have to be a "do this in Steam's UI" instruction.
 - Cover art is a separate artifact: `~/.steam/steam/userdata/<id>/config/grid/<appid>p.png`.
   A pack without art produces the grey placeholder tile, which is exactly what made the
   duplicates look wrong at a glance.


### PR DESCRIPTION
On SteamOS the streaming services people actually watch are **web pages**, and arrow keys cannot navigate them. Chromium has no spatial navigation by default, its `--enable-spatial-navigation` flag is documented to break on any page calling `Element.focus()` (Netflix does), and Firefox removed the feature entirely.

**Verified on the box:** uinput arrow keys moved Steam's own selection — **0 px** over 4 idle seconds vs **155,515 px** after two presses, selection moving exactly two tiles — but a browser tile grid only scrolls. So SWIPE mode, which drives Steam beautifully, does nothing useful on Netflix.

Every shipping Linux TV product converged on driving a **cursor**, not a focus ring (KDE's purpose-built Aura browser ships `navMode: "vMouse"`). This mode does that, in tile-sized jumps with a haptic per step — it *feels* like a d-pad while being a pointer, so it works on every service including those with no TV UI at all.

### App-only, and deliberately boring
Reuses `SwipeSurface` **verbatim** — same discrete stepping, same haptic rate-limit, same gesture-termination safety — changing only what a step *sends*. Nothing is held between steps, so unlike the d-pad path there is no latched axis to release: `onStepEnd` is a no-op by design, not omission. The click reuses the trackpad's tested 40 ms press/release shape.

Step size is a preference (Small/Medium/Large = 160/260/380 px) because "one tile" is not a fixed distance.

### Tests
7 cases: both directions of both axes (a sign flip is the entire bug class), single-axis movement, integer deltas (the wire truncates, and a fractional step drifts off the row), never-zero steps, and that opposite directions cancel exactly.

Harness, controls pressed: TV tab appears between MOUSE and REMOTE, selects, renders "swipe to move · tap to select"; the setting is findable by search and pressing "Large" persisted `tvStepPx: 380`.

### Also: a correction
The packaged-shortcuts roadmap entry said to edit `shortcuts.vdf` with Steam down. **That is wrong.** A prune (32→27) and a LaunchOptions edit were both applied with Steam shut down, verified on disk, and **both reverted** after Steam restarted. Steam holds an authoritative copy. Entry corrected.

### Not verified
That uinput **pointer** motion reaches a browser under gamescope. Keyboard is proven; the mouse test was inconclusive (no pixel change on a static profile picker). This mode's premise rests on it — worth a live check from your phone.