### PR TITLE
feat(app): in-app QR pairing scanner (Netflix-style) + one validator for every pairing payload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,18 +318,17 @@ jobs:
       - name: Unit tests (steam settings menus)
         run: python3 tests/test_steam_menus.py
 
-      # Makes branch feat/demo-mode UNMERGEABLE. Demo mode (tap indicators + a
-      # rear-camera PiP, for recording promo video) is a developer tool shipped as
-      # an ad-hoc, bundle-id-forked build that never touches TestFlight. Its own
-      # isolation test lives on that branch -- which is useless as a merge guard,
-      # because merging the branch merges its approval. So the guard lives HERE.
-      # The trap it catches: on that branch the expo-camera CONFIG PLUGIN is
-      # conditional but the DEPENDENCY is not, and autolinking keys off
-      # package.json -- measured, 24 modules with expo-camera in node_modules but
-      # absent from package.json, and it does not link. Declare it and it does. A
-      # merge would therefore compile camera code into the shipping binary with no
-      # purpose string. Red CI beats finding that out at upload.
-      - name: Unit tests (no camera in the shipping app)
+      # Two invariants, one guard (history in the test's own docstring):
+      # 1. The shipping camera is QR-PAIRING ONLY and MIC-LESS. expo-camera became
+      #    legitimate 2026-07-27 (the in-app pairing scanner, PR #292) -- but its
+      #    plugin defaults add RECORD_AUDIO + an iOS mic string, so the pins
+      #    (recordAudioAndroid/microphonePermission false) are enforced here.
+      # 2. Branch feat/demo-mode stays UNMERGEABLE (rear-camera PiP promo tool,
+      #    ad-hoc bundle-id fork). Its own isolation test is useless as a merge
+      #    guard -- merging the branch merges its approval -- so the guard lives
+      #    HERE. Autolinking keys off package.json (measured), which is why the
+      #    dependency and plugin must arrive together or not at all.
+      - name: Unit tests (camera is pairing-only + mic-less; demo mode unmergeable)
         run: python3 tests/test_no_camera_in_shipping_app.py
 
       # Windows non-Steam launchers (Epic / GOG / Xbox). These take a client id,

--- a/app/app.json
+++ b/app/app.json
@@ -58,7 +58,15 @@
           }
         }
       ],
-      "expo-iap"
+      "expo-iap",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "Couchside uses the camera only to read the pairing code shown on your box's screen.",
+          "microphonePermission": false,
+          "recordAudioAndroid": false
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -26,6 +26,8 @@ import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
 import { BoxScanPair } from '@/components/BoxScanPair';
+import { BoxScanQr } from '@/components/BoxScanQr';
+import { buildPairLink } from '@/lib/pairLink';
 import { GuideHoldSetup } from '@/components/GuideHoldSetup';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
@@ -75,24 +77,6 @@ import {
   type Palette,
 } from '@/lib/theme';
 
-/**
- * Build the pairing link for a box.
- *
- * HTTPS (not couchside://) because Android camera apps won't open custom
- * schemes from a QR; every scanner opens https. The couchside.tv/pair page
- * relaunches the app via the scheme (or offers install links). Params ride
- * the #FRAGMENT so the token never leaves the browser. Fragments aren't
- * sent to the server or its logs.
- */
-function pairingUrl(box: Box): string {
-  let q =
-    `host=${encodeURIComponent(box.host)}` +
-    `&port=${encodeURIComponent(String(box.port))}` +
-    `&token=${encodeURIComponent(box.token)}`;
-  // Pass the cached fallback IP along so the next device starts resilient too.
-  if (box.lastIp) q += `&ip=${encodeURIComponent(box.lastIp)}`;
-  return `https://couchside.tv/pair#${q}`;
-}
 
 /**
  * Modal that renders a box's pairing deep link as a scannable QR on a white
@@ -131,6 +115,11 @@ const SETUP_GUIDE_URL = 'https://couchside.tv/#install';
 
 function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void }) {
   const styles = useThemedStyles(makeStyles);
+  // The shared writer refuses a box whose link the shared reader would refuse
+  // (a host outside the LAN allowlist, a malformed port/token). Rendering a QR
+  // this same app's scanner rejects would be worse than not rendering one, so
+  // such a box gets the copy-by-hand fallback plus one line of why.
+  const url = box ? buildPairLink(box) : null;
   return (
     <Modal
       visible={box != null}
@@ -141,10 +130,16 @@ function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void
         {/* Stop taps on the sheet itself from closing the modal. */}
         <Pressable style={styles.qrSheet} onPress={() => {}}>
           <Text style={styles.qrTitle}>{box?.name ?? 'Pair box'}</Text>
-          <View style={styles.qrCard}>
-            {box && <QrView value={pairingUrl(box)} size={QR_SIZE} />}
-          </View>
-          <Text style={styles.qrCaption}>Scan with another device to pair it</Text>
+          {url != null && (
+            <View style={styles.qrCard}>
+              <QrView value={url} size={QR_SIZE} />
+            </View>
+          )}
+          <Text style={styles.qrCaption}>
+            {url != null
+              ? 'Scan with another device to pair it'
+              : "This box's address can't be encoded as a scannable code — enter these details by hand on the other device instead."}
+          </Text>
           {box && (
             <View style={styles.qrFallback}>
               <Text style={styles.qrFallbackText} selectable>
@@ -931,6 +926,8 @@ function SetupBody() {
       port: conn.port,
       token: conn.token,
       name: name.trim() || undefined,
+      // The one hand-typed path — see AddBoxInput.userTypedHost.
+      userTypedHost: true,
     });
     // Clear the add form after a successful add/pair.
     setName('');
@@ -1136,6 +1133,7 @@ function SetupBody() {
             carries the whole flow. */}
         <View style={styles.card}>
           <BoxScanPair />
+          <BoxScanQr />
         </View>
         {/* Manual host/port/token: collapsed fallback for headless / cross-subnet
             / non-Linux boxes that scanning can't reach. */}

--- a/app/components/BoxScanQr.tsx
+++ b/app/components/BoxScanQr.tsx
@@ -1,0 +1,551 @@
+/**
+ * Scan the pairing QR with the phone's own camera — the in-app version of
+ * pointing the system camera at the box's /pair screen, minus the detour
+ * through Safari and couchside.tv. Owner's reference: Netflix's scanner
+ * (full-bleed feed, four corner brackets, translucent bottom card).
+ *
+ * TRUST MODEL — why this is not a straight Netflix copy. Netflix's card says
+ * "Your controller will open automatically": auto-apply, no questions. Their QR
+ * resolves to Netflix-controlled infrastructure, so the worst a hostile code
+ * can do is nothing. Ours literally says "here is a host to trust and a bearer
+ * token to send it" — the app then opens a WebSocket to that host and polls it
+ * forever. So every decode goes through parsePairLink (SCAN_FORMS — the camera
+ * accepts ONLY the https form the agent emits), a hostile-but-valid code for a
+ * box the user already owns must be CONFIRMED before its token is overwritten
+ * (pairCollision), and the raw payload is never rendered, logged, or navigated
+ * with. The reject copy explains without echoing.
+ *
+ * THE LATCH (load-bearing, do not simplify): onBarcodeScanned fires at FRAME
+ * RATE while a code is in view. The SDK's internal 500 ms throttle only skips
+ * byte-identical event JSON, and bounds/cornerPoints jitter every handheld
+ * frame, so it never matches. A useState guard is too late — setState batches
+ * while more frames land. The `locked` ref closes the door synchronously, and
+ * flipping the callback to `undefined` sets the native barcodeScannerEnabled
+ * prop false, tearing the analyzer down (verified in the SDK 57 source; the
+ * iOS-only `active` prop is NOT that switch — Android ignores it).
+ *
+ * Camera is a NATIVE module: on a binary without it (an OTA bundle on an older
+ * build) the trigger row renders nothing, mirroring lib/boxDiscovery's UDP
+ * gate. Deliberately NOT gated off Platform.OS === 'web' — expo-camera has a
+ * real web implementation, and the web harness pressing this control is the
+ * §6 verification path.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  AppState,
+  Linking,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+
+import { hapticError, hapticSelection, hapticSuccess, hapticWarning } from '@/lib/haptics';
+import {
+  SCAN_FORMS,
+  pairCollision,
+  parsePairLink,
+  type PairLink,
+  type PairRejectReason,
+} from '@/lib/pairLink';
+import { navigateAfterPair } from '@/lib/postPair';
+import { DEFAULT_PORT } from '@/lib/settings';
+import { useBoxes } from '@/lib/SettingsContext';
+import { useThemedStyles, type Palette } from '@/lib/theme';
+
+// Lazy native-module gate — mirrors lib/boxDiscovery's UDP require. `null`
+// hides the whole feature, so a JS bundle on an older binary degrades to
+// "the row isn't there" instead of crashing at import (§3.7).
+type CameraModule = {
+  CameraView: React.ComponentType<Record<string, unknown>>;
+  useCameraPermissions: () => [
+    { granted: boolean; canAskAgain: boolean } | null,
+    () => Promise<unknown>,
+  ];
+};
+let Camera: CameraModule | null = null;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const m = require('expo-camera');
+  Camera = m?.CameraView && m?.useCameraPermissions ? (m as CameraModule) : null;
+} catch {
+  Camera = null;
+}
+
+type Phase =
+  | { k: 'scanning' }
+  | { k: 'rejected'; reason: PairRejectReason }
+  | { k: 'confirm'; link: PairLink; name: string }
+  | { k: 'pairing' }
+  | { k: 'done'; name: string }
+  | { k: 'failed' };
+
+/** Hold a reject banner long enough to read, then resume scanning. */
+const REJECT_HOLD_MS = 2500;
+/** Ignore re-decodes of the SAME rejected payload for this long, or the
+ *  banner strobes at frame rate while the user holds the phone still. */
+const SAME_REJECT_MS = 3000;
+/** Let "Paired" land before the modal closes and the app navigates. */
+const DONE_HOLD_MS = 600;
+/** Show the step-closer hint if nothing has decoded yet. */
+const HINT_AFTER_MS = 6000;
+
+const REJECT_COPY: Record<PairRejectReason, { title: string; sub: string }> = {
+  'store-code': {
+    title: "That's the install code",
+    sub: 'You already have the app. The pairing code is the big one, under "Pair your phone".',
+  },
+  'not-pair-link': {
+    title: 'Not a Couchside pairing code',
+    sub: "Scan the big code on your box's screen, under \"Pair your phone\".",
+  },
+  'bad-host': {
+    title: 'That code points off your network',
+    sub: "A Couchside code only ever names a box on your own network. This one doesn't, so it was ignored.",
+  },
+  'bad-port': {
+    title: 'That code is damaged',
+    sub: 'Part of it didn\'t read cleanly. Show the code again on the box and scan it once more.',
+  },
+  'bad-token': {
+    title: 'That code is damaged',
+    sub: 'Part of it didn\'t read cleanly. Show the code again on the box and scan it once more.',
+  },
+  'missing-host': {
+    title: 'That code is damaged',
+    sub: 'Part of it didn\'t read cleanly. Show the code again on the box and scan it once more.',
+  },
+  'missing-token': {
+    title: 'That code is damaged',
+    sub: 'Part of it didn\'t read cleanly. Show the code again on the box and scan it once more.',
+  },
+  'duplicate-param': {
+    title: 'Not a Couchside pairing code',
+    sub: "Scan the big code on your box's screen, under \"Pair your phone\".",
+  },
+  empty: {
+    title: 'Not a Couchside pairing code',
+    sub: "Scan the big code on your box's screen, under \"Pair your phone\".",
+  },
+  'too-long': {
+    title: 'Not a Couchside pairing code',
+    sub: "Scan the big code on your box's screen, under \"Pair your phone\".",
+  },
+};
+
+export function BoxScanQr() {
+  const styles = useThemedStyles(makeStyles);
+  const [open, setOpen] = useState(false);
+
+  // Native module absent (older binary running a newer OTA bundle): no row at
+  // all — probe-and-appear, same as every capability-gated control.
+  if (!Camera) return null;
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          hapticSelection();
+          setOpen(true);
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="Scan a pairing code"
+        style={({ pressed }) => [styles.trigger, pressed && styles.pressed]}>
+        <Ionicons name="qr-code-outline" size={16} color={styles.triggerText.color as string} />
+        <Text style={styles.triggerText}>Scan a pairing code</Text>
+      </Pressable>
+      {open && <ScannerModal onClose={() => setOpen(false)} />}
+    </>
+  );
+}
+
+function ScannerModal({ onClose }: { onClose: () => void }) {
+  const styles = useThemedStyles(makeStyles);
+  const { width } = useWindowDimensions();
+  const { boxes, addBox } = useBoxes();
+  const cam = Camera as CameraModule;
+  const { CameraView } = cam;
+  const [permission, requestPermission] = cam.useCameraPermissions();
+
+  const [phase, setPhase] = useState<Phase>({ k: 'scanning' });
+  const [hint, setHint] = useState(false);
+
+  // Synchronous latch — see the header. Closes on the first ACCEPTED decode,
+  // before any await; resets only when scanning deliberately resumes.
+  const locked = useRef(false);
+  const lastReject = useRef<{ data: string; at: number }>({ data: '', at: 0 });
+  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const later = useCallback((fn: () => void, ms: number) => {
+    timers.current.push(setTimeout(fn, ms));
+  }, []);
+  useEffect(() => () => timers.current.forEach(clearTimeout), []);
+
+  // Backgrounding mid-scan: drop back to scanning with the latch open, so a
+  // half-finished confirm can't act on stale state when the app returns.
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s !== 'active') {
+        locked.current = false;
+        setPhase((p) => (p.k === 'pairing' || p.k === 'done' ? p : { k: 'scanning' }));
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(() => setHint(true), HINT_AFTER_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  const pair = useCallback(
+    async (link: PairLink) => {
+      setPhase({ k: 'pairing' });
+      try {
+        const added = await addBox({
+          host: link.host,
+          port: link.port,
+          token: link.token,
+          lastIp: link.ip,
+        });
+        // The success beat fires HERE, after the collision gate and the write
+        // — not on decode. A success haptic before the one dialog that defends
+        // the user primes them to tap through it.
+        hapticSuccess();
+        setPhase({ k: 'done', name: added.name });
+        later(() => {
+          onClose();
+          navigateAfterPair(added);
+        }, DONE_HOLD_MS);
+      } catch {
+        hapticError();
+        setPhase({ k: 'failed' });
+      }
+    },
+    [addBox, later, onClose],
+  );
+
+  const onScan = useCallback(
+    ({ data }: { data: string }) => {
+      if (locked.current) return;
+      const parsed = parsePairLink(data, { forms: SCAN_FORMS, defaultPort: DEFAULT_PORT });
+
+      if (!parsed.ok) {
+        // No latch on a reject — the user may pan to the right code. Debounce
+        // the identical payload instead. The reason is shown; the payload never.
+        const now = Date.now();
+        if (lastReject.current.data === data && now - lastReject.current.at < SAME_REJECT_MS) {
+          return;
+        }
+        lastReject.current = { data, at: now };
+        hapticWarning();
+        setPhase({ k: 'rejected', reason: parsed.reason });
+        later(() => {
+          setPhase((p) => (p.k === 'rejected' ? { k: 'scanning' } : p));
+        }, REJECT_HOLD_MS);
+        return;
+      }
+
+      locked.current = true; // synchronous — closes the door on this tick
+      const c = pairCollision(boxes, parsed.link);
+      if (c.kind === 'token-change') {
+        // A distinct, non-success beat: this is the one dialog defending the
+        // user's working credential, and it must not arrive pre-approved.
+        hapticWarning();
+        setPhase({ k: 'confirm', link: parsed.link, name: c.name });
+        return;
+      }
+      void pair(parsed.link);
+    },
+    [boxes, later, pair],
+  );
+
+  // Live only while a decode may be acted on. `undefined` flips the native
+  // barcodeScannerEnabled prop off — a hard analyzer stop, not a dropped call.
+  const live = phase.k === 'scanning' || phase.k === 'rejected';
+
+  const RETICLE = Math.min(320, Math.max(220, Math.round(width * 0.68)));
+  const ARM = Math.round(RETICLE * 0.22);
+
+  let cardTitle: string;
+  let cardSub: string | null = null;
+  if (phase.k === 'rejected') {
+    const c = REJECT_COPY[phase.reason];
+    cardTitle = c.title;
+    cardSub = c.sub;
+  } else if (phase.k === 'confirm') {
+    cardTitle = `Replace the key for ${phase.name}?`;
+    cardSub =
+      `That code carries a different key than the one saved for ${phase.name}. ` +
+      'Replacing it is how you re-pair after the box was reset — but a code from ' +
+      'anywhere else would break the box you already have.';
+  } else if (phase.k === 'pairing') {
+    cardTitle = 'Pairing…';
+  } else if (phase.k === 'done') {
+    cardTitle = `Paired ${phase.name}`;
+    cardSub = 'Opening the remote.';
+  } else if (phase.k === 'failed') {
+    cardTitle = "Couldn't save that box";
+    cardSub =
+      "The code was good, but your phone's secure storage refused the write, so " +
+      'nothing was stored. Close and reopen Couchside, then scan again.';
+  } else {
+    cardTitle = 'Center the pairing code';
+    cardSub = hint
+      ? 'Not reading? Step closer until the code fills the brackets, or move a little to one side to get the room\'s reflection off the screen.'
+      : "The big code on your box's screen, under \"Pair your phone\".";
+  }
+
+  const bracketColor =
+    phase.k === 'failed'
+      ? '#f87171'
+      : phase.k === 'rejected'
+        ? '#fbbf24'
+        : phase.k === 'scanning'
+          ? '#ffffff'
+          : '#34d399';
+
+  const perm = permission; // null on first render — the doc's own guard
+  return (
+    <Modal visible transparent={false} animationType="slide" onRequestClose={onClose}>
+      <View style={styles.scanRoot}>
+        {perm?.granted ? (
+          <CameraView
+            style={StyleSheet.absoluteFill}
+            facing="back"
+            // Explicit: omitting barcodeTypes silently disables scanning on web.
+            barcodeScannerSettings={{ barcodeTypes: ['qr'] }}
+            onBarcodeScanned={live ? onScan : undefined}
+          />
+        ) : (
+          <PermissionGate
+            perm={perm}
+            request={requestPermission}
+            styles={styles}
+          />
+        )}
+
+        {/* Reticle — DECORATIVE: SDK 57 exposes no scan region, the detector
+            reads the whole frame. The brackets are aim guidance, nothing else.
+            CameraView cannot take children, so everything overlays as siblings. */}
+        {perm?.granted && (
+          <View
+            pointerEvents="none"
+            style={styles.reticleWrap}
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants">
+            <View style={{ width: RETICLE, height: RETICLE }}>
+              <View style={[styles.corner, styles.tl, { width: ARM, height: ARM, borderColor: bracketColor }]} />
+              <View style={[styles.corner, styles.tr, { width: ARM, height: ARM, borderColor: bracketColor }]} />
+              <View style={[styles.corner, styles.bl, { width: ARM, height: ARM, borderColor: bracketColor }]} />
+              <View style={[styles.corner, styles.br, { width: ARM, height: ARM, borderColor: bracketColor }]} />
+            </View>
+          </View>
+        )}
+
+        {/* Back chevron, 44pt target, over the feed. */}
+        <Pressable
+          onPress={onClose}
+          accessibilityRole="button"
+          accessibilityLabel="Back"
+          accessibilityHint="Returns to Setup without pairing"
+          style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}>
+          <Ionicons name="chevron-back" size={28} color="#ffffff" />
+        </Pressable>
+
+        {/* Bottom card — the Netflix element: glyph, bold title, lighter sub. */}
+        {perm?.granted && (
+          <View style={styles.cardWrap} accessible accessibilityLiveRegion="polite">
+            <View style={styles.scanCard}>
+              <Ionicons name="qr-code" size={22} color="#ffffff" style={styles.cardGlyph} />
+              <Text style={styles.cardTitle}>{cardTitle}</Text>
+              {cardSub != null && <Text style={styles.cardSub}>{cardSub}</Text>}
+              {phase.k === 'confirm' && (
+                <View style={styles.confirmRow}>
+                  <Pressable
+                    onPress={() => {
+                      hapticSelection();
+                      locked.current = false;
+                      setPhase({ k: 'scanning' });
+                    }}
+                    accessibilityRole="button"
+                    style={({ pressed }) => [styles.confirmBtn, pressed && styles.pressed]}>
+                    <Text style={styles.confirmBtnText}>KEEP MINE</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => void pair(phase.link)}
+                    accessibilityRole="button"
+                    style={({ pressed }) => [styles.confirmBtn, styles.confirmDanger, pressed && styles.pressed]}>
+                    <Text style={[styles.confirmBtnText, styles.confirmDangerText]}>REPLACE KEY</Text>
+                  </Pressable>
+                </View>
+              )}
+              {phase.k === 'failed' && (
+                <Pressable
+                  onPress={() => {
+                    hapticSelection();
+                    locked.current = false;
+                    setPhase({ k: 'scanning' });
+                  }}
+                  accessibilityRole="button"
+                  style={({ pressed }) => [styles.confirmBtn, styles.scanAgain, pressed && styles.pressed]}>
+                  <Text style={styles.confirmBtnText}>SCAN AGAIN</Text>
+                </Pressable>
+              )}
+            </View>
+          </View>
+        )}
+      </View>
+    </Modal>
+  );
+}
+
+function PermissionGate({
+  perm,
+  request,
+  styles,
+}: {
+  perm: { granted: boolean; canAskAgain: boolean } | null;
+  request: () => Promise<unknown>;
+  styles: ReturnType<typeof makeStyles>;
+}) {
+  if (!perm) return <View style={styles.scanRoot} />; // hook still resolving
+
+  const deniedForever = !perm.canAskAgain;
+  return (
+    <View style={[styles.scanRoot, styles.permWrap]}>
+      <Ionicons name="camera-outline" size={40} color="#8b97ad" />
+      <Text style={styles.permTitle}>Couchside needs the camera</Text>
+      <Text style={styles.permSub}>
+        {deniedForever
+          ? Platform.OS === 'ios'
+            ? "iOS won't ask again from inside the app — turn on Camera for Couchside in Settings, then come back."
+            : "Android won't ask again from inside the app — turn on Camera for Couchside in Settings (Permissions → Camera), then come back."
+          : 'Only to read the pairing code on your box\'s screen. Nothing is recorded, and no image leaves your phone.'}
+      </Text>
+      <Pressable
+        onPress={() => {
+          hapticSelection();
+          if (deniedForever) void Linking.openSettings();
+          else void request();
+        }}
+        accessibilityRole="button"
+        style={({ pressed }) => [styles.permBtn, pressed && styles.pressed]}>
+        <Text style={styles.permBtnText}>{deniedForever ? 'OPEN SETTINGS' : 'ALLOW CAMERA'}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    // Trigger row inside the ADD / PAIR card. styles.card has no `gap`.
+    trigger: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      marginTop: 10,
+      minHeight: 44,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      backgroundColor: t.inset,
+    },
+    triggerText: { color: t.blue, fontSize: 13, fontWeight: '700' },
+    pressed: { opacity: 0.7 },
+
+    // Scanner surface. Literal colours over a live feed, not theme tokens —
+    // the feed is not themed, and the card must hold AA over a white TV frame.
+    scanRoot: { flex: 1, backgroundColor: '#000000' },
+    reticleWrap: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    corner: { position: 'absolute' },
+    tl: { top: 0, left: 0, borderTopWidth: 4, borderLeftWidth: 4, borderTopLeftRadius: 16 },
+    tr: { top: 0, right: 0, borderTopWidth: 4, borderRightWidth: 4, borderTopRightRadius: 16 },
+    bl: { bottom: 0, left: 0, borderBottomWidth: 4, borderLeftWidth: 4, borderBottomLeftRadius: 16 },
+    br: { bottom: 0, right: 0, borderBottomWidth: 4, borderRightWidth: 4, borderBottomRightRadius: 16 },
+    backBtn: {
+      position: 'absolute',
+      top: 56,
+      left: 12,
+      width: 44,
+      height: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    cardWrap: {
+      position: 'absolute',
+      left: 16,
+      right: 16,
+      bottom: 40,
+      alignItems: 'center',
+    },
+    scanCard: {
+      alignSelf: 'stretch',
+      alignItems: 'center',
+      borderRadius: 16,
+      paddingVertical: 18,
+      paddingHorizontal: 20,
+      backgroundColor: 'rgba(11,18,32,0.72)',
+    },
+    cardGlyph: { marginBottom: 8 },
+    cardTitle: {
+      color: '#ffffff',
+      fontSize: 17,
+      fontWeight: '700',
+      textAlign: 'center',
+    },
+    cardSub: {
+      color: 'rgba(229,236,248,0.75)',
+      fontSize: 13,
+      lineHeight: 18,
+      textAlign: 'center',
+      marginTop: 6,
+    },
+    confirmRow: { flexDirection: 'row', gap: 10, marginTop: 14 },
+    confirmBtn: {
+      minHeight: 44,
+      paddingHorizontal: 18,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: 'rgba(255,255,255,0.35)',
+    },
+    confirmBtnText: { color: '#ffffff', fontSize: 13, fontWeight: '700' },
+    confirmDanger: { borderColor: '#f87171' },
+    confirmDangerText: { color: '#f87171' },
+    scanAgain: { marginTop: 14 },
+
+    // Permission gate — no feed behind it, so theme-ish darks are fine.
+    permWrap: { alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+    permTitle: { color: '#e5ecf8', fontSize: 17, fontWeight: '700', textAlign: 'center' },
+    permSub: {
+      color: '#8b97ad',
+      fontSize: 13,
+      lineHeight: 19,
+      textAlign: 'center',
+    },
+    permBtn: {
+      marginTop: 8,
+      minHeight: 44,
+      paddingHorizontal: 22,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: t.blue,
+    },
+    permBtnText: { color: t.blue, fontSize: 13, fontWeight: '700' },
+  });

--- a/app/lib/DeepLink.tsx
+++ b/app/lib/DeepLink.tsx
@@ -1,48 +1,10 @@
 import * as Linking from 'expo-linking';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { DEEPLINK_FORMS, parsePairLink } from './pairLink';
 import { navigateAfterPair } from './postPair';
 import { DEFAULT_PORT } from './settings';
 import { useBoxes } from './SettingsContext';
-
-/**
- * Parse a URL's query string, decoding each value EXACTLY ONCE.
- *
- * Deliberately not expo-linking's Linking.parse: in expo-linking 57 that runs
- * decodeURIComponent on values URLSearchParams has already decoded: a double
- * decode that mangles (or, on an invalid %-escape, throws away) any param
- * value containing '%'. A hand-entered token with a '%' would silently fail to
- * pair. This single-decodes, tolerates a missing '=', strips a fragment, and
- * never throws (a bad escape falls back to the raw substring).
- */
-function parseQuery(url: string): Record<string, string> {
-  const qStart = url.indexOf('?');
-  if (qStart < 0) return {};
-  let qs = url.slice(qStart + 1);
-  const hash = qs.indexOf('#');
-  if (hash >= 0) qs = qs.slice(0, hash);
-  const out: Record<string, string> = {};
-  for (const pair of qs.split('&')) {
-    if (!pair) continue;
-    const eq = pair.indexOf('=');
-    const rawKey = eq < 0 ? pair : pair.slice(0, eq);
-    const rawVal = eq < 0 ? '' : pair.slice(eq + 1);
-    let key = rawKey;
-    let val = rawVal;
-    try {
-      key = decodeURIComponent(rawKey);
-    } catch {
-      /* keep raw key */
-    }
-    try {
-      val = decodeURIComponent(rawVal);
-    } catch {
-      /* keep raw value */
-    }
-    out[key] = val;
-  }
-  return out;
-}
 
 /**
  * Root-level pairing deep-link handler.
@@ -76,11 +38,15 @@ export function DeepLinkHandler() {
   const apply = useCallback(
     (url: string | null | undefined) => {
       if (!url) return;
-      const q = parseQuery(url);
-      const host = (q.host ?? '').trim();
-      const token = q.token ?? '';
-      // Only a link that carries BOTH host and token is a pairing link.
-      if (!host || !token) return;
+      // ONE VALIDATOR, both callers (lib/pairLink.ts): until 2026-07-27 this
+      // handler accepted ANY host — `couchside://setup?host=evil.com&token=x`
+      // added a public box to the fleet, and the app then sent the token there
+      // and polled it forever. parsePairLink enforces the LAN allowlist, the
+      // origin binding, and reject-rather-than-sanitise; a refused link is a
+      // silent no-op here exactly as an incomplete one always was (there is no
+      // UI surface on a cold-start URL to explain into).
+      const parsed = parsePairLink(url, { forms: DEEPLINK_FORMS, defaultPort: DEFAULT_PORT });
+      if (!parsed.ok) return;
 
       // Arrived before the fleet loaded, apply it once ready (see effect below).
       if (!readyRef.current) {
@@ -88,10 +54,7 @@ export function DeepLinkHandler() {
         return;
       }
 
-      const portRaw = q.port ? parseInt(q.port, 10) : NaN;
-      const port =
-        Number.isFinite(portRaw) && portRaw > 0 && portRaw <= 65535 ? portRaw : DEFAULT_PORT;
-      const ip = q.ip || undefined;
+      const { host, port, token, ip } = parsed.link;
 
       // Navigate only once the box is actually stored and active, so the Pad
       // opens against the box that was just paired rather than the previous one.

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -11,6 +11,7 @@ import { AppState, AppStateStatus } from 'react-native';
 
 import { pingMatchesBox } from './api';
 import { getPref } from './prefs';
+import { isAllowedPairHost } from './pairLink';
 import {
   Box,
   BoxesState,
@@ -35,6 +36,15 @@ export type AddBoxInput = {
   padMode?: Box['padMode'];
   /** Fallback IP (e.g. from the pairing QR's &ip= param). */
   lastIp?: string;
+  /**
+   * The user personally typed this host into the manual add form. ONLY that
+   * form may set it. Every other producer of a host string is a machine
+   * (a QR decode, a deep link, a discovery response) and machine input must
+   * pass the pairing-host allowlist — see the gate in addBox. The manual form
+   * is exempt because the user typing `mybox.fritz.box` into a form IS the
+   * authority on their own network, and there is no attacker in that loop.
+   */
+  userTypedHost?: boolean;
 };
 
 type BoxesContextValue = {
@@ -116,6 +126,14 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     async (input: AddBoxInput): Promise<Box> => {
       const cur = current.current;
       const host = input.host.trim();
+      // CHOKE POINT (CLAUDE.md §3): every machine-supplied host must pass the
+      // pairing allowlist HERE, not only in the callers that remembered. The
+      // QR scanner and DeepLink validate upstream (this is their second
+      // check); discovery responses arrive UNVALIDATED from an unauthenticated
+      // UDP/HTTP reply, and any future caller starts closed by default.
+      if (!input.userTypedHost && !isAllowedPairHost(host)) {
+        throw new Error('host refused: not a LAN address or local name');
+      }
       const port =
         typeof input.port === 'number' && Number.isFinite(input.port)
           ? input.port

--- a/app/lib/__tests__/pairLink.test.ts
+++ b/app/lib/__tests__/pairLink.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Pairing-link validation — lib/pairLink.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the CI `app-input` job's glob.
+ *
+ * WHAT THIS GUARDS. A pairing link is the one string from outside the app that
+ * becomes a bearer-token destination: the app opens a WebSocket to that host,
+ * polls it forever, and will upload a user-picked file to it. A QR sticker on a
+ * public machine is therefore a one-tap exploit unless the accept surface is
+ * enumerable. Every ACCEPT below is a real producer's real output; every REJECT
+ * is an attack or a mistake we have a specific answer for.
+ *
+ * CONTROLS (CLAUDE.md §11.3) are in every table: each reject table also asserts
+ * the nearest legitimate string is ACCEPTED, so a passing reject test can never
+ * be a validator that refuses everything.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  DEEPLINK_FORMS,
+  SCAN_FORMS,
+  buildPairLink,
+  pairCollision,
+  parsePairLink,
+  type PairRejectReason,
+} from '../pairLink.ts';
+
+const PORT = 8787; // lib/settings.ts DEFAULT_PORT, passed in by the caller
+const scan = (raw: string) => parsePairLink(raw, { forms: SCAN_FORMS, defaultPort: PORT });
+const link = (raw: string) => parsePairLink(raw, { forms: DEEPLINK_FORMS, defaultPort: PORT });
+
+const T = '9f3c1a7b2e5d8064af12cd39e7b04a6518d2c7f0aa1b3e94'; // 48 hex, install.sh shape
+
+/**
+ * VERBATIM fixture. Produced by executing the agent's own build_pair_url()
+ * out of agent/couchsided.py (CLAUDE.md §6: fixtures copied from the real
+ * thing, not retyped). Note the UPPERCASE in the hostname — it is what
+ * socket.gethostname() actually returned on a real machine, and it is the
+ * reason this validator checks case without folding it.
+ */
+const AGENT_QR =
+  'https://couchside.tv/pair#host=MacBook-Pro-M2-4.local&port=8787' +
+  `&token=${T}&ip=10.1.1.89`;
+
+function ok(r: ReturnType<typeof scan>) {
+  assert.equal(r.ok, true, `expected accept, got reject: ${!r.ok ? r.reason : ''}`);
+  if (!r.ok) throw new Error('unreachable');
+  return r.link;
+}
+function why(r: ReturnType<typeof scan>): PairRejectReason | 'ACCEPTED' {
+  return r.ok ? 'ACCEPTED' : r.reason;
+}
+
+// ---------------------------------------------------------------- accepts ---
+
+test('CONTROL: the agent QR, executed out of couchsided.py, is accepted whole', () => {
+  const l = ok(scan(AGENT_QR));
+  assert.equal(l.host, 'MacBook-Pro-M2-4.local'); // case preserved, not folded
+  assert.equal(l.port, 8787);
+  assert.equal(l.token, T);
+  assert.equal(l.ip, '10.1.1.89');
+});
+
+test("CONTROL: the app's own SHOW QR output round-trips through the parser", () => {
+  const built = buildPairLink({ host: 'bazzite.local', port: 8787, token: T, lastIp: '10.1.1.50' });
+  assert.notEqual(built, null);
+  const l = ok(scan(built as string));
+  assert.deepEqual(l, { host: 'bazzite.local', port: 8787, token: T, ip: '10.1.1.50' });
+});
+
+test('a link with no ip= is accepted; ip is simply absent', () => {
+  const l = ok(scan(`https://couchside.tv/pair#host=deck.local&port=8787&token=${T}`));
+  assert.equal(l.ip, undefined);
+});
+
+test('port may be omitted and falls back to the port the CALLER supplied', () => {
+  assert.equal(ok(scan(`https://couchside.tv/pair#host=deck.local&token=${T}`)).port, PORT);
+});
+
+test('a private IPv4 host is accepted (show-qr.sh users pass an IP)', () => {
+  for (const h of ['10.1.1.89', '192.168.1.50', '172.16.0.2', '169.254.3.4', '100.64.0.9']) {
+    assert.equal(why(scan(`https://couchside.tv/pair#host=${h}&token=${T}`)), 'ACCEPTED', h);
+  }
+});
+
+test('a bare single label is accepted — agent/show-qr.sh emits one', () => {
+  assert.equal(why(link(`couchside://setup?host=steamdeck&port=8787&token=${T}`)), 'ACCEPTED');
+});
+
+test('a token containing % survives (single-decode, the DeepLink rationale)', () => {
+  const l = ok(scan('https://couchside.tv/pair#host=deck.local&token=abc%25def%25ghi'));
+  assert.equal(l.token, 'abc%def%ghi');
+});
+
+test('unknown params are ignored, not fatal (forward compat with a newer agent)', () => {
+  const l = ok(scan(`https://couchside.tv/pair#host=deck.local&token=${T}&futureCap=1`));
+  assert.equal(l.host, 'deck.local');
+});
+
+test('a trailing slash on the path is accepted', () => {
+  assert.equal(why(scan(`https://couchside.tv/pair/#host=deck.local&token=${T}`)), 'ACCEPTED');
+});
+
+// ------------------------------------------------------- form segregation ---
+
+test('BOTH STATES: the scheme form is accepted by DeepLink and refused by the scanner', () => {
+  const url = `couchside://setup?host=deck.local&port=8787&token=${T}`;
+  assert.equal(why(link(url)), 'ACCEPTED'); // shipped deep-link path keeps working
+  assert.equal(why(scan(url)), 'not-pair-link'); // a QR is never this form
+});
+
+test('scheme case is folded — Android hands the scheme back lowercased', () => {
+  assert.equal(why(link(`COUCHSIDE://SETUP?host=deck.local&token=${T}`)), 'ACCEPTED');
+});
+
+// ---------------------------------------------------------------- rejects ---
+
+test('ATTACK: origin lookalikes are all refused, and the real origin still passes', () => {
+  const cases: [string, string][] = [
+    ['suffix graft', `https://couchside.tv.evil.com/pair#host=deck.local&token=${T}`],
+    ['userinfo spoof', `https://couchside.tv@evil.com/pair#host=deck.local&token=${T}`],
+    ['backslash spoof', `https://couchside.tv\\@evil.com/pair#host=deck.local&token=${T}`],
+    ['subdomain', `https://pair.couchside.tv/pair#host=deck.local&token=${T}`],
+    ['www', `https://www.couchside.tv/pair#host=deck.local&token=${T}`],
+    ['plaintext http', `http://couchside.tv/pair#host=deck.local&token=${T}`],
+    ['origin in a query', `https://evil.com/pair?x=couchside.tv#host=deck.local&token=${T}`],
+    ['wrong path', `https://couchside.tv/pairs#host=deck.local&token=${T}`],
+    ['path traversal', `https://couchside.tv/pair/../x#host=deck.local&token=${T}`],
+  ];
+  for (const [label, url] of cases) {
+    assert.equal(why(scan(url)), 'not-pair-link', label);
+  }
+  // CONTROL: the genuine article, otherwise "everything is refused" would pass.
+  assert.equal(why(scan(AGENT_QR)), 'ACCEPTED', 'CONTROL genuine agent QR');
+});
+
+test('ATTACK: the host may not leave the LAN, and a LAN host still passes', () => {
+  const cases: [string, string][] = [
+    ['public IPv4', '1.2.3.4'],
+    ['public name', 'box.evil.com'],
+    ['loopback (no producer emits it)', '127.0.0.1'],
+    ['IPv6 loopback', '::1'],
+    ['v4-mapped v6 — public wearing a v6 costume', '::ffff:1.2.3.4'],
+    ['v6 ULA (ws:// has no bracket handling)', 'fd00::1'],
+    ['v6 link-local with zone', 'fe80::1%25en0'],
+    ['integer form', '2130706433'],
+    ['hex form', '0x7f.1'],
+    ['host:port smuggled into host', 'deck.local:9999'],
+    ['path smuggled into host', 'deck.local/evil'],
+    ['userinfo smuggled into host', 'user@evil.com'],
+    ['trailing-dot FQDN escape', 'evil.com.'],
+    ['empty label', 'deck..local'],
+    ['leading hyphen label', '-deck.local'],
+  ];
+  for (const [label, h] of cases) {
+    const r = scan(`https://couchside.tv/pair#host=${encodeURIComponent(h)}&token=${T}`);
+    assert.equal(why(r), 'bad-host', label);
+  }
+  // CONTROL: the shapes we DO allow, so this table cannot pass by refusing all.
+  for (const h of ['deck.local', '10.1.1.89', 'steamdeck']) {
+    assert.equal(why(scan(`https://couchside.tv/pair#host=${h}&token=${T}`)), 'ACCEPTED', h);
+  }
+});
+
+test('ATTACK: a bare label that is an address in disguise is refused', () => {
+  // MEASURED 2026-07-27 through plain getaddrinfo — no exotic parser needed:
+  //   0x08080808 -> 8.8.8.8, 0xdeadbeef -> 222.173.190.239, 0X8 -> 0.0.0.8,
+  //   134744072 -> 8.8.8.8. A "single label with no dot" allowlist would have
+  //   walked each of these straight to a PUBLIC address with the bearer token.
+  for (const h of ['0x08080808', '0xdeadbeef', '0X8', '0x', '134744072', '08', '1-2']) {
+    assert.equal(why(link(`couchside://setup?host=${h}&token=${T}`)), 'bad-host', h);
+  }
+  // CONTROLS, same run: real labels resolve as NAMES or not at all — measured
+  // "steamdeck" and "bazzite" do not getaddrinfo to an address. And a label
+  // that merely CONTAINS hex chars is a name, not a number.
+  for (const h of ['steamdeck', 'bazzite', 'deck0x1', 'b0x']) {
+    assert.equal(why(link(`couchside://setup?host=${h}&token=${T}`)), 'ACCEPTED', h);
+  }
+});
+
+test('ATTACK: leading-zero octets are refused — 010.0.0.1 is 8.0.0.1 to inet_aton', () => {
+  // Measured on the BSD resolver family iOS shares: getaddrinfo reads
+  // "010.0.0.1" as 10.0.0.1 (private) while inet_aton reads it as octal ->
+  // 8.0.0.1 (PUBLIC). Same string, two destinations, so the form is refused
+  // rather than reasoned about.
+  for (const h of ['010.0.0.1', '0177.0.0.1', '192.0168.1.1', '010.010.010.010']) {
+    assert.equal(why(scan(`https://couchside.tv/pair#host=${h}&token=${T}`)), 'bad-host', h);
+  }
+  // CONTROL: the same addresses without leading zeros are fine.
+  assert.equal(why(scan(`https://couchside.tv/pair#host=10.0.0.1&token=${T}`)), 'ACCEPTED');
+});
+
+test('ATTACK: a malformed port is REJECTED, never silently defaulted', () => {
+  for (const p of ['0', '65536', '99999', '8787x', '-1', '+80', '87 87', '0x1f', '', ' ']) {
+    const r = scan(`https://couchside.tv/pair#host=deck.local&port=${encodeURIComponent(p)}&token=${T}`);
+    // Only a literally EMPTY value means "absent" and falls back to the
+    // caller's default. A whitespace-only port is malformed, not absent — we
+    // reject rather than trim it into validity (CLAUDE.md §3.6). This
+    // expectation was wrong on first write and the test caught it.
+    const expected = p === '' ? 'ACCEPTED' : 'bad-port';
+    assert.equal(why(r), expected, `port=${JSON.stringify(p)}`);
+  }
+  // CONTROL: a real non-default port is accepted and carried through.
+  assert.equal(ok(scan(`https://couchside.tv/pair#host=deck.local&port=9001&token=${T}`)).port, 9001);
+});
+
+test('token shape: rejected when absent/short/whitespace/control, kept when merely unusual', () => {
+  const bad: [string, PairRejectReason][] = [
+    ['', 'missing-token'],
+    ['short', 'bad-token'],
+    ['has a space in it', 'bad-token'],
+    ['tab\there1234', 'bad-token'],
+    ['newline\n12345678', 'bad-token'],
+    ['x'.repeat(257), 'bad-token'],
+  ];
+  for (const [tok, reason] of bad) {
+    const r = scan(`https://couchside.tv/pair#host=deck.local&token=${encodeURIComponent(tok)}`);
+    assert.equal(why(r), reason, JSON.stringify(tok.slice(0, 20)));
+  }
+  // CONTROL: NOT hex-only. `--token` accepts a literal and migrated
+  // pre-Couchside tokens exist; tightening to /^[0-9a-f]{48}$/ would refuse
+  // legitimately configured boxes, so these must pass.
+  for (const tok of ['MyLiteralToken!', 'a'.repeat(8), 'rescue-remote-legacy-token-2024']) {
+    assert.equal(why(scan(`https://couchside.tv/pair#host=deck.local&token=${tok}`)), 'ACCEPTED', tok);
+  }
+});
+
+test('ATTACK: a repeated param is refused rather than resolved by last-wins', () => {
+  const r = scan(`https://couchside.tv/pair#host=deck.local&token=${T}&token=evil12345`);
+  assert.equal(why(r), 'duplicate-param');
+  const r2 = scan(`https://couchside.tv/pair#host=deck.local&host=evil.com&token=${T}`);
+  assert.equal(why(r2), 'duplicate-param');
+  // CONTROL: one of each is fine.
+  assert.equal(why(scan(AGENT_QR)), 'ACCEPTED');
+});
+
+test('__proto__ in the payload cannot pollute the parsed object', () => {
+  const r = scan(`https://couchside.tv/pair#__proto__=polluted&host=deck.local&token=${T}`);
+  assert.equal(why(r), 'ACCEPTED');
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+});
+
+test('a bad ip= is DROPPED, not fatal — it is only a fallback route', () => {
+  for (const bad of ['8.8.8.8', 'notanip', '010.0.0.1', '999.1.1.1']) {
+    const l = ok(scan(`https://couchside.tv/pair#host=deck.local&token=${T}&ip=${bad}`));
+    assert.equal(l.ip, undefined, bad);
+  }
+  // CONTROL: a good one survives. addBox allows loopback for ip, so we do too.
+  assert.equal(ok(scan(`https://couchside.tv/pair#host=deck.local&token=${T}&ip=127.0.0.1`)).ip, '127.0.0.1');
+});
+
+test('the OTHER QR on the box screen gets its own reason, not a generic one', () => {
+  assert.equal(why(scan('https://couchside.tv/#get')), 'store-code');
+});
+
+test('BOTH STATES: real-world non-Couchside QRs are refused without throwing', () => {
+  // The RN URL shim THROWS a TypeError on a string with '#' and no '://'
+  // (Libraries/Blob/URL.js:88 does .includes on undefined) while Node's URL
+  // parses it — which is exactly why this module never constructs a URL.
+  // These must all return a reason, never raise.
+  const junk: [string, PairRejectReason][] = [
+    ['WIFI:S=home;T=WPA;P=hunter2;;', 'not-pair-link'],
+    ['BEGIN:VCARD\nFN:Bob\nEND:VCARD', 'not-pair-link'],
+    ['https://example.com/hello', 'not-pair-link'],
+    ['javascript:alert(1)//#host=deck.local', 'not-pair-link'],
+    ['data:text/html,<script>1</script>', 'not-pair-link'],
+    ['deck.local:8787:sometoken', 'not-pair-link'],
+    ['', 'empty'],
+    ['   ', 'empty'],
+    ['x'.repeat(4096), 'too-long'],
+  ];
+  for (const [raw, reason] of junk) {
+    assert.equal(why(scan(raw)), reason, JSON.stringify(raw.slice(0, 30)));
+  }
+  // CONTROL: the genuine QR in the same run.
+  assert.equal(why(scan(AGENT_QR)), 'ACCEPTED');
+});
+
+test('a link missing host or token is named precisely, so the UI can explain', () => {
+  assert.equal(why(scan(`https://couchside.tv/pair#token=${T}`)), 'missing-host');
+  assert.equal(why(scan('https://couchside.tv/pair#host=deck.local')), 'missing-token');
+  assert.equal(why(scan('https://couchside.tv/pair')), 'missing-host');
+  assert.equal(why(scan('https://couchside.tv/pair#')), 'missing-host');
+});
+
+test('a rejection carries ONLY a reason — no field a bearer token could ride on', () => {
+  // The Logs tab and any future error toast will render whatever a reject
+  // carries; a token echoed there is a credential leak. Structural, not
+  // value-based: the reject object must have exactly {ok, reason}.
+  const r = scan(`https://couchside.tv/pair#host=evil.com&token=${T}`);
+  assert.equal(r.ok, false);
+  assert.deepEqual(Object.keys(r).sort(), ['ok', 'reason']);
+  assert.equal(JSON.stringify(r).includes(T), false, 'token leaked into the reject');
+});
+
+// ------------------------------------------------------------- collisions ---
+
+test('pairCollision: the token-change case is named, both other states observed', () => {
+  const fleet = [{ host: 'bazzite.local', port: 8787, token: T, name: 'Living Room' }];
+  // A hostile QR carrying a DIFFERENT token for a box the user already owns
+  // would silently swap their working credential — this is the case the
+  // scanner must confirm before addBox is allowed to overwrite.
+  const swap = pairCollision(fleet, { host: 'bazzite.local', port: 8787, token: 'evil1234' });
+  assert.deepEqual(swap, { kind: 'token-change', name: 'Living Room' });
+  // CONTROL both directions: a re-scan of the same QR is not a collision...
+  const same = pairCollision(fleet, { host: 'bazzite.local', port: 8787, token: T });
+  assert.deepEqual(same, { kind: 'same-token', name: 'Living Room' });
+  // ...and a different port is a different box, mirroring sameTarget exactly.
+  assert.deepEqual(pairCollision(fleet, { host: 'bazzite.local', port: 9001, token: T }), { kind: 'new' });
+  assert.deepEqual(pairCollision(fleet, { host: 'deck.local', port: 8787, token: T }), { kind: 'new' });
+});
+
+// ------------------------------------------------- writer/reader symmetry ---
+
+test('SYMMETRY: buildPairLink refuses every box whose link the reader would refuse', () => {
+  // The writer must be a subset of the reader (degrade closed): the app must
+  // never render a QR that its own scanner rejects.
+  const bad = [
+    { host: 'evil.com', port: 8787, token: T }, // public name
+    { host: '8.8.8.8', port: 8787, token: T }, // public IP
+    { host: '0x08080808', port: 8787, token: T }, // address in disguise
+    { host: '010.1.1.5', port: 8787, token: T }, // octal-ambiguous
+    { host: 'deck.local', port: 0, token: T }, // bad port
+    { host: 'deck.local', port: 8787, token: 'short' }, // bad token
+    { host: '', port: 8787, token: T }, // no host
+  ];
+  for (const b of bad) {
+    assert.equal(buildPairLink(b), null, JSON.stringify(b.host || b.port || b.token));
+  }
+  // CONTROL + round trip: every accepted build parses back to the same link,
+  // and a lastIp the reader would drop is dropped by the writer too.
+  const good = { host: 'bazzite.local', port: 9001, token: T, lastIp: '10.1.1.50' };
+  const url = buildPairLink(good);
+  assert.notEqual(url, null);
+  const l = ok(scan(url as string));
+  assert.deepEqual(l, { host: 'bazzite.local', port: 9001, token: T, ip: '10.1.1.50' });
+  const publicIp = buildPairLink({ ...good, lastIp: '8.8.8.8' });
+  assert.equal(ok(scan(publicIp as string)).ip, undefined, 'public lastIp must not be encoded');
+});

--- a/app/lib/pairLink.ts
+++ b/app/lib/pairLink.ts
@@ -1,0 +1,370 @@
+/**
+ * Decide whether an outside string is a Couchside pairing link — and refuse
+ * everything else. This is the ONLY place a string from outside the app is
+ * allowed to become a bearer-token destination.
+ *
+ * A pairing link says "trust this host, and send it this credential". The app
+ * then opens a WebSocket to it, polls it forever, and will upload a user-picked
+ * file to it. So a hostile QR sticker is not a cosmetic problem: it re-points a
+ * LAN-only, no-cloud app at somebody's server. Every rule below exists to make
+ * the set of reachable destinations enumerable.
+ *
+ * TWO CALLERS, ONE VALIDATOR. The in-app scanner and the inbound deep-link
+ * handler (lib/DeepLink.tsx) both go through here. If the scanner were the
+ * stricter of the two, an attacker would simply use a link instead of a QR and
+ * the work would be worthless. `forms` is a REQUIRED argument, so each call
+ * site has to state its accept surface out loud.
+ *
+ * NO `new URL()` — DELIBERATE, AND LOAD-BEARING. React Native replaces the
+ * global URL with a regex shim (`polyfillGlobal('URL', ...)` in
+ * react-native/Libraries/Core/setUpXHR.js -> Libraries/Blob/URL.js). Measured
+ * on RN 0.86, that shim disagrees with the Node WHATWG URL the test runner
+ * uses, in the accept direction:
+ *   - `new URL('WIFI:S=home;T=WPA;;#x')` THROWS TypeError in the shim (it does
+ *     `beforeHash.split('://')[1].includes('/')` on an undefined) and parses
+ *     fine in Node. That is a plain-text QR — the most likely thing a user
+ *     points this at by accident.
+ *   - `.hash` is `/#([^/]*)/`, so a fragment value containing '/' truncates the
+ *     rest away on device and keeps it in Node (`&ip=` silently vanishes).
+ *   - `https://couchside.tv\@evil.com/pair` parses as host `evil.com` in the
+ *     shim and host `couchside.tv` + path `/@evil.com/pair` in Node.
+ * A rule written against Node's URL is therefore verified against a parser the
+ * app does not run. Everything here is plain string work with identical
+ * behaviour in Hermes and in bare Node, so the tests test the shipped code.
+ *
+ * Reject, never repair (CLAUDE.md §3.6). A malformed field means this is not
+ * our code; nothing is defaulted into validity.
+ *
+ * ONE import, and only from another zero-import module: the LAN-IPv4 range
+ * rule lives in lib/lanIp.ts (it also guards the lastIp persist path — KI-033),
+ * so the octal-octet rejection exists in exactly one place. The `.ts` extension
+ * on the specifier is required by the bare-Node test runner and is already the
+ * repo's convention in lib/__tests__/.
+ */
+import { isValidLanIp } from './lanIp.ts';
+
+/** Which producer's format a caller is willing to accept. */
+export type PairLinkForm = 'https-pair' | 'couchside-setup';
+
+/**
+ * The frozen base table. A client string is compared for EQUALITY against
+ * these — never prefix-matched, never regex-matched against the origin. That
+ * is what kills `couchside.tv.evil.com`, `couchside.tv@evil.com`,
+ * `evil.com/?x=couchside.tv` and the backslash variants in one stroke: none of
+ * them produce a base that equals an entry.
+ *
+ * Extended only by adding an explicit entry (CLAUDE.md §3.3).
+ */
+const FORM_BASES: Readonly<Record<PairLinkForm, readonly string[]>> = Object.freeze({
+  // The QR on the box's own /pair page (agent build_pair_url) and in the app's
+  // SHOW QR modal (setup.tsx). Params ride the FRAGMENT so the token is never
+  // sent to couchside.tv.
+  'https-pair': Object.freeze(['https://couchside.tv/pair', 'https://couchside.tv/pair/']),
+  // What the couchside.tv/pair page bounces the phone to, and what
+  // agent/show-qr.sh prints. Params ride the QUERY.
+  'couchside-setup': Object.freeze(['couchside://setup']),
+});
+
+/** Where each form keeps its params: everything right of this separator. */
+const FORM_SEP: Readonly<Record<PairLinkForm, '#' | '?'>> = Object.freeze({
+  'https-pair': '#',
+  'couchside-setup': '?',
+});
+
+/** A QR scanner accepts only what our two QR producers actually emit. */
+export const SCAN_FORMS: readonly PairLinkForm[] = Object.freeze(['https-pair'] as const);
+
+/** The deep-link handler additionally accepts the scheme URL it is sent. */
+export const DEEPLINK_FORMS: readonly PairLinkForm[] = Object.freeze([
+  'https-pair',
+  'couchside-setup',
+] as const);
+
+/**
+ * The OTHER QR on the box's pairing screen: an install/store link, drawn right
+ * next to the pairing code. Catching it is the single most likely honest
+ * mistake, so it gets its own reason rather than "not a Couchside code".
+ * Exact string from the agent (`json.dumps("https://couchside.tv/#get")`).
+ */
+const STORE_CODE = 'https://couchside.tv/#get';
+
+/** Hostname suffixes a pairing link may carry. Frozen; explicit entries only. */
+const HOST_SUFFIXES: readonly string[] = Object.freeze(['.local']);
+
+/** Longer than any real payload (~145 chars); refuses a QR built to be a bomb. */
+const MAX_RAW_LEN = 2048;
+
+/** RFC-1123 label. Case is PRESERVED downstream — see hostShapeOk. */
+const LABEL_RE = /^[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/;
+
+/** Printable ASCII, no space, no controls. */
+const TOKEN_RE = /^[\x21-\x7e]+$/;
+
+const TOKEN_MIN = 8;
+const TOKEN_MAX = 256;
+
+export type PairLink = {
+  /** mDNS name or private IPv4 literal. Stored verbatim (see hostShapeOk). */
+  host: string;
+  port: number;
+  token: string;
+  /** Optional cached LAN IP fallback. Absent when the link omitted or failed it. */
+  ip?: string;
+};
+
+/**
+ * Why a string was refused. The screen maps these to copy; the raw payload is
+ * never echoed back to the user (it carries a live credential).
+ */
+export type PairRejectReason =
+  | 'empty'
+  | 'too-long'
+  | 'store-code'
+  | 'not-pair-link'
+  | 'duplicate-param'
+  | 'missing-host'
+  | 'bad-host'
+  | 'missing-token'
+  | 'bad-token'
+  | 'bad-port';
+
+export type PairLinkResult =
+  | { ok: true; link: PairLink }
+  | { ok: false; reason: PairRejectReason };
+
+const rej = (reason: PairRejectReason): PairLinkResult => ({ ok: false, reason });
+
+/**
+ * Single-decode each param value, exactly like lib/DeepLink.tsx's parseQuery:
+ * URLSearchParams + decodeURIComponent double-decodes and mangles any value
+ * containing '%', which a hand-set token may legitimately have.
+ *
+ * Returns null on a REPEATED key. No producer emits duplicates, and accepting
+ * them means the app and any other parser can disagree about which value wins
+ * (`token=good&token=evil`). Null-prototype map, so `__proto__=` is inert.
+ */
+function parseParams(qs: string): Record<string, string> | null {
+  const out: Record<string, string> = Object.create(null);
+  if (!qs) return out;
+  for (const piece of qs.split('&')) {
+    if (!piece) continue;
+    const eq = piece.indexOf('=');
+    const rawKey = eq < 0 ? piece : piece.slice(0, eq);
+    const rawVal = eq < 0 ? '' : piece.slice(eq + 1);
+    let key = rawKey;
+    let val = rawVal;
+    try {
+      key = decodeURIComponent(rawKey);
+    } catch {
+      /* keep raw key */
+    }
+    try {
+      val = decodeURIComponent(rawVal);
+    } catch {
+      /* keep raw value */
+    }
+    if (Object.prototype.hasOwnProperty.call(out, key)) return null;
+    out[key] = val;
+  }
+  return out;
+}
+
+/**
+ * A dotted-quad IPv4 in LAN space. Range + octal-octet rules live in
+ * lib/lanIp.ts (one gate, one corpus — KI-033); this only adds the loopback
+ * policy: false for `host` (the box never emits 127/8 — a link aiming the app
+ * at the PHONE'S own loopback has no legitimate producer) and true for `ip`,
+ * which matches the shipped isValidLanIp behaviour that addBox already applies.
+ */
+function isLanIpv4(v: string, allowLoopback: boolean): boolean {
+  if (!isValidLanIp(v)) return false;
+  return allowLoopback || !v.startsWith('127.');
+}
+
+/**
+ * Is `host` a destination this app is allowed to send a bearer token to?
+ *
+ * Accepts exactly three shapes:
+ *   1. A private IPv4 literal (isLanIpv4, loopback excluded).
+ *   2. A SINGLE label with no dot ("steamdeck"). agent/show-qr.sh builds its
+ *      URL from whatever the user typed after `ssh`, so a bare label is a
+ *      shipped producer. A name with no dot has no public suffix and cannot
+ *      address the internet on its own; the residual risk is a hostile DNS
+ *      search domain, which already implies a compromised LAN.
+ *   3. A multi-label name whose LOWERCASED form ends in an allowlisted suffix
+ *      (.local). This is what the agent emits.
+ *
+ * Everything else is refused, including every IPv6 form. IPv6 is not a
+ * conservatism: lib/gamepad.ts builds `ws://${host}:${port}` with no bracket
+ * handling, so a v6 literal makes a malformed URL. Accepting it would ship a
+ * rule we cannot honour. `::ffff:1.2.3.4` in particular is refused outright
+ * rather than unwrapped-and-rechecked — unwrapping is how that bypass lands.
+ *
+ * Case is checked but NOT folded. Hostnames are case-insensitive, but
+ * SettingsContext.addBox dedupes on an exact host string, so folding here
+ * would file a second row for a box the LAN-scan path stored with its original
+ * casing. See KNOWN_ISSUES for the dedupe hazard itself.
+ */
+export function isAllowedPairHost(host: string): boolean {
+  return hostShapeOk(host);
+}
+
+function hostShapeOk(host: string): boolean {
+  if (!host || host.length > 253) return false;
+  // Explicit refusals first, so the intent is auditable rather than implied by
+  // the label regex: userinfo, ports, paths, IPv6 brackets, escapes, spaces.
+  if (/[:/\\@?#%_[\]\s]/.test(host)) return false;
+  if (isLanIpv4(host, false)) return true;
+  // A dotted-quad-shaped string that failed the LAN test must not fall through
+  // to the hostname branch and get accepted as a "name" (1.2.3.4 has valid
+  // labels). Any all-numeric final label means it was meant as an address.
+  const labels = host.split('.');
+  if (labels.some((l) => !LABEL_RE.test(l))) return false;
+  if (/^\d+$/.test(labels[labels.length - 1])) return false;
+  if (labels.length === 1) {
+    // A single label must not be an ADDRESS IN DISGUISE. The all-digits rule
+    // above already refuses the 32-bit integer form (134744072 -> 8.8.8.8),
+    // but the C resolver also reads HEX literals as addresses. MEASURED
+    // 2026-07-27 through plain getaddrinfo — the ordinary path every fetch and
+    // WebSocket takes — with controls in the same run:
+    //
+    //     0x08080808  -> 8.8.8.8            PUBLIC
+    //     0xdeadbeef  -> 222.173.190.239    PUBLIC
+    //     0X8         -> 0.0.0.8
+    //     steamdeck   -> does not resolve   <- control: a real name is not an address
+    //     bazzite     -> does not resolve   <- control
+    //     10.0.0.1    -> 10.0.0.1           <- control
+    //
+    // So `#host=0x08080808` would walk a bare-label allowlist straight to
+    // 8.8.8.8 with the bearer token. Refuse the hex shape, and require at
+    // least one letter that is not part of a 0x prefix so nothing
+    // number-parseable survives as a "name".
+    if (/^0x[0-9a-f]*$/i.test(host)) return false;
+    return /[a-z]/i.test(host.replace(/^0x/i, ''));
+  }
+  const lower = host.toLowerCase();
+  return HOST_SUFFIXES.some((s) => lower.endsWith(s));
+}
+
+/**
+ * Parse and validate. Returns the link, or the reason it was refused.
+ *
+ * `defaultPort` is passed in rather than imported so this file keeps ZERO
+ * imports and runs under the bare-Node test runner CI already uses. It also
+ * means DEFAULT_PORT stays defined once, in lib/settings.ts, instead of being
+ * copied here to drift.
+ */
+export function parsePairLink(
+  raw: string,
+  opts: { forms: readonly PairLinkForm[]; defaultPort: number },
+): PairLinkResult {
+  if (typeof raw !== 'string') return rej('not-pair-link');
+  const text = raw.trim();
+  if (!text) return rej('empty');
+  if (text.length > MAX_RAW_LEN) return rej('too-long');
+  if (text === STORE_CODE) return rej('store-code');
+
+  let params: Record<string, string> | null | undefined;
+  for (const form of opts.forms) {
+    const sep = FORM_SEP[form];
+    const bases = FORM_BASES[form];
+    if (!sep || !bases) continue; // not a known form name — ignored, never trusted
+    const at = text.indexOf(sep);
+    const base = (at < 0 ? text : text.slice(0, at)).toLowerCase();
+    // Scheme and host are case-insensitive by RFC, and Android hands the
+    // scheme back lowercased while iOS does not. Folding the base cannot
+    // invent a new origin; it only removes a platform-dependent mismatch.
+    if (!bases.includes(base)) continue;
+    params = parseParams(at < 0 ? '' : text.slice(at + 1));
+    break;
+  }
+  if (params === undefined) return rej('not-pair-link');
+  if (params === null) return rej('duplicate-param');
+
+  const host = (params.host ?? '').trim();
+  if (!host) return rej('missing-host');
+  if (!hostShapeOk(host)) return rej('bad-host');
+
+  const token = params.token ?? '';
+  if (!token) return rej('missing-token');
+  if (token.length < TOKEN_MIN || token.length > TOKEN_MAX || !TOKEN_RE.test(token)) {
+    // Deliberately NOT /^[0-9a-f]{48}$/. That is what install.sh mints, but the
+    // agent's --token accepts a literal and pre-Couchside tokens were migrated
+    // forward; tightening this would refuse legitimately configured boxes.
+    return rej('bad-token');
+  }
+
+  // Absent is fine (the box's port is 8787 by default). Malformed is NOT
+  // silently defaulted the way DeepLink.tsx does today: a QR is machine-
+  // generated, so a broken port means this is not our code.
+  let port = opts.defaultPort;
+  const rawPort = params.port ?? '';
+  if (rawPort) {
+    if (!/^[0-9]{1,5}$/.test(rawPort)) return rej('bad-port');
+    port = Number(rawPort);
+    if (port < 1 || port > 65535) return rej('bad-port');
+  }
+
+  // `ip` is only a fallback route to a host we already validated, so a bad one
+  // is DROPPED rather than fatal — matching what addBox already does with it.
+  const rawIp = (params.ip ?? '').trim();
+  const ip = rawIp && isLanIpv4(rawIp, true) ? rawIp : undefined;
+
+  // Unknown params are ignored, not fatal: they cannot reach anything, and
+  // refusing them would break forward compatibility with a newer agent.
+  return { ok: true, link: { host, port, token, ip } };
+}
+
+/**
+ * What accepting this link would DO to the stored fleet.
+ *
+ * Matching mirrors SettingsContext's sameTarget (exact host string + port —
+ * NOT case-folded, because addBox dedupes on the exact string). The
+ * distinction that matters is `token-change`: addBox silently overwrites the
+ * stored token for a matched box, so a hostile QR for a host the user already
+ * owns would swap their working credential for the attacker's and the box
+ * would just go "offline". The scanner asks first; same-token and brand-new
+ * links have nothing to defend.
+ */
+export function pairCollision(
+  boxes: readonly { host: string; port: number; token: string; name: string }[],
+  link: PairLink,
+): { kind: 'new' } | { kind: 'same-token'; name: string } | { kind: 'token-change'; name: string } {
+  const hit = boxes.find((b) => b.host === link.host && b.port === link.port);
+  if (!hit) return { kind: 'new' };
+  if (hit.token === link.token) return { kind: 'same-token', name: hit.name };
+  return { kind: 'token-change', name: hit.name };
+}
+
+/**
+ * Build the pairing link the QR encodes — or return NULL for a box whose link
+ * parsePairLink would refuse. Kept here so the writer and the reader sit in
+ * one file — the format used to be stated in four places and parsed in none.
+ * Mirrors agent build_pair_url() byte for byte.
+ *
+ * The null return is the symmetry that makes the pair provable: the app can
+ * never render a QR its own scanner rejects (degrade closed, §3.7). A test
+ * round-trips every accepted build back through parsePairLink, and asserts
+ * that a box the reader would refuse builds nothing at all.
+ */
+export function buildPairLink(box: {
+  host: string;
+  port: number;
+  token: string;
+  lastIp?: string;
+}): string | null {
+  const host = (box.host ?? '').trim();
+  if (!hostShapeOk(host)) return null;
+  if (!Number.isInteger(box.port) || box.port < 1 || box.port > 65535) return null;
+  const token = box.token ?? '';
+  if (token.length < TOKEN_MIN || token.length > TOKEN_MAX || !TOKEN_RE.test(token)) return null;
+  let q =
+    `host=${encodeURIComponent(host)}` +
+    `&port=${encodeURIComponent(String(box.port))}` +
+    `&token=${encodeURIComponent(token)}`;
+  // A lastIp that would not survive the reader is dropped, not fatal — same
+  // policy as the reader's own ip handling.
+  if (box.lastIp && isLanIpv4(box.lastIp, true)) q += `&ip=${encodeURIComponent(box.lastIp)}`;
+  const url = `https://couchside.tv/pair#${q}`;
+  return url.length > MAX_RAW_LEN ? null : url;
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,6 +14,7 @@
         "expo": "~57.0.1",
         "expo-application": "~57.0.2",
         "expo-build-properties": "~57.0.2",
+        "expo-camera": "~57.0.3",
         "expo-clipboard": "~57.0.1",
         "expo-constants": "~57.0.2",
         "expo-document-picker": "57.0.0",
@@ -2580,6 +2581,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/emscripten": {
+      "version": "1.41.5",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-1.41.5.tgz",
+      "integrity": "sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -2984,6 +2991,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/barcode-detector": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/barcode-detector/-/barcode-detector-3.2.1.tgz",
+      "integrity": "sha512-zLL7AbT9uNJBUzYpKg9v5tUA4yQGReExSi60q0g660Mj0wjUhKmN0GrUF3qELo8ITW9THzyJXdZQkXLMnsieiw==",
+      "license": "MIT",
+      "dependencies": {
+        "zxing-wasm": "3.1.1"
       }
     },
     "node_modules/base64-js": {
@@ -3815,6 +3831,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-57.0.3.tgz",
+      "integrity": "sha512-Q+3aZ63eQCkdB6/FZrO/lfacNAg/j8JCeKQL2nBdf6vBeOo1Y2PKYx1/vK+U5LaRnIo/0tMGmCOzZ1JGhTeMIw==",
+      "license": "MIT",
+      "dependencies": {
+        "barcode-detector": "^3.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
       }
     },
     "node_modules/expo-clipboard": {
@@ -7597,6 +7633,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -8165,6 +8213,34 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zxing-wasm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/zxing-wasm/-/zxing-wasm-3.1.1.tgz",
+      "integrity": "sha512-g0sPJBIubO6zLcJh1jftLPIN6xziaqLsvLgtpGKwDrEhyXXqla3E3yjFrznlr78UHIOMzbJPi0HDWKs/KgaB7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/emscripten": "^1.41.5",
+        "type-fest": "^5.8.0"
+      },
+      "peerDependencies": {
+        "@types/emscripten": ">=1.39.6"
+      }
+    },
+    "node_modules/zxing-wasm/node_modules/type-fest": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/app/package.json
+++ b/app/package.json
@@ -9,6 +9,7 @@
     "expo": "~57.0.1",
     "expo-application": "~57.0.2",
     "expo-build-properties": "~57.0.2",
+    "expo-camera": "~57.0.3",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.2",
     "expo-document-picker": "57.0.0",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -588,6 +588,24 @@ recommendation was wrong, not merely superseded.
 
 ## ✅ Completed
 
+### In-app QR pairing scanner (Netflix-style) — SHIPPED 2026-07-27
+- **priority:** P1 · **risk:** med (new bearer-token ingress) · **affects:** app only
+- Full-bleed camera in a modal off Setup > ADD/PAIR: corner-bracket reticle, translucent
+  bottom card, back chevron — the Netflix look the owner asked for, minus Netflix's
+  auto-apply trust model (their QR resolves to their infrastructure; ours hands over a
+  bearer-token destination).
+- **One validator, both callers** (`lib/pairLink.ts`, 26 bare-Node tests): byte-exact
+  origin binding, LAN-only host allowlist (private IPv4 via lib/lanIp.ts, single
+  non-address labels, `.local`), duplicate-param + octal-octet + hex-literal rejection
+  (`0x08080808` getaddrinfo's to 8.8.8.8 — measured), reject-rather-than-sanitise.
+  DeepLink.tsx now routes through it too (closes KI-034: it accepted ANY host before).
+  `addBox` gained a choke-point gate; only the hand-typed form is exempt.
+- Token-change collisions confirm before overwriting (a hostile QR for a box you own
+  would otherwise silently swap your working credential); success haptic fires AFTER the
+  gate, not on decode.
+- **Requires a new native build** (expo-camera). Camera path untestable in the harness;
+  everything else verified there by pressing the controls.
+
 ### 2026-07-24 — Phone→box file drop (agent 2.9.54 + app FileDropCard)
 Send any file from the phone to the box. Agent gains a Bearer-gated `POST /api/upload?name=`
 that STREAMS the request body to `~/Downloads/Couchside` in 1 MiB chunks (before the 8 MiB

--- a/docs/memory/DEPENDENCIES.md
+++ b/docs/memory/DEPENDENCIES.md
@@ -27,6 +27,7 @@ prebuilt `ios/` directory checked in.
 
 | Package | Version | Why |
 |---|---|---|
+| `expo-camera` | `~57.0.3` | `CameraView` + `useCameraPermissions` behind the in-app QR pairing scanner (`BoxScanQr`). QR-only (`barcodeTypes: ['qr']`). Registered as an `app.json` plugin with `recordAudioAndroid: false` + `microphonePermission: false` — the plugin's DEFAULTS add RECORD_AUDIO / an iOS mic string to a scanner that records nothing (verified stripped via `expo config --type introspect`). `require()`d lazily so a JS bundle on a binary without the native module hides the feature instead of crashing. Pulls `barcode-detector` (web-only transitive). |
 | `expo-document-picker` | `~57.0.1` | Native file picker behind the "Send a file to your box" card (`FileDropCard`). `copyToCacheDirectory` so the picked file is a real file:// uri the uploader can stream. |
 | `expo-file-system` | `~57.0.1` | Streams the picked file to `POST /api/upload` via the SDK-57 `new File(uri).createUploadTask(..., { uploadType: UploadType.BINARY_CONTENT })` API — bytes never enter JS memory, so multi-GB games upload with live progress. **Lazy-imported** inside `lib/api.ts uploadFile()` so the web dev harness never has to load the native module. |
 

--- a/tests/test_no_camera_in_shipping_app.py
+++ b/tests/test_no_camera_in_shipping_app.py
@@ -1,42 +1,50 @@
 #!/usr/bin/env python3
-"""The shipping app must never gain camera capability. This blocks demo mode.
+"""The shipping app's camera is QR-pairing only and MIC-LESS. Demo mode stays unmergeable.
 
-WHAT THIS IS FOR
-----------------
-Branch `feat/demo-mode` (commit 976d7a2, "wip: demo-mode build for promo recording --
-NOT for merge") adds a developer-only recording aid: a tap-indicator overlay plus a
-rear-camera picture-in-picture. It is built as an ad-hoc, bundle-id-forked
-(`com.ets3d.rescueremote.demo`) build that never goes near TestFlight or the App Store.
+HISTORY — the invariant this file guards CHANGED, on purpose, once
+------------------------------------------------------------------
+Until 2026-07-27 this test enforced "the shipping app must never gain camera
+capability", written when branch `feat/demo-mode` (rear-camera PiP for promo
+recording, deliberately unmergeable) was the only thing that could bring a
+camera in. On 2026-07-27 the owner explicitly asked for an in-app QR pairing
+scanner (couchside PR #292), so `expo-camera` is now a LEGITIMATE shipping
+dependency and this test failing on that PR was the system working: the
+capability arrived by decision, not by accident, and the decision is recorded
+here.
 
-That branch is DELIBERATELY UNMERGEABLE. This test is the mechanism.
+WHAT IS STILL BANNED, AND WHY
+-----------------------------
+1. THE MICROPHONE. The scanner reads frames; it records nothing. expo-camera's
+   config plugin DEFAULTS to adding android.permission.RECORD_AUDIO and offers
+   an iOS mic string — a QR scanner that asks for the mic is both a store-review
+   smell and a lie against couchside.tv/privacy ("no image or video is
+   recorded"). So the plugin entry must pin `recordAudioAndroid: false` and
+   `microphonePermission: false`, and no mic purpose string may appear.
+   (Verified 2026-07-27 via `expo config --type introspect`: with those options
+   the manifest carries CAMERA but not RECORD_AUDIO, and the plist has no
+   NSMicrophoneUsageDescription.)
+2. THE DEMO-MODE FORK MACHINERY. `feat/demo-mode` is still deliberately
+   unmergeable, and the guard against it still has to live HERE on main —
+   a guard that lives on the branch merges its own approval. Its tells:
+   app.config.* (the bundle-id fork mechanism), the `.demo` bundle id, a
+   `demo` EAS profile, EXPO_PUBLIC_DEMO_BUILD, DemoCameraPip.tsx, and
+   react-native-vision-camera.
 
-WHY A TEST RATHER THAN A CONVENTION
------------------------------------
-The branch carries its own isolation test, and that is exactly the problem: a guard
-that lives on the branch disappears at the moment it would matter, because merging the
-branch merges the guard's own approval. The guard has to live HERE, on main, where a
-merge makes CI go red instead of quietly shipping a camera-linked binary.
-
-THE ACTUAL TRAP THIS CATCHES
-----------------------------
-On that branch the expo-camera CONFIG PLUGIN is conditional (added by app.config.js only
-when EXPO_PUBLIC_DEMO_BUILD=1), but the `expo-camera` DEPENDENCY in app/package.json is
-NOT. Expo autolinking keys off package.json, not off config plugins -- measured on this
-repo: with expo-camera present in node_modules but absent from main's package.json,
-`npx expo-modules-autolinking resolve -p ios --json` returns 24 modules and does not
-include it. Declare it in package.json and it links.
-
-So a merge would compile camera native code into the SHIPPING binary while
-NSCameraUsageDescription stayed absent -- precisely the state Apple's purpose-string
-checks exist to flag, and precisely what the owner said he does not want.
+THE AUTOLINKING TRAP, still true and still the reason this checks package.json
+------------------------------------------------------------------------------
+Expo autolinking keys off package.json, not off config plugins — measured on
+this repo. So a camera dependency in ANY dependency section links native code
+into the shipping binary regardless of plugins. That is why expo-camera's
+package.json entry must be paired with its properly-pinned plugin entry: the
+dependency without the plugin ships camera code with no purpose string
+(Apple flags exactly this), and the plugin without the pins re-grows the mic.
 
 IF THIS TEST FAILS
 ------------------
-You are probably mid-merge of demo mode. Do not "fix" it by adding a camera usage string.
-Back the merge out. Demo mode is built from its own branch with
-`eas build --profile demo -p ios --local`; see docs/DEMO_MODE.md on that branch.
-
-Pure stdlib, like every other test here.
+Mic findings: do not "fix" by adding a mic string — the scanner records
+nothing; restore the plugin pins. Demo findings: you are probably mid-merge of
+demo mode; back it out (it builds from its own branch, see docs/DEMO_MODE.md
+there). Pure stdlib, like every other test here.
 """
 import json
 import sys
@@ -45,13 +53,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 APP = ROOT / "app"
 
-# The dependency that started this. Kept narrow ON PURPOSE: a guard that also blocks
-# unrelated future work (expo-image-picker for an avatar, say) is a guard someone deletes
-# in frustration. This blocks the camera-preview path specifically.
-BANNED_DEPS = ("expo-camera", "react-native-vision-camera")
-
-# Purpose strings that must never appear in the shipping Info.plist.
-BANNED_PLIST_KEYS = ("NSCameraUsageDescription", "NSMicrophoneUsageDescription")
+# The one camera dependency the shipping app may declare, and the plugin option
+# pins that keep it mic-less. vision-camera remains banned outright (it is the
+# demo branch's tell, and nothing in the product needs it).
+ALLOWED_CAMERA_DEP = "expo-camera"
+BANNED_DEPS = ("react-native-vision-camera",)
 
 failures = []
 
@@ -61,13 +67,11 @@ def check(cond: bool, msg: str) -> None:
         failures.append(msg)
 
 
-# ------------------------------------------------------ package.json (the real trap)
+# ------------------------------------------------------ package.json (autolinking)
 
 pkg = json.loads((APP / "package.json").read_text())
-# All three sections, not just `dependencies`. Measured: moving expo-camera to
-# devDependencies does NOT stop the leak (autolinking still resolves 25 modules and
-# still links it), and optionalDependencies links it too while silently disabling the
-# demo camera. Every section that lands the package in node_modules is a leak path.
+# All three sections: measured, devDependencies and optionalDependencies both
+# still land the package in node_modules and autolinking still links it.
 declared = (
     set(pkg.get("dependencies", {}))
     | set(pkg.get("devDependencies", {}))
@@ -77,10 +81,8 @@ declared = (
 for dep in BANNED_DEPS:
     check(
         dep not in declared,
-        f"app/package.json declares `{dep}`. Expo autolinking keys off package.json, so "
-        f"this links camera native code into the SHIPPING binary even if no config "
-        f"plugin adds a usage string. This is the demo-mode merge trap -- back the merge "
-        f"out rather than adding a purpose string.",
+        f"app/package.json declares `{dep}`. That package is the demo branch's camera; "
+        f"the shipping scanner uses expo-camera. Back the merge out.",
     )
 
 # --------------------------------------------------- app.config.js (the fork mechanism)
@@ -98,21 +100,50 @@ for name in ("app.config.js", "app.config.ts", "app.config.mjs", "app.config.cjs
 app_json = json.loads((APP / "app.json").read_text())
 expo = app_json["expo"]
 
-plugins = [p[0] if isinstance(p, list) else p for p in expo.get("plugins", [])]
+raw_plugins = expo.get("plugins", [])
+plugin_names = [p[0] if isinstance(p, list) else p for p in raw_plugins]
+
 for dep in BANNED_DEPS:
     check(
-        dep not in plugins,
-        f"app.json lists the `{dep}` config plugin, which writes a camera purpose string "
-        f"into the shipping Info.plist.",
+        dep not in plugin_names,
+        f"app.json lists the `{dep}` config plugin — the demo branch's camera path.",
+    )
+
+# expo-camera: dependency and plugin must arrive TOGETHER, with the mic pinned off.
+has_dep = ALLOWED_CAMERA_DEP in declared
+has_plugin = ALLOWED_CAMERA_DEP in plugin_names
+check(
+    has_dep == has_plugin,
+    "expo-camera dependency and its config plugin must be added/removed together: the "
+    "dependency alone links camera code with no purpose string (autolinking keys off "
+    "package.json), and the plugin alone is a purpose string for code that isn't there.",
+)
+if has_plugin:
+    entry = next(p for p in raw_plugins if isinstance(p, list) and p[0] == ALLOWED_CAMERA_DEP)
+    opts = entry[1] if len(entry) > 1 and isinstance(entry[1], dict) else {}
+    check(
+        opts.get("recordAudioAndroid") is False,
+        "expo-camera plugin must pin `recordAudioAndroid: false` — the plugin DEFAULT "
+        "adds android.permission.RECORD_AUDIO to a scanner that records nothing.",
+    )
+    check(
+        opts.get("microphonePermission") is False,
+        "expo-camera plugin must pin `microphonePermission: false` — no mic purpose "
+        "string may ship; the scanner reads frames and records nothing.",
+    )
+    check(
+        bool(opts.get("cameraPermission")),
+        "expo-camera plugin must set an explicit cameraPermission string — the default "
+        "boilerplate ('Allow $(PRODUCT_NAME) to access your camera') explains nothing "
+        "and App Review flags vague purpose strings.",
     )
 
 info_plist = expo.get("ios", {}).get("infoPlist", {})
-for key in BANNED_PLIST_KEYS:
-    check(
-        key not in info_plist,
-        f"app.json's ios.infoPlist sets {key}. The shipping app does not use the camera "
-        f"or the microphone and must not ask for them.",
-    )
+check(
+    "NSMicrophoneUsageDescription" not in info_plist,
+    "app.json's ios.infoPlist sets NSMicrophoneUsageDescription. The shipping app must "
+    "never ask for the microphone.",
+)
 
 bundle_id = expo["ios"]["bundleIdentifier"]
 check(
@@ -148,13 +179,13 @@ check(
 # ------------------------------------------------------------------------- verdict
 
 if failures:
-    print("FAIL: the shipping app is gaining camera capability\n")
+    print("FAIL: shipping-app camera/mic policy violated\n")
     for f in failures:
         print(f"  * {f}\n")
     print(
-        "Demo mode is deliberately unmergeable. Build it from feat/demo-mode with\n"
-        "`eas build --profile demo -p ios --local` instead of merging it to main."
+        "The shipping camera is QR-pairing only and mic-less; demo mode builds from\n"
+        "feat/demo-mode with `eas build --profile demo -p ios --local`, never a merge."
     )
     sys.exit(1)
 
-print("ok: shipping app declares no camera dependency, plugin, or purpose string")
+print("ok: camera is pairing-only and mic-less; no demo-mode machinery on main")


### PR DESCRIPTION
> **Stacked on #291** (the KI-033 LAN-gate fix) — merge that first; this branch contains its commit.

The scanner from the owner's Netflix reference: full-bleed camera, four corner brackets, translucent bottom card with QR glyph + bold title + lighter sub, back chevron. What it deliberately does **not** copy is Netflix's trust model — their card promises "Your controller will open automatically" because their QR resolves to their own infrastructure. Ours says *"here is a host to trust and a bearer token to send it"*, so a decode is untrusted input.

## The validator (`app/lib/pairLink.ts`, 26 bare-Node tests)

One interpreter for every pairing payload — scanner, deep link, SHOW QR writer:

- **Origin**: byte-exact base equality against a frozen table. Kills `couchside.tv.evil.com`, `couchside.tv@evil.com`, backslash spoofs, origin-in-query. **No `new URL()`** — RN's global URL is a regex shim that disagrees with Node's parser *in the accept direction* (measured, documented in the module header), so a URL-based rule would be tested against a parser the app doesn't run.
- **Hosts**: private IPv4 (via `lib/lanIp.ts` from #291, loopback excluded), bare single labels that are **not addresses in disguise**, multi-label under `.local` only. Measured with controls: `getaddrinfo("0x08080808")` → **8.8.8.8**, `134744072` → 8.8.8.8, while `steamdeck`/`bazzite` don't resolve. A naive "bare labels can't route" rule walks a hex literal straight to a public host with the token.
- Repeated params rejected; malformed port rejected (absent defaults); token shape-checked, deliberately not format-checked (the attacker's token adds no safety; a strict format refuses legitimately `--token`-configured boxes); a reject carries a reason and **no other field** (asserted — nothing a credential can ride back to the UI on).
- `buildPairLink` returns `null` for any box the reader would refuse — **the writer is provably a subset of the reader** (round-trip tested). SHOW QR falls back to copy-by-hand with one line of why.

## Two holes closed on the way

- **KI-034**: `DeepLink.tsx` accepted **any** host — `couchside://setup?host=evil.com&token=x` silently added a public box and the app beaconed the token to it forever. Now routed through the same validator, **plus** a choke-point gate inside `addBox` so every future caller starts closed (`userTypedHost: true` exempts only the hand-typed form).
- **Token-swap clobber**: a valid QR for a host+port you already own but a different token now **asks first** (`pairCollision`) — the silent overwrite was how a hostile code could brick a working box. The success haptic fires *after* that gate, not on decode.

## The scan path details that matter

- `onBarcodeScanned` fires at frame rate (the SDK's 500 ms throttle only skips byte-identical event JSON; `bounds` jitters every handheld frame). Accept path latches via a ref before any await; flipping the callback to `undefined` drops the native analyzer (verified in SDK 57 source — the `active` prop is iOS-only and not that switch).
- Rejects don't latch (user may pan to the right code); the identical payload is debounced 3 s so the banner doesn't strobe.
- expo-camera plugin: `recordAudioAndroid: false`, `microphonePermission: false` — the defaults add RECORD_AUDIO + a mic string to a scanner that records nothing. **Verified from the artifact** (`expo config --type introspect`): camera string in, no mic key, no RECORD_AUDIO.
- Module `require()`d lazily — a JS bundle OTA'd onto a binary without the native module hides the row instead of crashing.

## Verified

- 92/92 app tests, `tsc` clean.
- Harness, pressing real controls: trigger renders in the ADD/PAIR card → modal opens → permission gate shows the exact copy → ALLOW CAMERA fires a real `getUserMedia` (the pane blocks camera; the gate held, no crash) → chevron closes.
- SHOW QR observed in **both states**: loopback-host box → fallback copy (null branch); `.local` box → QR + normal caption (control).

## NOT verified (needs a native build)

- Everything camera: live decode, the frame-rate latch on hardware (read from SDK source, not observed firing), OS permission dialogs, denied-forever → `openSettings`, dark-room glare ergonomics, `onMountError`.
- The deep-link path live (harness can't fire `couchside://`); covered at the validator + choke-point layers by tests.
- `expo prebuild` / EAS with expo-camera not yet attempted.

## Ship gate (separate repo)

couchside.tv currently states the app **"does not use the camera"** on `privacy/` and `app-review/` — affirmatively false once this binary exists. Those pages must deploy **before** any store submission of a build containing this. (Being fixed in `ets3d` next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)