### PR TITLE
docs(changelog): 2.9.63 — say plainly that greetd support is untested alpha

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -20,17 +20,26 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.63
 
-Boot-session settings now work on more kinds of box.
+A boot-session fix for Bazzite, and early groundwork for other kinds of box.
 
-- **"Boots into" reaches custom Steam machines.** It previously only worked on
-  boxes using SDDM — which covers Bazzite and SteamOS, and nothing else. The box
-  now identifies its own login manager, so machines built on **greetd** (common
-  on Arch/CachyOS gamescope builds and ChimeraOS) can set their boot session
-  too. Boxes running GDM or LightDM are correctly recognised as not-yet-supported
-  rather than silently doing nothing.
-- On greetd, your existing configuration is preserved and a backup is saved next
-  to it; if anything about the file cannot be changed safely, the box declines
-  to touch it rather than risk your boot.
+- **Fixed: "Boots into → Desktop" could leave a Bazzite box at the login
+  screen.** It pointed the automatic login at a desktop session that exists on
+  SteamOS but not on Bazzite, so the box stopped at the password prompt and then
+  came up in Game Mode anyway — and if your Couchside service runs under your own
+  login, it would not start until you signed in, so the phone lost the box. The
+  box now uses a desktop session it has confirmed is installed, and refuses to
+  change the setting at all if it cannot find one. **This is the part of this
+  release that is tested and working.**
+- **Groundwork, ALPHA — boxes that do not use SDDM.** The box can now identify
+  which login manager it runs, and there is early support for setting the boot
+  session on **greetd** (common on Arch/CachyOS gamescope builds and ChimeraOS).
+  **This has not been tested on a real greetd machine yet** — it is written
+  ahead of proper support rather than proven, so treat it as experimental and
+  expect it may not work. GDM and LightDM are recognised but not supported at
+  all yet; on those the setting simply will not appear.
+- If greetd support does run, your existing configuration is preserved and a
+  backup is saved beside it, and anything that cannot be changed safely is left
+  alone rather than risking your boot.
 
 ## 2.9.62
 


### PR DESCRIPTION
The 2.9.63 notes led with *"Boot-session settings now work on more kinds of box"* and told users greetd machines *"can set their boot session too"*.

That's an overclaim. **No greetd box was ever reachable** — the writer is built against greetd's documented config format and fixtures, and has never run on one. The PR body said so; the user-facing notes did not. The notes are what someone reads before pressing "Update now" on a machine across the room.

Rewritten so the release:
- **leads with what's proven** — the KI-038 Bazzite autologin fix, verified live on real hardware, explicitly marked as the tested part
- **labels the DM/greetd work ALPHA**, written ahead of real support rather than in place of it, and says plainly it may not work
- describes GDM/LightDM as recognised-but-unsupported, which is what they are

No code change. Requested by the owner before publishing — the right call, since this would otherwise have shipped a claim we can't stand behind to every box that updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)