### PR TITLE
chore(release): 2.9.30 store notes for both stores

### DIFF
--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,7 @@
-New in 2.9.29
+New in 2.9.30
 
-• Skip 10 or 30 seconds — new arrows on Now Playing jump back or forward 10 seconds; hold one for 30. Change either amount in Settings, or switch the hold off.
-• Kinder to your battery — the Pad no longer holds your screen on indefinitely. Let it sleep after 5, 10, 30 or 60 idle minutes, or keep it always on.
-• Vitals first — the file-sending card moved to the bottom of the Console tab.
+• Scan to pair — point your phone's camera at the code on your box's screen, right inside the app. Setup → Scan a pairing code. No browser detour, no typing.
+• Choose how your box starts up — a new Boots into card on the Actions tab: Game Mode, Desktop, or whichever you used last. The switches below it only change what's on screen now; this is the setting that decides power-on.
+• Launch Netflix, Hulu and the rest — non-Steam shortcuts on your box now appear in Launch, so the phone can start them.
+• One flick, one step — swiping the remote past a short menu no longer sails through it.
+• TV mode is off by default now, and labelled the rough beta it is. Turn it on in Settings if you want it.

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,0 +1,7 @@
+New in 2.9.30
+
+• Scan to pair — point your camera at the code on your box's screen, right in the app (Setup → Scan a pairing code).
+• Choose how your box starts up — a new Boots into card on Actions: Game Mode, Desktop, or last used.
+• Launch Netflix, Hulu and more — non-Steam shortcuts now show up in Launch.
+• One flick, one step — the remote no longer sails past short menus.
+• TV mode is off by default now, and labelled the rough beta it is.


### PR DESCRIPTION
The App Store notes still read **"New in 2.9.29"** and described 2.9.29's features — the stale-changelog trap §11.4 records. Rewritten for what build 99 / vc 66 actually add over live 2.9.29: in-app QR pairing scanner, Boots-into card, non-Steam launchers, the one-flick-one-step swipe fix, and TV mode demoted to an off-by-default beta.

Play caps notes at 500 chars (App Store allows far more), so Play gets its own trimmed file at 447 chars rather than a truncation.

Verified by reading the artifacts back, not exit codes: App Store submission reports whatsNew 712 chars en-US; Play production track reads back "New in 2.9.30", 447 chars, on versionCode 66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)