### PR TITLE
chore(agent): 2.9.58 — the boot-session feature needs its own version

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,17 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.58
+
+Choose which mode your box starts in.
+
+- **Boots into: Game Mode, Desktop, or Last used.** A new card at the top of the
+  Actions tab. The switches below it have always been one-shot — they change
+  what is on screen now and the box still comes back up however it was set. This
+  is the setting that actually decides that.
+- Works on Bazzite as well as SteamOS. They do it in completely different ways
+  under the hood, so boxes that can't do it simply don't show the card.
+
 ## 2.9.57
 
 Your streaming apps now show up in the phone's Launch tab.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.57"
+VERSION = "2.9.58"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 


### PR DESCRIPTION
The session-default code ([#285](https://github.com/emerytech/couchside/pull/285)) landed while `VERSION` still read **2.9.57**, which was already published. The assets were then republished at that same number, so **two different 2.9.57s exist** — the one on boxes and the one on the release.

Not cosmetic: the box update check compares version **strings**, so a box on the older 2.9.57 sees no newer version and never pulls the code.

**Caught on hardware.** Running the installed agent's own probe on both machines:

```
Bazzite living room   agent 2.9.57   has session code: False
SteamOS Legion Go S   agent 2.9.57   has session code: False
```

Bumping to 2.9.58 gives the feature a version boxes can move to, plus the changelog section `release-agent.sh` refuses to publish without.