### PR TITLE
feat(session): choose which mode the box boots into, on Bazzite AND SteamOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,13 @@ jobs:
       - name: Unit tests (non-Steam shortcut launchers)
         run: python3 tests/test_steam_shortcuts.py
 
+      # The boot-session default. The probe MUST parse steamosctl's output, not
+      # its exit status: on Bazzite it prints a D-Bus UnknownInterface error and
+      # exits 0, so an exit-code probe would claim the backend works on every
+      # Bazzite box. The first test is that exact lie.
+      - name: Unit tests (boot session default)
+        run: python3 tests/test_session_default.py
+
       # Stream-host liveness (the `online` field). remoteclients.vdf lists every
       # host ever streamed from and says nothing about which are ON, so picking a
       # game from a sleeping PC makes Steam offer a multi-GB install instead.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1390,7 +1390,8 @@ def set_caps(mock):
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
                  "screensaver", "couchmode", "desktop", "steamlink", "gaming",
-                 "streamhost", "steammenus", "boxbattery", "file_upload")}
+                 "streamhost", "steammenus", "boxbattery", "file_upload",
+                 "session_default")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1401,6 +1402,7 @@ def set_caps(mock):
         "power_schedule": safe(rtc_available),
         "screensaver": safe(screensaver_available),
         "couchmode": safe(couchmode_available),
+        "session_default": safe(session_default_available),
         "desktop": safe(desktop_available),
         "steamlink": safe(steamlink_available),
         "gaming": safe(gaming_available),
@@ -2780,6 +2782,179 @@ _DESKTOP_SESSIONS = {
     "plasmax11.desktop": "plasma",
 }
 _DEFAULT_DESKTOP_FALLBACK = "plasmax11.desktop"
+
+
+# ---------------------------------------------------------------------------
+# Boot session default — "which mode does this box come up in?"
+#
+# The session-switch ACTIONS above are one-shot: they move you now and leave the
+# boot default alone (see SESSION_ACTIONS). This is the persistent counterpart.
+#
+# TWO BACKENDS, because the obvious one does not work everywhere:
+#
+#   steamosctl  — SteamOS's own utility. MEASURED on Bazzite 2026-07-27: the
+#                 binary ships, but the call fails with
+#                 "org.freedesktop.DBus.Error.UnknownInterface ...
+#                 SessionManagement1" AND STILL EXITS 0. So the probe reads the
+#                 OUTPUT, never the exit status — an exit-code probe would
+#                 report this backend working on every Bazzite box and then
+#                 silently do nothing.
+#
+#   sddm        — the drop-in that actually decides it on Bazzite:
+#                 /etc/sddm.conf.d/steamos.conf carries
+#                 "[Autologin] Session=gamescope-session.desktop". We never edit
+#                 that file; we write our OWN later-sorting drop-in, so removing
+#                 ours restores the box's original behaviour exactly.
+#
+# Root-owned either way, so the sddm backend is gated on a real NOPASSWD grant
+# (last-match evaluated — see _sudo_nopasswd_allows for why exit codes lie
+# there too). No grant, no capability: the setting never appears rather than
+# appearing and failing.
+# ---------------------------------------------------------------------------
+
+# Closed set. A client selects one of these; it never reaches a command line.
+SESSION_DEFAULT_MODES = ("game", "desktop", "last")
+SDDM_DROPIN = "/etc/sddm.conf.d/zz-couchside-session.conf"
+GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"
+SDDM_STATE = "/var/lib/sddm/state.conf"
+
+
+def _steamosctl_session_ok():
+    """True only when steamosctl's session interface ANSWERS.
+
+    Deliberately parses output instead of trusting the exit status: on Bazzite
+    `steamosctl get-default-login-mode` prints a D-Bus UnknownInterface error
+    and exits 0."""
+    try:
+        r = subprocess.run(["steamosctl", "get-default-login-mode"],
+                           capture_output=True, text=True, timeout=5)
+    except Exception:
+        return False
+    out = ((r.stdout or "") + " " + (r.stderr or "")).strip().lower()
+    if not out or "error" in out or "unknowninterface" in out:
+        return False
+    return out.split()[0] in ("game", "desktop")
+
+
+def _sddm_session_ok():
+    """True when sudoers really lets us write our own sddm drop-in."""
+    return _sudo_nopasswd_allows(SDDM_DROPIN)
+
+
+def session_default_backend():
+    """"steamosctl" | "sddm" | None. steamosctl first: on a real Deck it is the
+    supported path and keeps Valve's own state consistent."""
+    if _steamosctl_session_ok():
+        return "steamosctl"
+    if _sddm_session_ok():
+        return "sddm"
+    return None
+
+
+def session_default_available():
+    return session_default_backend() is not None
+
+
+def _sddm_current_session_file():
+    """The session file SDDM will actually use, best-effort.
+
+    Reads OUR drop-in first (it sorts last, so it wins), then falls back to
+    SDDM's recorded last session. Returns "" when neither is readable —
+    degrading to "unknown" rather than claiming a mode we did not verify."""
+    for path in (SDDM_DROPIN, SDDM_STATE):
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    line = line.strip()
+                    if line.lower().startswith("session="):
+                        return os.path.basename(line.split("=", 1)[1].strip())
+        except OSError:
+            continue
+    return ""
+
+
+def session_default_get():
+    """{"available", "backend", "mode"} — mode is game|desktop|unknown."""
+    backend = session_default_backend()
+    if backend is None:
+        return {"available": False, "backend": None, "mode": "unknown"}
+    if backend == "steamosctl":
+        try:
+            r = subprocess.run(["steamosctl", "get-default-login-mode"],
+                               capture_output=True, text=True, timeout=5)
+            m = (r.stdout or "").strip().lower()
+        except Exception:
+            m = ""
+        return {"available": True, "backend": backend,
+                "mode": m if m in ("game", "desktop") else "unknown"}
+    name = _sddm_current_session_file()
+    if name == GAMESCOPE_SESSION_FILE:
+        mode = "game"
+    elif name in _DESKTOP_SESSIONS:
+        mode = "desktop"
+    else:
+        mode = "unknown"
+    return {"available": True, "backend": backend, "mode": mode}
+
+
+def _sddm_write(session_file):
+    """Write our drop-in via a sudo tee whose PATH IS FIXED IN THE SUDOERS RULE.
+
+    session_file is chosen by the agent from a frozen table — never client
+    input — and the whole file body is composed here."""
+    body = ("# Written by Couchside. Delete this file to restore the box's\n"
+            "# original boot behaviour; nothing else was modified.\n"
+            "[Autologin]\n"
+            "Session=%s\n" % session_file)
+    try:
+        r = subprocess.run(["sudo", "-n", "tee", SDDM_DROPIN],
+                           input=body, capture_output=True, text=True, timeout=8)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
+def session_default_set(mode):
+    """Set the boot default. Returns an ActionResult-shaped dict.
+
+    `mode` MUST already be one of SESSION_DEFAULT_MODES — the route checks
+    membership before calling, and nothing here interpolates it."""
+    start = time.monotonic()
+
+    def done(ok, err=""):
+        return {"ok": bool(ok), "exit_code": 0 if ok else 1, "stdout": "",
+                "stderr": err,
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+
+    backend = session_default_backend()
+    if backend is None:
+        return done(False, "no session backend on this box")
+
+    if mode == "last":
+        # SDDM already records the last session; what defeats it is the
+        # Autologin override. So "last" means: point the override at whatever
+        # is running NOW, and keep doing so as the session changes.
+        current = _sddm_current_session_file() or GAMESCOPE_SESSION_FILE
+        target = current if current in _DESKTOP_SESSIONS else GAMESCOPE_SESSION_FILE
+    elif mode == "game":
+        target = GAMESCOPE_SESSION_FILE
+    else:
+        target, _ = _default_desktop_session()
+
+    if backend == "steamosctl":
+        arg = "game" if target == GAMESCOPE_SESSION_FILE else "desktop"
+        try:
+            r = subprocess.run(["steamosctl", "set-default-login-mode", arg],
+                               capture_output=True, text=True, timeout=8)
+        except Exception as e:
+            return done(False, str(e)[:120])
+        out = ((r.stdout or "") + " " + (r.stderr or "")).lower()
+        # Same exit-0 lie as the getter: verify by reading it back.
+        if "error" in out:
+            return done(False, out.strip()[:160])
+        return done(session_default_get().get("mode") == arg)
+
+    return done(_sddm_write(target))
 
 
 def _default_desktop_session():
@@ -4677,6 +4852,22 @@ def _png(width, height, rgb):
             + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
             + chunk(b"IDAT", zlib.compress(raw, 6))
             + chunk(b"IEND", b""))
+
+
+_MOCK_SESSION = {"mode": "game"}
+
+
+def mock_session_default():
+    return {"available": True, "backend": "sddm", "mode": _MOCK_SESSION["mode"]}
+
+
+def mock_session_default_set(mode):
+    if mode == "last":
+        mode = _MOCK_SESSION["mode"]
+    _MOCK_SESSION["mode"] = mode
+    print("[mock] boot session default -> %s" % mode, flush=True)
+    return {"ok": True, "exit_code": 0, "stdout": "", "stderr": "",
+            "duration_ms": 4}
 
 
 def mock_launchers():
@@ -12363,6 +12554,12 @@ class Handler(BaseHTTPRequestHandler):
                                                else list_launchers()),
                                  "create_enabled": bool(ALLOW_APP_LAUNCHERS)},
                            started)
+            elif path == "/api/session/default":
+                # Read-only. Always 200 with available=false rather than 404 so
+                # the app can tell "old agent" (404) from "this box has no
+                # backend" (200 + false).
+                self._send(200, (mock_session_default() if self.mock
+                                 else session_default_get()), started)
             elif path == "/api/downloads":
                 # Always 200 (list may be empty). Old agents lack this route and
                 # 404 -> the app hides the section (probe-and-appear via 404->null).
@@ -13499,6 +13696,32 @@ class Handler(BaseHTTPRequestHandler):
                 if result is None:
                     self._send(404, {"error": "unknown player"}, started)
                     return
+                self._send(200, result, started)
+                return
+
+            # POST /api/session/default: {"mode":"game"|"desktop"|"last"}.
+            # The mode is MEMBERSHIP-CHECKED against a frozen tuple and then
+            # only ever compared, never interpolated: the session file written
+            # comes from the agent's own table.
+            if path == "/api/session/default":
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                    mode = req.get("mode")
+                except (ValueError, UnicodeDecodeError):
+                    self._send(400, {"ok": False, "error": "bad body"}, started)
+                    return
+                if mode not in SESSION_DEFAULT_MODES:
+                    self._send(400, {"ok": False,
+                                     "error": "unknown mode"}, started)
+                    return
+                if not self.mock and not session_default_available():
+                    self._send(404, {"ok": False,
+                                     "error": "no session backend"}, started)
+                    return
+                result = (mock_session_default_set(mode) if self.mock
+                          else session_default_set(mode))
                 self._send(200, result, started)
                 return
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -157,6 +157,10 @@ export type BoxCaps = {
    * (drop dir not writable) hides the card.
    */
   file_upload?: boolean;
+  /** Box can set which session it BOOTS into (agent >= 2.9.58). Two backends:
+   *  SteamOS's steamosctl, or an sddm drop-in on Bazzite — absent when neither
+   *  is usable, so the setting never appears on a box that cannot honour it. */
+  session_default?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -904,9 +908,20 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.steammenus === b.steammenus &&
     a.boxbattery === b.boxbattery &&
     a.launchers === b.launchers &&
-    a.file_upload === b.file_upload
+    a.file_upload === b.file_upload &&
+    a.session_default === b.session_default
   );
 }
+
+/** Which session the box boots into. "last" is a Couchside mode, not an OS one:
+ *  SDDM records the last session but the autologin override defeats it, so the
+ *  agent points the override at whatever is running. */
+export type SessionDefaultMode = 'game' | 'desktop' | 'last';
+export type SessionDefault = {
+  available: boolean;
+  backend: 'steamosctl' | 'sddm' | null;
+  mode: 'game' | 'desktop' | 'unknown';
+};
 
 /** Result of a successful POST /api/upload (agent >= 2.9.54). */
 export type UploadResult = { ok: boolean; name: string; bytes: number; path: string };

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -238,6 +238,10 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // (and to capsEqual) or the "Stream from PC" cap never persists. Optional:
   // absent stays undefined = unknown, so the app probes.
   const steamlink = bool('steamlink');
+  // session_default arrived with agent 2.9.58 (choose the boot session).
+  // Optional like the rest: absent stays undefined = unknown, so the app
+  // probes rather than assuming a box cannot do it.
+  const session_default = bool('session_default');
   // gaming arrived with agent 2.9.25 — same optional-cap drop trap; add it here
   // AND to capsEqual or the cap never persists and the card re-probes on launch.
   const gaming = bool('gaming');
@@ -262,7 +266,7 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
-    boxbattery, launchers, file_upload,
+    boxbattery, launchers, file_upload, session_default,
   };
 }
 

--- a/install.sh
+++ b/install.sh
@@ -809,6 +809,13 @@ JWRAP
 # couchside: allow the Couchside agent (running as $USER_NAME, no TTY) to run
 # exactly the privileged commands it needs, without a password.
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm
+# Boot session default (game / desktop / last). The PATH IS FIXED IN THE RULE,
+# so this grants writing exactly one file and nothing else -- not tee in
+# general. The agent composes the whole body from its own frozen table; the
+# phone only ever selects a mode from a closed set. Our own drop-in sorts after
+# the distro's steamos.conf, so removing this one file restores the box's
+# original boot behaviour exactly, with nothing of theirs edited.
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/sddm.conf.d/zz-couchside-session.conf
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl suspend

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -181,6 +181,7 @@
       "file_upload",
       "gaming",
       "steamlink",
+      "session_default",
       "steammenus",
       "streamhost"
     ]

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for the boot session default (game / desktop / last).
+
+Run: python3 tests/test_session_default.py
+
+WHY THIS EXISTS: the obvious implementation is wrong on Bazzite. MEASURED on a
+real Bazzite box 2026-07-27:
+
+    $ steamosctl get-default-login-mode
+    Error: org.freedesktop.DBus.Error.UnknownInterface: Unknown interface
+      'com.steampowered.SteamOSManager1.SessionManagement1'
+    $ echo $?
+    0
+
+The binary ships, the D-Bus interface behind it does not, AND IT EXITS 0. A
+probe that trusts the exit status reports this backend working on every Bazzite
+box and then silently does nothing — the exact "confident wrong claim" shape
+CLAUDE.md §11 is about. So the probe reads OUTPUT, and the first test here is
+that specific lie.
+
+SECURITY: the mode is a client-supplied string that ends in a root-owned file
+write. It is membership-checked against a frozen tuple and then only ever
+COMPARED — the session filename written comes from the agent's own table. The
+rejection tests are the ones to keep if this file is ever trimmed.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class FakeRun:
+    """Stand in for subprocess.run with a scripted (stdout, stderr, rc)."""
+
+    def __init__(self, stdout="", stderr="", rc=0):
+        self.out, self.err, self.rc = stdout, stderr, rc
+        self.calls = []
+
+    def __call__(self, argv, **kw):
+        self.calls.append(list(argv))
+
+        class R:
+            pass
+        r = R()
+        r.stdout, r.stderr, r.returncode = self.out, self.err, self.rc
+        return r
+
+
+def main():
+    real_run = cs.subprocess.run
+    real_sudo = cs._sudo_nopasswd_allows
+
+    print("the exit-0 lie (Bazzite)")
+    # Verbatim from the real box, including the 0 exit status.
+    cs.subprocess.run = FakeRun(
+        stderr=("Error: org.freedesktop.DBus.Error.UnknownInterface: Unknown "
+                "interface 'com.steampowered.SteamOSManager1.SessionManagement1'"),
+        rc=0)
+    check("steamosctl backend refused despite exit 0",
+          cs._steamosctl_session_ok(), False)
+    # Control: a healthy SteamOS box answers with a mode and IS accepted.
+    cs.subprocess.run = FakeRun(stdout="game\n", rc=0)
+    check("...and a real answer is accepted", cs._steamosctl_session_ok(), True)
+    # An empty answer is not an answer.
+    cs.subprocess.run = FakeRun(stdout="", rc=0)
+    check("empty output is refused", cs._steamosctl_session_ok(), False)
+
+    print("backend selection")
+    cs.subprocess.run = FakeRun(stdout="desktop\n", rc=0)
+    cs._sudo_nopasswd_allows = lambda needle: True
+    check("steamosctl wins when both are usable",
+          cs.session_default_backend(), "steamosctl")
+    cs.subprocess.run = FakeRun(stderr="Error: UnknownInterface", rc=0)
+    check("falls back to sddm on Bazzite", cs.session_default_backend(), "sddm")
+    cs._sudo_nopasswd_allows = lambda needle: False
+    check("no grant -> NO backend (degrade closed)",
+          cs.session_default_backend(), None)
+    check("...so the capability is absent", cs.session_default_available(), False)
+
+    print("the route's allowlist")
+    # Membership is what the route checks; anything outside is a 400.
+    for bad in ("gamemode", "GAME", "", None, "desktop; reboot", "../../x",
+                "last;rm -rf /", 1, True):
+        check("rejects %r" % (bad,), bad in cs.SESSION_DEFAULT_MODES, False)
+    for good in ("game", "desktop", "last"):
+        check("accepts %r" % good, good in cs.SESSION_DEFAULT_MODES, True)
+
+    print("no backend -> set fails rather than pretending")
+    cs.subprocess.run = FakeRun(stderr="Error: UnknownInterface", rc=0)
+    cs._sudo_nopasswd_allows = lambda needle: False
+    check("set() reports failure", cs.session_default_set("game")["ok"], False)
+
+    print("the sddm drop-in body")
+    # We must NEVER edit the box's own steamos.conf; we write our own file.
+    check("drop-in sorts after the distro's own file",
+          os.path.basename(cs.SDDM_DROPIN) > "steamos.conf", True)
+    check("drop-in is a separate file from the distro's",
+          cs.SDDM_DROPIN.endswith("zz-couchside-session.conf"), True)
+
+    written = {}
+
+    def fake_tee(argv, **kw):
+        written["argv"] = list(argv)
+        written["body"] = kw.get("input", "")
+
+        class R:
+            pass
+        r = R()
+        r.returncode, r.stdout, r.stderr = 0, "", ""
+        return r
+
+    cs.subprocess.run = fake_tee
+    cs._sudo_nopasswd_allows = lambda needle: True
+    # force the sddm path
+    ok = cs._sddm_write(cs.GAMESCOPE_SESSION_FILE)
+    check("write returns ok", ok, True)
+    check("writes via sudo tee at the FIXED path",
+          written["argv"], ["sudo", "-n", "tee", cs.SDDM_DROPIN])
+    check("body sets the gamescope session",
+          "Session=%s" % cs.GAMESCOPE_SESSION_FILE in written["body"], True)
+    check("body says how to undo it",
+          "Delete this file" in written["body"], True)
+
+    print("reading the current mode")
+    tmp = tempfile.mkdtemp()
+    drop = os.path.join(tmp, "zz.conf")
+    with open(drop, "w") as f:
+        f.write("[Autologin]\nSession=gamescope-session.desktop\n")
+    old = cs.SDDM_DROPIN
+    cs.SDDM_DROPIN = drop
+    try:
+        check("reads game from our drop-in",
+              cs._sddm_current_session_file(), "gamescope-session.desktop")
+        with open(drop, "w") as f:
+            f.write("[Autologin]\nSession=/usr/share/wayland-sessions/plasma.desktop\n")
+        check("basenames a full path", cs._sddm_current_session_file(),
+              "plasma.desktop")
+        with open(drop, "w") as f:
+            f.write("[Autologin]\n")
+        cs.SDDM_STATE = os.path.join(tmp, "missing.conf")
+        check("no Session anywhere -> empty, not a guess",
+              cs._sddm_current_session_file(), "")
+    finally:
+        cs.SDDM_DROPIN = old
+        cs.subprocess.run = real_run
+        cs._sudo_nopasswd_allows = real_sudo
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        return 1
+    print("all session-default tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The existing session actions are one-shot — they move you now and leave the boot default alone. This is the persistent counterpart: **game / desktop / last**.

### Two backends, because the obvious one is half a solution

The tool this was modelled on ([SteamOS-Session-Manager](https://github.com/MisterAnderson91/SteamOS-Session-Manager)) drives `steamosctl set-default-login-mode`, which is SteamOS-only. **Measured on a real Bazzite box:**

```
$ steamosctl get-default-login-mode
Error: org.freedesktop.DBus.Error.UnknownInterface: Unknown interface
  'com.steampowered.SteamOSManager1.SessionManagement1'
$ echo $?
0
```

The binary ships, the interface does not, **and it exits 0**. So the probe parses *output*, never exit status — an exit-code probe would report the backend healthy on every Bazzite box and silently do nothing. The first test is that exact lie, with a healthy SteamOS response as its control.

On Bazzite the boot session comes from sddm: `/etc/sddm.conf.d/steamos.conf` → `[Autologin] Session=gamescope-session.desktop`. **We never edit that file** — we write our own later-sorting drop-in, so deleting one file restores the box exactly.

### Allowlist

The mode is client-supplied and ends in a **root-owned file write**, so it is membership-checked against a frozen tuple and thereafter only compared — the session filename comes from the agent's own table, never the request. The sudoers grant names the **full path**, permitting exactly one file rather than `tee` in general.

**Degrades closed:** no working steamosctl and no grant → no backend → capability absent, so the setting never appears rather than appearing and failing. Verified both directions.

### Not done, and not claimed

- **No app UI yet** — this lands the distro-specific half.
- **"last" pins the override to the session running when you set it**; keeping it tracking needs a session-change hook.

### Not verified

The steamosctl path on real SteamOS hardware — I have no Deck. Bazzite's probe and file layout were measured on the box; the write is unit-tested against a faked sudo, not executed on hardware.
