### PR TITLE
chore(app): reconcile iOS buildNumber to 96 from the artifact

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "95",
+      "buildNumber": "96",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Read off the build, not the log (CONVENTIONS §5).

Android stays at vc 64 — that build is already on the Play internal track and this round is iOS-only, so bumping it here would strand a number nothing was built at.