### PR TITLE
fix(session): never point autologin at a desktop session that isn't installed (KI-038)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,21 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.62
+
+Fixes "Boots into: Desktop" on Bazzite.
+
+- **Setting your box to boot into Desktop could leave it at the login screen.**
+  It pointed the automatic login at a desktop session name that exists on
+  SteamOS but not on Bazzite, so the box stopped at the password prompt instead
+  and then came up in Game Mode anyway. If your box also runs the Couchside
+  service under your own login, it would not have started until you signed in —
+  so the phone lost the box. The box now checks which desktop sessions are
+  actually installed and uses one of those, and refuses to change the setting at
+  all if it cannot find one, rather than leaving you locked out.
+- If you hit this, the setting is repaired automatically the next time you set
+  it; no need to touch the box.
+
 ## 2.9.61
 
 Small fixes to the pairing screen and to updating.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.61"
+VERSION = "2.9.62"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -2832,6 +2832,45 @@ _DESKTOP_SESSIONS = {
 }
 _DEFAULT_DESKTOP_FALLBACK = "plasmax11.desktop"
 
+# Where a display manager looks for session files. SDDM's Autologin Session=
+# must name a file that EXISTS in one of these, or autologin fails outright.
+_SESSION_DIRS = ("/usr/share/wayland-sessions", "/usr/share/xsessions")
+
+
+def _installed_session_files():
+    """Every .desktop session name actually present on this box.
+
+    WHY THIS EXISTS — a real stranding, 2026-07-27. `_default_desktop_session()`
+    asks `steamosctl get-default-desktop-session`; on Bazzite that D-Bus
+    interface does not exist, so the read returns empty and we fell back to
+    _DEFAULT_DESKTOP_FALLBACK = "plasmax11.desktop". That is a SteamOS name.
+    Bazzite ships plasma.desktop (Wayland) and plasma-steamos-oneshot.desktop
+    (X11) and has NO plasmax11.desktop — so "Boots into: Desktop" wrote an
+    autologin session that does not exist. SDDM said so in its own log:
+
+        Unable to find autologin session entry "plasmax11.desktop"
+        Autologin failed!
+
+    ...and the box came up at the GREETER instead. The user then logged in by
+    hand and SDDM used its [Last] session, which was gamescope — so the setting
+    appeared to do nothing while actually breaking autologin. Worse, on a box
+    whose agent is a systemd --user service, no login means NO AGENT, so the
+    phone cannot even reach the box to undo it. Stranding a box at a password
+    prompt is the exact failure this product exists to prevent.
+
+    The lesson: "degrade closed" has to mean degrading to something VERIFIED to
+    work, not to a hardcoded name that happens to be right on one distro. So we
+    now look at what is actually installed rather than assuming."""
+    names = set()
+    for d in _SESSION_DIRS:
+        try:
+            for fn in os.listdir(d):
+                if fn.endswith(".desktop"):
+                    names.add(fn)
+        except OSError:
+            continue  # directory absent on this box; not an error
+    return names
+
 
 # ---------------------------------------------------------------------------
 # Boot session default — "which mode does this box come up in?"
@@ -2950,7 +2989,19 @@ def _sddm_write(session_file):
     """Write our drop-in via a sudo tee whose PATH IS FIXED IN THE SUDOERS RULE.
 
     session_file is chosen by the agent from a frozen table — never client
-    input — and the whole file body is composed here."""
+    input — and the whole file body is composed here.
+
+    REFUSES to write a session that is not installed. An autologin entry naming
+    a missing session does not degrade gracefully: SDDM logs "Unable to find
+    autologin session entry" and drops the box at the greeter, stranding a box
+    whose agent is a user service. Measured 2026-07-27 — this guard is the
+    reason that cannot happen again, and it sits HERE, at the single write, so
+    no future caller can route around it."""
+    installed = _installed_session_files()
+    if installed and session_file not in installed:
+        print("[session] refusing to write autologin for missing session %r"
+              % (session_file,), flush=True)
+        return False
     body = ("# Written by Couchside. Delete this file to restore the box's\n"
             "# original boot behaviour; nothing else was modified.\n"
             "[Autologin]\n"
@@ -2988,7 +3039,13 @@ def session_default_set(mode):
     elif mode == "game":
         target = GAMESCOPE_SESSION_FILE
     else:
-        target, _ = _default_desktop_session()
+        # Desktop: the session must EXIST or autologin fails and the box lands
+        # at the greeter with no agent (see _installed_session_files). Refusing
+        # is strictly better than writing a name we cannot vouch for -- the user
+        # keeps a working box and gets told why.
+        target = _desktop_session_for_autologin()
+        if not target:
+            return done(False, "no desktop session installed on this box")
 
     if backend == "steamosctl":
         arg = "game" if target == GAMESCOPE_SESSION_FILE else "desktop"
@@ -3011,7 +3068,12 @@ def _default_desktop_session():
     (session_file, session_select_arg) pair from the frozen table above.
 
     Degrades closed: any read failure, or a name not on the allowlist, returns
-    the X11 pair that shipped before -- never a guess, never a raw value."""
+    the X11 pair that shipped before -- never a guess, never a raw value.
+
+    NOTE: this answers "which desktop does the box PREFER", and its fallback is
+    fine for the one-shot switch it serves (steamos-session-select validates its
+    own argument and a bad switch is transient). It is NOT safe for writing a
+    PERSISTENT autologin entry -- see _desktop_session_for_autologin()."""
     try:
         r = subprocess.run(["steamosctl", "get-default-desktop-session"],
                            capture_output=True, text=True, timeout=5)
@@ -3021,6 +3083,56 @@ def _default_desktop_session():
     if name not in _DESKTOP_SESSIONS:
         name = _DEFAULT_DESKTOP_FALLBACK
     return name, _DESKTOP_SESSIONS[name]
+
+
+# Desktop sessions we will point autologin at, best first. SteamOS and Bazzite
+# ship DIFFERENT names, which is the whole reason this list exists rather than a
+# constant: SteamOS has plasmax11.desktop, Bazzite has plasma.desktop plus the
+# plasma-steamos-*-oneshot pair. Each entry is checked against what is actually
+# installed (_installed_session_files) before it can be written.
+#
+# Wayland plasma.desktop is preferred over X11 because it is what a modern
+# Bazzite/SteamOS desktop actually runs; the X11 names follow as fallbacks for
+# older images. The oneshot variants come LAST -- they exist to bounce back to
+# Game Mode, so autologging into one every boot would be surprising.
+_AUTOLOGIN_DESKTOP_PREFERENCE = (
+    "plasma.desktop",
+    "plasmax11.desktop",
+    "plasma-steamos-oneshot.desktop",
+    "plasma-steamos-wayland-oneshot.desktop",
+)
+
+
+def _desktop_session_for_autologin():
+    """A desktop session file that EXISTS on this box, or None.
+
+    None means "do not write" — refusing is the safe answer here. An autologin
+    entry naming a missing session does not fail quietly: SDDM abandons
+    autologin and drops the box at the greeter, which on a box whose agent is a
+    user service means the agent never starts and the phone loses the box
+    entirely (measured 2026-07-27, see _installed_session_files).
+
+    Preference order: whatever the box itself reports as its configured desktop
+    (so we honour a Wayland box rather than downgrading it), then
+    _AUTOLOGIN_DESKTOP_PREFERENCE, then — since both lists are SteamOS/Bazzite
+    specific — any other installed plasma session, so a distro we have not seen
+    still works. Every candidate must be an installed file; nothing is assumed.
+    """
+    installed = _installed_session_files()
+    if not installed:
+        return None  # cannot enumerate; refuse rather than guess
+
+    configured, _ = _default_desktop_session()
+    for cand in (configured,) + _AUTOLOGIN_DESKTOP_PREFERENCE:
+        if cand in installed:
+            return cand
+    # Unknown distro: take an installed plasma session rather than fail, but
+    # still only ever a file we have SEEN, and never the gamescope session
+    # (that is Game Mode, the opposite of what was asked for).
+    for name in sorted(installed):
+        if name.startswith("plasma") and name != GAMESCOPE_SESSION_FILE:
+            return name
+    return None
 
 
 def _session_to_desktop():

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -63,6 +63,79 @@ class FakeRun:
         return r
 
 
+
+def test_autologin_session_must_exist():
+    """The stranding bug, 2026-07-27 — and why this is the most important test
+    in this file.
+
+    "Boots into: Desktop" wrote an autologin session that did not exist on the
+    box. `_default_desktop_session()` asks `steamosctl get-default-desktop-
+    session`; on Bazzite that D-Bus interface is absent, so the read returned
+    empty and we fell back to the hardcoded "plasmax11.desktop" — a SteamOS
+    name. SDDM's own log, from the failing boot:
+
+        Unable to find autologin session entry "plasmax11.desktop"
+        Autologin failed!
+
+    The box came up at the GREETER. The owner logged in by hand, SDDM used its
+    [Last] session (gamescope), and the setting looked like it had done nothing
+    while actually having broken autologin. On a box whose agent is a systemd
+    --user service, no login means NO AGENT — so the phone could not reach the
+    box to undo it. Stranding a box at a password prompt is precisely the
+    failure this product exists to prevent.
+
+    FIXTURES ARE VERBATIM listings from the two real distros (CLAUDE.md §6):
+    Bazzite captured off bazzite.local, SteamOS being the x11-name image. The
+    same code must be right on BOTH — that is the whole point.
+    """
+    print("test_autologin_session_must_exist")
+    saved_inst = cs._installed_session_files
+    saved_cfg = cs._default_desktop_session
+    try:
+        BAZZITE = {"gamescope-session.desktop", "gamescope-session-steam.desktop",
+                   "plasma.desktop", "plasma-steamos-wayland-oneshot.desktop",
+                   "plasma-steamos-oneshot.desktop"}
+        STEAMOS = {"gamescope-session.desktop", "plasma.desktop",
+                   "plasmax11.desktop"}
+
+        def setup(installed, configured):
+            cs._installed_session_files = lambda: set(installed)
+            cs._default_desktop_session = lambda: (configured, "plasma")
+
+        # THE BUG: Bazzite, with the unreadable steamosctl driving the bad
+        # fallback. Must NOT return the missing name.
+        setup(BAZZITE, "plasmax11.desktop")
+        pick = cs._desktop_session_for_autologin()
+        check("bazzite never picks the missing plasmax11", pick != "plasmax11.desktop", True)
+        check("bazzite picks a session that EXISTS", pick in BAZZITE, True)
+
+        # CONTROL, the other distro: SteamOS genuinely HAS plasmax11, so the
+        # fix must not have broken it by blanket-avoiding that name.
+        setup(STEAMOS, "plasmax11.desktop")
+        check("steamos still honours its own configured x11 session",
+              cs._desktop_session_for_autologin(), "plasmax11.desktop")
+
+        # A Wayland-configured box is honoured on both, not downgraded.
+        for label, inst in (("bazzite", BAZZITE), ("steamos", STEAMOS)):
+            setup(inst, "plasma.desktop")
+            check("%s honours a Wayland-configured desktop" % label,
+                  cs._desktop_session_for_autologin(), "plasma.desktop")
+
+        # REFUSE rather than strand: nothing installed, or only Game Mode.
+        setup(set(), "plasmax11.desktop")
+        check("cannot enumerate -> refuse", cs._desktop_session_for_autologin(), None)
+        setup({"gamescope-session.desktop"}, "plasmax11.desktop")
+        check("no desktop session at all -> refuse", cs._desktop_session_for_autologin(), None)
+
+        # The write itself is guarded, so no future caller can route around it.
+        cs._installed_session_files = lambda: BAZZITE
+        check("_sddm_write refuses a session that is not installed",
+              cs._sddm_write("plasmax11.desktop"), False)
+    finally:
+        cs._installed_session_files = saved_inst
+        cs._default_desktop_session = saved_cfg
+
+
 def main():
     real_run = cs.subprocess.run
     real_sudo = cs._sudo_nopasswd_allows
@@ -106,6 +179,8 @@ def main():
     cs.subprocess.run = FakeRun(stderr="Error: UnknownInterface", rc=0)
     cs._sudo_nopasswd_allows = lambda needle: False
     check("set() reports failure", cs.session_default_set("game")["ok"], False)
+
+    test_autologin_session_must_exist()
 
     print("the sddm drop-in body")
     # We must NEVER edit the box's own steamos.conf; we write our own file.


### PR DESCRIPTION
**Reported from a real box:** "Boots into: Desktop" left it at the password screen with no agent running — and it then came up in **Game Mode** anyway.

SDDM's own log named the cause:

```
Unable to find autologin session entry "plasmax11.desktop"
Autologin failed!
```

`plasmax11.desktop` is a **SteamOS** name. Bazzite ships `plasma.desktop` and the `plasma-steamos-*-oneshot` pair, and has no such file.

## Why we wrote a name that doesn't exist

`_default_desktop_session()` reads `steamosctl get-default-desktop-session`. On Bazzite that D-Bus interface is absent, so the read returned empty and fell through to a hardcoded fallback. That fallback was **"degrade closed" in name only** — it degraded to a name nobody had verified exists on the platform. The old tests passed because they asserted the fallback *string*, never that the file was installed.

## Why it's HIGH, not cosmetic

The consequences compound in the worst direction:

1. Autologin fails → box stops at the greeter.
2. The greeter uses SDDM's `[Last]` session → **gamescope** → the setting looks like it did nothing, while having actually broken boot.
3. On a box whose agent is a `systemd --user` service, **no login means no agent** — so the phone loses the box and can't undo the setting.

Stranding a box at a password prompt is the exact failure this product exists to prevent.

## The fix

`_installed_session_files()` enumerates `/usr/share/wayland-sessions` and `/usr/share/xsessions`. `_desktop_session_for_autologin()` returns **only** a session found there — the box's own configured desktop first (so a Wayland box is honoured, not downgraded), then a SteamOS+Bazzite preference list, then any installed plasma session so an unseen distro still works — or **None**. None refuses the write, and `_sddm_write` refuses independently so no future caller can route around the guard.

## Verified — on both distros, live

| | old would write | new writes |
|---|---|---|
| **Bazzite** (measured on `bazzite.local`) | `plasmax11.desktop` — **exists: False** | `plasma.desktop` — exists: True |
| **SteamOS** | `plasmax11.desktop` — exists: True | `plasmax11.desktop` — unchanged |

No regression on the distro the old name was right for. Fixtures are verbatim listings from both. Refuses correctly when nothing is installed, or when only Game Mode is.

**Mutation-checked:** restoring the old logic fails 3 checks, led by *"bazzite picks a session that EXISTS"*.

Agent → **2.9.62**. The reporter's box has been repaired in place.

## Generalises

Any hardcoded per-distro filename is a latent version of this. Prefer probing the filesystem over trusting a name — especially where the failure mode is unreachability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)