### PR TITLE
fix(pad): one flick = one d-pad step, so short menus stop overshooting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,10 +465,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-      # --test-force-exit: a FAILING test throws before its client.close(), which
-      # leaks the 5s ping setInterval and would otherwise keep the run alive until
-      # the job times out. Force-exit makes a failure exit promptly (and report)
-      # instead of hanging. Passing runs close every client and exit on their own.
+      # --test-timeout, NOT --test-force-exit. Force-exit was here because a
+      # FAILING test throws before its client.close(), leaking the 5s ping
+      # setInterval and hanging the job. It fixed that but SILENTLY TRUNCATED THE
+      # RUN: measured 2026-07-26, three consecutive invocations reported 56, 51
+      # and 48 tests against 60 without the flag. Force-exit races the reporter,
+      # so CI could skip a failing test and still go green — on the input path,
+      # of all places. A per-test timeout kills a hang just as dead while letting
+      # every test actually run.
       - name: Input-path unit tests (gamepad lifecycle + trackpad gestures)
-        run: node --experimental-strip-types --test --test-force-exit lib/__tests__/*.test.ts hooks/__tests__/*.test.ts
+        run: node --experimental-strip-types --test --test-timeout=60000 lib/__tests__/*.test.ts hooks/__tests__/*.test.ts
         working-directory: app

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -18,6 +18,7 @@ import {
   useKeepAwakeTimeoutMin,
 } from '@/lib/keepAwake';
 import { getPref, setPref, usePref } from '@/lib/prefs';
+import { planSteps, type StepState } from '@/lib/swipeSteps';
 import { tvStepDelta } from '@/lib/tvNav';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { useNavigation } from 'expo-router';
@@ -183,7 +184,6 @@ function Stick({ onMove, onRelease }: StickProps) {
 // ---------- Swipe surface (Apple TV remote style) ----------
 
 /** Pixels of travel per emitted d-pad step. */
-const SWIPE_STEP = 56;
 /** Movement under this is still a tap. */
 const TAP_SLOP = 12;
 /** Touches longer than this aren't taps. */
@@ -219,14 +219,16 @@ type SwipeSurfaceProps = {
 };
 
 /**
- * Trackpad-like surface: dragging emits one d-pad step per SWIPE_STEP px along
- * the dominant axis (a long swipe = several steps, like scrolling a menu);
- * a quick tap is A/select.
+ * Trackpad-like surface: dragging emits d-pad steps along the dominant axis.
+ * The FIRST step comes quickly and repeats need much more travel, so a flick
+ * moves one item while a deliberate drag scrolls (see lib/swipeSteps.ts — a
+ * flat threshold sent 3-4 presses per flick and overshot Steam's sidebar).
+ * A quick tap is A/select.
  */
 function SwipeSurface({ onStep, onStepEnd, onSelect }: SwipeSurfaceProps) {
   const cb = useRef({ onStep, onStepEnd, onSelect });
   cb.current = { onStep, onStepEnd, onSelect };
-  const track = useRef({ consumedX: 0, consumedY: 0, moved: false, t0: 0 });
+  const track = useRef({ consumedX: 0, consumedY: 0, stepped: false, moved: false, t0: 0 });
   // Sensitivity read into a ref so the once-created responder sees live changes.
   // Higher sensitivity = smaller step = more steps per swipe.
   const sens = usePref('swipeSensitivity');
@@ -238,29 +240,21 @@ function SwipeSurface({ onStep, onStepEnd, onSelect }: SwipeSurfaceProps) {
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: () => true,
       onPanResponderGrant: () => {
-        track.current = { consumedX: 0, consumedY: 0, moved: false, t0: Date.now() };
+        track.current = { consumedX: 0, consumedY: 0, stepped: false, moved: false, t0: Date.now() };
       },
       onPanResponderMove: (_evt, g) => {
         const t = track.current;
         if (!t.moved && Math.hypot(g.dx, g.dy) > TAP_SLOP) t.moved = true;
-        const step = SWIPE_STEP / sensRef.current;
-        let stepped = false;
-        // Emit steps until the un-consumed travel is under one step on both axes.
-        for (;;) {
-          const availX = g.dx - t.consumedX;
-          const availY = g.dy - t.consumedY;
-          const ax = Math.abs(availX);
-          const ay = Math.abs(availY);
-          if (ax < step && ay < step) break;
-          stepped = true;
-          if (ax >= ay) {
-            t.consumedX += Math.sign(availX) * step;
-            cb.current.onStep(availX > 0 ? 'dr' : 'dl');
-          } else {
-            t.consumedY += Math.sign(availY) * step;
-            cb.current.onStep(availY > 0 ? 'dd' : 'du');
-          }
-        }
+        // First step is cheap, repeats are expensive — so a flick moves ONE
+        // item and a deliberate drag still scrolls. See lib/swipeSteps.ts for
+        // why (a flat 56px rule sent 3-4 presses per flick and overshot Steam's
+        // sidebar). The planner is pure and unit-tested; this just applies it.
+        const plan = planSteps(g.dx, g.dy, t as StepState, sensRef.current);
+        t.consumedX = plan.next.consumedX;
+        t.consumedY = plan.next.consumedY;
+        t.stepped = plan.next.stepped;
+        const stepped = plan.dirs.length > 0;
+        for (const d of plan.dirs) cb.current.onStep(d);
         // ONE haptic per move event, never one per step. This loop is unbounded
         // — a fast swipe emits a burst — and on iOS each selectionAsync() hops
         // to the main queue with a fresh feedback generator, so a per-step tick

--- a/app/lib/__tests__/swipeSteps.test.ts
+++ b/app/lib/__tests__/swipeSteps.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Swipe-to-d-pad stepping — lib/swipeSteps.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the CI `app-input` job's glob.
+ *
+ * REGRESSION UNDER TEST (reported 2026-07-26): pressing STEAM and swiping right
+ * to reach the open-apps entry overshot it. The old rule emitted one step per
+ * 56px with no first-vs-repeat distinction, so a natural ~200px flick sent
+ * THREE presses and sailed past a short menu. The first test below is that
+ * exact gesture, and it is the one to keep if this file is ever trimmed.
+ *
+ * This is the safety-critical input path (CLAUDE.md §4): "how many presses does
+ * one gesture send" must not be verified by feel.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SWIPE_FIRST_PX,
+  SWIPE_REPEAT_PX,
+  planSteps,
+  type StepState,
+} from '../swipeSteps.ts';
+
+const fresh = (): StepState => ({ consumedX: 0, consumedY: 0, stepped: false });
+
+/** Steps a whole gesture emits, fed in realistic incremental moves. */
+function gesture(points: [number, number][], sens = 1): string[] {
+  let st = fresh();
+  const out: string[] = [];
+  for (const [dx, dy] of points) {
+    const p = planSteps(dx, dy, st, sens);
+    out.push(...p.dirs);
+    st = p.next;
+  }
+  return out;
+}
+
+test('THE BUG: a normal flick right emits exactly one step', () => {
+  // ~200px, delivered as a real drag would be. Previously: 3 steps.
+  const dirs = gesture([[40, 0], [90, 0], [150, 0], [200, 0]]);
+  assert.deepEqual(dirs, ['dr'], `flick sent ${dirs.length} steps: ${dirs}`);
+});
+
+test('a deliberate long drag still scrolls several', () => {
+  const dirs = gesture([[100, 0], [250, 0], [400, 0], [560, 0]]);
+  assert.equal(dirs.length >= 3, true, `long drag sent only ${dirs.length}`);
+  assert.equal(new Set(dirs).size, 1, 'a straight drag must not change axis');
+  assert.equal(dirs[0], 'dr');
+});
+
+test('the first step fires as soon as the flick threshold is crossed', () => {
+  assert.deepEqual(planSteps(SWIPE_FIRST_PX, 0, fresh()).dirs, ['dr']);
+  // ...and not a pixel before it.
+  assert.deepEqual(planSteps(SWIPE_FIRST_PX - 1, 0, fresh()).dirs, []);
+});
+
+test('a repeat costs much more travel than the first step', () => {
+  // Just past the first threshold: one step, not two.
+  const a = planSteps(SWIPE_FIRST_PX + SWIPE_REPEAT_PX - 1, 0, fresh());
+  assert.equal(a.dirs.length, 1);
+  // One pixel past first+repeat: the second step lands.
+  const b = planSteps(SWIPE_FIRST_PX + SWIPE_REPEAT_PX, 0, fresh());
+  assert.equal(b.dirs.length, 2);
+});
+
+test('all four directions, with the sign right', () => {
+  assert.deepEqual(planSteps(200, 0, fresh()).dirs, ['dr']);
+  assert.deepEqual(planSteps(-200, 0, fresh()).dirs, ['dl']);
+  assert.deepEqual(planSteps(0, 200, fresh()).dirs, ['dd']);
+  assert.deepEqual(planSteps(0, -200, fresh()).dirs, ['du']);
+});
+
+test('a diagonal drag never emits two axes at once', () => {
+  // The dominant axis wins; a d-pad must never get two directions from one move.
+  const p = planSteps(300, 90, fresh());
+  assert.equal(new Set(p.dirs).size <= 1, true, `mixed axes: ${p.dirs}`);
+  assert.equal(p.dirs[0], 'dr');
+});
+
+test('sensitivity scales both thresholds, preserving its meaning', () => {
+  // Higher sensitivity = smaller steps = more of them for the same travel.
+  const low = gesture([[400, 0]], 0.6).length;
+  const mid = gesture([[400, 0]], 1).length;
+  const high = gesture([[400, 0]], 1.6).length;
+  assert.equal(low <= mid, true, `low=${low} mid=${mid}`);
+  assert.equal(mid <= high, true, `mid=${mid} high=${high}`);
+  assert.equal(high >= 2, true, 'high sensitivity should still scroll');
+});
+
+test('a zero or negative sensitivity cannot divide by zero or invert', () => {
+  for (const s of [0, -1]) {
+    const p = planSteps(200, 0, fresh(), s);
+    assert.deepEqual(p.dirs, ['dr'], `sensitivity ${s} misbehaved`);
+  }
+});
+
+test('no travel emits nothing, and state is unchanged', () => {
+  const p = planSteps(0, 0, fresh());
+  assert.deepEqual(p.dirs, []);
+  assert.deepEqual(p.next, fresh());
+});
+
+test('step count is bounded — a runaway gesture cannot flood input', () => {
+  // An absurd delta must not emit unbounded presses into the box.
+  const p = planSteps(1e9, 0, fresh());
+  assert.equal(p.dirs.length <= 64, true, `emitted ${p.dirs.length}`);
+});
+
+test('reversing mid-gesture steps back the other way', () => {
+  // Swipe right past the threshold, then drag back left past it.
+  const dirs = gesture([[220, 0], [0, 0], [-220, 0]]);
+  assert.equal(dirs.includes('dr'), true);
+  assert.equal(dirs.includes('dl'), true);
+});

--- a/app/lib/swipeSteps.ts
+++ b/app/lib/swipeSteps.ts
@@ -1,0 +1,91 @@
+/**
+ * Swipe-to-d-pad stepping, with ZERO runtime imports.
+ *
+ * THE BUG THIS FIXES (reported 2026-07-26): pressing STEAM and swiping right to
+ * reach the open-apps entry overshot it. The old rule emitted one step per
+ * SWIPE_STEP (56px) of travel with no distinction between the first step and
+ * the rest, so a natural ~200px flick emitted 3-4 presses. That is right for a
+ * long game grid — it is how you scroll one — and wrong for a short menu, where
+ * three presses sail past the entry you wanted.
+ *
+ * So the FIRST step is cheap and REPEATS are expensive: a flick moves one item,
+ * and a deliberate long drag still scrolls. That matches how a TV remote
+ * behaves, and it is the shape the reporter described wanting.
+ *
+ * Split out and import-free so it is unit-testable on bare Node — this is the
+ * safety-critical input path (CLAUDE.md §4), and "how many presses does a
+ * gesture send" is exactly the kind of thing that should not be verified by
+ * feel alone.
+ */
+
+/** Travel before the FIRST step of a gesture. Small, so a flick responds. */
+export const SWIPE_FIRST_PX = 56;
+/**
+ * ADDITIONAL travel before each step after the first.
+ *
+ * 160 was chosen so a normal flick (~200px on a phone) emits exactly one step —
+ * 56 + 160 = 216px is more than a flick — while a deliberate drag across the
+ * pad still scrolls several. Under the old flat 56px rule that same flick sent
+ * three.
+ */
+export const SWIPE_REPEAT_PX = 160;
+
+export type StepDir = 'du' | 'dd' | 'dl' | 'dr';
+
+export type StepState = {
+  /** Travel already turned into steps, per axis (signed). */
+  consumedX: number;
+  consumedY: number;
+  /** Has this gesture emitted anything yet? Gates first-vs-repeat spacing. */
+  stepped: boolean;
+};
+
+export type StepPlan = {
+  dirs: StepDir[];
+  next: StepState;
+};
+
+/**
+ * Steps to emit for a gesture currently at (dx, dy), given what it has already
+ * consumed. Pure: callers apply `next` and fire `dirs` in order.
+ *
+ * `sensitivity` scales BOTH thresholds — higher means smaller steps, i.e. more
+ * of them, preserving the existing preference's meaning.
+ *
+ * The dominant axis wins each iteration, matching the previous behaviour: a
+ * diagonal drag steps along whichever axis has more unconsumed travel, never
+ * both at once, so a d-pad never gets two directions from one movement.
+ */
+export function planSteps(
+  dx: number,
+  dy: number,
+  state: StepState,
+  sensitivity = 1,
+): StepPlan {
+  const sens = sensitivity > 0 ? sensitivity : 1;
+  const first = SWIPE_FIRST_PX / sens;
+  const repeat = SWIPE_REPEAT_PX / sens;
+
+  let { consumedX, consumedY, stepped } = state;
+  const dirs: StepDir[] = [];
+
+  // Bounded: each iteration consumes at least `first` (>0), so this terminates.
+  // Capped anyway — a runaway gesture must not be able to emit unbounded input.
+  for (let guard = 0; guard < 64; guard++) {
+    const availX = dx - consumedX;
+    const availY = dy - consumedY;
+    const ax = Math.abs(availX);
+    const ay = Math.abs(availY);
+    const need = stepped ? repeat : first;
+    if (ax < need && ay < need) break;
+    if (ax >= ay) {
+      consumedX += Math.sign(availX) * need;
+      dirs.push(availX > 0 ? 'dr' : 'dl');
+    } else {
+      consumedY += Math.sign(availY) * need;
+      dirs.push(availY > 0 ? 'dd' : 'du');
+    }
+    stepped = true;
+  }
+  return { dirs, next: { consumedX, consumedY, stepped } };
+}


### PR DESCRIPTION
**Reported:** pressing STEAM and swiping right to reach the open-apps entry sailed past it. The reporter later confirmed YouTube felt fine while Netflix did not — which fits exactly: VacuumTube's TV UI has long rows where three presses just moves three tiles, while Netflix's menu is short enough that three presses skip the target.

**Cause:** `SWIPE_STEP` was a flat 56 px with no first-vs-repeat distinction, so the emit loop turned a natural ~200 px flick into **3–4 d-pad presses**.

**Fix:** first step cheap (56 px), repeats expensive (160 px).

| swipe | old | new |
|---|---|---|
| 120 px | 2 | 1 |
| 200 px | **3** | **1** |
| 600 px | 10 | 4 |

A flick moves one item; a deliberate drag still scrolls.

Stepping moves into an import-free `lib/swipeSteps.ts` so it is unit-testable on bare Node — safety-critical input path (§4), and "how many presses does one gesture send" should not be verified by feel. **11 tests**, the first being the exact reported gesture; also the dominant axis never emitting two directions at once, sensitivity still scaling both thresholds, zero/negative sensitivity not dividing by zero, and a bounded step count so a runaway gesture cannot flood the box.

### Also fixes the test gate itself
CI ran with `--test-force-exit`, which races the reporter: three consecutive local invocations reported **56, 51, 48** tests against **60** without it. CI could skip a *failing* test and still go green — on the input path. Replaced with `--test-timeout=60000`, which kills a hang just as dead (the original reason force-exit existed) while letting every test run. Verified 60/60, terminates in 1.6s.