### PR TITLE
fix(app): cap binary responses from a box instead of buffering whatever arrives (KI-035)

### DIFF
--- a/app/lib/__tests__/responseCap.test.ts
+++ b/app/lib/__tests__/responseCap.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Binary-response size cap — lib/responseCap.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the CI app-input glob.
+ *
+ * WHAT THIS GUARDS (KI-035). `mediaArtSource` and `screenFrameSource` read a box's
+ * response with `arrayBuffer()` and no bound, then base64'd it (~1.33x) into a
+ * data: URI. A box returning hundreds of megabytes — hostile, wedged, or a
+ * capture tool gone wrong — took the phone's memory with it, and the screen
+ * preview POLLS, so it got a fresh attempt every frame.
+ *
+ * The rule has to fail in the SAFE direction on both sides: too strict and a
+ * legitimate screen frame stops rendering (the preview silently dies), too loose
+ * and the cap is decorative. Every reject case below is therefore paired with a
+ * realistic accept case.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  MAX_BINARY_BYTES,
+  isDeclaredTooLarge,
+  isUsableBodySize,
+} from '../responseCap.ts';
+
+const KB = 1024;
+const MB = 1024 * 1024;
+
+test('THE BUG: a huge declared body is refused before it is read', () => {
+  assert.equal(isDeclaredTooLarge(String(500 * MB)), true);
+  assert.equal(isDeclaredTooLarge(String(MAX_BINARY_BYTES + 1)), true);
+  // CONTROL, the direction that keeps the feature working: real payloads pass.
+  // A measured screen frame is ~100-400 KB; album art is smaller.
+  assert.equal(isDeclaredTooLarge(String(400 * KB)), false);
+  assert.equal(isDeclaredTooLarge(String(2 * MB)), false);
+  assert.equal(isDeclaredTooLarge(String(MAX_BINARY_BYTES)), false, 'exactly at the cap is allowed');
+});
+
+test('an unknown Content-Length is not treated as too big', () => {
+  // Refusing every response without a length would break any box that omits it;
+  // the post-read check is what covers this case instead.
+  for (const v of [null, undefined, '', '   ']) {
+    assert.equal(isDeclaredTooLarge(v as string | null), false, `${String(v)} was refused`);
+  }
+});
+
+test('a junk Content-Length falls through rather than being guessed at', () => {
+  for (const v of ['abc', '-1', '1.5', '1e9', '0x100', '12 34', '+5', 'Infinity', 'NaN']) {
+    assert.equal(isDeclaredTooLarge(v), false, `${v} was treated as a size`);
+  }
+  // CONTROL: a plain digit string IS parsed, so the above is genuinely about
+  // unparseable input and not a function that always returns false.
+  assert.equal(isDeclaredTooLarge(String(9 * MB)), true);
+});
+
+test('the post-read check is the backstop for a lying or absent length', () => {
+  // A body that arrived oversized despite the header must not be encoded.
+  assert.equal(isUsableBodySize(500 * MB), false);
+  assert.equal(isUsableBodySize(MAX_BINARY_BYTES + 1), false);
+  // CONTROL: normal sizes render.
+  assert.equal(isUsableBodySize(400 * KB), true);
+  assert.equal(isUsableBodySize(MAX_BINARY_BYTES), true, 'exactly at the cap renders');
+});
+
+test('an empty body is not renderable — preserving the old "no art" behaviour', () => {
+  // Both callers already returned null on 0 bytes; that must not regress into
+  // an empty data: URI reaching <Image>.
+  assert.equal(isUsableBodySize(0), false);
+  assert.equal(isUsableBodySize(-1), false);
+  assert.equal(isUsableBodySize(NaN), false);
+  assert.equal(isUsableBodySize(Infinity), false);
+  // CONTROL: one byte is a body.
+  assert.equal(isUsableBodySize(1), true);
+});
+
+test('the cap is generous enough that it cannot reject a real frame', () => {
+  // Guards against someone "tightening" this to a number that silently kills
+  // the screen preview. A measured frame is ~100-400 KB.
+  assert.equal(MAX_BINARY_BYTES >= 4 * MB, true, `cap ${MAX_BINARY_BYTES} is too tight`);
+  assert.equal(isUsableBodySize(400 * KB), true);
+  assert.equal(isDeclaredTooLarge(String(400 * KB)), false);
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2,6 +2,7 @@
  * Typed client for the Couchside agent API (contract v1).
  * Base URL: http://<host>:<port>  (default port 8787)
  */
+import { isDeclaredTooLarge, isUsableBodySize } from './responseCap';
 import { Settings } from './settings';
 
 /** The subset of Settings the API client actually needs. */
@@ -1094,9 +1095,14 @@ export async function mediaArtSource(
   try {
     const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
     if (!res.ok) return null;
+    // Refuse an oversized body BEFORE reading it — the only point where refusing
+    // actually avoids buffering the bytes (KI-035).
+    if (isDeclaredTooLarge(res.headers.get('Content-Length'))) return null;
     const type = res.headers.get('Content-Type') || 'image/jpeg';
     const buf = await res.arrayBuffer();
-    if (buf.byteLength === 0) return null;
+    // Backstop for a missing or dishonest Content-Length: stop here rather than
+    // base64-amplifying it ~1.33x and handing a giant string to <Image>.
+    if (!isUsableBodySize(buf.byteLength)) return null;
     return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
   } catch {
     return null;
@@ -1116,9 +1122,12 @@ export async function screenFrameSource(settings: ConnSettings): Promise<string 
   try {
     const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
     if (!res.ok) return null;
+    // Same cap as album art, and it matters more here: the preview POLLS, so an
+    // oversized frame gets a fresh chance at the phone's memory every tick.
+    if (isDeclaredTooLarge(res.headers.get('Content-Length'))) return null;
     const type = res.headers.get('Content-Type') || 'image/jpeg';
     const buf = await res.arrayBuffer();
-    if (buf.byteLength === 0) return null;
+    if (!isUsableBodySize(buf.byteLength)) return null;
     return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
   } catch {
     return null;

--- a/app/lib/responseCap.ts
+++ b/app/lib/responseCap.ts
@@ -1,0 +1,66 @@
+/**
+ * How large a binary response from a box is allowed to be. ZERO runtime imports,
+ * so the rule is unit-testable on bare Node like lib/lanIp.ts.
+ *
+ * WHY (KI-035). `mediaArtSource` and `screenFrameSource` both did
+ * `await res.arrayBuffer()` with no bound, then base64'd the result into a
+ * `data:` URI. A box that returns hundreds of megabytes — hostile, wedged, or
+ * just a capture tool gone wrong — is buffered whole into the phone's memory and
+ * then amplified ~1.33x by the base64 encode. The screen preview POLLS, so it
+ * gets a fresh chance every frame.
+ *
+ * These are small things by nature: a measured screen frame is ~100-400 KB and
+ * album art is smaller still. 8 MB is ~20x the largest thing we expect, so it
+ * cannot reject a legitimate frame, while still bounding the damage.
+ *
+ * WHAT THIS DOES NOT DO, stated plainly: React Native's fetch is the whatwg-fetch
+ * polyfill, whose `response.body` is not a readable stream, so a body cannot be
+ * aborted part-way from JS. When a server sends no `Content-Length`, or lies
+ * about it, the bytes are already buffered by the time we can measure them. The
+ * post-read check still prevents the base64 amplification and stops a giant
+ * string reaching <Image>, but the initial buffer is not preventable here — a
+ * true streaming cap needs a native fetch replacement. The agent does send
+ * Content-Length, so the pre-check is the live path in practice.
+ */
+
+/** Largest binary body accepted from a box (8 MB). */
+export const MAX_BINARY_BYTES = 8 * 1024 * 1024;
+
+/**
+ * Should a response be refused based on its declared Content-Length?
+ *
+ * Checked BEFORE reading the body, which is the only point where refusing
+ * actually avoids buffering the bytes. An absent, empty, or unparseable header
+ * returns false — "unknown" is not "too big", and refusing every response
+ * without a Content-Length would break any box that omits it. The post-read
+ * size check is what covers that case.
+ */
+export function isDeclaredTooLarge(
+  contentLength: string | null | undefined,
+  cap: number = MAX_BINARY_BYTES,
+): boolean {
+  if (contentLength == null) return false;
+  const s = String(contentLength).trim();
+  if (!s) return false;
+  // Exactly digits: a negative, fractional, or junk value is not a size we can
+  // reason about, so it falls through to the post-read check.
+  if (!/^\d+$/.test(s)) return false;
+  const n = Number(s);
+  if (!Number.isFinite(n)) return false;
+  return n > cap;
+}
+
+/**
+ * Is a body we have already read an acceptable size to encode and render?
+ *
+ * Rejects empty (nothing to show — the callers already treated 0 as "no art")
+ * and anything over the cap, which is the backstop for a missing or dishonest
+ * Content-Length.
+ */
+export function isUsableBodySize(
+  byteLength: number,
+  cap: number = MAX_BINARY_BYTES,
+): boolean {
+  if (!Number.isFinite(byteLength)) return false;
+  return byteLength > 0 && byteLength <= cap;
+}


### PR DESCRIPTION
`mediaArtSource` and `screenFrameSource` both did `await res.arrayBuffer()` with **no bound**, then base64'd the result (~1.33x) into a `data:` URI. A box returning hundreds of megabytes — hostile, wedged, or a capture tool gone wrong — took the phone's memory with it. The screen preview **polls**, so it got a fresh attempt every frame.

## The fix

- **Pre-read:** an oversized `Content-Length` is refused *before* the body is read — the only point where refusing actually avoids buffering the bytes.
- **Post-read:** a size check backstops a missing or dishonest header, stopping the base64 amplification and keeping a giant string away from `<Image>`.
- **Cap: 8 MB** — ~20x the largest expected payload (a measured screen frame is ~100–400 KB, album art smaller), so it cannot reject a legitimate frame. A test asserts the cap stays generous, because tightening it silently kills the screen preview.

Decision logic lives in the import-free `lib/responseCap.ts`, testable on bare Node. Unknown/unparseable lengths deliberately fall through to the post-read check — refusing every response without a `Content-Length` would break any box that omits one.

## Residual, stated plainly

React Native's fetch is the whatwg-fetch polyfill, whose `response.body` is **not** a readable stream, so a body cannot be aborted part-way from JS. With no `Content-Length`, or a lying one, the bytes are **already buffered** by the time they can be measured. The post-read check still prevents the 1.33x amplification and the giant string, but the initial buffer isn't preventable here — a true streaming cap needs a native fetch replacement. The agent does send `Content-Length`, so the pre-check is the live path. This is recorded in KI-035 rather than left in a commit message.

## Verified

6 new tests, every reject paired with a realistic accept (400 KB frame, exactly-at-cap) so the rule can't pass by refusing everything.

**Mutation-checked, both guards independently:** neutering the pre-read check fails 2 tests; neutering the post-read backstop fails 1.

103/103 app tests, `tsc` clean.

Found during the QR-scanner adversarial review — the scanner widened who can point the app at a host, which is what made this worth closing now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)