### PR TITLE
fix(install): only restart Decky when our panel actually changed (KI-037)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,15 @@ jobs:
       - name: Unit tests (decky detection)
         run: bash tests/test_decky_detect.sh
 
+      # Restarting plugin_loader restarts DECKY ITSELF, reloading every OTHER
+      # plugin the user has. install.sh used to do that on every agent update,
+      # even when our panel was byte-identical (KI-037) — which is how an
+      # unrelated plugin's memory growth came to look like our update caused it.
+      # Both directions are asserted: an always-skip guard would silently stop
+      # shipping plugin updates, which is worse than the bug it fixes.
+      - name: Unit tests (decky restart guard)
+        run: bash tests/test_decky_restart_guard.sh
+
       # Gaming card (/api/gaming): the card* glob trap (a cardN-DP-1 connector
       # dir must not be read as a GPU), the reaper AppId matcher incl. the
       # [oom_reaper] reject, the empty-power_supply desktop case + the uniq (never

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,11 @@ UNIT_DST="/etc/systemd/system/couchside.service"
 # installed here when Decky is present, and removed from here on --uninstall.
 DECKY_PLUGINS="${HOME}/homebrew/plugins"
 DECKY_PLUGIN_DIR="${DECKY_PLUGINS}/Couchside"
+# Checksum of the plugin tarball we last installed. Lets an update skip the
+# rm/extract/restart when the panel is already this exact build — restarting
+# plugin_loader restarts DECKY ITSELF, reloading every OTHER plugin the user
+# has, so it must not happen for no reason (KI-037).
+DECKY_STAMP="/etc/couchside/decky-plugin.sha256"
 # What actually proves Decky Loader is INSTALLED. Its own uninstaller removes
 # the unit and homebrew/services/PluginLoader but LEAVES homebrew/plugins behind
 # (see decky-loader dist/uninstall.sh), so `[ -d "$DECKY_PLUGINS" ]` reports a
@@ -416,6 +421,7 @@ if [ "$UNINSTALL" -eq 1 ]; then
     note "removed the udev/modules-load drop-ins"
     if [ "$NO_DECKY" -eq 0 ] && sudo test -d "$DECKY_PLUGIN_DIR"; then
         sudo rm -rf "$DECKY_PLUGIN_DIR"
+        sudo rm -f "$DECKY_STAMP"
         sudo systemctl restart plugin_loader.service 2>/dev/null || true
         note "removed the Decky Loader Game Mode panel"
     fi
@@ -1865,7 +1871,51 @@ if [ "$NO_DECKY" -eq 0 ] && decky_installed; then
     # `[ -d "$DECKY_PLUGINS" ]`. tar -C would fail on a Decky install that has
     # never had a plugin. Root-owned to match a store install.
     sudo mkdir -p "$DECKY_PLUGINS"
-    if decky_verify_ok \
+
+    # SKIP THE WHOLE THING WHEN OUR PLUGIN IS ALREADY THIS EXACT BUILD (KI-037).
+    #
+    # Restarting plugin_loader.service restarts DECKY LOADER, which reloads every
+    # OTHER plugin the user has — SteamGridDB, ProtonDB, LSFG-VK, whatever. This
+    # block used to rm/extract/restart unconditionally, so every agent update
+    # (including the one the phone's "update the box" button fires) yanked and
+    # reloaded third-party software we do not own and were not asked about.
+    #
+    # It surfaced as a support report: a user saw an unrelated plugin at 27 GiB
+    # "right after updating your app". The leak was not ours, but our restart
+    # reset every plugin's memory to zero and re-seeded it, which made another
+    # plugin's growth look like it began at our update. The correlation was real;
+    # the causation was not. Restarting a third-party service needs a reason, and
+    # "an unrelated update ran" is not one.
+    #
+    # The stamp is the VERIFIED TARBALL's checksum rather than a version string:
+    # it needs no parsing, and it also catches a republished same-version build.
+    # Guarded on the plugin dir still existing, so a user who deleted the plugin
+    # gets it back even when the stamp matches.
+    decky_stamp_of() {
+        # The hash line for our tarball, as already verified above.
+        awk '$2 == "Couchside.tar.gz" || $2 == "*Couchside.tar.gz" {print $1}' \
+            "${decky_tmp}/SHA256SUMS" 2>/dev/null | head -1
+    }
+    decky_up_to_date() {
+        local want have
+        want="$(decky_stamp_of)"
+        [ -n "$want" ] || return 1
+        have="$(sudo cat "$DECKY_STAMP" 2>/dev/null)" || return 1
+        [ "$want" = "$have" ] || return 1
+        # Stamp matches but the plugin is gone (user removed it) -> reinstall.
+        sudo test -d "$DECKY_PLUGIN_DIR" || return 1
+        return 0
+    }
+
+    # Verification runs ONCE (it downloads), and its result gates BOTH branches.
+    # Never fall back to "the tarball file exists" — an unverified tarball must
+    # never be extracted, which is the whole point of the gate above.
+    decky_ok=0
+    decky_verify_ok && decky_ok=1
+
+    if [ "$decky_ok" -eq 1 ] && decky_up_to_date; then
+        note "panel already up to date; leaving Decky Loader alone (not restarting other plugins)."
+    elif [ "$decky_ok" -eq 1 ] \
         && sudo rm -rf "$DECKY_PLUGIN_DIR" \
         && sudo tar -xzf "${decky_tmp}/Couchside.tar.gz" -C "$DECKY_PLUGINS"; then
         # Force root ownership: a release archive built in CI can carry the
@@ -1873,6 +1923,12 @@ if [ "$NO_DECKY" -eq 0 ] && decky_installed; then
         # skips a plugin it doesn't see as root-owned (no error, just missing
         # from the menu). Store installs are root-owned; match that.
         sudo chown -R root:root "$DECKY_PLUGIN_DIR" 2>/dev/null || true
+        # Record WHAT we installed, so the next run can skip all of this (and
+        # skip restarting everyone else's plugins). Written only after the
+        # extract succeeded — a stamp for a build that is not actually on disk
+        # would suppress a needed reinstall. Best-effort: a failed stamp write
+        # costs an unnecessary restart next time, never a missed update.
+        decky_stamp_of | sudo tee "$DECKY_STAMP" >/dev/null 2>&1 || true
         sudo systemctl restart plugin_loader.service 2>/dev/null || true
         # VERIFY, don't assume. The restart status used to be discarded
         # (`|| true`) and the success note printed unconditionally, so a box

--- a/tests/test_decky_restart_guard.sh
+++ b/tests/test_decky_restart_guard.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Tests install.sh's "don't restart Decky for no reason" guard (KI-037).
+#
+# Run: bash tests/test_decky_restart_guard.sh
+#
+# WHY THIS EXISTS. Restarting plugin_loader.service restarts DECKY LOADER, which
+# reloads EVERY plugin the user has — SteamGridDB, ProtonDB, LSFG-VK, whatever.
+# install.sh used to rm/extract/restart unconditionally, so every agent update
+# (including the one the phone's "update the box" button fires) yanked and
+# reloaded third-party software we do not own.
+#
+# It surfaced as a support report: a user saw an unrelated plugin at 27 GiB
+# "right after updating your app". The leak was not ours — but our restart reset
+# every plugin to zero and re-seeded it, so another plugin's growth looked like
+# it began at our update.
+#
+# BOTH DIRECTIONS ARE TESTED, and that is the point. A guard that always skipped
+# would silently stop shipping plugin updates — strictly worse than the bug it
+# fixes. So every "skips" case is paired with a "still installs" case.
+set -u
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SH="$ROOT/install.sh"
+fails=0
+
+check() { # name expected actual
+    if [ "$2" = "$3" ]; then
+        printf '  PASS  %s\n' "$1"
+    else
+        printf '  FAIL  %s (expected %s, got %s)\n' "$1" "$2" "$3"
+        fails=$((fails + 1))
+    fi
+}
+
+# Extract the two helpers under test from install.sh, so this exercises the
+# SHIPPED text rather than a retyped copy that could drift from it.
+eval "$(awk '/^    decky_stamp_of\(\) \{/,/^    \}/' "$SH")"
+eval "$(awk '/^    decky_up_to_date\(\) \{/,/^    \}/' "$SH")"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+decky_tmp="$tmp"
+DECKY_PLUGIN_DIR="$tmp/plugins/Couchside"
+DECKY_STAMP="$tmp/stamp.sha256"
+# The helpers call `sudo`; in this harness it is a passthrough shim.
+sudo() { "$@"; }
+
+HASH_A="aaaa111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+HASH_B="bbbb111122223333444455556666777788889999aaaabbbbccccddddeeeeffff"
+
+write_sums() { # hash
+    # Real SHA256SUMS layout, including the other assets, so the parser has to
+    # actually pick OUR line out rather than take the first one.
+    cat >"$tmp/SHA256SUMS" <<EOF
+0000000000000000000000000000000000000000000000000000000000000000  couchsided.py
+$1  Couchside.tar.gz
+1111111111111111111111111111111111111111111111111111111111111111  install.sh
+EOF
+}
+
+echo "parsing our line out of SHA256SUMS"
+write_sums "$HASH_A"
+check "picks the Couchside.tar.gz hash, not the first line" "$HASH_A" "$(decky_stamp_of)"
+
+# The binary-mode form (`*name`) that sha256sum emits with -b must parse too.
+cat >"$tmp/SHA256SUMS" <<EOF
+$HASH_B *Couchside.tar.gz
+EOF
+check "handles the binary-mode '*name' form" "$HASH_B" "$(decky_stamp_of)"
+
+echo
+echo "the guard: skips only when the SAME build is genuinely installed"
+mkdir -p "$DECKY_PLUGIN_DIR"
+write_sums "$HASH_A"
+printf '%s\n' "$HASH_A" >"$DECKY_STAMP"
+decky_up_to_date && r=skip || r=install
+check "same hash + plugin present -> SKIP (no Decky restart)" "skip" "$r"
+
+# CONTROL, the direction that matters most: a NEW build must still install, or
+# the guard would quietly stop delivering plugin updates forever.
+write_sums "$HASH_B"
+decky_up_to_date && r=skip || r=install
+check "different hash -> INSTALL (a real update still ships)" "install" "$r"
+
+echo
+echo "degrade toward installing whenever the state is not provably identical"
+write_sums "$HASH_A"
+rm -rf "$DECKY_PLUGIN_DIR"
+decky_up_to_date && r=skip || r=install
+check "stamp matches but plugin dir gone -> INSTALL" "install" "$r"
+
+mkdir -p "$DECKY_PLUGIN_DIR"
+rm -f "$DECKY_STAMP"
+decky_up_to_date && r=skip || r=install
+check "no stamp (first run, or upgrade from an older installer) -> INSTALL" "install" "$r"
+
+printf '' >"$DECKY_STAMP"
+decky_up_to_date && r=skip || r=install
+check "empty stamp -> INSTALL" "install" "$r"
+
+printf '%s\n' "$HASH_A" >"$DECKY_STAMP"
+rm -f "$tmp/SHA256SUMS"
+decky_up_to_date && r=skip || r=install
+check "no SHA256SUMS to compare against -> INSTALL" "install" "$r"
+
+write_sums "$HASH_A"
+printf 'not-a-hash\n' >"$DECKY_STAMP"
+decky_up_to_date && r=skip || r=install
+check "garbage stamp -> INSTALL" "install" "$r"
+
+echo
+if [ "$fails" -ne 0 ]; then
+    echo "FAILED: $fails check(s)"
+    exit 1
+fi
+echo "all decky restart-guard tests passed"


### PR DESCRIPTION
Restarting `plugin_loader.service` restarts **Decky Loader**, which reloads *every* plugin the user has. `install.sh` did that **unconditionally** — `rm -rf` our plugin dir, re-extract, restart — with no check for whether the installed panel was already that exact build. Since the phone's "update the box" button runs install.sh, every agent update yanked and reloaded third-party software we don't own.

## How it surfaced

An r/SteamOS user reported a Decky plugin eating **27.1 GiB** "right after updating your app", and asked whether ours leaks.

It wasn't ours. The process was `Decky LSFG-VK`, and Decky names each plugin's backend after that plugin — measured on a real box:

```
Couchside       (…/plugins/Couchside/main.py)          RSS  38.2 MB
SteamGridDB     (…/plugins/decky-steamgriddb/main.py)  RSS  37.3 MB
ProtonDB Badges (…/plugins/protondb-decky/main.py)
```

But **our restart is what reset every plugin to zero and re-seeded it**, which is exactly why another plugin's growth looked like it began at our update. The correlation was real; the causation wasn't. Restarting a third-party service needs a reason, and "an unrelated update ran" isn't one.

(Our plugin was audited at the same time: backend has no threads, no background loops, no asyncio tasks; its one `while True` streams a download under a hard byte cap; the frontend's single 5s interval is cleared on unmount.)

## The guard

Stamp the **verified** tarball's checksum at `/etc/couchside/decky-plugin.sha256`; skip the whole rm/extract/restart when the next run's tarball matches **and** our plugin dir is still present. Checksum rather than version string — nothing to parse, and it catches a republished same-version build. `--uninstall` clears the stamp.

**Security note:** verification now runs once and its result gates *both* branches. An earlier draft let a failed verify fall through to `[ -f tarball ]`, which would have extracted an **unverified** tarball — the exact hole the signature/checksum gate exists to close. It does not.

**Degrades toward installing:** missing/empty/garbage stamp, missing SHA256SUMS, or a user-deleted plugin dir all take the install path. The only skip is "provably the same build, still on disk".

## Verified

`tests/test_decky_restart_guard.sh` extracts the real helpers out of install.sh (so it fails on drift) and asserts **both directions** — an always-skip guard would silently stop shipping plugin updates, worse than the bug being fixed.

Mutation-checked: neutering the hash comparison turns three tests red, led by *"different hash -> INSTALL (a real update still ships)"*.

9/9 pass, `test_decky_detect.sh` still green, `bash -n` clean, new CI step added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)