### PR TITLE
fix(pad): a vertical flick moves one menu item, without touching horizontal

### DIFF
--- a/app/lib/__tests__/swipeSteps.test.ts
+++ b/app/lib/__tests__/swipeSteps.test.ts
@@ -19,6 +19,7 @@ import assert from 'node:assert/strict';
 import {
   SWIPE_FIRST_PX,
   SWIPE_REPEAT_PX,
+  SWIPE_REPEAT_Y_PX,
   planSteps,
   type StepState,
 } from '../swipeSteps.ts';
@@ -113,4 +114,66 @@ test('reversing mid-gesture steps back the other way', () => {
   const dirs = gesture([[220, 0], [0, 0], [-220, 0]]);
   assert.equal(dirs.includes('dr'), true);
   assert.equal(dirs.includes('dl'), true);
+});
+
+// ---------------------------------------------------------- vertical axis ---
+// Reported from the couch 2026-07-27: swiping DOWN in the Steam menu skipped
+// every other button, while horizontal tile navigation was confirmed GOOD. A
+// vertical gesture travels further for the same intent, so one shared repeat
+// threshold double-stepped it. The rule below fixes vertical WITHOUT touching
+// horizontal — and these tests are what make that a provable claim.
+
+test('THE BUG: a vertical menu flick emits exactly one step', () => {
+  // ~320px down, the band that produced two steps under the shared threshold.
+  const dirs = gesture([[0, 60], [0, 150], [0, 250], [0, 320]]);
+  assert.deepEqual(dirs, ['dd'], `vertical flick sent ${dirs.length}: ${dirs}`);
+});
+
+test('CONTROL: horizontal stepping is byte-for-byte unchanged', () => {
+  // These are the exact expectations from before the vertical fix. If a change
+  // to the vertical rule ever perturbs the horizontal axis, this fails.
+  assert.deepEqual(gesture([[40, 0], [90, 0], [150, 0], [200, 0]]), ['dr']);
+  assert.deepEqual(planSteps(SWIPE_FIRST_PX, 0, fresh()).dirs, ['dr']);
+  assert.deepEqual(planSteps(SWIPE_FIRST_PX - 1, 0, fresh()).dirs, []);
+  assert.equal(planSteps(SWIPE_FIRST_PX + SWIPE_REPEAT_PX - 1, 0, fresh()).dirs.length, 1);
+  assert.equal(planSteps(SWIPE_FIRST_PX + SWIPE_REPEAT_PX, 0, fresh()).dirs.length, 2);
+  const long = gesture([[100, 0], [250, 0], [400, 0], [560, 0]]);
+  assert.equal(long.length >= 3, true, `long horizontal drag sent ${long.length}`);
+});
+
+test('the first step costs the same on both axes', () => {
+  // A flick in ANY direction moves one item at the same distance; only the
+  // REPEAT differs. Both directions of each axis.
+  assert.deepEqual(planSteps(0, SWIPE_FIRST_PX, fresh()).dirs, ['dd']);
+  assert.deepEqual(planSteps(0, -SWIPE_FIRST_PX, fresh()).dirs, ['du']);
+  assert.deepEqual(planSteps(0, SWIPE_FIRST_PX - 1, fresh()).dirs, []);
+  assert.deepEqual(planSteps(0, -(SWIPE_FIRST_PX - 1), fresh()).dirs, []);
+});
+
+test('a vertical repeat needs its own, larger threshold', () => {
+  // One pixel short of first+repeatY: still one step.
+  assert.equal(planSteps(0, SWIPE_FIRST_PX + SWIPE_REPEAT_Y_PX - 1, fresh()).dirs.length, 1);
+  // Exactly at it: the second step lands.
+  assert.equal(planSteps(0, SWIPE_FIRST_PX + SWIPE_REPEAT_Y_PX, fresh()).dirs.length, 2);
+  // ...and it is strictly harder than a horizontal repeat, in both directions.
+  assert.equal(SWIPE_REPEAT_Y_PX > SWIPE_REPEAT_PX, true);
+  assert.equal(planSteps(0, -(SWIPE_FIRST_PX + SWIPE_REPEAT_Y_PX), fresh()).dirs.length, 2);
+});
+
+test('a deliberate long drag down still scrolls several', () => {
+  // The escape hatch: scrolling a long library must remain possible.
+  const dirs = gesture([[0, 200], [0, 500], [0, 800], [0, 1100]]);
+  assert.equal(dirs.length >= 3, true, `long vertical drag sent only ${dirs.length}`);
+  assert.equal(new Set(dirs).size, 1, 'a straight drag must not change axis');
+  assert.equal(dirs[0], 'dd');
+});
+
+test('an axis that has not earned its step does not steal one', () => {
+  // Y leads in raw travel but is short of its own bar, while X has cleared its
+  // own. Stepping Y here would be the overshoot this module exists to prevent.
+  let st = fresh();
+  const warm = planSteps(0, SWIPE_FIRST_PX, st); // spend the cheap first step
+  st = warm.next;
+  const p = planSteps(SWIPE_REPEAT_PX + 10, SWIPE_FIRST_PX + SWIPE_REPEAT_Y_PX - 50, st);
+  assert.equal(p.dirs.every((d) => d === 'dr' || d === 'dl'), true, `stepped Y early: ${p.dirs}`);
 });

--- a/app/lib/swipeSteps.ts
+++ b/app/lib/swipeSteps.ts
@@ -29,6 +29,33 @@ export const SWIPE_FIRST_PX = 56;
  * three.
  */
 export const SWIPE_REPEAT_PX = 160;
+/**
+ * ADDITIONAL travel before each step after the first, VERTICALLY.
+ *
+ * WHY VERTICAL IS DIFFERENT (reported from the couch 2026-07-27): "swiping down
+ * in the Steam menu skips every other button", while horizontal tile navigation
+ * was confirmed working. Same code, same thresholds — so the difference is the
+ * gesture, not the rule. A thumb swiping DOWN travels much further than the same
+ * intent swiping ACROSS: the screen is taller than it is wide and the thumb arcs
+ * away from the joint. With one shared 160px repeat, a one-item-intent vertical
+ * flick sailed past 56+160=216px and emitted two steps, while an equivalent
+ * horizontal flick stayed under it and emitted one.
+ *
+ * MEASURED against the same planner, one continuous flick:
+ *
+ *     flick    live 2.9.29   2.9.30 (shared 160)   this (vertical 300)
+ *     180px         3                1                     1
+ *     220px         3                2                     1
+ *     320px         5                2                     1
+ *     400px         7                3                     2
+ *
+ * 300 is chosen so the second vertical step needs 56+300=356px — past any
+ * flick, still reachable by a deliberate drag down the pad, which is how you
+ * scroll a long library. HORIZONTAL IS DELIBERATELY UNCHANGED at 160: the tile
+ * navigation that value produced was confirmed good on hardware, and this file
+ * must not put that at risk to fix the other axis.
+ */
+export const SWIPE_REPEAT_Y_PX = 300;
 
 export type StepDir = 'du' | 'dd' | 'dl' | 'dr';
 
@@ -64,7 +91,8 @@ export function planSteps(
 ): StepPlan {
   const sens = sensitivity > 0 ? sensitivity : 1;
   const first = SWIPE_FIRST_PX / sens;
-  const repeat = SWIPE_REPEAT_PX / sens;
+  const repeatX = SWIPE_REPEAT_PX / sens;
+  const repeatY = SWIPE_REPEAT_Y_PX / sens;
 
   let { consumedX, consumedY, stepped } = state;
   const dirs: StepDir[] = [];
@@ -76,13 +104,24 @@ export function planSteps(
     const availY = dy - consumedY;
     const ax = Math.abs(availX);
     const ay = Math.abs(availY);
-    const need = stepped ? repeat : first;
-    if (ax < need && ay < need) break;
-    if (ax >= ay) {
-      consumedX += Math.sign(availX) * need;
+    // Per-axis thresholds: a repeat costs more vertically (see
+    // SWIPE_REPEAT_Y_PX). The FIRST step is identical on both axes, so a flick
+    // in any direction still moves one item at the same distance.
+    const needX = stepped ? repeatX : first;
+    const needY = stepped ? repeatY : first;
+    const canX = ax >= needX;
+    const canY = ay >= needY;
+    if (!canX && !canY) break;
+    // Dominant axis still wins — but only among axes that have actually earned
+    // a step. Previously one shared threshold meant the dominant axis always
+    // qualified; with different thresholds an axis can lead in raw travel while
+    // still being short of its own bar, and stepping it then would be the
+    // overshoot this whole module exists to prevent.
+    if (canX && (!canY || ax >= ay)) {
+      consumedX += Math.sign(availX) * needX;
       dirs.push(availX > 0 ? 'dr' : 'dl');
     } else {
-      consumedY += Math.sign(availY) * need;
+      consumedY += Math.sign(availY) * needY;
       dirs.push(availY > 0 ? 'dd' : 'du');
     }
     stepped = true;


### PR DESCRIPTION
Reported from the couch: **swiping down in the Steam menu skips every other button**, while horizontal tile navigation was confirmed **good** on hardware.

Same code, same thresholds on both axes — so the difference is the *gesture*, not the rule. A thumb swiping down travels much further than the same intent swiping across (taller screen, thumb arcs away from the joint), so a one-item vertical flick sailed past the shared `56+160=216px` repeat and emitted two steps where an equivalent horizontal flick emitted one.

## The change

Repeat threshold is now **per-axis**: horizontal stays **160**, vertical becomes **300** (second vertical step needs 356px — past any flick, still reachable by a deliberate drag, which is how a long library scrolls). The **first** step is unchanged on both axes, so a flick in any direction still moves one item at the same distance.

Measured on the planner, one continuous flick:

| flick | live 2.9.29 | 2.9.30 (shared) | **this** | horizontal (unchanged) |
|---|---|---|---|---|
| 180px | 3 | 1 | **1** | 1 |
| 220px | 3 | 2 | **1** | 2 |
| 320px | 5 | 2 | **1** | 2 |
| 400px | 7 | 3 | **2** | 3 |

## Horizontal is untouched — asserted, not promised

The owner asked that the working navigation not be put at risk to chase the alpha TV nav. So the new **CONTROL test carries the exact pre-fix horizontal expectations** (first step at 56, none at 55, one step below `first+repeat`, two at it, long drag still scrolling) and fails if the vertical rule ever perturbs that axis.

One subtlety this forced: with a single shared threshold the dominant axis always qualified. With different thresholds an axis can lead in raw travel while still short of its own bar — so the dominant axis now wins only **among axes that have earned a step**. Stepping the other would be the exact overshoot this module exists to prevent. Covered by its own test.

## Verified

103/103 app tests (6 new), `tsc` clean.

## NOT verified

**300 is a judgment call about a thumb.** No test settles how a flick *feels*, so this goes to TestFlight to be felt on hardware before it ships to users — which is why it was deliberately kept out of the 2.9.30 production push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)