### PR TITLE
fix(app): reject leading-zero octets in the LAN-address gate (KI-033)

### DIFF
--- a/app/lib/__tests__/lanIp.test.ts
+++ b/app/lib/__tests__/lanIp.test.ts
@@ -1,0 +1,82 @@
+/**
+ * LAN-address gate — lib/lanIp.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * THE BUG THIS EXISTS FOR (KI-033, found 2026-07-27): `010.1.1.5` was accepted
+ * as private. JS reads octets with `Number()`, always decimal, so `'010'` is 10;
+ * the OS reads a leading zero as octal via inet_aton, so it resolves to 8.1.1.5,
+ * a public address. The gate exists specifically to stop a value learned from an
+ * unauthenticated ping response from becoming a bearer-token destination, so an
+ * accept there defeats the whole control.
+ *
+ * Every octal case below is paired with the plain-decimal address it was
+ * MEASURED to resolve to, and with a control in the opposite direction, per
+ * CLAUDE.md §11 rule 3 — an all-rejects test would pass just as well against a
+ * function that rejects everything.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isValidLanIp } from '../lanIp.ts';
+
+test('THE BUG: a leading zero cannot smuggle a public address through', () => {
+  // Measured: inet_aton('010.1.1.5') -> 8.1.1.5, which is public.
+  assert.equal(isValidLanIp('010.1.1.5'), false, '010.1.1.5 resolves to 8.1.1.5');
+  // CONTROL, the other direction: the address it *looks* like really is private,
+  // so this test cannot pass by rejecting everything shaped like an IP.
+  assert.equal(isValidLanIp('10.1.1.5'), true);
+  // CONTROL: what it actually resolves to is rejected when written plainly.
+  assert.equal(isValidLanIp('8.1.1.5'), false);
+});
+
+test('leading zeros are refused in every octet position', () => {
+  for (const v of ['010.1.1.5', '10.010.1.5', '10.1.010.5', '10.1.1.05', '0127.0.0.1']) {
+    assert.equal(isValidLanIp(v), false, `${v} was accepted`);
+  }
+  // A bare zero octet is legitimate and must still pass.
+  assert.equal(isValidLanIp('10.0.0.1'), true);
+  assert.equal(isValidLanIp('192.168.0.1'), true);
+});
+
+test('every private range is accepted', () => {
+  for (const v of [
+    '10.0.0.1', '10.255.255.254',
+    '127.0.0.1',
+    '192.168.1.5',
+    '172.16.0.1', '172.31.255.254',
+    '169.254.1.1', // link-local
+    '100.64.0.1', '100.127.255.254', // CGNAT — Tailscale lives here
+  ]) {
+    assert.equal(isValidLanIp(v), true, `${v} was rejected`);
+  }
+});
+
+test('public and near-miss ranges are refused', () => {
+  for (const v of [
+    '8.8.8.8', '1.1.1.1', '203.0.113.5',
+    '172.15.0.1', '172.32.0.1', // just outside 172.16/12
+    '192.169.1.1', '191.168.1.1', // near-miss on 192.168
+    '100.63.255.255', '100.128.0.1', // just outside CGNAT
+    '169.253.1.1', // just outside link-local
+  ]) {
+    assert.equal(isValidLanIp(v), false, `${v} was accepted`);
+  }
+});
+
+test('anything that is not four decimal octets is refused', () => {
+  for (const v of [
+    'bazzite.local', 'localhost', '', ' ', '10.1.1', '10.1.1.5.6',
+    '10.1.1.-5', '10.1.1.5 ', ' 10.1.1.5', '10.1.1.5/24', '10.1.1.5:8787',
+    '::1', 'fe80::1', '0x0a.1.1.5', '167772161', // the integer form of 10.0.0.1
+    '10.1.1.256', '256.1.1.1',
+  ]) {
+    assert.equal(isValidLanIp(v), false, `${v} was accepted`);
+  }
+});
+
+test('a non-string cannot throw or sneak through', () => {
+  for (const v of [null, undefined, 42, {}, [], true]) {
+    assert.equal(isValidLanIp(v as unknown as string), false, `${String(v)} was accepted`);
+  }
+});

--- a/app/lib/lanIp.ts
+++ b/app/lib/lanIp.ts
@@ -1,0 +1,52 @@
+/**
+ * Is this string an IPv4 literal on the LAN? ZERO runtime imports.
+ *
+ * WHY IT IS ITS OWN FILE. This is a security control: it is the gate that stops
+ * a value learned from an UNAUTHENTICATED source from becoming a destination we
+ * send a bearer token to. It used to live in lib/settings.ts, which imports
+ * react-native and expo-secure-store and therefore cannot be loaded by the bare
+ * Node test runner this repo uses for pure modules — so the rule below shipped
+ * with no test, and a hole sat in it (KI-033). Import-free so the corpus in
+ * lib/__tests__/lanIp.test.ts can actually exercise it.
+ *
+ * THE HOLE, MEASURED 2026-07-27. The old pattern was `\d{1,3}` per octet, then
+ * `Number()`. JS `Number()` is always decimal, so `Number('010')` is 10 and
+ * `010.1.1.5` was read as 10.x.x.x — private, accepted. Every OS resolver reads
+ * a leading zero as OCTAL (inet_aton), so that same string resolves to
+ * 8.1.1.5 — a PUBLIC address. With controls in both directions:
+ *
+ *     input          this function   inet_aton resolves to
+ *     10.1.1.5       accept          10.1.1.5     <- control, correct accept
+ *     8.1.1.5        reject          8.1.1.5      <- control, correct reject
+ *     010.1.1.5      WAS accept      8.1.1.5      <- the escape, now rejected
+ *
+ * The rule is therefore: an octet is a bare `0`, or 1-3 digits not starting
+ * with `0`. Never widen this back to `\d{1,3}`; the length cap alone only
+ * catches the four-digit forms like `0177`.
+ */
+
+/** An octet: a single 0, or 1-3 digits with no leading zero. */
+const OCTET = '(0|[1-9]\\d{0,2})';
+const IPV4 = new RegExp(`^${OCTET}\\.${OCTET}\\.${OCTET}\\.${OCTET}$`);
+
+/**
+ * True for an IPv4 literal in private / loopback / link-local / CGNAT space.
+ *
+ * Rejects public addresses and rejects hostnames outright — a name is not
+ * checkable here, since what it resolves to is up to whoever answers DNS.
+ * IPv6 is intentionally unsupported: returning false for it is the closed
+ * direction, so an IPv6 literal is simply never accepted as a fallback.
+ */
+export function isValidLanIp(v: string): boolean {
+  if (typeof v !== 'string') return false;
+  const m = IPV4.exec(v);
+  if (!m) return false;
+  const [a, b, c, d] = m.slice(1).map(Number);
+  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
+  if (a === 10 || a === 127) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (Tailscale lives here)
+  return false;
+}

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { isValidLanIp } from './lanIp';
 import * as SecureStore from 'expo-secure-store';
 
 import type { BoxCaps } from './api';
@@ -159,24 +160,16 @@ export function nextBoxId(): string {
 // ---------- normalization ----------
 
 /**
- * Conservative validator for cached fallback IPs (Box.lastIp): an IPv4
- * literal in private / loopback / link-local / CGNAT (Tailscale) space.
- * Rejects public addresses and hostnames so a value learned from an
- * UNAUTHENTICATED ping response can never redirect bearer-token traffic off
- * the LAN. (IPv6 fallback intentionally unsupported for now.)
+ * Conservative validator for cached fallback IPs (Box.lastIp).
+ *
+ * Re-exported from lib/lanIp.ts rather than defined here: this module imports
+ * react-native and expo-secure-store, so it cannot be loaded by the bare-Node
+ * test runner, and this rule shipped untested long enough to grow a hole
+ * (KI-033 — a leading-zero octet read as decimal by JS and octal by the OS).
+ * The re-export keeps the existing importers working; lib/lanIp.ts holds the
+ * rule and the reasoning, and lib/__tests__/lanIp.test.ts holds the corpus.
  */
-export function isValidLanIp(v: string): boolean {
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(v);
-  if (!m) return false;
-  const [a, b, c, d] = m.slice(1).map(Number);
-  if (a > 255 || b > 255 || c > 255 || d > 255) return false;
-  if (a === 10 || a === 127) return true;
-  if (a === 192 && b === 168) return true;
-  if (a === 172 && b >= 16 && b <= 31) return true;
-  if (a === 169 && b === 254) return true; // link-local
-  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT (Tailscale lives here)
-  return false;
-}
+export { isValidLanIp };
 
 /** A canonical "aa:bb:cc:dd:ee:ff" MAC, or null. Accepts ':' or '-' separators
  * and lowercases the result. Rejects the all-zero address, which no NIC uses


### PR DESCRIPTION
## The bug

`isValidLanIp` accepted `010.1.1.5` as a private address. JS reads octets with `Number()` — always decimal, so `'010'` is 10 and the string parses as `10.x.x.x`. Every OS resolver reads a leading zero as **octal** via `inet_aton`, so the same string resolves to **`8.1.1.5`** — public.

Measured, with controls in both directions:

| input | old gate | `inet_aton` resolves to |
|---|---|---|
| `10.1.1.5` | accept ✓ (control) | `10.1.1.5` |
| `8.1.1.5` | reject ✓ (control) | `8.1.1.5` |
| `010.1.1.5` | **accept** | **`8.1.1.5`** |

## Why it matters

The gate guards the `lastIp` persist path in `SettingsContext`, whose own comment says why it exists: a value learned from an **unauthenticated** `/api/ping` response must never become a destination bearer-token traffic is sent to. A hostile LAN responder returning `010.1.1.5` got a public address silently persisted as a box's fallback IP.

Not remotely exploitable alone — it needs a host answering the LAN sweep, which is inside the product's trust boundary. Rated high anyway (KI-033): it defeats a control added for exactly this scenario.

## The fix

Octet rule becomes: a bare `0`, or 1–3 digits **not starting with `0`**. The old `\d{1,3}` length cap only blocked 4-digit forms like `0177`.

The rule moves to a new import-free module `app/lib/lanIp.ts`. Its old home, `lib/settings.ts`, imports `react-native` + `expo-secure-store` and cannot load in the bare-Node test runner — which is *why* this rule shipped untested long enough to grow the hole. `settings.ts` re-exports it; all three existing importers (`SettingsContext`, `RemotePowerBar`, `settings.ts` itself) are unchanged.

## Verified

- New corpus `app/lib/__tests__/lanIp.test.ts` (6 tests): the octal escape in every octet position, paired accept/reject controls (cannot pass by rejecting everything), all five private ranges, near-miss public ranges (`172.15`, `172.32`, `192.169`, `100.63`, `100.128`, `169.253`), non-string inputs.
- Picked up by the existing CI glob (`lib/__tests__/*.test.ts`).
- Full app suite 88/88; `tsc --noEmit` clean.

## NOT verified

- No runtime test that the *OS* resolves `010.1.1.5` to `8.1.1.5` from inside the app — that measurement was made with `inet_aton` on the dev machine. The gate now rejects the string regardless of what any resolver would do with it, which is the closed direction.

Found by adversarial review while designing the QR pairing scanner (next PR), which validates scanned hosts with this same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)