### PR TITLE
chore(app): 2.9.30 — TestFlight build for TV pad mode

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.29",
+    "version": "2.9.30",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",


### PR DESCRIPTION
Opens the next version so TV pad mode ([#277](https://github.com/emerytech/couchside/pull/277)) can be tried on a device.

2.9.29 reached **READY_FOR_SALE**, so this starts a new version rather than adding a build to one already live.

`buildNumber`/`versionCode` untouched — EAS `autoIncrement` owns them and they are reconciled back from the artifacts afterwards (CONVENTIONS §5). Last release shipped iOS 92 / vc 62, so this should build at **93**.

Built on the **production** profile, not `beta` — `beta` sets `EXPO_PUBLIC_BETA_UNLOCK=1`, which would hand out the paid unlock. TestFlight distribution works fine from a production build (that is how 92 reached it).