### PR TITLE
chore(scripts): release-agent.sh says which agent version it is publishing

### DIFF
--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -37,6 +37,26 @@ for f in "${files[@]}"; do
     [ -f "$agent/$f" ] || { echo "error: missing agent/$f" >&2; exit 2; }
 done
 
+# ---- Say what this run will DO before doing any of it. The <tag> argument is
+# the APP release the assets ride on; the AGENT version lives inside the files.
+# That mismatch reads as "releasing 2.9.29" when it means "publishing agent
+# 2.9.58 onto release v2.9.29", and it confused a real release — so the script
+# now states both, shows what the tag currently serves, and asks.
+agent_ver_preview="$(grep -m1 '^VERSION' "$agent/couchsided.py" | cut -d'"' -f2)"
+win_ver_preview="$(grep -m1 '^VERSION' "$agent/win/couchsided-win.py" | cut -d'"' -f2)"
+published="$(curl -fsSL --max-time 10 "https://github.com/$REPO/releases/download/$tag/agent-version.txt" 2>/dev/null | head -1 || true)"
+echo "==> this will publish agent $agent_ver_preview (windows $win_ver_preview) onto release $tag"
+echo "==> release $tag currently serves agent: ${published:-<none/unreadable>}"
+if [ "${published:-}" = "$agent_ver_preview" ]; then
+    echo "==> NOTE: that is the SAME version — this run would republish identical-version assets."
+fi
+# Prompt only when interactive; automation (non-TTY) proceeds, same as before.
+if [ -t 0 ]; then
+    printf '==> continue? [y/N] '
+    read -r _ans
+    case "$_ans" in y|Y|yes|YES) ;; *) echo "aborted (nothing uploaded)"; exit 1 ;; esac
+fi
+
 # Pick an openssl that supports Ed25519 one-shot signing (-rawin).
 ossl="openssl"
 if ! "$ossl" pkeyutl -help 2>&1 | grep -q -- '-rawin'; then


### PR DESCRIPTION
`release-agent.sh <tag>` takes the **app release tag** the signed assets attach to — but the **agent version** lives inside the uploaded files. So the command reads `release-agent.sh v2.9.29` unchanged across agent 2.9.53 → 2.9.57 → 2.9.58, which looks like it is re-shipping an old version. That mismatch caused a real "why is this always 2.9.29?" moment.

Before touching anything, it now prints:

```
==> this will publish agent 2.9.58 (windows 0.4.3-win) onto release v2.9.29
==> release v2.9.29 currently serves agent: 2.9.57
```

The second line is fetched from the tag's live `agent-version.txt`, so it shows what boxes are *actually* being served — that is how the 2.9.57/2.9.58 gap becomes visible instead of implied. When the two match it adds a NOTE (republishing identical-version assets is usually a mistake).

Interactive runs confirm before uploading; non-TTY runs proceed unchanged so nothing automated breaks.

## Verified, both directions, with a dummy key

| on disk | output |
|---|---|
| agent 2.9.58 | reports `2.9.57 → 2.9.58`, no NOTE |
| VERSION forced to 2.9.57 | same-version NOTE fires |

Neither run uploaded anything — the dummy key fails at the signing step, which is *after* the banner. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)