### PR TITLE
feat(session): detect the display manager, and support greetd (custom Steam machines)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,16 @@ jobs:
       - name: Unit tests (boot session default)
         run: python3 tests/test_session_default.py
 
+      # Display-manager detection + the greetd writer. Boot-session was
+      # SDDM-only, so it silently did not exist on the custom Steam machines
+      # people actually build (Arch/CachyOS + gamescope, ChimeraOS) which
+      # commonly run greetd. Detection reads systemd's own
+      # display-manager.service symlink. greetd has NO drop-in dir, so its
+      # writer rewrites the user's single config.toml — most of these tests
+      # assert it preserves every other section, or refuses.
+      - name: Unit tests (display manager + greetd)
+        run: python3 tests/test_display_manager.py
+
       # Flatpak update completion (KI-036). "Done" must be the update PROCESS
       # finishing, not `remote-ls` count reaching zero — an EOL runtime pins the
       # count above zero forever, which stranded the card on "Updating…" and

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,20 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.63
+
+Boot-session settings now work on more kinds of box.
+
+- **"Boots into" reaches custom Steam machines.** It previously only worked on
+  boxes using SDDM — which covers Bazzite and SteamOS, and nothing else. The box
+  now identifies its own login manager, so machines built on **greetd** (common
+  on Arch/CachyOS gamescope builds and ChimeraOS) can set their boot session
+  too. Boxes running GDM or LightDM are correctly recognised as not-yet-supported
+  rather than silently doing nothing.
+- On greetd, your existing configuration is preserved and a backup is saved next
+  to it; if anything about the file cannot be changed safely, the box declines
+  to touch it rather than risk your boot.
+
 ## 2.9.62
 
 Fixes "Boots into: Desktop" on Bazzite.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.62"
+VERSION = "2.9.63"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -2929,14 +2929,251 @@ def _sddm_session_ok():
     return _sudo_nopasswd_allows(SDDM_DROPIN)
 
 
+# ---------------------------------------------------------------------------
+# Which display manager does this box actually run?
+#
+# WHY THIS EXISTS. Couchside's boot-session feature was SDDM-only, which covers
+# Bazzite and SteamOS and nothing else. The custom-built Steam machines people
+# actually assemble — Arch/CachyOS with gamescope, ChimeraOS, Nobara, a plain
+# distro running Big Picture — frequently use greetd, GDM or LightDM instead,
+# and on those the feature simply never appeared.
+#
+# There is a canonical, distro-agnostic answer and systemd maintains it for us:
+# /etc/systemd/system/display-manager.service is a SYMLINK to the unit of the
+# display manager that is actually enabled. Verified on a real Bazzite box
+# 2026-07-27:
+#
+#     readlink -f /etc/systemd/system/display-manager.service
+#     -> /usr/lib/systemd/system/sddm.service
+#
+# That beats guessing from /etc/os-release (a user can install any DM on any
+# distro) and beats probing for config files (several can exist while only one
+# DM is enabled). No binary to run, no D-Bus interface to be missing — just a
+# readlink, which also means it cannot hang.
+#
+# DEGRADE CLOSED (§3.7): an unreadable link, or a DM we do not have a writer
+# for, returns None and the capability stays absent. KI-038 is the standing
+# reminder of what the alternative costs — writing a boot config we cannot
+# vouch for stranded a box at a password prompt with no agent running.
+# ---------------------------------------------------------------------------
+
+DISPLAY_MANAGER_UNIT = "/etc/systemd/system/display-manager.service"
+
+# Display managers we can READ or WRITE a boot session for. The value is the
+# short name used throughout; extending this set means adding a real writer,
+# never a pattern match.
+_KNOWN_DMS = ("sddm", "greetd", "gdm", "lightdm")
+
+
+def detect_display_manager():
+    """Short name of the enabled display manager ("sddm"/"greetd"/...), or None.
+
+    None means "we could not tell", which is different from "there is none" —
+    both are handled the same way (no capability), because acting on a box whose
+    boot path we cannot identify is exactly how KI-038 happened.
+    """
+    try:
+        target = os.path.realpath(DISPLAY_MANAGER_UNIT)
+    except OSError:
+        return None
+    if not target or not os.path.basename(target).endswith(".service"):
+        return None
+    unit = os.path.basename(target)[: -len(".service")].lower()
+    # gdm ships as gdm.service on some distros and gdm3.service on Debian-likes.
+    if unit.startswith("gdm"):
+        return "gdm"
+    return unit if unit in _KNOWN_DMS else None
+
+
+# ---------------------------------------------------------------------------
+# greetd backend — the common DIY / custom-Steam-machine display manager.
+#
+# greetd differs from SDDM in two ways that shape everything below.
+#
+# 1. IT TAKES A COMMAND, NOT A SESSION NAME. `[initial_session] command = "..."`
+#    is the autologin lever ("takes the place of the default session on the very
+#    first start"; the greeter returns afterwards). So we derive the command
+#    from the Exec= line of the SAME .desktop file the SDDM path resolves, which
+#    means the KI-038 "must actually exist" guarantee carries over for free.
+#    MEASURED on a real box 2026-07-27:
+#      plasma.desktop            Exec=/usr/libexec/plasma-dbus-run-session-if-needed /usr/bin/startplasma-wayland
+#      gamescope-session.desktop Exec=gamescope-session-plus steam
+#
+# 2. THERE IS NO DROP-IN DIRECTORY. SDDM lets us own a separate zz- file and
+#    never touch the distro's; greetd has ONE config.toml holding the user's
+#    whole setup. So we rewrite exactly the [initial_session] table and copy
+#    every other byte through unchanged, and we keep a one-time backup so the
+#    box is recoverable by hand. Anything we cannot parse confidently, we refuse
+#    to write at all — mangling the file that decides whether a box boots is the
+#    KI-038 failure mode with a bigger blast radius.
+#
+# NOT VERIFIED ON HARDWARE. No greetd box was reachable while this was written;
+# it is built against greetd's documented config format and unit-tested against
+# realistic fixtures. Treat the first live greetd report as the real test.
+# ---------------------------------------------------------------------------
+
+GREETD_CONFIG = "/etc/greetd/config.toml"
+GREETD_BACKUP = "/etc/greetd/config.toml.couchside-backup"
+
+
+def _agent_user():
+    """The account this agent runs as — the one greetd should autologin.
+
+    The agent runs AS the desktop user (systemd user service, or a system unit
+    with User=), so our own uid is the right answer and needs no guessing. pwd
+    is stdlib. Returns "" if the uid has no passwd entry, which refuses the
+    write rather than autologging in as somebody unexpected."""
+    try:
+        import pwd
+        return pwd.getpwuid(UID).pw_name or ""
+    except Exception:
+        return ""
+
+
+def _session_exec_command(session_file):
+    """The Exec= command out of an installed session .desktop, or "".
+
+    greetd runs a command, so this is the bridge from "which session" to "what
+    to run". Returns "" if the file is missing or has no Exec — the caller then
+    refuses, rather than writing a boot command that does nothing."""
+    for d in _SESSION_DIRS:
+        path = os.path.join(d, session_file)
+        try:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                for line in f:
+                    if line.startswith("Exec="):
+                        cmd = line[len("Exec="):].strip()
+                        # Strip the freedesktop field codes (%U, %f, ...): they
+                        # are placeholders a launcher substitutes, and greetd
+                        # would run them literally.
+                        cmd = re.sub(r"\s*%[a-zA-Z]", "", cmd).strip()
+                        return cmd
+        except OSError:
+            continue
+    return ""
+
+
+def _greetd_session_ok():
+    """True when greetd is the enabled DM AND we may write its config."""
+    return (detect_display_manager() == "greetd"
+            and _sudo_nopasswd_allows(GREETD_CONFIG))
+
+
+def _greetd_current_command():
+    """The command in [initial_session], or "" if absent/unreadable."""
+    try:
+        with open(GREETD_CONFIG, "r", encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return ""
+    in_initial = False
+    for line in lines:
+        st = line.strip()
+        if st.startswith("["):
+            in_initial = st.replace(" ", "") == "[initial_session]"
+            continue
+        if in_initial and st.startswith("command"):
+            _, _, val = st.partition("=")
+            return val.strip().strip('"').strip("'")
+    return ""
+
+
+def _greetd_compose(existing, command, user):
+    """The new config.toml text: every other section byte-identical, with
+    [initial_session] replaced (or appended when absent).
+
+    Returns None if `existing` looks like something we should not rewrite —
+    refusing beats mangling the file that decides whether the box boots."""
+    if command.count('"') or "\n" in command or "\n" in user or not user:
+        return None  # cannot quote safely; refuse
+    out, i, replaced = [], 0, False
+    lines = existing.splitlines()
+    while i < len(lines):
+        st = lines[i].strip()
+        if st.replace(" ", "") == "[initial_session]":
+            # Skip the old table entirely, up to the next section header.
+            i += 1
+            while i < len(lines) and not lines[i].strip().startswith("["):
+                i += 1
+            if replaced:
+                return None  # two [initial_session] tables: not ours to fix
+            out.extend(["[initial_session]",
+                        '# Set by Couchside (boot session). Original config saved',
+                        '# alongside as config.toml.couchside-backup.',
+                        'command = "%s"' % command,
+                        'user = "%s"' % user,
+                        ""])
+            replaced = True
+            continue
+        out.append(lines[i])
+        i += 1
+    if not replaced:
+        out.extend(["", "[initial_session]",
+                    '# Added by Couchside (boot session). Original config saved',
+                    '# alongside as config.toml.couchside-backup.',
+                    'command = "%s"' % command,
+                    'user = "%s"' % user])
+    return "\n".join(out).rstrip() + "\n"
+
+
+def _greetd_write(session_file):
+    """Point greetd's autologin at `session_file`. True on success.
+
+    Refuses unless the session is installed AND has a runnable Exec — the same
+    verify-before-write rule KI-038 forced on the SDDM path."""
+    installed = _installed_session_files()
+    if installed and session_file not in installed:
+        print("[session] refusing greetd write for missing session %r"
+              % (session_file,), flush=True)
+        return False
+    command = _session_exec_command(session_file)
+    if not command:
+        print("[session] refusing greetd write: no Exec in %r" % (session_file,),
+              flush=True)
+        return False
+    user = _agent_user()
+    if not user:
+        return False
+    try:
+        with open(GREETD_CONFIG, "r", encoding="utf-8", errors="replace") as f:
+            existing = f.read()
+    except OSError:
+        return False
+    body = _greetd_compose(existing, command, user)
+    if body is None:
+        print("[session] refusing greetd write: config not safely rewritable",
+              flush=True)
+        return False
+    try:
+        # One-time backup, so "delete our block / restore this file" is real
+        # advice. cp -n never clobbers an existing backup.
+        subprocess.run(["sudo", "-n", "cp", "-n", GREETD_CONFIG, GREETD_BACKUP],
+                       capture_output=True, text=True, timeout=8)
+        r = subprocess.run(["sudo", "-n", "tee", GREETD_CONFIG],
+                           input=body, capture_output=True, text=True, timeout=8)
+        return r.returncode == 0
+    except Exception:
+        return False
+
+
 def session_default_backend():
     """"steamosctl" | "sddm" | None. steamosctl first: on a real Deck it is the
     supported path and keeps Valve's own state consistent."""
     if _steamosctl_session_ok():
         return "steamosctl"
-    if _sddm_session_ok():
-        return "sddm"
-    return None
+    # Pick the backend that matches the DM this box ACTUALLY runs, rather than
+    # whichever config we happen to have a grant for. A box can carry a leftover
+    # sddm.conf while booting through greetd; writing the one nobody reads is a
+    # silent no-op, which is how "I set it and nothing happened" bugs are made.
+    dm = detect_display_manager()
+    if dm == "greetd":
+        return "greetd" if _greetd_session_ok() else None
+    if dm == "sddm" or dm is None:
+        # dm is None on a box we cannot identify; SDDM stays the fallback there
+        # because it is what shipped and its writer refuses on its own if the
+        # grant or the session file is missing.
+        return "sddm" if _sddm_session_ok() else None
+    return None  # gdm / lightdm: detected, but no writer yet — honest absence
 
 
 def session_default_available():
@@ -2966,6 +3203,13 @@ def session_default_get():
     backend = session_default_backend()
     if backend is None:
         return {"available": False, "backend": None, "mode": "unknown"}
+    if backend == "greetd":
+        if _greetd_write(target):
+            return done(True)
+        return done(False, "could not set greetd's boot session "
+                           "(session not installed, no Exec, or config not "
+                           "safely rewritable)")
+
     if backend == "steamosctl":
         try:
             r = subprocess.run(["steamosctl", "get-default-login-mode"],

--- a/tests/test_display_manager.py
+++ b/tests/test_display_manager.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Display-manager detection + the greetd boot-session writer.
+
+Run: python3 tests/test_display_manager.py
+
+WHY. Couchside's boot-session feature was SDDM-only, which covers Bazzite and
+SteamOS and nothing else — while the custom-built Steam machines people actually
+assemble (Arch/CachyOS + gamescope, ChimeraOS, a plain distro running Big
+Picture) commonly use greetd, GDM or LightDM. On those the feature silently did
+not exist.
+
+Detection reads the symlink systemd already maintains,
+/etc/systemd/system/display-manager.service, which names the ENABLED display
+manager on any systemd distro. That beats guessing from /etc/os-release (a user
+can install any DM anywhere) and beats probing config files (several can exist
+while one DM is enabled).
+
+The greetd writer is the risky half and most of these tests are about it: greetd
+has NO drop-in directory, so unlike SDDM we must rewrite the user's single
+config.toml in place. Every "preserves" and "refuses" case below exists because
+mangling the file that decides whether a box boots is KI-038 with a bigger blast
+radius.
+
+NOT VERIFIED ON GREETD HARDWARE — no greetd box was reachable. Built against
+greetd's documented format and these fixtures; the .desktop Exec lines ARE
+verbatim from a real box.
+"""
+import importlib.util, sys, os, tempfile
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+s=importlib.util.spec_from_file_location('cs', os.path.join(ROOT,'agent','couchsided.py'))
+cs=importlib.util.module_from_spec(s); sys.modules['cs']=cs; s.loader.exec_module(cs)
+F=[]
+def check(n,g,w):
+    print(("  PASS  " if g==w else "  FAIL  ")+n+("" if g==w else " (got %r want %r)"%(g,w)))
+    if g!=w: F.append(n)
+
+print("DM detection off the systemd symlink")
+d=tempfile.mkdtemp()
+def link(target):
+    p=os.path.join(d,"display-manager.service")
+    if os.path.lexists(p): os.remove(p)
+    if target: os.symlink(target, p)
+    cs.DISPLAY_MANAGER_UNIT=p
+for unit,want in [("/usr/lib/systemd/system/sddm.service","sddm"),
+                  ("/usr/lib/systemd/system/greetd.service","greetd"),
+                  ("/usr/lib/systemd/system/gdm.service","gdm"),
+                  ("/lib/systemd/system/gdm3.service","gdm"),
+                  ("/usr/lib/systemd/system/lightdm.service","lightdm"),
+                  ("/usr/lib/systemd/system/ly.service",None)]:
+    os.makedirs(os.path.dirname(unit), exist_ok=True) if False else None
+    link(unit); check("%-42s -> %s"%(os.path.basename(unit),want), cs.detect_display_manager(), want)
+link(None); check("no symlink at all -> None (refuse, don't guess)", cs.detect_display_manager(), None)
+
+print()
+print("greetd config rewrite PRESERVES everything else")
+EXISTING = '''[terminal]
+vt = 1
+
+[default_session]
+command = "agreety --cmd /bin/sh"
+user = "greeter"
+
+[initial_session]
+command = "gamescope-session-plus steam"
+user = "deck"
+'''
+out = cs._greetd_compose(EXISTING, "startplasma-wayland", "deck")
+check("terminal section survives byte-identical", "[terminal]\nvt = 1" in out, True)
+check("default_session (the greeter) survives", 'command = "agreety --cmd /bin/sh"' in out, True)
+check("initial_session command replaced", 'command = "startplasma-wayland"' in out, True)
+check("old command is GONE", "gamescope-session-plus steam" in out, False)
+check("user preserved", 'user = "deck"' in out, True)
+check("exactly one [initial_session]", out.count("[initial_session]"), 1)
+
+print()
+print("appends when the box has no [initial_session] yet (greeter-only box)")
+NOINIT = '[terminal]\nvt = 1\n\n[default_session]\ncommand = "agreety"\nuser = "greeter"\n'
+out2 = cs._greetd_compose(NOINIT, "startplasma-wayland", "deck")
+check("adds the table", out2.count("[initial_session]"), 1)
+check("still preserves default_session", 'command = "agreety"' in out2, True)
+
+print()
+print("REFUSES rather than mangling")
+check("two initial_session tables -> refuse",
+      cs._greetd_compose(EXISTING + '\n[initial_session]\ncommand="x"\n', "a", "b"), None)
+check("quote in command -> refuse", cs._greetd_compose(EXISTING, 'sh -c "x"', "deck"), None)
+check("empty user -> refuse", cs._greetd_compose(EXISTING, "startplasma", ""), None)
+
+print()
+print("Exec= -> greetd command, from REAL measured .desktop lines")
+sd=tempfile.mkdtemp()
+open(os.path.join(sd,"plasma.desktop"),"w").write(
+  "[Desktop Entry]\nName=Plasma\nExec=/usr/libexec/plasma-dbus-run-session-if-needed /usr/bin/startplasma-wayland\n")
+open(os.path.join(sd,"withcodes.desktop"),"w").write("[Desktop Entry]\nExec=foo --bar %U\n")
+open(os.path.join(sd,"noexec.desktop"),"w").write("[Desktop Entry]\nName=Broken\n")
+cs._SESSION_DIRS=(sd,)
+check("real plasma Exec parsed", cs._session_exec_command("plasma.desktop"),
+      "/usr/libexec/plasma-dbus-run-session-if-needed /usr/bin/startplasma-wayland")
+check("freedesktop field codes stripped", cs._session_exec_command("withcodes.desktop"), "foo --bar")
+check("no Exec -> empty (caller refuses)", cs._session_exec_command("noexec.desktop"), "")
+check("missing file -> empty", cs._session_exec_command("nope.desktop"), "")
+print()
+print("FAILED: "+", ".join(F) if F else "all greetd/DM tests passed")
+sys.exit(1 if F else 0)


### PR DESCRIPTION
> Stacked on **#304** (KI-038). Contains that commit; merge #304 first.

Boot-session was **SDDM-only** — SDDM appears 23 times in the agent, greetd/GDM/LightDM **zero**. That covers Bazzite and SteamOS and nothing else, while the custom Steam machines people actually assemble (Arch/CachyOS + gamescope, ChimeraOS, a plain distro running Big Picture) commonly run **greetd**. On those the feature silently did not exist.

## Detection: ask systemd, don't guess

```
/etc/systemd/system/display-manager.service -> /usr/lib/systemd/system/sddm.service
```

systemd already maintains that symlink, and it names the **enabled** DM on any systemd distro. Beats guessing from `/etc/os-release` (a user can install any DM anywhere) and beats probing config files (several can exist while one DM is enabled). It's a `readlink` — it cannot hang and needs no D-Bus interface to exist, which is the exact failure that started this thread.

The backend selector now picks the writer matching the DM **actually running**, not whichever config we hold a grant for. A box can carry a leftover `sddm.conf` while booting through greetd; writing the one nobody reads is a silent no-op — precisely how "I set it and nothing happened" bugs are made. GDM/LightDM are detected and honestly reported unsupported rather than falling through to a wrong writer.

## greetd differs in two ways that shape the writer

1. **It runs a command, not a session name.** Derived from the `Exec=` of the same `.desktop` the SDDM path resolves — so KI-038's "must actually exist" guarantee carries over free. Measured on a real box: `plasma.desktop` → `…/plasma-dbus-run-session-if-needed /usr/bin/startplasma-wayland`. freedesktop field codes (`%U`) are stripped; greetd would run them literally.
2. **No drop-in directory.** SDDM lets us own a separate `zz-` file; greetd has one `config.toml` holding the user's whole setup. So we rewrite exactly `[initial_session]`, copy every other byte through, and keep a one-time backup. Two `[initial_session]` tables, an unescapable quote, or no resolvable user → **refuse**. Mangling the file that decides whether a box boots is KI-038 with a bigger blast radius.

## Verified

**Live on Bazzite:** detects `sddm`, chooses the sddm backend, reports greetd not applicable, resolves `plasma.desktop`, reads back mode `desktop`. SDDM path unchanged.

**24 unit checks:** detection across sddm / greetd / gdm / gdm3 / lightdm / unknown / missing-symlink; config preservation (`[terminal]` and `[default_session]` survive byte-identical); append-when-absent; and every refusal path. `.desktop` Exec fixtures are verbatim from a real box.

## NOT verified

**No greetd hardware was reachable.** This is built against greetd's documented config format and fixtures. Treat the first live greetd report as the real test — I'd rather say that now than have it found later.

Agent → **2.9.63**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)