### PR TITLE
feat(pad): make TV mode opt-in and label it an unpolished beta

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -931,6 +931,7 @@ function PadScreen() {
   const focusedRef = useRef(false);
   const keepAwakeOn = useKeepAwakeEnabled();
   const keepAwakeTimeout = useKeepAwakeTimeoutMin();
+  const tvNavEnabled = usePref('tvNavEnabled');
 
   // Wake-lock state. wakeHeldRef mirrors what we last told expo-keep-awake so
   // the poll is a no-op in the steady state instead of re-issuing a native call
@@ -1224,7 +1225,10 @@ function PadScreen() {
   // toggled by a chip on the surface. So the segmented control (and the
   // large-pad rule) treat it AS swipe; only the step handler differs.
   const tabMode: PadMode = mode === 'tvnav' ? 'swipe' : mode;
-  const tvNav = mode === 'tvnav';
+  // Gated on the opt-in: a box persisted on 'tvnav' while the pref is off
+  // falls back to plain swipe rather than being stuck in a mode whose
+  // toggle is no longer rendered.
+  const tvNav = mode === 'tvnav' && tvNavEnabled;
   const largePad =
     trackpadLarge && (mode === 'trackpad' || mode === 'swipe' || tvNav);
   // Auto-raise the phone keyboard when the box raises its own. The counter is
@@ -1549,7 +1553,7 @@ function PadScreen() {
   // arrow keys for Steam's own UI, pointer jumps for browser streaming apps),
   // not a separate input device, and the mode row was already full at phone
   // width once the STEAM tab appears.
-  const tvToggleChip = (
+  const tvToggleChip = !tvNavEnabled ? null : (
     <Pressable
       onPress={() => {
         setMode(tvNav ? 'swipe' : 'tvnav');

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -777,6 +777,7 @@ function SetupBody() {
   const mediaHoldSkip = usePref('mediaHoldSkip');
   const mediaHoldSkipSec = usePref('mediaHoldSkipSec');
   const tvStepPx = usePref('tvStepPx');
+  const tvNavEnabled = usePref('tvNavEnabled');
   const themeMode = useThemeMode();
   const accent = useAccent();
   const scheme = useResolvedScheme();
@@ -1471,9 +1472,19 @@ function SetupBody() {
                   }}
                 />
               )}
+              <TogglePref
+                label="TV navigation (beta)"
+                sub="UNPOLISHED — off by default. Adds a TV toggle to the swipe pad that moves the pointer in jumps instead of sending arrow keys. It does NOT feel like a TV remote: a d-pad moves a focus ring the app draws, while this moves a visible mouse cursor, and streaming sites have no focus model for it to land on. Useful on surfaces that do; rough everywhere else."
+                value={tvNavEnabled}
+                onValueChange={(v) => {
+                  void setPref('tvNavEnabled', v);
+                  hapticSelection();
+                }}
+              />
+              {tvNavEnabled && (
               <SegPref
                 label="TV mode step size"
-                sub="How far one swipe step moves the pointer in TV mode. TV mode drives the cursor in tile-sized jumps for streaming apps, where arrow keys only scroll the page. Bigger steps cross a row faster; smaller ones land on dense grids more reliably."
+                sub="How far one swipe step moves the pointer in TV mode. Bigger steps cross a row faster; smaller ones land on dense grids more reliably. No size makes it snap to tiles — nothing is reading the layout, so this is a distance, not a target."
                 options={TV_STEPS.map((n) => ({
                   value: n,
                   label: n === 160 ? 'Small' : n === 260 ? 'Medium' : 'Large',
@@ -1484,6 +1495,7 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+              )}
               <SegPref
                 label="Open on"
                 sub="The tab the app starts on. Pairing wins on first run — with no box paired you still land on Setup."

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -188,6 +188,19 @@ export type Prefs = {
    *  drawn on. Too small and a row takes many swipes; too large and it skips
    *  tiles. */
   tvStepPx: TvStepPx;
+  /** Show the TV-navigation toggle on the swipe surface.
+   *
+   *  OFF by default, and deliberately so. TV nav drives the POINTER in jumps,
+   *  and the premise was that this would feel like a d-pad. It does not: a
+   *  d-pad moves a focus ring the app draws, whereas a cursor is just a cursor,
+   *  and Netflix's web UI has no focus model for the jumps to land on. Reported
+   *  from the couch as "it just moves the mouse cursor a bit and you can see the
+   *  cursor" — which is an accurate description of what it is.
+   *
+   *  Kept because it is still useful on surfaces that DO have a focus model,
+   *  and because hiding the cursor would be worse (with no focus ring, the
+   *  cursor is the only feedback there is). Opt-in rather than removed. */
+  tvNavEnabled: boolean;
 };
 
 export const DEFAULTS: Prefs = {
@@ -226,6 +239,7 @@ export const DEFAULTS: Prefs = {
   mediaHoldSkip: true,
   mediaHoldSkipSec: 30,
   tvStepPx: TV_STEP_DEFAULT,
+  tvNavEnabled: false,
 };
 
 /** The choices each select-style pref offers (kept next to the store it feeds). */
@@ -338,6 +352,7 @@ function normalize(raw: unknown): Prefs {
       DEFAULTS.mediaHoldSkipSec,
     ) as MediaHoldSkipSec,
     tvStepPx: num(o.tvStepPx, TV_STEPS, DEFAULTS.tvStepPx) as TvStepPx,
+    tvNavEnabled: bool(o.tvNavEnabled, DEFAULTS.tvNavEnabled),
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,9 +159,20 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   Nothing is held between steps, so there is no latched axis to release.
 - Step size is a preference (Small/Medium/Large = 160/260/380 px) because "one tile" is
   not a fixed distance: it depends on the service's grid density and the screen.
-- **Still unproven:** that uinput pointer motion reaches a browser under gamescope.
-  Keyboard is verified; the mouse test was inconclusive (injected moves produced no pixel
-  change on a static profile picker). Worth a live check with this mode on a real phone.
+- **The open question got answered, and the answer was no.** Tested from the couch
+  2026-07-26: "it just moves the mouse cursor a bit and you can see the cursor." So uinput
+  pointer motion DOES reach the browser under gamescope — the thing this entry listed as
+  unproven is now proven — but the premise the mode was built on does not hold. The claim
+  above ("it FEELS like a d-pad while being a pointer") assumed the jump would land ON
+  something. A d-pad moves a focus ring the app draws; this moves a visible cursor, and a
+  browser tile grid has no focus model for a jump to land on, so nothing highlights and the
+  step size is just a distance. Hiding the cursor would be worse, not better: with no focus
+  ring, the cursor is the only feedback there is. Bigger steps overshoot different things.
+- **Demoted to opt-in 2026-07-26 (`tvNavEnabled`, default OFF)** rather than removed. It is
+  still the right shape on any surface that DOES draw focus, and the machinery is shared
+  with SWIPE so it costs nothing to keep. Labelled UNPOLISHED in Preferences, in the copy,
+  so nobody turns it on expecting a TV remote. Do not promote it back to default-on without
+  a focused-window capability to snap against — that is the missing piece, not step tuning.
 
 ### Packaged media shortcuts, installable from the phone
 - **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** shortcut


### PR DESCRIPTION
TV navigation moves behind a preference, `tvNavEnabled`, **default OFF**. The toggle chip does not render unless the pref is on, and the step-size preference is hidden with it.

## Why

Tested from the couch: *"it just moves the mouse cursor a bit and you can see the cursor."*

That is an accurate description of what it does. It also answers the open question this feature's roadmap entry was carrying — uinput pointer motion **does** reach a browser under gamescope, which was listed as unproven — while invalidating the thing built on top of it.

The mode was sold as feeling like a d-pad while being a pointer. That assumed the jump would land *on* something. A d-pad moves a focus ring the app draws; this moves a visible cursor, and a browser tile grid has no focus model for a jump to land on, so nothing highlights and the step size is just a distance. Two follow-ups that look obvious are both worse:

- **Hide the cursor** — with no focus ring, the cursor is the only feedback there is.
- **Tune the step size** — bigger steps overshoot different things.

Kept rather than removed: it is still the right shape on any surface that *does* draw focus, and it shares all its machinery with `SwipeSurface`, so the ongoing cost is the pref itself.

## What changed

- `app/lib/prefs.ts` — `tvNavEnabled` in `Prefs` / `DEFAULTS` / `normalize()`. The reasoning is recorded at the field so the default is not later "fixed" by someone assuming it was an oversight.
- `app/app/(tabs)/pad.tsx` — chip gated on the pref. `tvNav` is `mode === 'tvnav' && pref`, so a box already persisted on that mode falls back to plain swipe rather than being stuck in a mode whose toggle is no longer drawn.
- `app/app/(tabs)/setup.tsx` — the toggle, labelled **TV navigation (beta)** with sub-text opening on `UNPOLISHED — off by default` and stating plainly what it is not. Step size nests under it.
- Rewrote the step-size sub-text, which still claimed the cursor moves "in tile-sized jumps for streaming apps". It does not snap to tiles — nothing reads the layout. Leaving that would keep selling the failed premise from inside the feature.
- `docs/ROADMAP.md` — records the negative result and what would actually unblock it.

## Verified

Driven in the web harness by **pressing the real switch**, not by editing localStorage, and **both states observed**:

| pref | swipe surface renders |
|---|---|
| off (default) | `BACK  STEAM  ⋯  MENU` |
| on | `TV` + `BACK  STEAM  ⋯  MENU` |

The other three chips appear in both readings — that is the control, so the TV chip's absence is specific to it and not a failed render. Also confirmed the step-size pref appears and disappears with the toggle, and that a box stored on `padMode: 'tvnav'` with the pref off comes up on a normal mode row.

`tsc --noEmit` clean. 60/60 app tests pass.

## NOT verified

- **No unit test for the pref.** `lib/prefs.ts` imports `expo-secure-store` and `react`, so it will not load in the bare-Node runner the import-free libs use; a test means module mocking. The harness press is the evidence here.
- **Nothing re-tested on hardware.** This change only hides an existing feature, and that feature's on-box behaviour is exactly what was rejected.

## Not fixed here

Auto-switching TV mode still needs a focused-window agent capability. Until that exists there is nothing to snap to, and no step size substitutes for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)