### PR TITLE
chore(app): reconcile iOS buildNumber to 93 from the artifact

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "92",
+      "buildNumber": "93",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Build 93 exists on EAS (2.9.30, production) but `app.json` still said 92, so the next `autoIncrement` would have produced **93 a second time**. Reconciled from the artifact, not the log (CONVENTIONS §5) — the same drift that nearly shipped a duplicate `versionCode` last release.

93 was never submitted anywhere: it carries the TV **tab**, replaced by the on-screen toggle in [#281](https://github.com/emerytech/couchside/pull/281). The next build supersedes it.

`versionCode` stays 62 (shipped on Play), so Android autoIncrements to 63.