### PR TITLE
feat(pair): the "get the app" QR opens a dedicated page, not the website

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,19 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.61
+
+Small fixes to the pairing screen and to updating.
+
+- **The "get the app" code now opens a page with just the two store links** —
+  App Store and Google Play, nothing else. It used to drop you on the middle of
+  the website, which is a lot to wade through when you are stood in front of the
+  TV holding a phone.
+- **Updating no longer restarts your other Decky plugins.** Every update used to
+  reload Decky Loader whether or not the Couchside panel had actually changed,
+  which restarted everything else you have installed alongside it. Now it only
+  happens when the panel is genuinely new.
+
 ## 2.9.60
 
 Your box now tells the app more about itself, and box-software updates finish cleanly.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.60"
+VERSION = "2.9.61"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -13180,12 +13180,20 @@ def render_pair_page(token, port):
     url_html = (pair_url.replace("&", "&amp;").replace("<", "&lt;")
                         .replace(">", "&gt;"))  # safe HTML text
     # One "get the app first" QR for a fresh installer who doesn't have
-    # Couchside yet. It points at couchside.tv, whose hero already carries BOTH
-    # store badges, so the phone picks its own store instead of the box making
-    # someone aim a camera at the right one of two codes. A single small canvas
-    # also leaves the one-screen layout roomier. The big QR above stays the
-    # pairing deep link for someone who already has the app.
-    get_js = json.dumps("https://couchside.tv/#get")
+    # Couchside yet. ONE code carrying BOTH stores, so the phone picks its own
+    # instead of the box making someone aim a camera at the right one of two
+    # codes. A single small canvas also leaves the one-screen layout roomier.
+    # The big QR above stays the pairing deep link for someone who has the app.
+    #
+    # /get/ is a DEDICATED page: the two store links and nothing else. It used
+    # to point at couchside.tv/#get, which is an anchor into the marketing home
+    # page — nav, pitch, footer, the agent installer, somewhere to wander off
+    # to. That is the wrong page for the only person who ever sees this code:
+    # someone standing in front of a TV, phone in hand, who has already decided.
+    # Keep this in sync with STORE_CODE in app/lib/pairLink.ts, which gives this
+    # exact string the friendly "that's the install code" answer when it is
+    # scanned into the app's pairing scanner by mistake.
+    get_js = json.dumps("https://couchside.tv/get/")
     return (
         "<!doctype html><html lang=\"en\"><head>"
         "<meta charset=\"utf-8\">"

--- a/app/lib/__tests__/pairLink.test.ts
+++ b/app/lib/__tests__/pairLink.test.ts
@@ -252,7 +252,16 @@ test('a bad ip= is DROPPED, not fatal — it is only a fallback route', () => {
 });
 
 test('the OTHER QR on the box screen gets its own reason, not a generic one', () => {
+  // BOTH forms: agents before 2.9.61 encode the marketing-page anchor, newer
+  // ones the dedicated /get/ page, and a phone meets both while un-updated
+  // boxes exist. The helpful answer must not depend on which one it sees.
+  assert.equal(why(scan('https://couchside.tv/get/')), 'store-code');
   assert.equal(why(scan('https://couchside.tv/#get')), 'store-code');
+  // CONTROL: a near-miss is NOT silently folded into the friendly reason —
+  // these are exact strings, not a prefix match on the domain.
+  assert.equal(why(scan('https://couchside.tv/get')), 'not-pair-link');
+  assert.equal(why(scan('https://couchside.tv/getx/')), 'not-pair-link');
+  assert.equal(why(scan('https://couchside.tv/')), 'not-pair-link');
 });
 
 test('BOTH STATES: real-world non-Couchside QRs are refused without throwing', () => {

--- a/app/lib/pairLink.ts
+++ b/app/lib/pairLink.ts
@@ -84,9 +84,18 @@ export const DEEPLINK_FORMS: readonly PairLinkForm[] = Object.freeze([
  * The OTHER QR on the box's pairing screen: an install/store link, drawn right
  * next to the pairing code. Catching it is the single most likely honest
  * mistake, so it gets its own reason rather than "not a Couchside code".
- * Exact string from the agent (`json.dumps("https://couchside.tv/#get")`).
+ *
+ * BOTH forms are listed because a box updates on its own schedule: agents
+ * before 2.9.61 encode the old marketing-page anchor, newer ones encode the
+ * dedicated /get/ page. A phone on the current app will meet both for as long
+ * as un-updated boxes exist, and the friendly answer should not depend on which
+ * one it happens to be looking at. Exact strings from the agent's
+ * `json.dumps(...)` — keep in sync with couchsided.py's `get_js`.
  */
-const STORE_CODE = 'https://couchside.tv/#get';
+const STORE_CODES: readonly string[] = Object.freeze([
+  'https://couchside.tv/get/',
+  'https://couchside.tv/#get',
+]);
 
 /** Hostname suffixes a pairing link may carry. Frozen; explicit entries only. */
 const HOST_SUFFIXES: readonly string[] = Object.freeze(['.local']);
@@ -262,7 +271,7 @@ export function parsePairLink(
   const text = raw.trim();
   if (!text) return rej('empty');
   if (text.length > MAX_RAW_LEN) return rej('too-long');
-  if (text === STORE_CODE) return rej('store-code');
+  if (STORE_CODES.includes(text)) return rej('store-code');
 
   let params: Record<string, string> | null | undefined;
   for (const form of opts.forms) {

--- a/tests/test_pair_page.py
+++ b/tests/test_pair_page.py
@@ -101,14 +101,23 @@ def test_idle_page_has_the_tutorial():
 def test_idle_page_has_store_qr_code():
     """A fresh installer without the app needs to install it first. Rather than
     make them aim a camera at the right one of two store codes, the page carries
-    ONE code to couchside.tv, whose hero holds both store badges — the phone
-    then picks its own store. Drawn by the same offline generator as the
-    pairing QR."""
+    ONE code carrying both stores — the phone then picks its own. Drawn by the
+    same offline generator as the pairing QR.
+
+    The target is the DEDICATED /get/ page (agent >= 2.9.61), not the old
+    couchside.tv/#get anchor into the marketing home page. That anchor dropped a
+    brand-new user into nav, pitch, footer and the agent installer while they
+    stood in front of a TV holding a phone; /get/ is the two store links and
+    nothing else. Asserted as an exact string BOTH ways, because the failure
+    that matters is silently drifting back to a page with somewhere to wander
+    off to."""
     print("test_idle_page_has_store_qr_code")
     html = cs.render_pair_page("a" * 64, 8787)
     check("store QR canvas present", 'id="qr-get"' in html, True)
-    check("store URL points at couchside.tv/#get",
-          "https://couchside.tv/#get" in html, True)
+    check("store URL is the dedicated /get/ page",
+          "https://couchside.tv/get/" in html, True)
+    check("...and NOT the old marketing-page anchor",
+          "https://couchside.tv/#get" in html, False)
     check("store label names both stores",
           "App Store" in html and "Google Play" in html, True)
     # The store canvas goes through the same generator as the pairing QR —


### PR DESCRIPTION
The small QR on the box's pairing screen pointed at `couchside.tv/#get` — an anchor into the marketing home page: nav, pitch, footer, the agent installer, several places to wander off to. Wrong page for the only person who ever scans it — someone in front of a TV, phone in hand, already decided.

It now opens **`/get/`**: the two store links, stacked, and nothing else. (Page lands in the `ets3d` repo; deliberately noindex and unlinked from the site, self-contained so an unrelated `style.css?v=` bump can never break it.)

Agent → **2.9.61**.

## The scanner keeps its friendly error

`STORE_CODE` in `lib/pairLink.ts` is what turns a mis-scanned install code into *"That's the install code"* rather than a generic reject. Boxes update on their own schedule, so a current phone meets the **old** anchor for as long as un-updated boxes exist — the validator now accepts **both**, and the helpful answer doesn't depend on which one it sees.

Controls included: `/get` (no slash), `/getx/`, and the bare domain are **not** folded into that reason — these are exact strings, not a prefix match on the domain.

## Also

Agent 2.9.60 was published *before* KI-037 merged, so the 2.9.61 changelog covers both this and the Decky-restart fix — boxes skipping versions must be told everything they're getting.

26/26 pairLink tests, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)