### PR TITLE
Revert "refactor(pad): TV nav becomes a corner toggle" — keep TV as a tab

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -828,6 +828,11 @@ const MODES: { key: PadMode; label: string }[] = [
   // "MOUSE", not "TRACK": the surface IS a mouse — drag moves the pointer, tap
   // clicks. "Track" named the mechanism and left people guessing at the effect.
   { key: 'trackpad', label: 'MOUSE' },
+  // Same swipe gesture as SWIPE, but each step nudges the POINTER instead of
+  // sending an arrow key — for browser-based streaming apps, where arrow keys
+  // only scroll the page. Sits next to MOUSE because it IS the mouse, driven
+  // in tile-sized jumps.
+  { key: 'tvnav', label: 'TV' },
   { key: 'remote', label: 'REMOTE' },
   // Sits AFTER remote on purpose: it is one swipe further from the surface you
   // reach for most. Conditional -- see `modes` below; a box without Steam menus
@@ -1226,13 +1231,8 @@ function PadScreen() {
   // collapses the pill + mode tabs + button/keyboard rows so the surface fills
   // the pane. A floating chip restores the chrome. Not meaningful for the
   // menus/remote/gamepad modes, which have no full-pane drag surface.
-  // 'tvnav' is not a tab — it is SWIPE with the steps rerouted to the pointer,
-  // toggled by a chip on the surface. So the segmented control (and the
-  // large-pad rule) treat it AS swipe; only the step handler differs.
-  const tabMode: PadMode = mode === 'tvnav' ? 'swipe' : mode;
-  const tvNav = mode === 'tvnav';
   const largePad =
-    trackpadLarge && (mode === 'trackpad' || mode === 'swipe' || tvNav);
+    trackpadLarge && (mode === 'trackpad' || mode === 'swipe');
   // Auto-raise the phone keyboard when the box raises its own. The counter is
   // what KeyboardBar watches; the ref lets the (memoised) socket callback read
   // the current pref without re-subscribing.
@@ -1273,11 +1273,11 @@ function PadScreen() {
   // (wrapping), matching the segmented control's order.
   const cycleMode = useCallback(
     (dir: 1 | -1) => {
-      const i = modes.findIndex((m) => m.key === tabMode);
+      const i = modes.findIndex((m) => m.key === mode);
       const from = i < 0 ? 0 : i;
       setMode(modes[(from + dir + modes.length) % modes.length].key);
     },
-    [tabMode, setMode, modes],
+    [mode, setMode, modes],
   );
 
   // Bounce off a mode this box can't serve -- the persisted padMode may say
@@ -1543,32 +1543,6 @@ function PadScreen() {
       </Pressable>
     ) : null;
 
-  // Top-LEFT so it never collides with the expand chip on the right. Flips what
-  // a swipe step SENDS — arrow keys (Steam's own UI) vs pointer jumps (browser
-  // streaming apps, where arrows only scroll). Deliberately on the surface
-  // rather than in the mode row: it is a property of the swipe, not a separate
-  // input device, and the row was already full at phone width.
-  const tvToggleChip = (
-    <Pressable
-      onPress={() => {
-        setMode(tvNav ? 'swipe' : 'tvnav');
-      }}
-      style={styles.tvToggleChip}
-      hitSlop={12}
-      accessibilityRole="button"
-      accessibilityLabel={tvNav ? 'Switch to Steam navigation' : 'Switch to TV navigation'}
-      accessibilityHint={
-        tvNav
-          ? 'Swipe will send arrow keys, for Steam'
-          : 'Swipe will move the pointer, for streaming apps'
-      }>
-      <Ionicons name={tvNav ? 'tv' : 'logo-steam'} size={15} color={tvNav ? t.blue : t.textDim} />
-      <Text style={[styles.tvToggleText, tvNav && { color: t.blue }]}>
-        {tvNav ? 'TV' : 'STEAM'}
-      </Text>
-    </Pressable>
-  );
-
   return (
     <View
       style={[
@@ -1611,10 +1585,10 @@ function PadScreen() {
               <Pressable
                 key={m.key}
                 onPress={() => setMode(m.key)}
-                style={[styles.modeSeg, tabMode === m.key && styles.modeSegActive]}>
+                style={[styles.modeSeg, mode === m.key && styles.modeSegActive]}>
                 <Text
                   numberOfLines={1}
-                  style={[styles.modeSegText, tabMode === m.key && styles.modeSegTextActive]}>
+                  style={[styles.modeSegText, mode === m.key && styles.modeSegTextActive]}>
                   {m.label}
                 </Text>
               </Pressable>
@@ -1689,19 +1663,19 @@ function PadScreen() {
           <RemoteView client={client} settings={settings} />
           {keyboardBar}
         </>
-      ) : mode === 'swipe' || tvNav ? (
+      ) : mode === 'tvnav' ? (
         <>
-          {/* Apple-TV-remote style: big swipe/tap surface + three big buttons.
-              The SAME surface serves both: in TV nav a step moves the pointer
-              and a tap clicks; otherwise a step is an arrow key and a tap is
-              select. */}
           <View style={styles.tpWrap}>
-            <SwipeSurface
-              onStep={tvNav ? tvStep : dpadStep}
-              onStepEnd={tvNav ? NOOP : dpadRelease}
-              onSelect={tvNav ? tvClick : selectTap}
-            />
-            {tvToggleChip}
+            <SwipeSurface onStep={tvStep} onStepEnd={NOOP} onSelect={tvClick} />
+            {padToggleChip}
+          </View>
+          {keyboardBar}
+        </>
+      ) : mode === 'swipe' ? (
+        <>
+          {/* Apple-TV-remote style: big swipe/tap surface + three big buttons */}
+          <View style={styles.tpWrap}>
+            <SwipeSurface onStep={dpadStep} onStepEnd={dpadRelease} onSelect={selectTap} />
             {padToggleChip}
           </View>
           {!largePad && (
@@ -2091,28 +2065,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     position: 'relative',
   },
   // Corner chip that toggles large-pad mode (expand <-> contract) in one tap.
-  tvToggleChip: {
-    position: 'absolute',
-    top: 8,
-    left: 8,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 5,
-    paddingHorizontal: 10,
-    height: 34,
-    backgroundColor: t.inset,
-    borderColor: t.cardBorder,
-    borderWidth: 1,
-    borderRadius: 999,
-    zIndex: 10,
-  },
-  tvToggleText: {
-    color: t.textDim,
-    fontSize: 11,
-    fontWeight: '700',
-    letterSpacing: 0.5,
-    fontFamily: mono,
-  },
   tpToggleChip: {
     position: 'absolute',
     top: 8,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -144,16 +144,6 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   KDE's purpose-built Aura browser ships `navMode: "vMouse"`. This mode does that, but in
   tile-sized jumps with a haptic per step, so it FEELS like a d-pad while being a pointer.
   It therefore works on every service, including the ones with no TV UI at all.
-- **Not a tab.** Revised 2026-07-26 on owner feedback: it is a chip in the surface's top-left
-  corner that flips what a swipe step SENDS (arrow keys for Steam vs pointer jumps for
-  browser apps). The mode row was already full at phone width, and TV is a property of the
-  swipe rather than a separate input device — the segmented control still reads SWIPE.
-- **Auto-switching was investigated and is NOT possible today.** `/api/gaming` reports only
-  session and output — no running app for a Steam-launched shortcut (measured with Netflix
-  up). `/api/media` shows ZERO MPRIS players while Netflix is open but idle; a player only
-  appears once something plays, which is exactly when tile navigation is no longer needed.
-  There is no focused-window endpoint. Auto-switch would need a NEW agent capability
-  reporting the focused window under gamescope.
 - **App-only.** Reuses `SwipeSurface` verbatim — same discrete stepping, same haptic
   rate-limit, same gesture-termination safety — and only changes what a step SENDS.
   Nothing is held between steps, so there is no latched axis to release.


### PR DESCRIPTION
Owner reviewed the corner-chip version and prefers the tab. Straight revert of [#279](https://github.com/emerytech/couchside/pull/279).

Back to: `PAD · SWIPE · MOUSE · TV · REMOTE`, no chip on the swipe surface. `tvnav` is a normal tab again, so the segmented control binds to `mode` directly and the `tabMode` indirection is gone.

Typecheck 0, tests pass. The behaviour from [#277](https://github.com/emerytech/couchside/pull/277) is untouched — this only moves where you select it.

Auto-switch findings from the reverted PR stay recorded in the roadmap: `/api/gaming` reports no running app for a Steam-launched shortcut, `/api/media` shows zero MPRIS players while a service is open but idle, and there is no focused-window endpoint — so auto-switching would need a new agent capability.