### PR TITLE
chore(app): reconcile build numbers from the 2.9.30 artifacts (iOS 95 / vc 64)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "93",
+      "buildNumber": "95",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 62
+      "versionCode": 64
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Read off the builds, not the log (CONVENTIONS §5). Doing this every round is what stops the drift that nearly shipped a duplicate `versionCode` on 2.9.29 and would have rebuilt 93 twice this time.

93/63 and 94 are superseded: **93** carried the TV *tab* (replaced by the on-screen toggle in [#281](https://github.com/emerytech/couchside/pull/281)) and **94** predates the swipe-overshoot fix ([#283](https://github.com/emerytech/couchside/pull/283)). **95 / 64** are the first builds carrying both.