### PR TITLE
feat(console): DISPLAY + AUDIO readout card (agent 2.9.60)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,20 @@ jobs:
       - name: Unit tests (gaming card)
         run: python3 tests/test_gaming_card.py
 
+      # Display + audio readout. This feature is almost entirely probes, and
+      # almost every source on a Linux box answers "what CAN this display do"
+      # while the Console tab claims to show "what IS it doing" — so the tests
+      # that matter are the ones proving a capability never ships as a state:
+      # EDID's preferred timing and gamescopectl's ValidRefreshRates never
+      # become the current mode, and /sys/.../modes (a LIST, with no refresh
+      # rate in it at all) never does either. Plus the two measured lies:
+      # kscreen-doctor SIGABRTs with rc=134 and zero output, which must read as
+      # "unavailable" and not as "no displays"; and GAMESCOPE_DISPLAY_HDR_ENABLED
+      # reads 1 on a box whose panel reports no HDR, because it is Steam's
+      # REQUEST rather than state. Fixtures are verbatim hardware captures.
+      - name: Unit tests (display + audio readout)
+        run: python3 tests/test_display_audio.py
+
       # The on-box pairing page: both loopback gates (peer IP + Host header,
       # anti-DNS-rebinding — a box's token must never leave its own screen), the
       # idle tutorial + its reload-into-PIN handoff, the PIN state machine

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.59"
+VERSION = "2.9.60"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1391,7 +1391,7 @@ def set_caps(mock):
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
                  "screensaver", "couchmode", "desktop", "steamlink", "gaming",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
-                 "session_default")}
+                 "session_default", "display_info")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1410,6 +1410,7 @@ def set_caps(mock):
         "steammenus": safe(steammenus_available),
         "boxbattery": safe(box_battery_available),
         "file_upload": safe(lambda: os.access(_drop_dir(), os.W_OK)),
+        "display_info": safe(display_info_available),
     }
 
 
@@ -2334,6 +2335,8 @@ def real_status():
     temp = read_cpu_temp_c()
     mem = read_mem()
     battery = read_box_battery()
+    display = display_info()
+    audio = audio_info()
     now = int(time.time())
     _record_history(now, temp, load[0] if load else None, mem)
     return {
@@ -2349,6 +2352,14 @@ def real_status():
         # new ones can treat "absent" as "this box has no battery" rather than
         # having to distinguish that from 0%.
         **({"battery": battery} if battery else {}),
+        # The panel the box is driving, and the default audio OUT/IN devices.
+        # Same shape of contract as `battery`: ADDITIVE, and OMITTED ENTIRELY
+        # when nothing could be read, so absence means "unavailable" and never
+        # has to be told apart from a null. Every field inside them is likewise
+        # independently optional -- see the module note above display_info() for
+        # what each name is allowed to claim.
+        **({"display": display} if display else {}),
+        **({"audio": audio} if audio else {}),
         "net": net_info_cached(),
         "agent_version": VERSION,
         # CAPS is a boot-time snapshot, but "desktop" is SESSION-volatile (it
@@ -3688,6 +3699,12 @@ def mock_status():
         # minutes for minutes_to_full to exercise the charging layout.
         "battery": {"pct": 58, "status": "Discharging", "on_ac": False,
                     "minutes": 251, "watts": 7.7, "profile": "balanced"},
+        # Mock drives a 4K HDR VRR TV so every display row is renderable, and a
+        # sink/source pair that are DIFFERENT devices with a long description --
+        # see mock_display_info() / mock_audio_info() for why those specific
+        # values.
+        "display": mock_display_info(),
+        "audio": mock_audio_info(),
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
                 "wired": True, "wol_armed": True},
         "agent_version": VERSION,
@@ -10965,6 +10982,1060 @@ def mock_gaming():
 
 
 # ---------------------------------------------------------------------------
+# Display + audio facts (additive blocks on GET /api/status: "display", "audio")
+#
+# What the Console tab shows: the panel the box is actually driving (resolution,
+# refresh, HDR, VRR, who made it, which connector) and the default audio OUT and
+# IN devices.
+#
+# HONESTY IS THE FEATURE HERE. Almost every source below answers "what can this
+# display do", and only two of them answer "what is it doing right now". Those
+# are different questions and this module never lets one masquerade as the
+# other, because the failure mode is a phone confidently reporting 60 Hz on a
+# box running at 120:
+#
+#   current_*    ONLY from a live compositor that told us its output mode.
+#   preferred_*  the display's own preferred timing, from EDID. A CAPABILITY.
+#   supported_*  lists of what the panel/compositor will accept. CAPABILITIES.
+#   *_supported  capability.   *_active  state. Never derived from each other
+#                except in the one direction that is a fact rather than a guess
+#                (a panel that cannot do HDR is certainly not doing HDR).
+#
+# MEASURED 2026-07-27 on the Bazzite box (Lenovo TIO24Gen3T on DP-1), IN GAME
+# MODE. Every claim below is from that capture unless marked otherwise:
+#
+#  * /sys/class/drm/card1-DP-1/modes lists "1920x1080" five times and carries NO
+#    refresh rate at all. It is the mode LIST, not the current mode -- hence
+#    `supported_modes`.
+#  * /sys/kernel/debug/dri/1/state is EACCES as the desktop user. Not used; we
+#    do not sudo for a readout.
+#  * kscreen-doctor EXISTS (/usr/bin/kscreen-doctor) and SIGABRTs with rc=134
+#    and ZERO bytes of stdout in Game Mode -- no KDE session to talk to. A crash
+#    must read as "unavailable", never as "this box has no displays", so the
+#    parser requires non-empty PARSED output and ignores the exit code.
+#  * `gamescopectl` with no arguments prints a gamescope_control info block
+#    (connector, make, model, ValidRefreshRates). Its subcommands and convar
+#    reads return "Command not found." -- convars are NOT readable, so HDR/VRR
+#    state does not come from there. NOTE also that `gamescopectl <convar>
+#    <value>` is a live WRITE surface; this module only ever runs the bare
+#    binary with no arguments.
+#  * gamescope publishes its real state as X11 root-window atoms on its PRIMARY
+#    XWayland (GAMESCOPE_XWAYLAND_SERVER_ID == 0; on server 1 every atom reads
+#    not-found, verified both ways). Read with a ~90-line stdlib X11 client
+#    below rather than xprop/xrandr, which are not guaranteed on stock SteamOS.
+#  * THE HDR TRAP: GAMESCOPE_DISPLAY_HDR_ENABLED read 1 on this box while
+#    GAMESCOPE_DISPLAY_SUPPORTS_HDR read 0, on an SDR panel whose EDID has no
+#    HDR block. In gamescope's source that atom is only ever READ by the
+#    compositor -- it is Steam's "turn HDR on if available" REQUEST, not state.
+#    Sourcing "HDR: On" from it would put HDR On on the Console tab of a machine
+#    driving an 8-bit SDR monitor. The state atom is GAMESCOPE_HDR_OUTPUT_FEEDBACK
+#    and it is written only inside gamescope's output-mode-change handler, so on
+#    this box it does not exist at all. Absent is NOT off.
+#
+# NOT VERIFIED, and deliberately recorded as such:
+#  * The kscreen-doctor path was only ever observed CRASHING. Its JSON shape here
+#    comes from libkscreen's schema, not from a capture; the parser is written to
+#    reject anything it does not fully recognise.
+#  * A gamescope box whose render size differs from its scanout mode (a Deck
+#    rendering 1280x800 into a 4K TV) is untested. current_width/height come from
+#    the X screen size of XWayland server 0, which gamescope sets from
+#    g_nOutputWidth/Height (the OUTPUT size) -- source says scanout, no hardware
+#    proved it.
+#  * vrr_supported has never been observed True, on any panel we could reach.
+#
+# Naming note: the couch-mode switch already has a client-supplied WRITE flag
+# called `hdr` (POST /api/couch-mode). These read-back fields are deliberately
+# `hdr_supported` / `hdr_active` so nobody confuses a request with a reading.
+# ---------------------------------------------------------------------------
+
+# Both blocks ride /api/status, which every app screen and every Fleet row polls
+# at ~5s -- and usePoll retries a FAILING poll every 2s. An uncached probe would
+# put gamescopectl + two wpctl forks (and, off Game Mode, a core-dumping
+# kscreen-doctor) on that path. TTL-memoized like _gaming_payload, but longer:
+# which monitor is plugged in changes on a human timescale, not a poll timescale.
+# The cache is overwritten with whatever the last probe produced, including a
+# degraded one -- a failure must never be papered over with the previous answer.
+_DISPLAY_TTL = 15.0
+_DISPLAY_CACHE = {"val": None, "at": 0.0}
+_AUDIO_CACHE = {"val": None, "at": 0.0}
+_DISPLAY_LOCK = threading.Lock()
+
+# Module constants so tests can point them at fixtures (same pattern as _DRM_DIR).
+_X11_UNIX_DIR = "/tmp/.X11-unix"
+_KSCREEN_TIMEOUT_S = 4
+_GAMESCOPECTL_TIMEOUT_S = 4
+_WPCTL_TIMEOUT_S = 4
+# kscreen-doctor does not fail, it ABORTS -- rc=134, "the monitored command
+# dumped core". Retrying that every TTL on a box sitting at a login screen would
+# hand systemd-coredump a new core dump four times a minute forever, so a failed
+# probe is remembered. This is a stale NEGATIVE (we report nothing for a while),
+# which degrades closed; it can never turn into a stale positive.
+_KSCREEN_BACKOFF_S = 120.0
+_KSCREEN_FAILED_AT = {"t": 0.0}
+
+
+# --- EDID ------------------------------------------------------------------
+#
+# EDID is the display describing ITSELF. It is burned into the monitor and is
+# byte-identical whether the box is driving it at 1920x1080@60, at 640x480, or
+# has it blanked -- confirmed indirectly on the box, where /sys EDID and
+# gamescope's cached ~/.config/gamescope/edid.bin from an earlier boot hash the
+# same. So it answers "what display is this / what can it do" and NEVER "what
+# mode is being driven right now".
+#
+# CONTROL for the parser (CLAUDE.md §11.3): on the measured box `gamescopectl`
+# independently reported Make "Lenovo Group Limited" / Model "TIO24Gen3T" for the
+# same connector, and the manufacturer word 0x30ae must decode to the Lenovo PNP
+# id "LEN". The fixture test asserts both.
+
+_EDID_HEADER = b"\x00\xff\xff\xff\xff\xff\xff\x00"
+_EDID_TAG_SERIAL = 0xFF
+_EDID_TAG_NAME = 0xFC
+_EDID_TAG_RANGE = 0xFD
+
+
+def _edid_text(block):
+    """ASCII payload of a 0xFC/0xFF/0xFE descriptor: bytes 5..17, terminated by
+    0x0A, space-padded. A non-printable byte makes the whole descriptor unusable
+    -- reject, never sanitise (§3.6): garbage here becomes a monitor name on
+    somebody's phone."""
+    raw = block[5:18]
+    nl = raw.find(b"\x0a")
+    if nl >= 0:
+        raw = raw[:nl]
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    text = text.rstrip(" ")
+    if not text or any(ord(c) < 0x20 or ord(c) > 0x7E for c in text):
+        return None
+    return text
+
+
+def _edid_manufacturer(word):
+    """3-letter PNP id from the big-endian 16-bit manufacturer field. Five bits
+    per letter, 1='A'. Bit 15 is reserved-zero, so a set bit means this is not a
+    manufacturer field -- return None rather than a plausible string."""
+    if word & 0x8000:
+        return None
+    letters = []
+    for shift in (10, 5, 0):
+        v = (word >> shift) & 0x1F
+        if not 1 <= v <= 26:
+            return None
+        letters.append(chr(ord("A") + v - 1))
+    return "".join(letters)
+
+
+def _edid_detailed_timing(block):
+    """Parse an 18-byte DETAILED TIMING descriptor -> dict, or None.
+
+    Refresh is COMPUTED, not read: EDID stores a pixel clock and blanking, so
+    Hz = pixel_clock / (htotal * vtotal). On the measured fixture that is
+    148500 kHz / (2200 * 1125) = 60.000 Hz, which agrees with gamescopectl's
+    ValidRefreshRates: 60."""
+    pixclk_10khz = block[0] | (block[1] << 8)
+    if pixclk_10khz == 0:
+        return None                       # 0 here means "not a detailed timing"
+    h_active = block[2] | ((block[4] & 0xF0) << 4)
+    h_blank = block[3] | ((block[4] & 0x0F) << 8)
+    v_active = block[5] | ((block[7] & 0xF0) << 4)
+    v_blank = block[6] | ((block[7] & 0x0F) << 8)
+    h_total = h_active + h_blank
+    v_total = v_active + v_blank
+    if h_active <= 0 or v_active <= 0 or h_total <= 0 or v_total <= 0:
+        return None
+    return {
+        "width": h_active,
+        "height": v_active,
+        "pixel_clock_khz": pixclk_10khz * 10,
+        "interlaced": bool(block[17] & 0x80),
+        "refresh_hz": round(pixclk_10khz * 10000 / float(h_total * v_total), 3),
+    }
+
+
+def _cta_data_blocks(ext):
+    """Yield (tag, extended_tag_or_None, payload) for each CTA-861 data block in
+    a 128-byte extension block. Bails out silently on any malformed length -- a
+    truncated block must not be able to produce a confident answer."""
+    if len(ext) < 128 or ext[0] != 0x02:
+        return
+    dtd_off = ext[2]
+    if dtd_off < 4 or dtd_off > 127:      # 0 = no DTDs and no data blocks
+        return
+    i = 4
+    while i < dtd_off:
+        header = ext[i]
+        tag = header >> 5
+        length = header & 0x1F
+        if length == 0 or i + 1 + length > dtd_off:
+            return
+        payload = ext[i + 1:i + 1 + length]
+        yield (tag, payload[0] if (tag == 7 and payload) else None, payload)
+        i += 1 + length
+
+
+def _edid_capabilities(blob):
+    """CAPABILITY flags from the CTA-861 extension blocks.
+
+    EVERY KEY HERE IS A CAPABILITY, NOT A STATE. hdr_supported True means the
+    panel says it CAN do HDR and says nothing about whether HDR is on. Returns {}
+    when there is no extension block to read -- "we saw no claim" is not the same
+    as "the display cannot", so callers must distinguish absent from False.
+
+    Two bugs lived here until a second real fixture (a Hisense 4K HDR TV) was
+    added as a positive control, because against the SDR Lenovo panel both
+    branches were only ever observed NOT firing: the colorimetry bitmap is
+    payload[1] (payload[2] is the metadata profile), and the HDMI Forum OUI is
+    stored LSB-first, so bytes d8 5d c4 are 0xC45DD8 and not 0x00D85D."""
+    n_ext = blob[126] if len(blob) >= 127 else 0
+    caps = {}
+    seen_cta = False
+    for k in range(n_ext):
+        ext = blob[128 * (k + 1):128 * (k + 2)]
+        if len(ext) < 128 or ext[0] != 0x02:
+            continue
+        seen_cta = True
+        for tag, ext_tag, payload in _cta_data_blocks(ext):
+            if tag == 7 and ext_tag == 0x06:            # HDR Static Metadata
+                eotf = payload[1] if len(payload) > 1 else 0
+                caps["hdr_supported"] = bool(eotf & 0x06)   # ST2084 / HLG bits
+            elif tag == 3 and len(payload) >= 3:        # Vendor Specific
+                oui = payload[0] | (payload[1] << 8) | (payload[2] << 16)
+                if oui == 0x00001A and len(payload) >= 8:   # AMD FreeSync range
+                    caps["vrr_min_hz"] = payload[6]
+                    caps["vrr_max_hz"] = payload[7]
+                    caps["vrr_supported"] = True
+                elif oui == 0xC45DD8 and len(payload) >= 10:  # HDMI Forum VSDB
+                    vmin = payload[8] & 0x3F
+                    vmax = ((payload[8] & 0xC0) << 2) | payload[9]
+                    if vmin and vmax:
+                        caps["vrr_min_hz"] = vmin
+                        caps["vrr_max_hz"] = vmax
+                        caps["vrr_supported"] = True
+    if seen_cta:
+        caps.setdefault("hdr_supported", False)
+        caps.setdefault("vrr_supported", False)
+    return caps
+
+
+def _parse_edid(blob):
+    """Parse EDID BYTES -> dict, or None if this is not a usable EDID. Requires
+    the 8-byte magic header AND a valid base-block checksum; a bad checksum is a
+    REJECT, not a warning."""
+    if not blob or len(blob) < 128:
+        return None
+    blob = bytes(blob)
+    if blob[:8] != _EDID_HEADER:
+        return None
+    if sum(blob[:128]) & 0xFF:
+        return None                       # base block checksum is 0 mod 256
+    out = {}
+    mfr = _edid_manufacturer((blob[8] << 8) | blob[9])
+    if mfr:
+        out["manufacturer"] = mfr
+    serial_num = blob[12] | (blob[13] << 8) | (blob[14] << 16) | (blob[15] << 24)
+    if serial_num:
+        out["serial_number"] = serial_num
+    week, year = blob[16], blob[17]
+    if year:
+        out["year"] = 1990 + year
+        if 1 <= week <= 54:
+            out["week"] = week
+    out["edid_version"] = "%d.%d" % (blob[18], blob[19])
+    # The four 18-byte descriptors. The first detailed timing is the PREFERRED
+    # one (EDID 1.3+ requires that); the rest are a mix of timings and 0x00 00 00
+    # <tag> display descriptors.
+    for off in (54, 72, 90, 108):
+        block = blob[off:off + 18]
+        if len(block) < 18:
+            break
+        if block[0] or block[1]:
+            timing = _edid_detailed_timing(block)
+            if timing and "preferred" not in out:
+                out["preferred"] = timing
+            continue
+        tag = block[3]
+        if tag == _EDID_TAG_NAME:
+            name = _edid_text(block)
+            if name:
+                out["name"] = name
+        elif tag == _EDID_TAG_SERIAL:
+            text = _edid_text(block)
+            if text:
+                out["serial"] = text
+        elif tag == _EDID_TAG_RANGE and block[5] and block[6]:
+            # The panel's supported vertical refresh RANGE. Capability again.
+            out["vrefresh_min_hz"] = block[5]
+            out["vrefresh_max_hz"] = block[6]
+    out.update(_edid_capabilities(blob))
+    return out
+
+
+def _edid_summary(blob):
+    """The wire fields one connector's EDID contributes, or {} when unusable.
+
+    Nothing here is called `refresh` or `resolution` unqualified, because EDID
+    cannot answer those questions -- see the module note."""
+    e = _parse_edid(blob)
+    if e is None:
+        return {}
+    out = {}
+    if "name" in e:
+        out["monitor_name"] = e["name"]
+    if "manufacturer" in e:
+        out["monitor_vendor"] = e["manufacturer"]
+    if "serial" in e:
+        out["monitor_serial"] = e["serial"]
+    elif "serial_number" in e:
+        out["monitor_serial"] = str(e["serial_number"])
+    if "year" in e:
+        out["monitor_year"] = e["year"]
+    p = e.get("preferred")
+    if p:
+        out["preferred_width"] = p["width"]
+        out["preferred_height"] = p["height"]
+        out["preferred_refresh_hz"] = round(p["refresh_hz"], 1)
+    for k in ("hdr_supported", "vrr_supported", "vrr_min_hz", "vrr_max_hz",
+              "vrefresh_min_hz", "vrefresh_max_hz"):
+        if k in e:
+            out[k] = e[k]
+    return out
+
+
+# --- DRM sysfs: the headless floor -----------------------------------------
+
+
+def _drm_connector_dir(name):
+    """Path of the flat DRM connector directory for `name` ("DP-1" ->
+    /sys/class/drm/card1-DP-1), or None. Matched with an anchored regex rather
+    than a glob so a connector name can never behave like a pattern."""
+    want = re.compile(r"card\d+-" + re.escape(name) + r"$")
+    try:
+        for entry in sorted(os.listdir(_DRM_DIR)):
+            if want.match(entry):
+                return os.path.join(_DRM_DIR, entry)
+    except OSError:
+        return None
+    return None
+
+
+def _drm_text(path):
+    """Stripped contents of a one-line sysfs file, or None (never raises)."""
+    try:
+        with open(path) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+_DRM_MODE_RE = re.compile(r"^\d{2,5}x\d{2,5}i?$")
+
+
+def _drm_modes(path):
+    """The connector's mode LIST from sysfs, deduped in order, or [].
+
+    THIS IS NOT THE CURRENT MODE and it carries no refresh rate whatsoever: the
+    measured DP-1 lists "1920x1080" four times and "1920x1080i" twice. It ships
+    as `supported_modes` for that reason."""
+    raw = _drm_text(os.path.join(path, "modes"))
+    if not raw:
+        return []
+    seen, out = set(), []
+    for line in raw.splitlines():
+        m = line.strip()
+        if not _DRM_MODE_RE.match(m) or m in seen:
+            continue
+        seen.add(m)
+        out.append(m)
+        if len(out) >= 24:                # a TV can list dozens; cap the payload
+            break
+    return out
+
+
+def _drm_display_facts(name):
+    """Everything one connector can be asked for with no session at all:
+    connected/enabled, the EDID identity + capabilities, and the mode list."""
+    path = _drm_connector_dir(name)
+    if path is None:
+        return {}
+    facts = {}
+    status = _drm_text(os.path.join(path, "status"))
+    if status in ("connected", "disconnected"):
+        facts["connected"] = status == "connected"
+    enabled = _drm_text(os.path.join(path, "enabled"))
+    if enabled in ("enabled", "disabled"):
+        facts["enabled"] = enabled == "enabled"
+    try:
+        with open(os.path.join(path, "edid"), "rb") as f:
+            blob = f.read(2048)           # base block + up to 15 extensions
+    except OSError:
+        blob = b""
+    facts.update(_edid_summary(blob))
+    modes = _drm_modes(path)
+    if modes:
+        facts["supported_modes"] = modes
+    return facts
+
+
+# --- gamescope: the only source of CURRENT mode in Game Mode ----------------
+
+
+class _X11Client:
+    """Read-only X11 client: connect to a display socket and read CARD32 root
+    properties. Pure stdlib (socket + struct), ~90 lines, because xprop and
+    xrandr are not guaranteed present on stock SteamOS and the agent may not add
+    a dependency to read a number.
+
+    Constructing it connects and performs the setup handshake, so it RAISES on
+    anything unexpected; every call site wraps it. Always .close() it."""
+
+    _CONNECT_TIMEOUT_S = 2.0
+
+    def __init__(self, display_num):
+        self.s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.s.settimeout(self._CONNECT_TIMEOUT_S)
+        self.s.connect(os.path.join(_X11_UNIX_DIR, "X%d" % display_num))
+        name, data = self._xauth(display_num)
+        req = struct.pack("<BxHHHH2x", 0x6C, 11, 0, len(name), len(data))
+        req += name + b"\x00" * self._pad(len(name))
+        req += data + b"\x00" * self._pad(len(data))
+        self.s.sendall(req)
+        head = self._recv(8)
+        success, _, _, _, extra = struct.unpack("<BBHHH", head)
+        body = self._recv(extra * 4)
+        if success != 1:
+            raise OSError("X11 setup refused")
+        # Fixed part of the setup reply is 32 bytes, then the padded vendor
+        # string, then nformats * 8 bytes of FORMAT, then the first SCREEN.
+        (_rel, _rbase, _rmask, _motion, vlen, _maxreq,
+         _nscreens, nformats) = struct.unpack_from("<IIIIHHBB", body, 0)
+        off = 32 + vlen + self._pad(vlen) + nformats * 8
+        # SCREEN: root, default_colormap, white, black, input_masks (5 CARD32),
+        # then width_in_pixels / height_in_pixels as CARD16. The X screen size of
+        # gamescope's server 0 IS its output size, which is where the current
+        # resolution comes from -- no xrandr needed.
+        (self.root, _cmap, _white, _black, _masks,
+         self.width, self.height) = struct.unpack_from("<IIIIIHH", body, off)
+
+    @staticmethod
+    def _pad(n):
+        return (4 - (n % 4)) % 4
+
+    def _recv(self, n):
+        buf = b""
+        while len(buf) < n:
+            chunk = self.s.recv(n - len(buf))
+            if not chunk:
+                raise OSError("short read")
+            buf += chunk
+        return buf
+
+    @staticmethod
+    def _xauth(display_num):
+        """(name, data) for this display from the Xauthority file, or empty. The
+        gamescope XWayland accepted an unauthenticated connection on the measured
+        box; this is here so an authenticated one still works."""
+        path = os.environ.get("XAUTHORITY") or os.path.expanduser("~/.Xauthority")
+        try:
+            with open(path, "rb") as f:
+                raw = f.read()
+        except OSError:
+            return (b"", b"")
+        def field(buf, at):
+            """(bytes, next_offset) for one big-endian length-prefixed field."""
+            (ln,) = struct.unpack_from(">H", buf, at)
+            return buf[at + 2:at + 2 + ln], at + 2 + ln
+
+        i = 0
+        try:
+            while i + 2 <= len(raw):
+                i += 2                                     # family (CARD16)
+                _addr, i = field(raw, i)
+                number, i = field(raw, i)
+                name, i = field(raw, i)
+                data, i = field(raw, i)
+                if number.decode("ascii", "replace") == str(display_num):
+                    return (name, data)
+        except (struct.error, IndexError):
+            return (b"", b"")
+        return (b"", b"")
+
+    def _intern_atom(self, name):
+        """Atom id for an EXISTING atom (only-if-exists=1), or None."""
+        raw = name.encode("ascii")
+        pad = self._pad(len(raw))
+        self.s.sendall(struct.pack("<BBHHxx", 16, 1, 2 + (len(raw) + pad) // 4,
+                                   len(raw)) + raw + b"\x00" * pad)
+        head = self._recv(32)             # reply and error are both 32 bytes
+        if head[0] != 1:
+            return None
+        (atom,) = struct.unpack_from("<I", head, 8)
+        return atom or None
+
+    def read_cardinal(self, name):
+        """First CARD32 of a 32-bit root-window property, or None when the atom
+        does not exist / the property is unset / it is not 32-bit. Absent is
+        never coerced to 0 -- for HDR and VRR that difference is the whole
+        point."""
+        atom = self._intern_atom(name)
+        if atom is None:
+            return None
+        self.s.sendall(struct.pack("<BBHIIIII", 20, 0, 6, self.root, atom,
+                                   0, 0, 1024))
+        head = self._recv(32)
+        if head[0] != 1:
+            return None
+        fmt = head[1]
+        (rlen,) = struct.unpack_from("<I", head, 4)
+        (ptype, _after, nitems) = struct.unpack_from("<III", head, 8)
+        body = self._recv(rlen * 4)
+        if ptype == 0 or fmt != 32 or nitems < 1:
+            return None
+        (val,) = struct.unpack_from("<I", body, 0)
+        return val
+
+    def close(self):
+        try:
+            self.s.close()
+        except OSError:
+            pass
+
+
+def _gamescope_x11():
+    """gamescope's PRIMARY XWayland as an _X11Client, or None.
+
+    gamescope runs --xwayland-count 2 and publishes the display atoms ONLY on
+    server 0; on server 1 every atom reads not-found (verified both ways). So do
+    not hardcode :0 -- open each socket, ask it for GAMESCOPE_XWAYLAND_SERVER_ID
+    and require 0. A Plasma XWayland has no such atom and is therefore skipped,
+    which is also what keeps this from reading a desktop session's numbers."""
+    try:
+        entries = sorted(os.listdir(_X11_UNIX_DIR))
+    except OSError:
+        return None
+    for entry in entries:
+        if not (entry.startswith("X") and entry[1:].isdigit()):
+            continue
+        client = None
+        try:
+            client = _X11Client(int(entry[1:]))
+            if client.read_cardinal("GAMESCOPE_XWAYLAND_SERVER_ID") == 0:
+                return client
+        except Exception:
+            pass
+        if client is not None:
+            client.close()
+    return None
+
+
+_GAMESCOPECTL_FIELD_RE = re.compile(r"^\s*-\s*([A-Za-z][A-Za-z ]*):\s*(\S.*?)\s*$")
+
+
+def _gamescopectl_display_info(gs_socket):
+    """The `gamescopectl` (no arguments) gamescope_control block, as a dict.
+
+    VERBATIM from the box:
+        gamescope_control info:
+          - Connector Name: DP-1
+          - Display Make: Lenovo Group Limited
+          - Display Model: TIO24Gen3T
+          - Display Flags: 0x0
+          - ValidRefreshRates: 60
+
+    ValidRefreshRates is the list of rates the compositor will ACCEPT, not the
+    one it is driving -- it ships as `supported_refresh_hz`. Display Flags is
+    likewise pure capability (gamescope-control.xml names the bits
+    internal_display / supports_hdr / supports_vrr), and the X11 atoms answer
+    capability more directly, so the flags are read past rather than decoded.
+
+    Run with the bare binary and NO arguments: `gamescopectl <convar> <value>` is
+    a live write surface."""
+    if not shutil.which("gamescopectl"):
+        return {}
+    env = _user_env()
+    env["WAYLAND_DISPLAY"] = gs_socket
+    try:
+        r = subprocess.run(["gamescopectl"], capture_output=True,
+                           timeout=_GAMESCOPECTL_TIMEOUT_S, env=env)
+    except Exception:
+        return {}
+    if r.returncode != 0:
+        return {}
+    text = (r.stdout or b"").decode("utf-8", "replace")
+    fields = {}
+    for line in text.splitlines():
+        m = _GAMESCOPECTL_FIELD_RE.match(line)
+        if m:
+            fields[m.group(1).strip()] = m.group(2)
+    out = {}
+    conn = fields.get("Connector Name")
+    if conn and re.match(r"^[A-Za-z]+(-[A-Za-z0-9]+)*$", conn):
+        out["connector"] = conn
+    make = fields.get("Display Make")
+    if make:
+        out["monitor_make"] = make[:64]
+    model = fields.get("Display Model")
+    if model:
+        out["monitor_model"] = model[:64]
+    rates = []
+    for tok in re.split(r"[,\s]+", fields.get("ValidRefreshRates", "")):
+        try:
+            hz = int(tok)
+        except ValueError:
+            continue
+        if 10 <= hz <= 1000 and hz not in rates:
+            rates.append(hz)
+    if rates:
+        out["supported_refresh_hz"] = sorted(rates)
+    return out
+
+
+def _gamescope_display_facts(gs_socket):
+    """Live display facts from a running gamescope. {} when it will not answer.
+
+    STATE comes from the atoms; CAPABILITY from the atoms and gamescopectl. Each
+    field is set only when its own read succeeded, so a half-answering compositor
+    yields half a block rather than a block with invented halves."""
+    facts = {}
+    client = _gamescope_x11()
+    if client is not None:
+        try:
+            if client.width and client.height:
+                facts["current_width"] = client.width
+                facts["current_height"] = client.height
+            hz = client.read_cardinal("GAMESCOPE_DISPLAY_REFRESH_RATE_FEEDBACK")
+            if hz is not None and 10 <= hz <= 1000:
+                facts["current_refresh_hz"] = float(hz)
+            vrr = client.read_cardinal("GAMESCOPE_VRR_FEEDBACK")
+            if vrr is not None:
+                facts["vrr_active"] = bool(vrr)
+            vrr_cap = client.read_cardinal("GAMESCOPE_VRR_CAPABLE")
+            if vrr_cap is not None:
+                facts["vrr_supported"] = bool(vrr_cap)
+            hdr_cap = client.read_cardinal("GAMESCOPE_DISPLAY_SUPPORTS_HDR")
+            if hdr_cap is not None:
+                facts["hdr_supported"] = bool(hdr_cap)
+            # ONLY this atom. GAMESCOPE_DISPLAY_HDR_ENABLED is Steam's request
+            # and read 1 on an SDR panel -- see the module note. Absent here
+            # means unknown, and unknown means the key is simply not sent.
+            hdr_on = client.read_cardinal("GAMESCOPE_HDR_OUTPUT_FEEDBACK")
+            if hdr_on is not None:
+                facts["hdr_active"] = bool(hdr_on)
+        except Exception:
+            pass
+        finally:
+            client.close()
+    facts.update(_gamescopectl_display_info(gs_socket))
+    return facts
+
+
+# --- kscreen-doctor: the desktop (Plasma) path ------------------------------
+
+
+def _kscreen_mode(output):
+    """current_* fields for one kscreen-doctor output object, or {}.
+
+    The current mode is the entry in `modes` whose id equals `currentModeId`;
+    anything else in that list is a mode the panel merely offers. Refresh is
+    range-checked, and a value over 1000 is read as mHz -- libkscreen has
+    reported both units and an unrecognised number is dropped, not guessed."""
+    cur = output.get("currentModeId")
+    modes = output.get("modes")
+    if cur is None or not isinstance(modes, list):
+        return {}
+    for m in modes:
+        if not isinstance(m, dict) or str(m.get("id")) != str(cur):
+            continue
+        out = {}
+        size = m.get("size")
+        if isinstance(size, dict):
+            w, h = size.get("width"), size.get("height")
+            if (isinstance(w, int) and isinstance(h, int)
+                    and not isinstance(w, bool) and not isinstance(h, bool)
+                    and w > 0 and h > 0):
+                out["current_width"] = w
+                out["current_height"] = h
+        hz = m.get("refreshRate")
+        if isinstance(hz, (int, float)) and not isinstance(hz, bool):
+            hz = float(hz)
+            if hz > 1000.0:
+                hz = hz / 1000.0
+            if 10.0 <= hz <= 1000.0:
+                out["current_refresh_hz"] = round(hz, 2)
+        return out
+    return {}
+
+
+def _kscreen_display_facts(connector):
+    """Live display facts from a Plasma session via `kscreen-doctor --json`, or {}.
+
+    THE EXIT CODE IS NOT CONSULTED, deliberately. MEASURED in Game Mode: the
+    binary exists and SIGABRTs (rc=134, "the monitored command dumped core") with
+    ZERO bytes on stdout and zero on stderr. `_couch_run` reports that faithfully,
+    but a crash and "this box has no displays" would look identical to any caller
+    that trusted a status code, so the gate is non-empty output that PARSES into
+    an outputs list. Everything else degrades to {}.
+
+    UNVERIFIED: the success path. kscreen-doctor was never observed answering --
+    the owner's box was in Game Mode throughout. The shape below is libkscreen's
+    documented JSON, and the parser rejects anything it does not recognise."""
+    if not shutil.which("kscreen-doctor"):
+        return {}
+    now = time.monotonic()
+    last = _KSCREEN_FAILED_AT["t"]
+    if last and now - last < _KSCREEN_BACKOFF_S:
+        return {}
+    r = _couch_run(["kscreen-doctor", "--json"],
+                   timeout=_KSCREEN_TIMEOUT_S, max_out=None)
+    data = None
+    text = (r.get("stdout") or "").strip()
+    if text:
+        try:
+            data = json.loads(text)
+        except ValueError:
+            data = None
+    outputs = data.get("outputs") if isinstance(data, dict) else None
+    if not isinstance(outputs, list) or not outputs:
+        _KSCREEN_FAILED_AT["t"] = now
+        return {}
+    _KSCREEN_FAILED_AT["t"] = 0.0
+    outputs = [o for o in outputs if isinstance(o, dict)]
+    match = None
+    for o in outputs:
+        if o.get("name") == connector:
+            match = o
+            break
+    if match is None:
+        for o in outputs:
+            if o.get("enabled") and o.get("connected"):
+                match = o
+                break
+    if match is None:
+        return {}
+    facts = {}
+    if isinstance(match.get("connected"), bool):
+        facts["connected"] = match["connected"]
+    if isinstance(match.get("enabled"), bool):
+        facts["enabled"] = match["enabled"]
+    facts.update(_kscreen_mode(match))
+    return facts
+
+
+# --- audio: default sink (OUT) and default source (IN) ----------------------
+
+
+_WPCTL_PROP_RE = re.compile(
+    r'^[\s*|│├└-]*(node\.name|node\.description)\s*=\s*"?(.*?)"?\s*$')
+
+
+def _wpctl_default_node(token):
+    """{name, description} for @DEFAULT_AUDIO_SINK@ / @DEFAULT_AUDIO_SOURCE@, or
+    None. `wpctl inspect` is used rather than parsing the `wpctl status` tree:
+    the tree marks defaults with a bare '*' in a box-drawing table, while inspect
+    hands back the node's own properties. VERBATIM from the box:
+
+        * node.description = "Built-in Audio Analog Stereo"
+        * node.name = "alsa_output.pci-0000_00_1f.3.analog-stereo"
+
+    `token` is one of two literals chosen HERE; no client input reaches this argv.
+    Missing wpctl, no pipewire, or no default device all return None, which makes
+    the field absent -- never an empty string the app would render as a device."""
+    wp = shutil.which("wpctl")
+    if wp is None:
+        return None
+    try:
+        r = subprocess.run([wp, "inspect", token], capture_output=True,
+                           timeout=_WPCTL_TIMEOUT_S, env=_user_env())
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    out = {}
+    for line in (r.stdout or b"").decode("utf-8", "replace").splitlines():
+        m = _WPCTL_PROP_RE.match(line)
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2).strip()
+        if not val:
+            continue
+        out.setdefault("name" if key == "node.name" else "description",
+                       val[:128])
+    return out or None
+
+
+def _audio_info_uncached():
+    """{output, input, output_name, input_name} or None.
+
+    `output`/`input` are what a human reads (node.description); the raw node
+    names ride along as additive extras for bug reports. When a node has no
+    description its NAME is used rather than dropping the device -- the name is
+    still a true identity, and an unnamed default device is worse than an ugly
+    one. Nothing is invented: a device we could not read at all is simply absent.
+    """
+    out = {}
+    for token, label in (("@DEFAULT_AUDIO_SINK@", "output"),
+                         ("@DEFAULT_AUDIO_SOURCE@", "input")):
+        node = _wpctl_default_node(token)
+        if not node:
+            continue
+        text = node.get("description") or node.get("name")
+        if text:
+            out[label] = text
+        if node.get("name"):
+            out[label + "_name"] = node["name"]
+    return out or None
+
+
+def audio_info():
+    """The default audio OUT and IN devices, TTL-memoized. None when neither
+    could be read, so the key is omitted rather than sent empty.
+
+    Both directions on purpose, and they are frequently DIFFERENT devices: on the
+    measured box the default sink was the built-in analog output while the
+    default source was the monitor's USB microphone."""
+    now = time.monotonic()
+    with _DISPLAY_LOCK:
+        c = _AUDIO_CACHE
+        if c["at"] and now - c["at"] <= _DISPLAY_TTL:
+            return c["val"]
+    try:
+        val = _audio_info_uncached()
+    except Exception:
+        val = None                        # a readout may never break /api/status
+    with _DISPLAY_LOCK:
+        _AUDIO_CACHE["val"] = val
+        _AUDIO_CACHE["at"] = now
+    return val
+
+
+# --- composition ------------------------------------------------------------
+#
+# The probes above each return FLAT internal facts (current_*, preferred_*,
+# hdr_supported, ...). _display_wire() turns whatever survived into the one wire
+# shape, which is deliberately NESTED so a reader cannot mistake a capability for
+# a state: `mode` is what is being scanned out, `preferred_mode` is what the
+# panel would like, `hdr.supported` vs `hdr.enabled`, `vrr.supported` vs
+# `vrr.active`. Nothing back-fills across that line. On most boxes the two are
+# equal, which is exactly why conflating them looks right everywhere except the
+# box where it is wrong.
+
+
+def _mode_obj(facts, prefix):
+    """{width, height, refresh_hz?} from `<prefix>_width/_height/_refresh_hz`, or
+    None. Requires BOTH dimensions: a mode with no size is not a mode, and the
+    app's DisplayMode type says so too. Refresh rides along only when read."""
+    w, h = facts.get(prefix + "_width"), facts.get(prefix + "_height")
+    if not isinstance(w, int) or not isinstance(h, int) or w <= 0 or h <= 0:
+        return None
+    mode = {"width": w, "height": h}
+    hz = facts.get(prefix + "_refresh_hz")
+    if isinstance(hz, (int, float)):
+        mode["refresh_hz"] = round(float(hz), 2)
+    return mode
+
+
+def _display_wire(facts, name, mode_source):
+    """Flat probe facts -> the /api/display-info `display` object."""
+    out = {"connector": name,
+           "internal": name.startswith(_INTERNAL_OUTPUT_PREFIXES)}
+    for src, dst in (("connected", "connected"), ("enabled", "enabled"),
+                     ("monitor_name", "monitor"), ("monitor_serial", "serial"),
+                     ("monitor_year", "year"),
+                     ("supported_modes", "supported_modes"),
+                     ("supported_refresh_hz", "refresh_rates_hz")):
+        if src in facts:
+            out[dst] = facts[src]
+    # `make` is the human-readable manufacturer when a compositor handed one over
+    # ("Lenovo Group Limited"); EDID itself only carries the 3-letter PNP id
+    # ("LEN"), which is a poor label but a true one, so it is the fallback rather
+    # than an omission.
+    make = facts.get("monitor_make") or facts.get("monitor_vendor")
+    if make:
+        out["make"] = make
+    mode = _mode_obj(facts, "current")
+    if mode:
+        out["mode"] = mode
+        # Extra, additive: WHICH probe produced `mode`, so a bug report says
+        # where the number came from instead of guessing. Omitted rather than
+        # sent as null if a caller ever composes a mode without one.
+        if mode_source:
+            out["mode_source"] = mode_source
+    preferred = _mode_obj(facts, "preferred")
+    if preferred:
+        out["preferred_mode"] = preferred
+    hdr, vrr = {}, {}
+    if "hdr_supported" in facts:
+        hdr["supported"] = facts["hdr_supported"]
+    if "hdr_active" in facts:
+        hdr["enabled"] = facts["hdr_active"]
+    if "vrr_supported" in facts:
+        vrr["supported"] = facts["vrr_supported"]
+    if "vrr_active" in facts:
+        vrr["active"] = facts["vrr_active"]
+    for key in ("vrr_min_hz", "vrr_max_hz"):
+        if key in facts:
+            vrr[key[4:]] = facts[key]          # vrr_min_hz -> min_hz
+    if hdr:
+        out["hdr"] = hdr
+    if vrr:
+        out["vrr"] = vrr
+    return out
+
+
+def _infer_inactive(facts):
+    """The ONE inference this module makes, in place.
+
+    A panel that MEASURABLY cannot do HDR is certainly not displaying HDR, so an
+    explicit `hdr_supported: False` settles `hdr_active: False` (same for VRR).
+    It fires only on an explicit False -- an ABSENT capability stays absent, so
+    "we could not tell" never turns into "off". That asymmetry is the whole
+    reason the gamescope probe refuses to read GAMESCOPE_DISPLAY_HDR_ENABLED:
+    the honest answer to "is HDR on" is usually silence."""
+    for cap, state in (("hdr_supported", "hdr_active"),
+                       ("vrr_supported", "vrr_active")):
+        if state not in facts and facts.get(cap) is False:
+            facts[state] = False
+    return facts
+
+
+def _display_info_uncached():
+    """Assemble one display's facts from whichever probes answered. None when
+    there is no display to describe at all."""
+    # Which session is live decides who can be asked for the CURRENT mode. The
+    # gamescope socket is liveness-filtered by _wayland_display_sockets(), which
+    # flocks the companion .lock file -- a leftover socket FILE outlives Game
+    # Mode and reading it as a live compositor already cost this project a
+    # release (2.9.56). Note that helper leans toward "assume live", so nothing
+    # here is gated on the socket: every field still requires its OWN probe to
+    # have succeeded.
+    gs = [s for s in _wayland_display_sockets() if s.startswith("gamescope-")]
+    live, mode_source = {}, None
+    if gs:
+        live, mode_source = _gamescope_display_facts(gs[0]), "gamescope"
+    # gamescope names the connector it is driving; trust that over our own guess,
+    # so on a multi-display box the EDID we read belongs to the panel whose
+    # refresh rate we are about to report.
+    active = _active_output()
+    name = live.pop("connector", None) or (active or {}).get("name")
+    if not name:
+        return None
+    if not gs:
+        live, mode_source = _kscreen_display_facts(name), "kscreen"
+
+    facts = _drm_display_facts(name)
+    # gamescopectl's Display Model backs up the EDID name; it never overrides it,
+    # because the EDID 0xFC descriptor is the source the card labels the monitor.
+    model = live.pop("monitor_model", None)
+    if model:
+        facts.setdefault("monitor_name", model)
+    facts.update(live)
+
+    return _display_wire(_infer_inactive(facts), name, mode_source)
+
+
+def display_info():
+    """The /api/status "display" block, TTL-memoized. None on a headless box."""
+    now = time.monotonic()
+    with _DISPLAY_LOCK:
+        c = _DISPLAY_CACHE
+        if c["at"] and now - c["at"] <= _DISPLAY_TTL:
+            return c["val"]
+    try:
+        val = _display_info_uncached()
+    except Exception:
+        val = None                        # a readout may never break /api/status
+    with _DISPLAY_LOCK:
+        _DISPLAY_CACHE["val"] = val
+        _DISPLAY_CACHE["at"] = now
+    return val
+
+
+def display_info_available():
+    """Boot-time caps hint for `display_info`: this box has something to report.
+    display_info() / audio_info() remain the live authority (per-field
+    probe-and-appear), so this only tells an old-app-new-agent pair whether the
+    card is worth showing at all. Never raises; False on anything unexpected."""
+    try:
+        if shutil.which("wpctl"):
+            return True
+        return _drm_connector_dir_any()
+    except Exception:
+        return False
+
+
+def _drm_connector_dir_any():
+    """True when _DRM_DIR holds at least one flat connector directory."""
+    want = re.compile(r"card\d+-\S+$")
+    try:
+        return any(want.match(e) for e in os.listdir(_DRM_DIR))
+    except OSError:
+        return False
+
+
+def display_payload():
+    """The GET /api/display-info body. `available` is False (rather than a 404)
+    when nothing could be read, so the app can tell "this agent is too old" from
+    "this box had nothing to say"."""
+    display = display_info()
+    audio = audio_info()
+    out = {"available": bool(display or audio)}
+    if display:
+        out["display"] = display
+    if audio:
+        out["audio"] = audio
+    return out
+
+
+def mock_display_info():
+    """--mock display block, so the Console card is exercisable with no hardware.
+
+    Deliberately NOT the measured Lenovo panel. The current mode (120 Hz) differs
+    from the preferred mode (60 Hz) so a card that conflates the capability with
+    the state is visibly WRONG in the harness rather than accidentally right, and
+    hdr.enabled / vrr.active are opposite so both state rows render."""
+    return {
+        "connector": "HDMI-A-1",
+        "internal": False,
+        "connected": True,
+        "enabled": True,
+        "monitor": "OLED65C9PUA",
+        "make": "LG Electronics",
+        "serial": "912NTVGCM123",
+        "year": 2019,
+        "mode": {"width": 3840, "height": 2160, "refresh_hz": 120.0},
+        "mode_source": "gamescope",
+        "preferred_mode": {"width": 3840, "height": 2160, "refresh_hz": 60.0},
+        "refresh_rates_hz": [60, 100, 120],
+        "supported_modes": ["3840x2160", "2560x1440", "1920x1080", "1280x720"],
+        "hdr": {"supported": True, "enabled": True},
+        "vrr": {"supported": True, "active": False, "min_hz": 48,
+                "max_hz": 120},
+    }
+
+
+def mock_audio_info():
+    """--mock audio block. Output and input are DIFFERENT devices (as they were
+    on the real box), and the input description is the 52-character string
+    measured there: a label/value row is exactly where a long value shoves its
+    siblings off a phone screen, and a mock with two short identical strings
+    would prove nothing about that."""
+    return {
+        "output": "LG TV SSCR2 Digital Stereo (HDMI)",
+        "output_name": "alsa_output.pci-0000_00_1f.3.hdmi-stereo",
+        "input": "Thinkcentre TIO24Gen3Touch for USB-audio Analog Stereo",
+        "input_name": "alsa_input.usb-Lenovo_Thinkcentre_TIO24Gen3Touch_for_"
+                      "USB-audio_000000000000-00.analog-stereo",
+    }
+
+
+def mock_display_payload():
+    return {"available": True, "display": mock_display_info(),
+            "audio": mock_audio_info()}
+
+
+# ---------------------------------------------------------------------------
 # Stream host detection (GET /api/stream-host) — CouchOS roadmap phase 4a.
 #
 # DETECT ONLY: is a Steam Remote Play session being served BY this box right now?
@@ -12703,6 +13774,21 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "not found"}, started)
                 else:
                     self._send(200, {"devices": devs}, started)
+            elif path == "/api/display-info":
+                # READ-ONLY description of the panel this box is driving plus the
+                # default audio devices. Distinct from /api/displays below, which
+                # is the Couch Mode output PICKER: this one answers on boxes that
+                # cannot do the handoff at all, and changes nothing.
+                #
+                # Always 200 with `available` rather than a 404, so the app can
+                # tell "this agent is too old" (404 -> route absent) from "this
+                # box had nothing readable to say" (available: false). The same
+                # payload also rides /api/status as the `display` / `audio` keys,
+                # from the same TTL-memoized probe -- one contract, one cost.
+                # Every field inside is independently optional; see the module
+                # note above display_info() for what each name may claim.
+                data = mock_display_payload() if self.mock else display_payload()
+                self._send(200, data, started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
+import { DisplayAudioCard } from '@/components/DisplayAudioCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
@@ -305,6 +306,14 @@ function ConsoleScreen() {
             )}
           </>
         )}
+
+        {/* What the box is driving: mode, panel, HDR/VRR, default audio in/out
+            (probe-and-appear; agent >= 2.9.59).
+            HERE, directly above the preview, on purpose: the two are one
+            region — the specs of the screen, then the picture on it. Below the
+            vitals you opened this tab to read, above UNITS, which is reference
+            config rather than something you watch. */}
+        <DisplayAudioCard />
 
         {/* Live screen preview (probe-and-appear; hidden when no capture path) */}
         <ScreenPreview />

--- a/app/components/DisplayAudioCard.tsx
+++ b/app/components/DisplayAudioCard.tsx
@@ -1,0 +1,269 @@
+/**
+ * DISPLAY & AUDIO (Console tab) — what the box is actually driving: the mode,
+ * the panel it is plugged into, HDR/VRR, and the default audio out/in.
+ *
+ * Probe-and-appear, the BootSessionCard shape exactly: a 404 (agent too old)
+ * or `available: false` (nothing readable on this box) renders NOTHING. There
+ * is no placeholder card, because a card full of dashes is worse than no card.
+ *
+ * WHY EVERY ROW IS DEFENSIVE, and why that is not paranoia: no single source on
+ * a Linux box answers all of this. The current mode comes from the compositor
+ * and only exists in Game Mode; the panel name and preferred mode come from
+ * EDID and exist headless; HDR/VRR state is readable on some paths and simply
+ * is not on others. The agent omits what it could not read (CLAUDE.md §3.7,
+ * degrade closed), so an absent field means "couldn't tell" and renders as a
+ * dim em dash. It must never be rendered as a value, and never as an error —
+ * "couldn't read the refresh rate" is not a fault condition, it is Tuesday.
+ *
+ * THE CLAIM THIS CARD IS CAREFUL NOT TO MAKE: a preferred mode from EDID and a
+ * list of valid refresh rates are CAPABILITIES, not the current state. On most
+ * boxes they happen to equal what is being scanned out, so printing them as
+ * "RESOLUTION / REFRESH" unqualified would look right everywhere except the one
+ * box where it is wrong. Where a value is a capability the row says so, in the
+ * value itself, every time.
+ *
+ * Slow cadence on purpose: this is three subprocesses on the box (compositor
+ * query + two WirePlumber reads) and a monitor does not change while you watch
+ * it. The refresh control in the header is how you get an answer NOW — after
+ * plugging in a TV, or switching to Game Mode.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, type DisplayInfo, type DisplayMode } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { useSkinKit } from '@/lib/skin';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** A monitor's specs do not change while you look at them. */
+const POLL_MS = 30000;
+
+/** The one thing an unreadable field is allowed to render as. */
+const DASH = '—';
+
+/** 60 -> "60", 59.955 -> "59.96". Trailing zeros dropped so an integer rate
+ *  does not read as a suspiciously precise measurement. */
+function fmtHz(hz: number): string {
+  return String(Number(hz.toFixed(2)));
+}
+
+function fmtSize(m: DisplayMode): string {
+  return `${m.width} × ${m.height}`;
+}
+
+/** What to print for a value that has a live state, a capability, or neither.
+ *  Order matters: an explicit "not supported" outranks any claimed state, so a
+ *  panel that says it cannot do HDR can never be labelled HDR ON. An unknown
+ *  live state falls back to the capability word, never to "off". */
+function stateWord(supported?: boolean, on?: boolean): string {
+  if (supported === false) return 'not supported';
+  if (on === true) return 'on';
+  if (on === false) return 'off';
+  if (supported === true) return 'supported';
+  return DASH;
+}
+
+/**
+ * One label/value row. `note` is the qualifier that keeps the card honest
+ * ("preferred", "supported") and renders dim, right after the value.
+ *
+ * numberOfLines={1} is load-bearing, not polish: an audio device description
+ * ("Thinkcentre TIO24Gen3Touch for USB-audio Analog Stereo") is 52 characters
+ * and will shove the label off the left edge on a phone if it is allowed to
+ * wrap or grow.
+ */
+function Row({
+  label,
+  value,
+  note,
+  dim,
+}: {
+  label: string;
+  value: string;
+  note?: string;
+  dim?: boolean;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View
+      style={styles.lineRow}
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={
+        value === DASH
+          ? `${label}: unavailable`
+          : `${label}: ${value}${note ? `, ${note}` : ''}`
+      }>
+      <Text style={styles.lineLabel}>{label}</Text>
+      <Text
+        style={[styles.lineVal, (dim || value === DASH) && styles.lineValDim]}
+        numberOfLines={1}>
+        {value}
+        {note ? <Text style={styles.note}>{`  ${note}`}</Text> : null}
+      </Text>
+    </View>
+  );
+}
+
+export function DisplayAudioCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  const poll = usePoll<DisplayInfo | null>(
+    () => api.displayInfo(settings), POLL_MS, ready && configured, hostKey(settings));
+
+  const d = poll.data;
+  // Absent capability or old agent -> render nothing at all.
+  if (!d || !d.available) return null;
+
+  const disp = d.display;
+  const audio = d.audio;
+  // available:true with both halves missing would be an agent bug, but it
+  // would render as a card of six dashes, so treat it the same as absent.
+  if (!disp && !audio) return null;
+
+  // Resolution and refresh are resolved SEPARATELY from the same three
+  // candidate sources, because the compositor can answer one and not the other
+  // (the measured Game Mode path gives a size with no rate). Each carries the
+  // note that says which kind of answer it is.
+  let resValue = DASH;
+  let resNote: string | undefined;
+  if (disp?.mode) {
+    resValue = fmtSize(disp.mode);
+  } else if (disp?.preferred_mode) {
+    resValue = fmtSize(disp.preferred_mode);
+    resNote = 'preferred';
+  }
+
+  let hzValue = DASH;
+  let hzNote: string | undefined;
+  if (disp?.mode?.refresh_hz != null) {
+    hzValue = `${fmtHz(disp.mode.refresh_hz)} Hz`;
+  } else if (disp?.preferred_mode?.refresh_hz != null) {
+    hzValue = `${fmtHz(disp.preferred_mode.refresh_hz)} Hz`;
+    hzNote = 'preferred';
+  } else if (disp?.refresh_rates_hz?.length) {
+    // The compositor's list of VALID rates. On a 60-only panel this is [60],
+    // which is exactly the case that would pass for a current reading.
+    hzValue = `${disp.refresh_rates_hz.map(fmtHz).join(' / ')} Hz`;
+    hzNote = 'supported';
+  }
+
+  const hdr = stateWord(disp?.hdr?.supported, disp?.hdr?.enabled);
+  const vrr = stateWord(disp?.vrr?.supported, disp?.vrr?.active);
+
+  // The panel's own name. Manufacturer only as a fallback: "Lenovo Group
+  // Limited TIO24Gen3T" does not fit a phone row, and the model is the half
+  // that identifies the thing in front of you.
+  const monitor = disp?.monitor || disp?.make || DASH;
+
+  const connector = disp?.connector || DASH;
+  const connNote =
+    disp?.connector == null
+      ? undefined
+      : [
+          disp.connected === true ? 'connected' : disp.connected === false ? 'no signal' : null,
+          disp.internal === true ? 'built-in' : disp.internal === false ? 'external' : null,
+        ]
+          .filter(Boolean)
+          .join(' · ') || undefined;
+
+  return (
+    <Card index={6}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>DISPLAY / AUDIO</Text>
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            poll.refresh();
+          }}
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel="Refresh display and audio info"
+          style={({ pressed }) => [styles.refreshBtn, pressed && styles.pressed]}>
+          <Ionicons name="refresh" size={13} color={t.textDim} />
+        </Pressable>
+      </View>
+
+      {disp && (
+        <View style={styles.block}>
+          <Row label="RES" value={resValue} note={resNote} />
+          <Row label="REFRESH" value={hzValue} note={hzNote} />
+          <Row label="HDR" value={hdr} dim={hdr !== 'on'} />
+          <Row label="VRR" value={vrr} dim={vrr !== 'on'} />
+          <Row label="MONITOR" value={monitor} />
+          <Row label="OUTPUT" value={connector} note={connNote} />
+        </View>
+      )}
+
+      {audio && (
+        <View style={styles.block}>
+          <Text style={styles.sectionLabel}>AUDIO</Text>
+          <Row label="OUT" value={audio.output || DASH} />
+          <Row label="IN" value={audio.input || DASH} />
+        </View>
+      )}
+    </Card>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 10,
+    },
+    cardTitle: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+    refreshBtn: {
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingVertical: 4,
+      paddingHorizontal: 9,
+    },
+    pressed: { opacity: 0.7 },
+
+    block: { gap: 6 },
+    sectionLabel: {
+      color: t.textFaint,
+      fontSize: 10,
+      fontWeight: '700',
+      letterSpacing: 1.2,
+      fontFamily: mono,
+      marginTop: 10,
+    },
+    lineRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+    lineLabel: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 0.8,
+      fontFamily: mono,
+      minWidth: 62,
+    },
+    // flex + right-align rather than marginLeft:'auto': a long value has to
+    // SHRINK inside the row, not push the label out of it.
+    lineVal: {
+      color: t.text,
+      fontSize: 14,
+      fontFamily: mono,
+      flex: 1,
+      textAlign: 'right',
+    },
+    lineValDim: { color: t.textFaint },
+    note: { color: t.textFaint, fontSize: 12, fontFamily: mono },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -161,6 +161,14 @@ export type BoxCaps = {
    *  SteamOS's steamosctl, or an sddm drop-in on Bazzite — absent when neither
    *  is usable, so the setting never appears on a box that cannot honour it. */
   session_default?: boolean;
+  /**
+   * Display + audio readout (agent >= 2.9.59): mode, panel identity, HDR/VRR,
+   * default sink and source. Gates the Console-tab "DISPLAY & AUDIO" card.
+   * Linux-only — every source behind it is DRM sysfs, a Wayland compositor, or
+   * WirePlumber. Optional: absent on older agents and on Windows, so undefined
+   * reads as "unknown, probe" and only an explicit false skips the request.
+   */
+  display_info?: boolean;
 };
 
 /** One connected display, from GET /api/displays. */
@@ -182,6 +190,78 @@ export type Displays = {
       hardcodes its preference: no). false hides the picker — a dead control is
       worse than none. undefined (older agent) keeps the picker visible. */
   output_forcing?: boolean;
+};
+
+/**
+ * One display mode. `refresh_hz` is absent whenever the agent could read the
+ * SIZE but not the rate — the two come from different sources on the box, so
+ * they are independently optional rather than one object that is all-or-nothing.
+ */
+export type DisplayMode = {
+  width: number;
+  height: number;
+  refresh_hz?: number;
+};
+
+/**
+ * GET /api/display-info (agent >= 2.9.59): what the box is actually driving —
+ * mode, panel identity, HDR/VRR, and the default audio devices.
+ *
+ * EVERY FIELD IS INDEPENDENTLY OPTIONAL, and that is the whole contract. There
+ * is no single source on a Linux box that answers all of this: the current mode
+ * comes from the compositor (Game Mode only), the panel name and preferred mode
+ * come from EDID in sysfs (any session), and the audio devices come from
+ * WirePlumber. The agent OMITS what it could not read rather than guessing, so
+ * an absent key means "couldn't tell", never "no" — the UI must render it as a
+ * dash, never as a value. Degrading closed is the point (CLAUDE.md §3.7).
+ *
+ * The distinction that matters most: `mode` is what is being scanned out RIGHT
+ * NOW; `preferred_mode` is what the panel's EDID says it would LIKE, which is a
+ * capability and identical whether the box is driving it or is blanked. They
+ * are separate keys — never back-fill one from the other — because on most
+ * boxes they happen to be equal, so conflating them looks correct everywhere
+ * except the box where it is wrong.
+ */
+export type DisplayInfo = {
+  /** False when nothing at all could be read; the card hides. */
+  available: boolean;
+  display?: {
+    /** DRM connector, e.g. "DP-1" / "HDMI-A-1". */
+    connector?: string;
+    /** DRM status: true = a panel is plugged in and awake. */
+    connected?: boolean;
+    /** True for a built-in panel (eDP/LVDS/DSI); false = external monitor/TV. */
+    internal?: boolean;
+    /** EDID product name (0xFC descriptor), e.g. "TIO24Gen3T". */
+    monitor?: string;
+    /** EDID manufacturer, e.g. "Lenovo Group Limited". Shown only when there
+        is no `monitor` — together they are far too long for one row. */
+    make?: string;
+    /** The mode being scanned out now. Compositor-sourced; absent on any box
+        where the agent could not ask one (no session, desktop path unread). */
+    mode?: DisplayMode;
+    /** The panel's preferred mode from EDID. A CAPABILITY — the card labels it
+        "preferred" and never prints it as the current mode. */
+    preferred_mode?: DisplayMode;
+    /** Rates the compositor reports as valid for this panel. A SUPPORTED list,
+        not the current rate: a 60-only panel reports [60] whether it is lit or
+        dark. Labelled "supported" wherever it is shown. */
+    refresh_rates_hz?: number[];
+    /** `supported` from EDID/compositor capability; `enabled` is the live
+        state and is absent when the box exposes no honest read of it — which
+        is the normal case in Game Mode. Absent `enabled` must render as
+        "supported", never as "off". */
+    hdr?: { supported?: boolean; enabled?: boolean };
+    /** Same split as `hdr`: capability vs. live state, each optional. */
+    vrr?: { supported?: boolean; active?: boolean };
+  };
+  audio?: {
+    /** Default sink description ("Built-in Audio Analog Stereo"). */
+    output?: string;
+    /** Default source description. Frequently a DIFFERENT device from the
+        sink, so the two are separate fields and both are shown. */
+    input?: string;
+  };
 };
 
 /** One stage of the Couch Mode ceremony (GET /api/couch-mode/status, agent
@@ -917,7 +997,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.boxbattery === b.boxbattery &&
     a.launchers === b.launchers &&
     a.file_upload === b.file_upload &&
-    a.session_default === b.session_default
+    a.session_default === b.session_default &&
+    a.display_info === b.display_info
   );
 }
 
@@ -2014,6 +2095,23 @@ export const api = {
   ): Promise<Displays | null> {
     return probeGated(caps?.couchmode, () =>
       probeOrNull(request<Displays>(settings, '/api/displays')));
+  },
+
+  /**
+   * Display + audio readout for the Console card (agent >= 2.9.59). Distinct
+   * from `displays()` above, which is the Couch Mode output PICKER: this one is
+   * a read-only description of the panel currently attached, and it answers on
+   * boxes that can't do the handoff at all.
+   *
+   * Probe-and-appear: null on a 404 (older agent) so the card hides, and every
+   * field inside the payload is independently optional — see DisplayInfo.
+   */
+  displayInfo(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<DisplayInfo | null> {
+    return probeGated(caps?.display_info, () =>
+      probeOrNull(request<DisplayInfo>(settings, '/api/display-info')));
   },
 
   /** Enter Couch Mode: fling Game Mode onto `output` (HDR optional). */

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -256,10 +256,14 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // here (and from capsEqual) and the cap never persists, so the "Send a file"
   // card re-probes every launch.
   const file_upload = bool('file_upload');
+  // display_info arrived with agent 2.9.59 — same optional-cap drop trap: omit
+  // it here (and from capsEqual) and the cap never persists, so the Console
+  // "DISPLAY & AUDIO" card re-probes /api/display-info on every launch.
+  const display_info = bool('display_info');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
-    boxbattery, launchers, file_upload, session_default,
+    boxbattery, launchers, file_upload, session_default, display_info,
   };
 }
 

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -172,12 +172,13 @@
     ]
   },
   "linuxOnlyCapabilities": {
-    "_doc": "Linux-only TODAY. gaming reads sysfs and streamhost reads /proc/net, so they are inherently Linux. steamlink and steammenus are portable in principle and simply are NOT ported -- recorded here so the Windows gap is visible as a decision rather than rediscovered as a surprise. The app treats a MISSING cap as unknown (not false), so a Windows box just doesn't offer these.",
+    "_doc": "Linux-only TODAY. gaming reads sysfs and streamhost reads /proc/net, and display_info reads DRM sysfs + a Wayland compositor + WirePlumber, so they are inherently Linux. steamlink and steammenus are portable in principle and simply are NOT ported -- recorded here so the Windows gap is visible as a decision rather than rediscovered as a surprise. The app treats a MISSING cap as unknown (not false), so a Windows box just doesn't offer these.",
     "platforms": [
       "linux"
     ],
     "keys": [
       "boxbattery",
+      "display_info",
       "file_upload",
       "gaming",
       "steamlink",

--- a/tests/test_display_audio.py
+++ b/tests/test_display_audio.py
@@ -1,0 +1,882 @@
+#!/usr/bin/env python3
+"""Tests for the display + audio readout (/api/display-info, /api/status).
+
+Run: python3 tests/test_display_audio.py
+
+WHY THIS EXISTS: this feature is almost entirely probes, and almost every source
+on the box answers "what CAN this display do" while the Console tab is supposed
+to show "what IS it doing". Those are different questions, and every trap below
+is a real one that was measured on hardware, not imagined:
+
+  * `ValidRefreshRates: 60` from gamescopectl and /sys/.../modes are LISTS of
+    what the panel offers. Neither is the current mode, and /sys/.../modes has
+    no refresh rate in it at all.
+  * EDID's preferred timing is burned into the monitor and identical whether the
+    box is driving it or has it blanked. On the measured box it HAPPENS to equal
+    the real output mode, so code that reports it as "current" looks correct
+    there and is wrong on any box not running at its preferred mode.
+  * GAMESCOPE_DISPLAY_HDR_ENABLED read 1 on a box whose panel reports
+    SUPPORTS_HDR 0 and whose EDID has no HDR block. It is Steam's REQUEST, not
+    state. Sourcing "HDR: On" from it would put HDR On on the Console tab of a
+    machine driving an 8-bit SDR monitor. There is a test for exactly that.
+  * kscreen-doctor EXISTS on the box and SIGABRTs (rc=134) with zero bytes of
+    output. A probe that trusted the exit code would read a core dump as "this
+    box has no displays" -- so the parser ignores rc and requires parsed output.
+
+FIXTURES are VERBATIM from real hardware (CLAUDE.md §6), captured 2026-07-27:
+the Bazzite box (bazzite@100.103.155.101, Lenovo TIO24Gen3T on DP-1, IN GAME
+MODE) for everything except the Hisense EDID, which came from EMERY-PC's
+registry and is here as the POSITIVE CONTROL for the HDR branch -- without it
+hdr_supported would only ever have been observed False (§11.2).
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# ---------------------------------------------------------------------------
+# VERBATIM hardware fixtures
+# ---------------------------------------------------------------------------
+
+# /sys/class/drm/card1-DP-1/edid, hexdumped. CONTROL: gamescopectl on the same
+# box at the same moment independently reported Display Make "Lenovo Group
+# Limited" / Display Model "TIO24Gen3T" for this connector, and 0x30ae is
+# Lenovo's PNP id "LEN".
+EDID_LENOVO_TIO24 = (
+    "00ffffffffffff0030aeb31034433730311d0104a5351e783e0565a756529c270f5054"
+    "bdcf00714f81008180818c9500950fb300a940023a801871382d40582c45000f282100"
+    "001e000000ff0056333035303743340a20202020000000fd001e4b1e5315000a202020"
+    "202020000000fc0054494f323447656e33540a2020013902031ef14b01020304051411"
+    "1213901f230907078301000065030c002000d60980a0205e63103060b20c0f28210000"
+    "1a0e1f008051001e30408037000f282100001e662156aa51001e30468f33000f282100"
+    "001ed449403062b0324040c013000f282100001e1a4f403062b0324040c013000f2821"
+    "00001e00000000000000ba"
+)
+
+# POSITIVE CONTROL for the HDR branch: a real Hisense 4K HDR TV, read from
+# EMERY-PC's HKLM\...\Enum\DISPLAY\HEC002F\...\Device Parameters\EDID.
+EDID_HISENSE_HDR = (
+    "00ffffffffffff0020a32f00010000000c1d0103807341780acf74a3574cb02309484c"
+    "21080081c0814081800101010101010101010104740030f2705a80b0588a00501d7400"
+    "001e023a801871382d40582c4500501d7400001e000000fc00484953454e53450a2020"
+    "202020000000fd00184b0f511e000a202020202020017c02036771525f5e5d01020405"
+    "101113141f202122626364320907071507505706013d07c06704035f7e0183010000e2"
+    "00f9e305ff016e030c004000383c20008001020304e50e60616a6be61146d0007080e3"
+    "060d01eb0146d0004463727c6c6f7ce5018b849001011d8018711c1620582c2500c48e"
+    "2100009e0000000000000f"
+)
+
+# `gamescopectl` with NO arguments, in Game Mode.
+GAMESCOPECTL_OUT = """gamescopectl version c31743d+ (gcc 15.2.1)
+gamescope_control info:
+  - Connector Name: DP-1
+  - Display Make: Lenovo Group Limited
+  - Display Model: TIO24Gen3T
+  - Display Flags: 0x0
+  - ValidRefreshRates: 60
+  Features:
+  - Reshade Shaders (1) - Version: 1 - Flags: 0x0
+  - Display Info (2) - Version: 1 - Flags: 0x0
+  - Pixel Filter (3) - Version: 1 - Flags: 0x0
+  - Refresh Cycle Only Change Refresh Rate (4) - Version: 1 - Flags: 0x0
+  - Mura Correction (5) - Version: 1 - Flags: 0x0
+  - Unknown (6) - Version: 1 - Flags: 0x0
+  - Unknown (7) - Version: 1 - Flags: 0x0
+"""
+
+# Every gamescopectl SUBCOMMAND on this build, including the convar reads that
+# would have given HDR/VRR state if they worked.
+GAMESCOPECTL_NOT_FOUND = "Command not found.\n"
+
+# `wpctl inspect @DEFAULT_AUDIO_SINK@` and `@DEFAULT_AUDIO_SOURCE@`. Note the
+# defaults are DIFFERENT devices: analog OUT built into the box, USB mic IN on
+# the monitor. A test that used one device for both would prove nothing.
+WPCTL_SINK = """id 53, type PipeWire:Interface:Node
+  * node.description = "Built-in Audio Analog Stereo"
+  * node.name = "alsa_output.pci-0000_00_1f.3.analog-stereo"
+"""
+WPCTL_SOURCE = """id 62, type PipeWire:Interface:Node
+  * node.description = "Thinkcentre TIO24Gen3Touch for USB-audio Analog Stereo"
+  * node.name = "alsa_input.usb-Lenovo_Thinkcentre_TIO24Gen3Touch_for_USB-audio_000000000000-00.analog-stereo"
+"""
+
+# /sys/class/drm/card1-*  (status / enabled), and the head of DP-1's `modes`.
+# The repetition is verbatim: the file lists 1920x1080 four times because the
+# same size appears at several timings, and carries NO refresh rate at all.
+DRM_CONNECTORS = [
+    ("card1-DP-1", "connected", "enabled"),
+    ("card1-DP-2", "disconnected", "disabled"),
+    ("card1-HDMI-A-1", "disconnected", "disabled"),
+    ("card1-HDMI-A-2", "disconnected", "disabled"),
+    ("card1-HDMI-A-3", "disconnected", "disabled"),
+]
+DRM_MODES_DP1 = "1920x1080\n1920x1080\n1920x1080\n1920x1080i\n1920x1080i\n"
+
+# The gamescope X11 root atoms, exactly as measured. Note SUPPORTS_HDR 0 while
+# DISPLAY_HDR_ENABLED is 1 -- the trap.
+ATOMS_MEASURED = {
+    "GAMESCOPE_XWAYLAND_SERVER_ID": 0,
+    "GAMESCOPE_DISPLAY_REFRESH_RATE_FEEDBACK": 60,
+    "GAMESCOPE_VRR_FEEDBACK": 0,
+    "GAMESCOPE_VRR_CAPABLE": 0,
+    "GAMESCOPE_DISPLAY_SUPPORTS_HDR": 0,
+    "GAMESCOPE_DISPLAY_HDR_ENABLED": 1,
+    # GAMESCOPE_HDR_OUTPUT_FEEDBACK is ABSENT on this box: gamescope only writes
+    # it inside the output-mode-change handler. Absent is not off.
+}
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeProc:
+    def __init__(self, stdout=b"", stderr=b"", rc=0):
+        self.stdout, self.stderr, self.returncode = stdout, stderr, rc
+
+
+class FakeRun:
+    """subprocess.run stand-in that dispatches on the binary name. Records every
+    argv so a test can prove WHAT ran (and that nothing else did)."""
+
+    def __init__(self, table):
+        self.table = table          # basename -> FakeProc or callable(argv)
+        self.calls = []
+
+    def __call__(self, argv, **kw):
+        self.calls.append(list(argv))
+        entry = self.table.get(os.path.basename(argv[0]))
+        if entry is None:
+            raise FileNotFoundError(argv[0])
+        return entry(argv) if callable(entry) else entry
+
+
+class FakeX11:
+    """An _X11Client that answers from a dict. `None` for an atom means the
+    property does not exist, which is the case the whole HDR story turns on."""
+
+    def __init__(self, atoms, width=0, height=0):
+        self.atoms, self.width, self.height = atoms, width, height
+        self.closed = False
+
+    def read_cardinal(self, name):
+        return self.atoms.get(name)
+
+    def close(self):
+        self.closed = True
+
+
+def drm_fixture():
+    """A /sys/class/drm tree copied from the measured box."""
+    root = tempfile.mkdtemp(prefix="drm-")
+    for name, status, enabled in DRM_CONNECTORS:
+        d = os.path.join(root, name)
+        os.makedirs(d)
+        open(os.path.join(d, "status"), "w").write(status + "\n")
+        open(os.path.join(d, "enabled"), "w").write(enabled + "\n")
+        if status == "connected":
+            open(os.path.join(d, "modes"), "w").write(DRM_MODES_DP1)
+            open(os.path.join(d, "edid"), "wb").write(
+                bytes.fromhex(EDID_LENOVO_TIO24))
+    # A GPU dir, so the connector matcher is proven not to eat one.
+    os.makedirs(os.path.join(root, "card1"))
+    return root
+
+
+def reset_caches():
+    cs._DISPLAY_CACHE.update({"val": None, "at": 0.0})
+    cs._AUDIO_CACHE.update({"val": None, "at": 0.0})
+    cs._KSCREEN_FAILED_AT["t"] = 0.0
+
+
+# ---------------------------------------------------------------------------
+# EDID
+# ---------------------------------------------------------------------------
+
+def test_edid():
+    print("EDID: identity, against gamescopectl as the control")
+    e = cs._parse_edid(bytes.fromhex(EDID_LENOVO_TIO24))
+    check("manufacturer word 0x30ae -> LEN (Lenovo PNP id)",
+          e.get("manufacturer"), "LEN")
+    check("0xFC descriptor == gamescopectl's Display Model",
+          e.get("name"), "TIO24Gen3T")
+    check("0xFF descriptor is the unit serial", e.get("serial"), "V30507C4")
+    check("EDID version", e.get("edid_version"), "1.4")
+
+    print("EDID: preferred timing is COMPUTED, and is a capability")
+    p = e["preferred"]
+    check("preferred size", (p["width"], p["height"]), (1920, 1080))
+    check("preferred is progressive (sysfs lists 1080 before 1080i)",
+          p["interlaced"], False)
+    # 148500 kHz / (2200 * 1125). Agrees with gamescopectl ValidRefreshRates: 60.
+    check("refresh derived from pixel clock, not read", p["pixel_clock_khz"],
+          148500)
+    check("...and lands on 60.000 Hz", round(p["refresh_hz"], 3), 60.0)
+    s = cs._edid_summary(bytes.fromhex(EDID_LENOVO_TIO24))
+    check("summary names it PREFERRED, never current",
+          sorted(k for k in s if "refresh" in k or "width" in k),
+          # vrefresh_* is the panel's supported refresh RANGE -- also a
+          # capability, also named so nobody can read it as the current rate.
+          ["preferred_refresh_hz", "preferred_width",
+           "vrefresh_max_hz", "vrefresh_min_hz"])
+    check("no key in the EDID summary is called `current_*`",
+          [k for k in s if k.startswith("current")], [])
+    check("...and none is an unqualified `refresh_hz` / `width` / `height`",
+          [k for k in s if k in ("refresh_hz", "width", "height")], [])
+
+    print("EDID: rejected rather than repaired")
+    blob = bytes.fromhex(EDID_LENOVO_TIO24)
+    for label, bad in (("empty", b""),
+                       ("short (64 bytes)", blob[:64]),
+                       ("all zeros", bytes(128)),
+                       ("bad magic header", b"\xff" + blob[1:]),
+                       ("corrupt byte -> checksum fails",
+                        blob[:60] + b"\x00" + blob[61:])):
+        check("refuses %s" % label, cs._parse_edid(bad), None)
+    check("...and the summary of an unusable EDID is {} not a half record",
+          cs._edid_summary(b"\x00" * 128), {})
+
+    print("EDID: HDR/VRR capability, observed in BOTH states")
+    check("SDR Lenovo panel: hdr_supported False", e.get("hdr_supported"), False)
+    check("SDR Lenovo panel: vrr_supported False", e.get("vrr_supported"), False)
+    h = cs._parse_edid(bytes.fromhex(EDID_HISENSE_HDR))
+    check("Hisense 4K TV: manufacturer HEC", h.get("manufacturer"), "HEC")
+    check("Hisense 4K TV: hdr_supported FIRES True", h.get("hdr_supported"), True)
+    check("Hisense 4K TV: no VRR block -> still False",
+          h.get("vrr_supported"), False)
+    # A truncated read must not become a confident "no HDR".
+    half = cs._parse_edid(bytes.fromhex(EDID_HISENSE_HDR)[:128])
+    check("128-byte read omits hdr_supported rather than claiming False",
+          "hdr_supported" in half, False)
+
+
+# ---------------------------------------------------------------------------
+# DRM sysfs: the headless floor
+# ---------------------------------------------------------------------------
+
+def test_drm():
+    root = drm_fixture()
+    orig = cs._DRM_DIR
+    cs._DRM_DIR = root
+    try:
+        print("DRM sysfs: the connector that is plugged in")
+        f = cs._drm_display_facts("DP-1")
+        check("connected", f.get("connected"), True)
+        check("enabled", f.get("enabled"), True)
+        check("EDID read through sysfs gives the monitor name",
+              f.get("monitor_name"), "TIO24Gen3T")
+        check("preferred size from EDID",
+              (f.get("preferred_width"), f.get("preferred_height")), (1920, 1080))
+
+        print("DRM sysfs: the mode LIST is never the current mode")
+        # THE test this file exists for. `modes` is a list of sizes with no
+        # refresh rate in it; presenting it as the current mode is the bug.
+        check("modes deduped, in file order",
+              f.get("supported_modes"), ["1920x1080", "1920x1080i"])
+        check("...named `supported_modes`, and NO current_* came out of sysfs",
+              [k for k in f if k.startswith("current")], [])
+        wire = cs._display_wire(f, "DP-1", None)
+        check("the wire object built from sysfs alone has NO `mode`",
+              "mode" in wire, False)
+        check("...but does carry preferred_mode",
+              wire.get("preferred_mode"),
+              {"width": 1920, "height": 1080, "refresh_hz": 60.0})
+
+        print("DRM sysfs: the disconnected connector (the other state)")
+        d = cs._drm_display_facts("HDMI-A-2")
+        check("connected False", d.get("connected"), False)
+        check("enabled False", d.get("enabled"), False)
+        check("no EDID -> no monitor name invented", "monitor_name" in d, False)
+        check("no modes file -> no supported_modes", "supported_modes" in d, False)
+
+        print("DRM sysfs: an unknown connector is not a pattern")
+        check("unknown name -> no directory", cs._drm_connector_dir("DP-9"), None)
+        check("...and no facts", cs._drm_display_facts("DP-9"), {})
+        check("a bare GPU dir is not a connector", cs._drm_connector_dir("1"), None)
+        check("a glob-shaped name matches nothing",
+              cs._drm_connector_dir("*"), None)
+        check("connector dir resolves under the fixture root",
+              os.path.basename(cs._drm_connector_dir("DP-1")), "card1-DP-1")
+    finally:
+        cs._DRM_DIR = orig
+        import shutil
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# gamescopectl
+# ---------------------------------------------------------------------------
+
+def test_gamescopectl():
+    real_run, real_which = cs.subprocess.run, cs.shutil.which
+    cs.shutil.which = lambda b: "/usr/bin/" + b
+    try:
+        print("gamescopectl: the info block parses")
+        cs.subprocess.run = FakeRun(
+            {"gamescopectl": FakeProc(stdout=GAMESCOPECTL_OUT.encode())})
+        g = cs._gamescopectl_display_info("gamescope-0")
+        check("connector", g.get("connector"), "DP-1")
+        check("make", g.get("monitor_make"), "Lenovo Group Limited")
+        check("model", g.get("monitor_model"), "TIO24Gen3T")
+
+        print("gamescopectl: ValidRefreshRates is a SUPPORTED list, not the rate")
+        check("parsed as a list", g.get("supported_refresh_hz"), [60])
+        check("named `supported_refresh_hz`",
+              [k for k in g if k.startswith("current")], [])
+        wire = cs._display_wire(g, "DP-1", "gamescope")
+        check("a wire object built from it alone has NO `mode`",
+              "mode" in wire, False)
+        check("the supported list lands in refresh_rates_hz",
+              wire.get("refresh_rates_hz"), [60])
+
+        print("gamescopectl: the not-firing state")
+        cs.subprocess.run = FakeRun(
+            {"gamescopectl": FakeProc(stdout=GAMESCOPECTL_NOT_FOUND.encode(),
+                                      rc=1)})
+        check("non-zero exit -> {}", cs._gamescopectl_display_info("gamescope-0"),
+              {})
+        cs.subprocess.run = FakeRun({"gamescopectl": FakeProc(stdout=b"")})
+        check("empty output -> {}", cs._gamescopectl_display_info("gamescope-0"),
+              {})
+        cs.shutil.which = lambda b: None
+        check("binary absent -> {} (no subprocess at all)",
+              cs._gamescopectl_display_info("gamescope-0"), {})
+
+        print("gamescopectl: only the bare binary ever runs")
+        # `gamescopectl <convar> <value>` is a live WRITE surface on the box.
+        cs.shutil.which = lambda b: "/usr/bin/" + b
+        run = FakeRun({"gamescopectl": FakeProc(stdout=GAMESCOPECTL_OUT.encode())})
+        cs.subprocess.run = run
+        cs._gamescopectl_display_info("gamescope-0")
+        check("argv is exactly ['gamescopectl']", run.calls, [["gamescopectl"]])
+    finally:
+        cs.subprocess.run, cs.shutil.which = real_run, real_which
+
+
+# ---------------------------------------------------------------------------
+# kscreen-doctor: the crash IS the measured state
+# ---------------------------------------------------------------------------
+
+# SYNTHETIC, and labelled as such: kscreen-doctor was never observed answering
+# (the owner's box was in Game Mode throughout), so this is libkscreen's
+# documented JSON shape, not a capture. It is the CONTROL that proves the crash
+# test above is measuring a crash and not a parser that never works.
+# The current mode is the SECOND entry on purpose, behind a 144Hz decoy: taking
+# modes[0] is the obvious wrong implementation.
+KSCREEN_JSON_SYNTHETIC = json.dumps({
+    "outputs": [
+        {"name": "eDP-1", "connected": False, "enabled": False, "modes": []},
+        {"name": "DP-1", "connected": True, "enabled": True,
+         "currentModeId": "83",
+         "modes": [
+             {"id": "81", "name": "1920x1080@144",
+              "size": {"width": 1920, "height": 1080}, "refreshRate": 144.0},
+             {"id": "83", "name": "2560x1440@59.95",
+              "size": {"width": 2560, "height": 1440}, "refreshRate": 59.951},
+         ]},
+    ]
+})
+
+
+def test_kscreen():
+    real_which, real_couch = cs.shutil.which, cs._couch_run
+    cs.shutil.which = lambda b: "/usr/bin/" + b
+    try:
+        print("kscreen-doctor: SIGABRT reads as unavailable, not as 'no displays'")
+        # VERBATIM: rc=134 ("the monitored command dumped core"), zero bytes on
+        # BOTH streams. _couch_run reports that faithfully.
+        reset_caches()
+        cs._couch_run = lambda *a, **k: {"ok": False, "exit_code": 134,
+                                         "stdout": "", "stderr": ""}
+        check("crash -> {}", cs._kscreen_display_facts("DP-1"), {})
+        check("...and the failure is remembered, so it stops core-dumping",
+              cs._KSCREEN_FAILED_AT["t"] > 0, True)
+
+        print("kscreen-doctor: CONTROL -- healthy output IS parsed")
+        reset_caches()
+        cs._couch_run = lambda *a, **k: {"ok": True, "exit_code": 0,
+                                         "stdout": KSCREEN_JSON_SYNTHETIC,
+                                         "stderr": ""}
+        f = cs._kscreen_display_facts("DP-1")
+        check("current size taken from currentModeId, not modes[0]",
+              (f.get("current_width"), f.get("current_height")), (2560, 1440))
+        check("current refresh", f.get("current_refresh_hz"), 59.95)
+        check("connected/enabled", (f.get("connected"), f.get("enabled")),
+              (True, True))
+        check("...and the failure memo cleared", cs._KSCREEN_FAILED_AT["t"], 0.0)
+
+        print("kscreen-doctor: OUTPUT is the gate, never the exit code")
+        # Both directions of the same lesson.
+        reset_caches()
+        cs._couch_run = lambda *a, **k: {"ok": True, "exit_code": 0,
+                                         "stdout": "", "stderr": ""}
+        check("exit 0 with no output -> {}", cs._kscreen_display_facts("DP-1"), {})
+        reset_caches()
+        cs._couch_run = lambda *a, **k: {"ok": False, "exit_code": 134,
+                                         "stdout": KSCREEN_JSON_SYNTHETIC,
+                                         "stderr": "warning noise"}
+        check("crashed-but-answered IS parsed (rc is not consulted)",
+              cs._kscreen_display_facts("DP-1").get("current_width"), 2560)
+
+        print("kscreen-doctor: garbage is refused, not repaired")
+        for label, out in (("not JSON", "Segmentation fault"),
+                           ("JSON but not an object", "[1,2,3]"),
+                           ("no outputs key", '{"screen":{}}'),
+                           ("empty outputs", '{"outputs":[]}')):
+            reset_caches()
+            cs._couch_run = (lambda o: lambda *a, **k: {
+                "ok": True, "exit_code": 0, "stdout": o, "stderr": ""})(out)
+            check("refuses %s" % label, cs._kscreen_display_facts("DP-1"), {})
+
+        print("kscreen-doctor: an implausible refresh is dropped, not guessed")
+        for label, hz, want in (("mHz (60000) normalized", 60000.0, 60.0),
+                                ("0 dropped", 0.0, None),
+                                ("nonsense (9e9) dropped", 9e9, None),
+                                ("a string dropped", "60", None)):
+            out = {"currentModeId": "1",
+                   "modes": [{"id": "1", "size": {"width": 1920, "height": 1080},
+                              "refreshRate": hz}]}
+            check(label, cs._kscreen_mode(out).get("current_refresh_hz"), want)
+        check("...and the SIZE still survives a dropped refresh",
+              cs._kscreen_mode({"currentModeId": "1", "modes": [
+                  {"id": "1", "size": {"width": 1920, "height": 1080},
+                   "refreshRate": None}]}).get("current_width"), 1920)
+
+        print("kscreen-doctor: absent binary is not an error")
+        reset_caches()
+        cs.shutil.which = lambda b: None
+        check("no binary -> {}", cs._kscreen_display_facts("DP-1"), {})
+    finally:
+        cs.shutil.which, cs._couch_run = real_which, real_couch
+        reset_caches()
+
+
+# ---------------------------------------------------------------------------
+# gamescope atoms: the HDR trap
+# ---------------------------------------------------------------------------
+
+def test_gamescope_atoms():
+    real_x11, real_ctl = cs._gamescope_x11, cs._gamescopectl_display_info
+    cs._gamescopectl_display_info = lambda sock: {}
+    try:
+        print("gamescope atoms: the measured box, verbatim")
+        client = FakeX11(ATOMS_MEASURED, width=1920, height=1080)
+        cs._gamescope_x11 = lambda: client
+        f = cs._gamescope_display_facts("gamescope-0")
+        check("current size from the X screen of server 0",
+              (f.get("current_width"), f.get("current_height")), (1920, 1080))
+        check("current refresh from the FEEDBACK atom",
+              f.get("current_refresh_hz"), 60.0)
+        check("vrr_active read (0 -> False, a real answer)",
+              f.get("vrr_active"), False)
+        check("vrr_supported read from VRR_CAPABLE", f.get("vrr_supported"), False)
+        check("hdr_supported read from DISPLAY_SUPPORTS_HDR",
+              f.get("hdr_supported"), False)
+        check("the client is closed", client.closed, True)
+
+        print("gamescope atoms: DISPLAY_HDR_ENABLED is a REQUEST and is ignored")
+        # On the measured box that atom is 1 while the panel reports no HDR at
+        # all. Reading it would print "HDR On" for an 8-bit SDR monitor. The
+        # probe must not produce hdr_active from it AT ALL -- absent, not True.
+        check("the probe reads no hdr_active from DISPLAY_HDR_ENABLED",
+              f.get("hdr_active"), None)
+        info = cs._display_wire(cs._infer_inactive(dict(f)), "DP-1", "gamescope")
+        check("...and after the supported=False inference the wire says OFF",
+              info["hdr"], {"supported": False, "enabled": False})
+
+        print("gamescope atoms: unknown HDR stays unknown (both states)")
+        # Panel SUPPORTS HDR, but the state atom is absent (gamescope only
+        # writes it on a mode change). Absent must not become False.
+        atoms = dict(ATOMS_MEASURED, GAMESCOPE_DISPLAY_SUPPORTS_HDR=1)
+        cs._gamescope_x11 = lambda: FakeX11(atoms, 3840, 2160)
+        f2 = cs._gamescope_display_facts("gamescope-0")
+        check("hdr_supported True", f2.get("hdr_supported"), True)
+        check("hdr_active ABSENT, not False", "hdr_active" in f2, False)
+        w2 = cs._display_wire(f2, "DP-1", "gamescope")
+        check("wire carries supported with no `enabled` key",
+              w2["hdr"], {"supported": True})
+
+        print("gamescope atoms: the state atom firing (the other half)")
+        atoms = dict(ATOMS_MEASURED, GAMESCOPE_DISPLAY_SUPPORTS_HDR=1,
+                     GAMESCOPE_HDR_OUTPUT_FEEDBACK=1, GAMESCOPE_VRR_CAPABLE=1,
+                     GAMESCOPE_VRR_FEEDBACK=1)
+        cs._gamescope_x11 = lambda: FakeX11(atoms, 3840, 2160)
+        f3 = cs._gamescope_display_facts("gamescope-0")
+        check("hdr_active True from HDR_OUTPUT_FEEDBACK", f3.get("hdr_active"), True)
+        check("vrr_active True from VRR_FEEDBACK", f3.get("vrr_active"), True)
+        check("vrr_supported True from VRR_CAPABLE", f3.get("vrr_supported"), True)
+
+        print("gamescope atoms: a compositor that answers nothing")
+        cs._gamescope_x11 = lambda: None
+        check("no X11 client -> no facts at all",
+              cs._gamescope_display_facts("gamescope-0"), {})
+        cs._gamescope_x11 = lambda: FakeX11({}, 0, 0)
+        check("client with no atoms and no screen size -> {}",
+              cs._gamescope_display_facts("gamescope-0"), {})
+
+        print("gamescope atoms: an out-of-range refresh is dropped")
+        for hz in (0, 5, 5000):
+            cs._gamescope_x11 = lambda hz=hz: FakeX11(
+                {"GAMESCOPE_DISPLAY_REFRESH_RATE_FEEDBACK": hz}, 1920, 1080)
+            got = cs._gamescope_display_facts("gamescope-0")
+            check("refresh %r dropped" % hz, "current_refresh_hz" in got, False)
+    finally:
+        cs._gamescope_x11, cs._gamescopectl_display_info = real_x11, real_ctl
+
+
+def test_x11_server_selection():
+    """gamescope publishes the atoms ONLY on XWayland server 0; server 1 answers
+    not-found for every one. Verified both ways on the box, so the picker reads
+    GAMESCOPE_XWAYLAND_SERVER_ID instead of hardcoding :0."""
+    print("X11: the PRIMARY gamescope XWayland is chosen by its atom")
+    root = tempfile.mkdtemp(prefix="x11-")
+    # X0 first in sort order, and deliberately NOT the gamescope primary.
+    for n in ("X0", "X1", "junk"):
+        open(os.path.join(root, n), "w").close()
+    orig_dir, orig_cls = cs._X11_UNIX_DIR, cs._X11Client
+    cs._X11_UNIX_DIR = root
+    made = {}
+    try:
+        def factory(num):
+            atoms = ({"GAMESCOPE_XWAYLAND_SERVER_ID": 0} if num == 1
+                     else {})                       # X0 = a Plasma XWayland
+            made[num] = FakeX11(atoms, 1920, 1080)
+            return made[num]
+        cs._X11Client = factory
+        got = cs._gamescope_x11()
+        check("skips the server with no gamescope atom", got is made[1], True)
+        check("...and closes the one it rejected", made[0].closed, True)
+        check("...and leaves the chosen one open", made[1].closed, False)
+
+        print("X11: nothing to find (the other state)")
+        made.clear()
+        cs._X11Client = lambda num: made.setdefault(num, FakeX11({}, 0, 0))
+        check("no gamescope atom anywhere -> None", cs._gamescope_x11(), None)
+        check("...and every client opened is closed",
+              all(c.closed for c in made.values()), True)
+
+        print("X11: a server that refuses the connection is skipped, not fatal")
+        def boom(num):
+            raise OSError("connection refused")
+        cs._X11Client = boom
+        check("all connects fail -> None", cs._gamescope_x11(), None)
+        cs._X11_UNIX_DIR = os.path.join(root, "does-not-exist")
+        check("no socket dir at all -> None", cs._gamescope_x11(), None)
+    finally:
+        cs._X11_UNIX_DIR, cs._X11Client = orig_dir, orig_cls
+        import shutil
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Audio
+# ---------------------------------------------------------------------------
+
+def test_audio():
+    real_run, real_which = cs.subprocess.run, cs.shutil.which
+    try:
+        print("audio: wpctl inspect, both directions")
+        reset_caches()
+        cs.shutil.which = lambda b: "/usr/bin/" + b
+
+        def wpctl(argv):
+            if argv[2] == "@DEFAULT_AUDIO_SINK@":
+                return FakeProc(stdout=WPCTL_SINK.encode())
+            return FakeProc(stdout=WPCTL_SOURCE.encode())
+        run = FakeRun({"wpctl": wpctl})
+        cs.subprocess.run = run
+        a = cs.audio_info()
+        check("default OUT description", a.get("output"),
+              "Built-in Audio Analog Stereo")
+        check("default OUT node name", a.get("output_name"),
+              "alsa_output.pci-0000_00_1f.3.analog-stereo")
+        check("default IN description", a.get("input"),
+              "Thinkcentre TIO24Gen3Touch for USB-audio Analog Stereo")
+        check("default IN node name", a.get("input_name"),
+              "alsa_input.usb-Lenovo_Thinkcentre_TIO24Gen3Touch_for_USB-audio_"
+              "000000000000-00.analog-stereo")
+        check("OUT and IN are different devices, as measured",
+              a["output"] != a["input"], True)
+        check("only the two agent-chosen literals are ever passed to wpctl",
+              sorted(c[2] for c in run.calls),
+              ["@DEFAULT_AUDIO_SINK@", "@DEFAULT_AUDIO_SOURCE@"])
+
+        print("audio: unavailable is absent, not an error")
+        reset_caches()
+        cs.shutil.which = lambda b: None
+        check("no wpctl -> None", cs.audio_info(), None)
+        reset_caches()
+        cs.shutil.which = lambda b: "/usr/bin/" + b
+        cs.subprocess.run = FakeRun({"wpctl": FakeProc(stdout=b"", rc=1)})
+        check("wpctl fails (no pipewire) -> None", cs.audio_info(), None)
+        reset_caches()
+        cs.subprocess.run = FakeRun(
+            {"wpctl": FakeProc(stdout=b"id 53, type PipeWire:Interface:Node\n")})
+        check("no node properties -> None", cs.audio_info(), None)
+
+        print("audio: one direction readable, the other not")
+        reset_caches()
+
+        def only_sink(argv):
+            if argv[2] == "@DEFAULT_AUDIO_SINK@":
+                return FakeProc(stdout=WPCTL_SINK.encode())
+            return FakeProc(stdout=b"", rc=1)       # no default source
+        cs.subprocess.run = FakeRun({"wpctl": only_sink})
+        a = cs.audio_info()
+        check("output present", a.get("output"), "Built-in Audio Analog Stereo")
+        check("input key simply absent", "input" in a, False)
+
+        print("audio: a node with a name but no description")
+        reset_caches()
+        cs.subprocess.run = FakeRun({"wpctl": FakeProc(
+            stdout=b'id 7, type PipeWire:Interface:Node\n'
+                   b'  * node.name = "alsa_output.usb-Generic-00.iec958"\n')})
+        check("falls back to the node name, never an empty string",
+              cs.audio_info().get("output"), "alsa_output.usb-Generic-00.iec958")
+    finally:
+        cs.subprocess.run, cs.shutil.which = real_run, real_which
+        reset_caches()
+
+
+# ---------------------------------------------------------------------------
+# Composition: a capability is never reported as a state
+# ---------------------------------------------------------------------------
+
+def test_composition():
+    root = drm_fixture()
+    saved = (cs._DRM_DIR, cs._wayland_display_sockets, cs._active_output,
+             cs._gamescope_x11, cs._gamescopectl_display_info, cs._couch_run,
+             cs.shutil.which, cs.subprocess.run)
+    cs._DRM_DIR = root
+    cs._active_output = lambda: {"name": "DP-1", "internal": False}
+    cs.shutil.which = lambda b: "/usr/bin/" + b
+    try:
+        print("composition: Game Mode, exactly as measured")
+        reset_caches()
+        cs._wayland_display_sockets = lambda: ["gamescope-0"]
+        cs._gamescope_x11 = lambda: FakeX11(ATOMS_MEASURED, 1920, 1080)
+        cs.subprocess.run = FakeRun(
+            {"gamescopectl": FakeProc(stdout=GAMESCOPECTL_OUT.encode())})
+        d = cs.display_info()
+        check("connector", d.get("connector"), "DP-1")
+        check("external panel", d.get("internal"), False)
+        check("monitor name from EDID", d.get("monitor"), "TIO24Gen3T")
+        check("make from gamescopectl", d.get("make"), "Lenovo Group Limited")
+        check("current mode", d.get("mode"),
+              {"width": 1920, "height": 1080, "refresh_hz": 60.0})
+        check("mode is attributed to its source", d.get("mode_source"),
+              "gamescope")
+        check("preferred mode is a SEPARATE key",
+              d.get("preferred_mode"),
+              {"width": 1920, "height": 1080, "refresh_hz": 60.0})
+        check("supported list is a THIRD key", d.get("refresh_rates_hz"), [60])
+        check("sysfs mode list is a FOURTH key",
+              d.get("supported_modes"), ["1920x1080", "1920x1080i"])
+        check("HDR off (from a measured capability, never from the request atom)",
+              d.get("hdr"), {"supported": False, "enabled": False})
+        check("VRR off", d.get("vrr"), {"supported": False, "active": False})
+        check("no top-level key is called `refresh_hz` or `resolution`",
+              [k for k in d if k in ("refresh_hz", "resolution", "current")], [])
+
+        print("composition: a capability is NEVER emitted as the current mode")
+        # Kill every live source. EDID's preferred timing and gamescopectl's
+        # supported list both still read 60Hz/1920x1080 -- and neither may
+        # become `mode`. On this box they happen to equal the real mode, which
+        # is exactly why a back-fill would look correct here and be wrong
+        # everywhere else.
+        reset_caches()
+        cs._wayland_display_sockets = lambda: []
+        cs._couch_run = lambda *a, **k: {"ok": False, "exit_code": 134,
+                                         "stdout": "", "stderr": ""}
+        d2 = cs.display_info()
+        check("no live session -> NO `mode`", "mode" in d2, False)
+        check("...and no mode_source", "mode_source" in d2, False)
+        check("...but preferred_mode still reported, labelled as such",
+              d2.get("preferred_mode"),
+              {"width": 1920, "height": 1080, "refresh_hz": 60.0})
+        check("...and the sysfs mode LIST is still only a list",
+              d2.get("supported_modes"), ["1920x1080", "1920x1080i"])
+        check("...HDR still known off, because the EDID capability is a measured "
+              "False", d2.get("hdr"), {"supported": False, "enabled": False})
+
+        print("composition: unknown capability -> no state at all")
+        # An EDID with no CTA extension says nothing about HDR. That must stay
+        # silence, not "off".
+        reset_caches()
+        wire = cs._display_wire({"connected": True}, "DP-1", None)
+        check("no hdr key", "hdr" in wire, False)
+        check("no vrr key", "vrr" in wire, False)
+        check("no mode key", "mode" in wire, False)
+        check("connector and internal always present",
+              (wire["connector"], wire["internal"]), ("DP-1", False))
+        check("an eDP connector reads as internal",
+              cs._display_wire({}, "eDP-1", None)["internal"], True)
+
+        print("composition: the inference fires ONLY on a measured False")
+        check("supported False -> active False (a fact, not a guess)",
+              cs._infer_inactive({"hdr_supported": False,
+                                  "vrr_supported": False}),
+              {"hdr_supported": False, "hdr_active": False,
+               "vrr_supported": False, "vrr_active": False})
+        check("supported ABSENT -> state stays absent (unknown is not off)",
+              cs._infer_inactive({}), {})
+        check("supported True -> state stays absent (unknown is not on either)",
+              cs._infer_inactive({"hdr_supported": True}),
+              {"hdr_supported": True})
+        check("a real state reading is never overwritten",
+              cs._infer_inactive({"hdr_supported": False, "hdr_active": True}),
+              {"hdr_supported": False, "hdr_active": True})
+
+        print("composition: gamescope names the connector it is driving")
+        reset_caches()
+        cs._wayland_display_sockets = lambda: ["gamescope-0"]
+        cs._gamescope_x11 = lambda: None
+        cs.subprocess.run = FakeRun(
+            {"gamescopectl": FakeProc(stdout=GAMESCOPECTL_OUT.encode())})
+        cs._active_output = lambda: {"name": "HDMI-A-1", "internal": False}
+        d3 = cs.display_info()
+        check("gamescopectl's connector wins over the sysfs guess",
+              d3.get("connector"), "DP-1")
+        check("...so the EDID read belongs to that panel",
+              d3.get("monitor"), "TIO24Gen3T")
+
+        print("composition: headless")
+        reset_caches()
+        cs._active_output = lambda: None
+        cs._wayland_display_sockets = lambda: []
+        cs.subprocess.run = FakeRun({})
+        check("nothing connected -> None (the key is omitted entirely)",
+              cs.display_info(), None)
+
+        print("composition: a probe that raises can never break /api/status")
+        reset_caches()
+        def boom():
+            raise RuntimeError("probe exploded")
+        orig_unc = cs._display_info_uncached
+        cs._display_info_uncached = boom
+        try:
+            check("exception -> None, not a traceback", cs.display_info(), None)
+        finally:
+            cs._display_info_uncached = orig_unc
+    finally:
+        (cs._DRM_DIR, cs._wayland_display_sockets, cs._active_output,
+         cs._gamescope_x11, cs._gamescopectl_display_info, cs._couch_run,
+         cs.shutil.which, cs.subprocess.run) = saved
+        reset_caches()
+        import shutil
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Wiring: caps, payload, mock
+# ---------------------------------------------------------------------------
+
+def test_wiring():
+    print("status: the blocks are additive and OMITTED when unavailable")
+    saved = (cs.display_info, cs.audio_info)
+    try:
+        cs.display_info = lambda: None
+        cs.audio_info = lambda: None
+        s = cs.real_status()
+        check("no display key on a box that could not read one",
+              "display" in s, False)
+        check("no audio key either", "audio" in s, False)
+        check("...and the pre-existing keys are untouched",
+              all(k in s for k in ("hostname", "uptime_s", "caps", "net",
+                                   "agent_version", "history")), True)
+        cs.display_info = lambda: {"connector": "DP-1"}
+        cs.audio_info = lambda: {"output": "x"}
+        s = cs.real_status()
+        check("present when readable (the other state)",
+              (s.get("display"), s.get("audio")),
+              ({"connector": "DP-1"}, {"output": "x"}))
+
+        print("/api/display-info payload")
+        p = cs.display_payload()
+        check("available True with data", p["available"], True)
+        check("carries both blocks", sorted(p), ["audio", "available", "display"])
+        cs.display_info = lambda: None
+        cs.audio_info = lambda: None
+        p = cs.display_payload()
+        check("available False with nothing", p, {"available": False})
+    finally:
+        cs.display_info, cs.audio_info = saved
+
+    print("caps: display_info is wired at every enforced site")
+    # The five-site rule plus protocol.json. tests/test_protocol_parity.py is the
+    # authority; this is the local canary so a failure here names the feature.
+    cs.set_caps(True)
+    check("agent mock branch", cs.CAPS.get("display_info"), True)
+    cs.set_caps(False)
+    check("agent real branch declares the key",
+          "display_info" in cs.CAPS, True)
+    check("...and its value is a real bool, never None",
+          isinstance(cs.CAPS["display_info"], bool), True)
+    spec = json.load(open(os.path.join(ROOT, "protocol", "protocol.json")))
+    check("protocol.json declares it linux-only",
+          "display_info" in spec["linuxOnlyCapabilities"]["keys"], True)
+    api = open(os.path.join(ROOT, "app", "lib", "api.ts")).read()
+    st = open(os.path.join(ROOT, "app", "lib", "settings.ts")).read()
+    check("app BoxCaps", "  display_info?: boolean;" in api, True)
+    check("app capsEqual", "a.display_info === b.display_info" in api, True)
+    check("app normalizeCaps", "bool('display_info')" in st, True)
+    win = open(os.path.join(ROOT, "agent", "win", "couchsided-win.py")).read()
+    check("the Windows agent does NOT declare it",
+          "display_info" in win, False)
+    cs.set_caps(True)
+
+    print("mock: the harness gets something worth rendering")
+    m = cs.mock_display_payload()
+    d, a = m["display"], m["audio"]
+    check("current mode differs from preferred, so conflating them SHOWS",
+          d["mode"]["refresh_hz"] != d["preferred_mode"]["refresh_hz"], True)
+    check("HDR on and VRR off, so both state rows are exercisable",
+          (d["hdr"]["enabled"], d["vrr"]["active"]), (True, False))
+    check("audio OUT and IN are different devices",
+          a["output"] != a["input"], True)
+    check("...and the IN description is long enough to catch a row overflow",
+          len(a["input"]) > 45, True)
+    check("mock_status carries both blocks",
+          sorted(k for k in cs.mock_status() if k in ("display", "audio")),
+          ["audio", "display"])
+
+
+def main():
+    test_edid()
+    test_drm()
+    test_gamescopectl()
+    test_kscreen()
+    test_gamescope_atoms()
+    test_x11_server_selection()
+    test_audio()
+    test_composition()
+    test_wiring()
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        return 1
+    print("all display/audio tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> Stacked on **#295** (flatpak completion, agent 2.9.59). Rebased on top; bumps agent to **2.9.60** so a box already on the flatpak-only 2.9.59 is still offered this.

Answers the couch question the owner asked — *"what is my box actually sending the TV?"*: resolution + refresh, plus HDR, VRR, monitor name, connector state, and audio **out and in**.

## Card

```
DISPLAY / AUDIO
RES      3840 × 2160        REFRESH  120 Hz
HDR      on                 VRR      off
MONITOR  OLED65C9PUA
OUTPUT   HDMI-A-1 connected · external
AUDIO    OUT  LG TV SSCR2 Digital Stereo (HDMI)
         IN   Thinkcentre TIO24Gen3Touch USB-audio
```

## Agent (2.9.60)

Additive `display`/`audio` on `/api/status` + read-only `GET /api/display-info`; cap `display_info` at all six sites, linux-only. Three session-aware probes:

- **gamescopectl** (Game Mode) — make/model/connector/valid-refresh, plus a ~90-line **stdlib X11 client** for the current scanout mode and the VRR/HDR feedback atoms.
- **kscreen-doctor** (Plasma) — exit code ignored (it SIGABRTs with no session, real rc=134), non-empty parsed output is the gate, failures cached 120s.
- **DRM sysfs + EDID** floor — works headless. Audio via `wpctl inspect` default sink+source.

**Honesty is the point.** `mode` (current), `preferred_mode` (EDID capability), `refresh_rates_hz` (valid list), `supported_modes` (sysfs) are four separate keys — never back-filled from each other. On the measured box all read 1920x1080/60, which is exactly why conflating them looks right there and is wrong elsewhere.

**HDR/VRR is state, not capability.** VRR from `GAMESCOPE_VRR_FEEDBACK`; HDR **only** from `GAMESCOPE_HDR_OUTPUT_FEEDBACK` — never `GAMESCOPE_DISPLAY_HDR_ENABLED`, which is Steam's *request* and reads `1` on this SDR panel (the trap, reproduced live and refused). Unknown stays absent; "off" is only ever explicit.

## Verified

- **Agent** `tests/test_display_audio.py` — fixtures verbatim from the box (Lenovo + Hisense EDID hex, gamescopectl block, both wpctl outputs, DRM rows). **Four mutation controls all caught red:** preferred-as-current, HDR-from-request-atom, kscreen-trusting-rc, sysfs-list-as-current.
- **Live** on the Bazzite box (Game Mode): X11 client connects 1ms, reads mode + atoms incl. a negative-control atom → None; `display_info()` 5ms, `audio_info()` 25ms; 60 uncached cycles **0 fd delta**; HDR correctly false despite `DISPLAY_HDR_ENABLED=1`.
- **App card in the web harness, both states:** `available:true` renders every field; forcing `available:false` removes the card while battery + screen cards stay — the control, so the absence is specific to display-info.
- 97/97 app tests, tsc clean, protocol parity (all six cap sites) OK.

## NOT verified

- kscreen-doctor **success** path (only ever seen crashing; its JSON fixture is libkscreen's documented schema, labelled synthetic).
- `vrr.supported:true` and `GAMESCOPE_HDR_OUTPUT_FEEDBACK` present — no HDR/VRR panel reachable; unit-tested against synthetic atoms.
- Scaled-output current mode on a Deck rendering into a 4K TV.

🤖 Generated with [Claude Code](https://claude.com/claude-code)