### PR TITLE
docs(readme): link the Bazzite docs page and the Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ curl -fsSL https://couchside.tv/install.sh | bash
 
 The installer copies the service to `~/.local/opt/couchside/`, generates a token at `/etc/couchside/token`, installs a scoped sudoers rule, enables `couchside.service`, opens `8787/tcp` in the local firewall, and finishes by printing a pairing QR code.
 
+Running **Bazzite**? The same steps are in the official [Bazzite documentation](https://docs.bazzite.gg/Advanced/couchside/). On **Windows**, download [`CouchsideSetup.exe`](https://couchside.tv/windows) instead and double-click it.
+
 ## Get the app
 
 - **Android → [Google Play](https://play.google.com/store/apps/details?id=com.ets3d.rescueremote)** — available now.


### PR DESCRIPTION
Bazzite merged a Couchside page into its own docs ([ublue-os/docs.bazzite.gg#489](https://github.com/ublue-os/docs.bazzite.gg/pull/489), merged 2026-07-27) and it is live:

- https://docs.bazzite.gg/Advanced/couchside/ — "Setting Up Couchside"
- https://docs.bazzite.gg/General/community-links/ — community links entry

Nothing in this repo or on couchside.tv pointed back at it, so the link was one-way. This adds it to the README's install section, and points Windows readers at `CouchsideSetup.exe` instead of leaving `curl … | bash` as the only visible path.

**Verified:** both docs URLs return 200 and render the Couchside content. The matching site-side link shipped to couchside.tv/setup in ets3d `c83bffb`.

**Not verified:** nothing to exercise — docs-only change, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)