### PR TITLE
fix(update): flatpak completion via process signal, not an unreachable count (KI-036)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,13 @@ jobs:
       - name: Unit tests (boot session default)
         run: python3 tests/test_session_default.py
 
+      # Flatpak update completion (KI-036). "Done" must be the update PROCESS
+      # finishing, not `remote-ls` count reaching zero — an EOL runtime pins the
+      # count above zero forever, which stranded the card on "Updating…" and
+      # blocked the OS step behind it. Device-confirmed 2026-07-27.
+      - name: Unit tests (flatpak update completion)
+        run: python3 tests/test_flatpak_completion.py
+
       # Stream-host liveness (the `online` field). remoteclients.vdf lists every
       # host ever streamed from and says nothing about which are ON, so picking a
       # game from a sleeping PC makes Steam offer a multi-GB install instead.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.58"
+VERSION = "2.9.59"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1730,6 +1730,20 @@ FLATPAK_UPDATE_LOG = "/tmp/couchside-flatpak-update.log"
 # run this one fixed update, never arbitrary flatpak subcommands (install / run /
 # override / remote-add). Same airtight shape as the journal wrapper.
 FLATPAK_UPDATE_WRAPPER = "/etc/couchside/couchside-flatpak-update"
+# Handle to the detached flatpak-update child, so a later status GET can report
+# whether the update is still RUNNING — the honest completion signal.
+#
+# WHY (KI-036, device-confirmed 2026-07-27): the app used to infer "done" from
+# `flatpak remote-ls --updates` reaching zero. That list counts runtimes
+# `flatpak update` will NOT apply — an end-of-life runtime (measured:
+# org.freedesktop.Platform 23.08) shows as "update available" while the update
+# says "Nothing to do" and cannot cross the EOL major boundary. So the count is
+# pinned above zero, "done" is UNREACHABLE, and the app spun ten minutes then —
+# on an "update everything" press — blocked the OS update behind that dead wait.
+# Whether OUR child is still alive IS reachable and correct. We hold the Popen
+# object (the child stays our direct child even with start_new_session), so
+# poll() is authoritative and reaps the zombie on completion.
+_FLATPAK_PROC = None
 # The no-root fallback when the wrapper grant is absent: update only the USER's
 # own --user installs, which never need root. On a box whose flatpaks are all
 # system-installed this updates nothing (honest — the app then prompts to enable
@@ -1834,9 +1848,33 @@ def flatpak_update():
     if rc is not None and rc != 0:
         return {"started": False, "elevated": elevated, "exit_code": rc,
                 "log": FLATPAK_UPDATE_LOG, "lines": read_flatpak_log()}
+    # Keep the handle so flatpak_running() can report completion. Stored only on
+    # a clean start; a same-tick failure above returns without touching it.
+    global _FLATPAK_PROC
+    _FLATPAK_PROC = proc
     print("[update] flatpak update started (elevated=%s, log: %s)"
           % (elevated, FLATPAK_UPDATE_LOG), flush=True)
     return {"started": True, "elevated": elevated, "log": FLATPAK_UPDATE_LOG}
+
+
+def flatpak_running():
+    """True while the flatpak update this agent launched is still executing.
+
+    This is the completion signal the app polls — NOT `count == 0`, which an
+    un-updatable EOL runtime can pin above zero forever (KI-036). poll() on the
+    Popen we hold is authoritative and reaps the child on exit.
+
+    Degrade-closed toward DONE: if we never launched one (None), or the agent
+    restarted and lost the handle, or poll() raises, we report False. A false
+    'still running' would strand the card on "Updating…"; a false 'done' at
+    worst shows a stale pending count the next status refresh corrects."""
+    proc = _FLATPAK_PROC
+    if proc is None:
+        return False
+    try:
+        return proc.poll() is None
+    except Exception:
+        return False
 
 
 # ---------------------------------------------------------------------------
@@ -12587,8 +12625,14 @@ class Handler(BaseHTTPRequestHandler):
                     # updated (owner opted in) or only --user ones — so it can
                     # prompt "enable system updates on your box" when False.
                     elevated = True if self.mock else flatpak_can_elevate()
+                    # running: is our update child still executing? The app polls
+                    # THIS for completion, not count==0 (KI-036: an EOL runtime
+                    # pins count above zero, so count==0 is unreachable). Mock is
+                    # never mid-update, so False.
+                    running = False if self.mock else flatpak_running()
                     self._send(200, {"available": True, "count": len(pending),
-                                     "updates": pending, "elevated": elevated},
+                                     "updates": pending, "elevated": elevated,
+                                     "running": running},
                                started)
             elif path == "/api/update/flatpak/log":
                 # Progress transcript of a running/last flatpak update. CONSTANT

--- a/app/components/SystemUpdatesCard.tsx
+++ b/app/components/SystemUpdatesCard.tsx
@@ -21,6 +21,7 @@ import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
 import { api, FlatpakStatus, hostKey, OsStatus } from '@/lib/api';
+import { isFlatpakUpdateComplete } from '@/lib/flatpakUpdate';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles } from '@/lib/theme';
@@ -121,10 +122,22 @@ export function SystemUpdatesCard() {
     setFpStep('running');
     try {
       const r = await api.flatpakUpdate(settings);
-      const done = r.started
-        ? await drain(async () => ((await api.flatpakStatus(settings))?.count ?? -1) === 0)
-        : false;
-      setFpStep(done ? 'done' : 'skipped');
+      if (r.started) {
+        // Wait for the box's update PROCESS to finish, polled via `running`
+        // (agent >= 2.9.59) — NOT `count === 0`. An end-of-life runtime that
+        // `flatpak update` can't apply pins the count above zero forever, so
+        // count===0 was unreachable: the drain ran its full 10 minutes, a
+        // successful update showed as "skipped", and in "update everything" the
+        // OS step was blocked behind that dead wait (KI-036). Old agents don't
+        // send `running`, so fall back to the historical count===0 there.
+        await drain(async () => isFlatpakUpdateComplete(await api.flatpakStatus(settings)));
+        // It launched and we waited it out. A count that remains is an
+        // un-updatable app (e.g. an EOL runtime) — honest to leave shown, not a
+        // failure. Only an update that never STARTED is "skipped".
+        setFpStep('done');
+      } else {
+        setFpStep('skipped');
+      }
     } catch {
       setFpStep('skipped');
     }

--- a/app/lib/__tests__/flatpakUpdate.test.ts
+++ b/app/lib/__tests__/flatpakUpdate.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Flatpak-update completion — lib/flatpakUpdate.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the CI app-input glob.
+ *
+ * THE BUG (KI-036, device-confirmed 2026-07-27): "done" was `count === 0`, but
+ * an end-of-life runtime `flatpak update` can't apply pins the count above zero,
+ * so done was unreachable — the card spun ten minutes and blocked the OS update
+ * behind it. The first test is that exact scenario: a NEW agent reports the
+ * process finished (running=false) while the count is still nonzero, and that
+ * MUST read as complete.
+ *
+ * Controls run both directions (CLAUDE.md §11.3): every "complete" case is
+ * paired with a "not complete" one, so a function that always returned true
+ * would fail.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isFlatpakUpdateComplete } from '../flatpakUpdate.ts';
+
+test('THE BUG: a finished update with an un-updatable app left over is COMPLETE', () => {
+  // New agent: process done, but the EOL runtime keeps count at 1.
+  assert.equal(isFlatpakUpdateComplete({ running: false, count: 1 }), true);
+  // ...even with several stuck EOL apps.
+  assert.equal(isFlatpakUpdateComplete({ running: false, count: 5 }), true);
+  // CONTROL, opposite direction: while the process is still running it is NOT
+  // complete, whatever the count — so this cannot pass by always returning true.
+  assert.equal(isFlatpakUpdateComplete({ running: true, count: 0 }), false);
+  assert.equal(isFlatpakUpdateComplete({ running: true, count: 5 }), false);
+});
+
+test('new agent: running is the sole signal, count is ignored', () => {
+  assert.equal(isFlatpakUpdateComplete({ running: false, count: 0 }), true);
+  assert.equal(isFlatpakUpdateComplete({ running: true, count: 0 }), false);
+});
+
+test('old agent (no running field) falls back to count === 0, unchanged', () => {
+  assert.equal(isFlatpakUpdateComplete({ count: 0 }), true);
+  assert.equal(isFlatpakUpdateComplete({ count: 1 }), false);
+  // The EOL runtime is exactly why the old path hangs — documented, not fixed
+  // for old agents (they never send `running`). This asserts the pre-fix
+  // behaviour is preserved so upgrading the app alone changes nothing there.
+  assert.equal(isFlatpakUpdateComplete({ count: 3 }), false);
+});
+
+test('a not-yet-readable status keeps the poller waiting', () => {
+  assert.equal(isFlatpakUpdateComplete(null), false);
+  assert.equal(isFlatpakUpdateComplete(undefined), false);
+});
+
+test('running takes precedence even when count would say otherwise', () => {
+  // Both fields present and disagreeing: the process signal wins in both
+  // directions — done-with-leftovers is done; still-running-at-zero is not.
+  assert.equal(isFlatpakUpdateComplete({ running: false, count: 9 }), true);
+  assert.equal(isFlatpakUpdateComplete({ running: true, count: 0 }), false);
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -521,6 +521,14 @@ export type FlatpakStatus = {
    * and the card should point at the opt-in instead of pretending.
    */
   elevated: boolean;
+  /**
+   * Whether the box's flatpak-update process is still running (agent >= 2.9.59).
+   * This is the completion signal to poll — NOT `count === 0`. An end-of-life
+   * runtime that `flatpak update` cannot apply keeps `count` above zero forever
+   * (KI-036), so waiting for zero hangs; waiting for `running` to go false does
+   * not. Absent on older agents — callers must fall back to `count === 0` then.
+   */
+  running?: boolean;
 };
 
 export type UpdateCheck = {

--- a/app/lib/flatpakUpdate.ts
+++ b/app/lib/flatpakUpdate.ts
@@ -1,0 +1,41 @@
+/**
+ * When is a box's flatpak update actually FINISHED? Zero runtime imports, so it
+ * is unit-testable on bare Node like lib/lanIp.ts and lib/swipeSteps.ts.
+ *
+ * THE BUG THIS FIXES (KI-036, device-confirmed 2026-07-27). The card used to
+ * treat "done" as `count === 0`, where count is `flatpak remote-ls --updates`.
+ * That list counts runtimes `flatpak update` will NOT apply: an end-of-life
+ * runtime (measured: org.freedesktop.Platform 23.08) reports as "update
+ * available" while the update says "Nothing to do" and cannot cross the EOL
+ * major boundary. So the count is pinned above zero, `count === 0` is
+ * UNREACHABLE, and the drain ran its full ten minutes — marking a successful
+ * update "skipped" and, on an "update everything" press, blocking the OS update
+ * behind that dead wait.
+ *
+ * The honest signal is whether the box's update PROCESS is still running, which
+ * the agent reports as `running` (>= 2.9.59). Completion is `running === false`.
+ * A remaining count then just means some app can't be updated (EOL) — true, and
+ * not a failure. Older agents don't send `running`; there we fall back to the
+ * historical `count === 0`, i.e. the old behaviour, so nothing regresses.
+ */
+
+export type FlatpakProgress = {
+  /** Pending count from the box's remote-ls (includes un-updatable EOL apps). */
+  count: number;
+  /** Is the box's update process still executing? Absent on agents < 2.9.59. */
+  running?: boolean;
+};
+
+/**
+ * True once the update has finished and the poller may stop.
+ *
+ * - `null` (status not yet readable) → false: keep waiting.
+ * - `running` present (new agent) → finished exactly when it is false, whatever
+ *   the count. This is the fix: a nonzero count no longer blocks completion.
+ * - `running` absent (old agent) → fall back to `count === 0`, unchanged.
+ */
+export function isFlatpakUpdateComplete(status: FlatpakProgress | null | undefined): boolean {
+  if (status == null) return false;
+  if (typeof status.running === 'boolean') return status.running === false;
+  return status.count === 0;
+}

--- a/tests/test_flatpak_completion.py
+++ b/tests/test_flatpak_completion.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Flatpak update completion signal (KI-036).
+
+Run: python3 tests/test_flatpak_completion.py
+
+WHY THIS EXISTS — device-confirmed 2026-07-27 on a real Bazzite box. The app
+used to infer "flatpak update done" from `flatpak remote-ls --updates` reaching
+zero. That list counts runtimes `flatpak update` will NOT apply: an end-of-life
+runtime (MEASURED: org.freedesktop.Platform 23.08, "no longer receiving fixes")
+shows as "update available" while the update itself prints "Nothing to do" and
+cannot cross the EOL major-version boundary. So the count is pinned above zero,
+zero is unreachable, and the app spun for ten minutes — then, on an "update
+everything" press, blocked the OS update behind that dead wait.
+
+The fix moves completion to a signal that IS reachable: whether the box's own
+update child process is still running. `flatpak_running()` reports it off the
+Popen handle the agent holds, and `/api/update/flatpak` exposes it as `running`.
+
+DEGRADE-CLOSED DIRECTION (CLAUDE.md §3.7): toward DONE. A false "still running"
+would strand the card on "Updating…" forever; a false "done" at worst shows a
+stale pending count the next status refresh corrects. So every unknown state
+(no process, lost handle after an agent restart, poll() raising) reports False.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class FakeProc:
+    """Stand in for the Popen handle: poll() returns None while alive, then rc."""
+
+    def __init__(self, rc):
+        self._rc = rc
+
+    def poll(self):
+        return self._rc
+
+
+class BoomProc:
+    def poll(self):
+        raise OSError("process handle gone")
+
+
+def main():
+    saved = cs._FLATPAK_PROC
+    try:
+        print("flatpak_running(): reachable completion signal, degrade-closed to DONE")
+
+        # No update was ever launched -> not running (done).
+        cs._FLATPAK_PROC = None
+        check("no process -> not running", cs.flatpak_running(), False)
+
+        # A live child (poll None) IS running. This is the ONLY True case, and it
+        # is the control: without it every other assertion could pass by always
+        # returning False.
+        cs._FLATPAK_PROC = FakeProc(None)
+        check("live child -> running", cs.flatpak_running(), True)
+
+        # Finished, success. THE BUG SCENARIO: the process is done even though a
+        # pending count may remain (the EOL runtime) — this is what the count==0
+        # rule could never see.
+        cs._FLATPAK_PROC = FakeProc(0)
+        check("exited 0 -> not running", cs.flatpak_running(), False)
+
+        # Finished, failure -> still "not running" (done); the failure surfaces
+        # via the log/exit path, not by claiming the process is alive.
+        cs._FLATPAK_PROC = FakeProc(1)
+        check("exited nonzero -> not running", cs.flatpak_running(), False)
+
+        # Handle wedged (agent restarted mid-update, PID reused, poll raises):
+        # degrade closed toward done rather than strand the UI.
+        cs._FLATPAK_PROC = BoomProc()
+        check("poll() raises -> not running", cs.flatpak_running(), False)
+
+        print("the status field the app polls")
+        # The status endpoint must actually carry `running` — assert the key is
+        # produced. Build the same dict the handler sends (mock=False path).
+        cs._FLATPAK_PROC = FakeProc(None)
+        status = {"available": True, "count": 1, "updates": ["x 1.0"],
+                  "elevated": False, "running": cs.flatpak_running()}
+        check("status carries a 'running' key", "running" in status, True)
+        check("running True while the child is alive", status["running"], True)
+        # And the KI-036 invariant expressed on the agent side: a nonzero pending
+        # count does NOT imply still-running once the child has exited.
+        cs._FLATPAK_PROC = FakeProc(0)
+        check("count>0 with a finished process -> running False",
+              (status["count"] > 0) and (cs.flatpak_running() is False), True)
+    finally:
+        cs._FLATPAK_PROC = saved
+
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        return 1
+    print("all flatpak-completion tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Device-confirmed on the living-room Bazzite box, 2026-07-27**, during the box-software update test.

## The bug

The Box-software card inferred "flatpak update done" from `flatpak remote-ls --updates` reaching **0**. But that list counts runtimes `flatpak update` will never apply — an end-of-life runtime (measured: `org.freedesktop.Platform 23.08`) shows as "update available" while the update itself prints **"Nothing to do"** and can't cross the EOL major boundary. So the count is pinned above zero and **0 is unreachable**:

- the 10-minute drain ran in full → a *successful* update showed as **"skipped"**
- on the single "update everything" button, `await runFlatpak()` blocked the OS step behind that dead wait — `POST /api/update/os` **never fired**, card stuck on "Updating…"

Reproduced live: flatpak POST 13:21:01 → "Nothing to do" in ~1s → 10 minutes of polls for a count that stays at 1. EOL runtimes are common on Bazzite/SteamOS, so this was near the default experience.

## The fix

Completion is now **whether the box's own update process is still running** — a reachable signal. The agent already launched the update via `Popen` and threw the handle away; it now keeps it and exposes `flatpak_running()` (`poll()` on the handle, which also reaps the child) as an additive `running` field on `GET /api/update/flatpak`. The app polls that. A remaining count then just means an app can't be updated (honest to show), and flatpak now finishes in seconds so the OS step fires promptly.

Completion logic lives in `app/lib/flatpakUpdate.ts` (import-free, bare-Node testable like `lib/lanIp.ts`): done when `running === false`, falling back to `count === 0` on agents that don't send `running` — so upgrading the app alone never regresses an old box.

Agent → **2.9.59** (additive field). Degrade-closed toward *done*: no handle / lost handle after a restart / `poll()` raising all report not-running, because a false "still running" strands the UI while a false "done" only shows a stale count the next refresh corrects.

## Verified

- **Agent** `tests/test_flatpak_completion.py`: `flatpak_running()` across none / alive / exited-0 / exited-nonzero / poll-raises, plus the KI-036 invariant (count>0 with a finished process ≠ running). Controls both directions.
- **App** `lib/__tests__/flatpakUpdate.test.ts`: the bug case `{running:false,count:5}` reads complete; the control `{running:true,count:0}` does not; old-agent `count===0` fallback intact.
- 97/97 app tests, `tsc` clean, protocol parity OK.
- **Live** on the Bazzite box (patched agent on a spare port, against the real EOL runtime): status reports **`count=1` AND `running=false` simultaneously** — the exact state where the old `count===0` rule hangs and the new `running===false` rule correctly completes.

## NOT verified

The `running===true` window live — this box's only pending flatpak is an instant "Nothing to do" no-op, and the status endpoint reads `running` *after* a ~3s `remote-ls`, so a fast update always finishes first. That path is covered by unit tests (`poll()` returning `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)