### PR TITLE
feat(setup): the empty state becomes a card that advances itself

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -27,6 +27,7 @@ import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
 import { BoxScanPair } from '@/components/BoxScanPair';
 import { BoxScanQr } from '@/components/BoxScanQr';
+import { SetupProgress, SETUP_GUIDE_URL } from '@/components/SetupProgress';
 import { buildPairLink } from '@/lib/pairLink';
 import { GuideHoldSetup } from '@/components/GuideHoldSetup';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
@@ -109,9 +110,9 @@ const APP_BUILD =
       ? String(Constants.expoConfig.android.versionCode)
       : '');
 
-// couchside.tv setup guide — how to install the agent on a box. New users who
-// grabbed the app from a store land here with no idea a box-side agent exists.
-const SETUP_GUIDE_URL = 'https://couchside.tv/#install';
+// SETUP_GUIDE_URL now lives with the card that owns the "install the agent"
+// story (components/SetupProgress.tsx) and is imported above — one definition,
+// and importing it the other way round would make the two files a cycle.
 
 function PairingQrModal({ box, onClose }: { box: Box | null; onClose: () => void }) {
   const styles = useThemedStyles(makeStyles);
@@ -1027,26 +1028,12 @@ function SetupBody() {
             {/* ---- Fleet list ---- */}
             <Text style={styles.sectionLabel}>YOUR FLEET</Text>
         {boxes.length === 0 ? (
-          <View style={styles.card}>
-            <Text style={styles.emptyText}>
-              No boxes yet. Tap Scan for boxes below — your box shows a PIN on its
-              own screen and you type it here. No IP or token needed.
-            </Text>
-            {/* The box needs the agent installed before it can be paired at
-                all — surface the setup guide right where a new user gets stuck. */}
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                void Linking.openURL(SETUP_GUIDE_URL);
-              }}
-              style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
-              <Ionicons name="hardware-chip-outline" size={15} color={t.blue} style={styles.emptyLinkIcon} />
-              <Text style={styles.emptyLinkText}>
-                Haven&apos;t installed the Couchside service? Setup guide
-              </Text>
-              <Ionicons name="open-outline" size={13} color={t.blue} style={styles.emptyLinkIcon} />
-            </Pressable>
-          </View>
+          /* The empty state is the whole funnel: measured, ~9-15 strangers
+             downloaded the app in its first six days and ~0 paired a box. The
+             card sweeps the LAN by itself and flips to "found your box" while
+             the installer is still scrolling on their PC. It keeps the setup
+             guide link inside it as the escape hatch. */
+          <SetupProgress />
         ) : (
           boxes.map((box) => {
             const isActive = box.id === activeBoxId;
@@ -2018,28 +2005,9 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     padding: 14,
     marginBottom: 12,
   },
-  emptyText: { color: t.textDim, fontSize: 13, lineHeight: 19 },
-  emptyLink: {
-    flexDirection: 'row',
-    // flex-start, not center: once the label wraps to two lines, centred icons
-    // float in the middle of the block instead of sitting on the first line.
-    alignItems: 'flex-start',
-    gap: 6,
-    marginTop: 12,
-  },
-  // flex:1 is load-bearing. Without it the Text takes its INTRINSIC width, so a
-  // label wider than the row pushes the trailing ↗ off the edge rather than
-  // wrapping. It fit on iOS and overflowed on Android, which is exactly the
-  // shape of bug that a single-platform check misses.
-  // Aligns the glyphs with the first line of a wrapped label.
-  emptyLinkIcon: { marginTop: 2 },
-  emptyLinkText: {
-    color: t.blue,
-    fontSize: 13,
-    fontWeight: '600',
-    flex: 1,
-    lineHeight: 18,
-  },
+  // emptyText / emptyLink* moved with the empty state they styled, into
+  // components/SetupProgress.tsx — including the two comments that record why
+  // alignItems is flex-start and why flex:1 on the label is load-bearing.
   boxCard: {
     backgroundColor: t.card,
     borderColor: t.cardBorder,

--- a/app/components/SetupProgress.tsx
+++ b/app/components/SetupProgress.tsx
@@ -1,0 +1,811 @@
+/**
+ * The no-box empty state, as a card that ADVANCES ITSELF.
+ *
+ * WHY IT EXISTS (measured): in the first six days after launch ~9-15 strangers
+ * downloaded the app and ~0 got an agent paired. The app is useless without the
+ * box-side agent and a store download gives no hint one exists, so the old empty
+ * state — a paragraph and two links to a website — was the whole funnel.
+ *
+ * WHAT MAKES IT WORK: the agent binds at the MIDPOINT of install.sh, ~850 lines
+ * before the terminal prints its QR. So the phone can say "found your box" while
+ * the installer is still scrolling, with the user standing at their PC. That is
+ * the moment the funnel dies and the one this card is engineered for: it sweeps
+ * the LAN on its own and flips the instant /api/ping answers, before the user
+ * has typed anything.
+ *
+ * SECURITY MODEL (do not "fix" the asymmetry): /api/ping, /api/pair/start and
+ * /api/pair/finish are unauthenticated and LAN-reachable — that IS the
+ * zero-terminal path. /pair and /api/pair/status are loopback-only, so the phone
+ * can never read the PIN: /api/pair/start pops it FULL-SCREEN ON THE BOX'S OWN
+ * TV and returns only {ok, ttl}. Physical presence is the proof and the secret
+ * never crosses the network. This card needs NO new agent endpoint and no new
+ * /api/ping field — it is app-only.
+ *
+ * NO REANIMATED. State changes are the feedback. An animation here would buy a
+ * pulse and cost the whole animation-verification trap surface (rAF runs at 0fps
+ * in the web harness), on the one screen whose behaviour most needs proving.
+ *
+ * Every DECISION lives in lib/setupPhase.ts and is unit-tested on bare Node
+ * (lib/__tests__/setupPhase.test.ts). This file owns effects and pixels only.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Linking from 'expo-linking';
+import * as Network from 'expo-network';
+import { useFocusEffect } from 'expo-router';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  AppState,
+  type AppStateStatus,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+
+import { ApiError, pairFinish, pairStart } from '@/lib/api';
+import { scanForBoxes, selfIp, type FoundBox } from '@/lib/boxDiscovery';
+import { hapticLight, hapticSelection, hapticSuccess } from '@/lib/haptics';
+import { navigateAfterPair } from '@/lib/postPair';
+import { useBoxes } from '@/lib/SettingsContext';
+import {
+  acceptsSighting,
+  DIAGNOSE_AFTER_MS,
+  formatCountdown,
+  netVerdict,
+  nextPhase,
+  stepMarks,
+  sweepPolicy,
+  ttlRemaining,
+  type NetFacts,
+  type SetupEvent,
+  type SetupPhase,
+  type StepMark,
+} from '@/lib/setupPhase';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/**
+ * couchside.tv setup guide — how to install the agent on a box. New users who
+ * grabbed the app from a store land here with no idea a box-side agent exists.
+ * Lives here rather than in setup.tsx because this card is the primary consumer;
+ * setup.tsx imports it (one direction only — the reverse would be a cycle).
+ */
+export const SETUP_GUIDE_URL = 'https://couchside.tv/#install';
+
+/** The four steps, in the order a new user actually performs them. */
+const STEPS = [
+  'On your PC, switch to Desktop Mode and open a terminal.',
+  'Open couchside.tv and run the install command.',
+  'Watch this screen — it updates by itself.',
+  'A PIN appears on your TV. Type it here.',
+];
+
+export function SetupProgress() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { addBox } = useBoxes();
+
+  const [phase, setPhase] = useState<SetupPhase>({ k: 'idle' });
+  const [pin, setPin] = useState('');
+  /** Client-side note that must NOT change phase — e.g. a short PIN, which the
+   *  agent would count as one of its five attempts. */
+  const [hint, setHint] = useState<string | null>(null);
+  const [subnet, setSubnet] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const mounted = useRef(true);
+  const phaseRef = useRef<SetupPhase>(phase);
+  /** Set by the search effect while this screen is focused; null otherwise. */
+  const ctl = useRef<{ start: () => void; stop: () => void } | null>(null);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  /**
+   * The ref is the authority, the state is the mirror.
+   *
+   * setState is not synchronous, so a handler that dispatches and then asks the
+   * loop to restart would have the loop read the PREVIOUS phase and refuse to
+   * run. Reducing off the ref makes every dispatch immediately visible to the
+   * async code that has to make a decision on it. Safe because nextPhase is
+   * pure and dispatch is only ever called from handlers and effects, never
+   * during render.
+   */
+  const dispatch = useCallback((e: SetupEvent) => {
+    const n = nextPhase(phaseRef.current, e);
+    phaseRef.current = n;
+    setPhase(n);
+  }, []);
+
+  // ---------------------------------------------------------------------
+  // The search loop
+  // ---------------------------------------------------------------------
+  // Runs ONLY while: this screen is focused (useFocusEffect), the app is active
+  // (AppState), and the phase is still looking. The component itself is rendered
+  // only when the fleet is empty, which is the third condition from the spec —
+  // and is also why any box found here is new *to this phone*, the only sense of
+  // "new" that matters (the agent has no first-run flag to ask about).
+  useFocusEffect(
+    useCallback(() => {
+      let gen = 0;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      let ac: AbortController | null = null;
+      let startedAt = 0;
+      let appActive = AppState.currentState === 'active' || AppState.currentState == null;
+
+      const stop = () => {
+        gen++; // invalidates any cycle currently suspended in an await
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        if (ac) {
+          // Synchronous: a worker suspended in pingHost resumes, sees aborted,
+          // and exits. Without this ~254 fetches keep running after a blur.
+          ac.abort();
+          ac = null;
+        }
+      };
+
+      const cycle = async (g: number) => {
+        const live = () => g === gen && mounted.current && appActive;
+        if (!live()) return;
+        // Never sweep once the user has committed to a box. Same predicate the
+        // reducer uses to refuse a late sighting.
+        if (!acceptsSighting(phaseRef.current)) return;
+        /** Set the moment a box is in hand. Immune to the one-render lag on
+         *  phaseRef, which is why the "schedule another sweep?" test below reads
+         *  this and not the ref. */
+        let committed = false;
+
+        // 1. Is a sweep even meaningful from here? Answered from facts only —
+        //    there is no API that reports iOS Local Network permission, so the
+        //    card never claims to know that (see netVerdict).
+        const facts: NetFacts = {};
+        try {
+          const st = await Network.getNetworkStateAsync();
+          facts.networkType = st?.type != null ? String(st.type) : undefined;
+          facts.isConnected = st?.isConnected;
+        } catch {
+          // Unknown network type is not a verdict; fall through to the IP test.
+        }
+        try {
+          facts.selfIp = await selfIp();
+        } catch {
+          facts.selfIp = undefined;
+        }
+        if (!live()) return;
+        const v = netVerdict(facts);
+        if (v.k !== 'sweepable') {
+          setSubnet(null);
+          // Terminal for the loop: it will not fix itself by sweeping harder.
+          // The user gets an explicit "Try again" back to idle.
+          dispatch({ t: 'NO_NET', verdict: v });
+          return;
+        }
+        setSubnet(v.subnet);
+
+        if (startedAt === 0) startedAt = Date.now();
+        dispatch({ t: 'SWEEP_START', now: startedAt });
+        if (sweepPolicy(Date.now() - startedAt).giveUp) {
+          dispatch({ t: 'GIVE_UP' });
+          return;
+        }
+
+        ac = new AbortController();
+        try {
+          const boxes = await scanForBoxes({
+            timeoutMs: 3000,
+            signal: ac.signal,
+            // THE POINT OF THE WHOLE FEATURE: fired the instant a host answers,
+            // seconds before the sweep drains.
+            onFound: (b: FoundBox) => {
+              if (!live()) return;
+              committed = true;
+              dispatch({ t: 'FOUND', box: b });
+              // The fleet is empty and this card commits to ONE box, so the
+              // remaining ~250 probes have nothing left to learn. Stop them.
+              ac?.abort();
+            },
+          });
+          if (!live()) return;
+          // The resolved array is authoritative on completion; a FOUND that no
+          // longer applies is identity in the reducer, so this cannot clobber a
+          // PIN the user is already typing.
+          if (boxes.length > 0) {
+            committed = true;
+            dispatch({ t: 'FOUND', box: boxes[0] });
+          } else if (!committed) {
+            dispatch({ t: 'SWEEP_EMPTY' });
+          }
+        } catch {
+          if (!live()) return;
+          // A scan that threw found nothing. Never a stuck spinner.
+          if (!committed) dispatch({ t: 'SWEEP_EMPTY' });
+        } finally {
+          ac = null;
+        }
+
+        if (!live() || committed) return;
+        const next = sweepPolicy(Date.now() - startedAt);
+        if (next.giveUp) {
+          dispatch({ t: 'GIVE_UP' });
+          return;
+        }
+        timer = setTimeout(() => void cycle(g), next.delayMs);
+      };
+
+      /** Begin (or resume) searching, with a FRESH give-up budget. Coming back
+       *  to a focused Setup tab, or back into the app, is the user asking again
+       *  — the five minutes are there to stop background battery burn, not to
+       *  refuse someone who is standing right there watching. */
+      const start = () => {
+        stop();
+        startedAt = 0;
+        void cycle(gen);
+      };
+
+      ctl.current = { start, stop };
+
+      const sub = AppState.addEventListener('change', (s: AppStateStatus) => {
+        const nowActive = s === 'active';
+        if (nowActive === appActive) return;
+        appActive = nowActive;
+        if (appActive) start();
+        else stop();
+      });
+      if (appActive) start();
+
+      return () => {
+        stop();
+        sub.remove();
+        ctl.current = null;
+      };
+    }, [dispatch]),
+  );
+
+  // ---------------------------------------------------------------------
+  // PIN countdown
+  // ---------------------------------------------------------------------
+  const expiresAt =
+    phase.k === 'pin' || phase.k === 'pairing' || phase.k === 'failed' ? phase.expiresAt : 0;
+
+  useEffect(() => {
+    if (expiresAt <= 0) return;
+    setNowMs(Date.now());
+    const id = setInterval(() => {
+      const n = Date.now();
+      setNowMs(n);
+      if (n >= expiresAt) clearInterval(id); // stop at zero; never count negative
+    }, 1000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  const secsLeft = expiresAt > 0 ? ttlRemaining(expiresAt, nowMs) : 0;
+
+  // ---------------------------------------------------------------------
+  // Handlers. Every one of them sets a terminal phase in BOTH the ok and the
+  // catch branch (BoxScanPair's rule), and there is always a path back.
+  // ---------------------------------------------------------------------
+
+  const startPair = useCallback(async () => {
+    const p = phaseRef.current;
+    if (p.k !== 'found' && p.k !== 'pin' && p.k !== 'failed') return;
+    const box = p.box;
+    hapticSelection();
+    ctl.current?.stop(); // stop sweeping the moment the user commits to a box
+    setHint(null);
+    setPin('');
+    dispatch({ t: 'START_PIN' });
+    try {
+      const r = await pairStart(box.ip, box.port);
+      if (!mounted.current) return;
+      if (r.ok) {
+        // Drive the countdown off the RETURNED ttl: inside the agent's 3 s
+        // start-debounce it hands back the LIVE pairing's remaining seconds,
+        // not a fresh 120.
+        dispatch({
+          t: 'START_OK',
+          ttl: typeof r.ttl === 'number' && r.ttl > 0 ? r.ttl : 120,
+          now: Date.now(),
+        });
+      } else if (r.error === 'unauthorized') {
+        // An agent predating PIN pairing answers 401 here, and unauthPost
+        // resolves that body rather than throwing. Printing "unauthorized" at a
+        // user would be verbatim and useless.
+        dispatch({ t: 'UNSUPPORTED' });
+      } else {
+        dispatch({ t: 'START_ERR', msg: r.error ?? 'That box would not start pairing.' });
+      }
+    } catch (e: unknown) {
+      if (!mounted.current) return;
+      dispatch({
+        t: 'START_ERR',
+        msg: e instanceof ApiError ? e.message : 'Could not reach that box.',
+      });
+    }
+  }, [dispatch]);
+
+  const submitPin = useCallback(async () => {
+    const p = phaseRef.current;
+    if (p.k !== 'pin' && p.k !== 'failed') return;
+    const box = p.box;
+    const code = pin.trim();
+    if (code.length !== 6) {
+      // Deliberately NOT a phase change: the agent counts a wrong PIN against a
+      // hard limit of five, and a half-typed one must never spend an attempt.
+      setHint('Enter the 6-digit PIN from the box.');
+      return;
+    }
+    setHint(null);
+    dispatch({ t: 'SUBMIT' });
+    try {
+      const r = await pairFinish(box.ip, box.port, code);
+      if (!mounted.current) return;
+      if (r.ok && r.token) {
+        // addBox gets its OWN try/catch: it THROWS when its pairing-host
+        // allowlist refuses the discovered host, and by then the agent has
+        // CONSUMED the PIN. Folding that into the outer catch would report
+        // "could not reach that box" — a lie, about an unrecoverable state.
+        try {
+          // No userTypedHost: a discovered host is machine-supplied by
+          // definition and must pass the allowlist in addBox.
+          const added = await addBox({
+            host: box.host,
+            port: r.port ?? box.port,
+            token: r.token,
+            lastIp: box.ip,
+          });
+          if (!mounted.current) return;
+          dispatch({ t: 'PAIR_OK' });
+          hapticSuccess();
+          navigateAfterPair(added); // straight to the remote — lib/postPair.ts
+        } catch (e: unknown) {
+          if (!mounted.current) return;
+          dispatch({
+            t: 'PAIR_ERR',
+            dead: true, // the PIN is spent server-side; no countdown may survive
+            msg: `${e instanceof Error ? e.message : String(e)}. Add this box with "Scan a pairing code" or "Add by IP" below.`,
+          });
+        }
+        return;
+      }
+      // FINDING 1 (HIGH). Two of the agent's three failures mean the session is
+      // GONE server-side — both agents do `PAIR_PIN = None` before raising
+      // "no active pairing …" and "too many wrong PINs …". Without marking those
+      // dead, the card carried `expiresAt` forward and kept rendering "A 6-digit
+      // PIN is on <box>'s screen. Expires in 1:03." over a PIN that no longer
+      // exists, with the input live and PAIR enabled — every press guaranteed to
+      // fail. The flagship scenario hits this: the installer restarting the
+      // agent mid-pair (PAIR_PIN is an in-memory global) lands on "no active
+      // pairing" while the countdown runs on.
+      //
+      // Matching on the message is safe HERE and only here: the two substrings
+      // below are identical in both agents and contain no dash, so the em-dash
+      // vs hyphen difference the note at the render site warns about cannot
+      // bite. The agent's own string is still what the user is SHOWN — this
+      // only decides whether the countdown dies with it.
+      const spent = /too many wrong PINs|no active pairing/i.test(r.error ?? '');
+      dispatch({
+        t: 'PAIR_ERR',
+        dead: spent,
+        msg: r.error ?? 'Pairing failed — check the PIN and retry.',
+      });
+    } catch (e: unknown) {
+      if (!mounted.current) return;
+      dispatch({
+        t: 'PAIR_ERR',
+        msg: e instanceof ApiError ? e.message : 'Could not reach that box.',
+      });
+    }
+  }, [pin, addBox, dispatch]);
+
+  /** Back to the found box without losing it (no re-scan needed). */
+  const back = useCallback(() => {
+    hapticLight();
+    setPin('');
+    setHint(null);
+    dispatch({ t: 'BACK' });
+  }, [dispatch]);
+
+  /** Resume searching: from stalled ("Keep looking") or a network verdict. */
+  const keepLooking = useCallback(() => {
+    hapticLight();
+    dispatch({ t: 'KEEP_LOOKING', now: Date.now() });
+    ctl.current?.start();
+  }, [dispatch]);
+
+  /** The explicit path back to idle from a box the user does not want — the
+   *  wrong machine answered, or its agent is too old to PIN-pair. */
+  const searchAgain = useCallback(() => {
+    hapticLight();
+    setPin('');
+    setHint(null);
+    dispatch({ t: 'RESET' });
+    ctl.current?.start();
+  }, [dispatch]);
+
+  const openGuide = useCallback(() => {
+    hapticLight();
+    void Linking.openURL(SETUP_GUIDE_URL);
+  }, []);
+
+  const openSettings = useCallback(() => {
+    hapticLight();
+    void Linking.openSettings();
+  }, []);
+
+  // ---------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------
+  const marks = stepMarks(phase);
+  const elapsed =
+    phase.k === 'looking' || phase.k === 'stalled' ? Math.max(0, Date.now() - phase.since) : 0;
+  const showDiagnosis =
+    (phase.k === 'looking' && elapsed >= DIAGNOSE_AFTER_MS) || phase.k === 'stalled';
+
+  return (
+    <View style={styles.card}>
+      {(phase.k === 'idle' ||
+        phase.k === 'looking' ||
+        phase.k === 'stalled' ||
+        phase.k === 'nonet') && (
+        <>
+          <Text style={styles.lead}>
+            Couchside needs a small service running on the box you want to control. It takes about
+            a minute.
+          </Text>
+          <View style={styles.steps}>
+            {STEPS.map((label, i) => (
+              <StepLine key={label} n={i + 1} label={label} mark={marks[i]} />
+            ))}
+          </View>
+        </>
+      )}
+
+      {phase.k === 'looking' && !showDiagnosis && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator size="small" color={t.blue} />
+          <Text style={styles.statusText}>
+            {subnet
+              ? `Looking for your box on ${subnet}… leave this open, it updates by itself.`
+              : 'Looking for your box…'}
+          </Text>
+        </View>
+      )}
+
+      {/* The honest not-finding-anything state. There is NO API in Expo SDK 57
+          that reports iOS Local Network permission, and RN's fetch collapses a
+          denial, a timeout and a dead host into one identical TypeError — so the
+          card offers a differential diagnosis instead of claiming to know which
+          it is. It is also better copy: the likeliest reason by far is that the
+          installer simply has not finished yet. */}
+      {showDiagnosis && (
+        <View style={styles.diag}>
+          <Text style={styles.diagTitle}>
+            {phase.k === 'stalled'
+              ? `Stopped looking${subnet ? ` on ${subnet}` : ''} to save battery.`
+              : `Still nothing${subnet ? ` on ${subnet}` : ''}. Usually one of:`}
+          </Text>
+          <Text style={styles.diagItem}>
+            · the installer has not finished on your PC yet — keep this open
+          </Text>
+          <Text style={styles.diagItem}>
+            · your phone is on a different network from your box (guest Wi-Fi, or the other band
+            on a mesh router)
+          </Text>
+          <Text style={styles.diagItem}>
+            · this phone is blocking local-network access for Couchside
+          </Text>
+          <View style={styles.btnRow}>
+            {phase.k === 'stalled' && (
+              <Pressable
+                onPress={keepLooking}
+                accessibilityRole="button"
+                accessibilityLabel="Keep looking for a box"
+                style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+                <Text style={styles.btnPrimaryText}>KEEP LOOKING</Text>
+              </Pressable>
+            )}
+            <Pressable
+              onPress={openSettings}
+              accessibilityRole="button"
+              accessibilityLabel="Open this app's system settings"
+              style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}>
+              <Text style={styles.btnGhostText}>OPEN SETTINGS</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {/* Facts, not guesses: these two are actually knowable. */}
+      {phase.k === 'nonet' && (
+        <View style={styles.diag}>
+          <Text style={styles.diagTitle}>
+            {phase.verdict.k === 'offline'
+              ? 'This phone has no network connection, so there is nothing to search.'
+              : phase.verdict.k === 'cellular'
+                ? 'This phone is on mobile data. Join the same Wi-Fi as your box and the search starts again.'
+                : 'This phone has no local-network address, so there is no network to search.'}
+          </Text>
+          <View style={styles.btnRow}>
+            <Pressable
+              onPress={keepLooking}
+              accessibilityRole="button"
+              accessibilityLabel="Try searching again"
+              style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+              <Text style={styles.btnPrimaryText}>TRY AGAIN</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {/* THE PAYOFF. Can fire while the installer is still scrolling. */}
+      {phase.k === 'found' && (
+        <View style={styles.foundWrap}>
+          <View style={styles.foundRow}>
+            <Ionicons name="checkmark-circle" size={20} color={t.green} />
+            <View style={styles.foundBody}>
+              <Text style={styles.foundName} numberOfLines={1}>
+                Found {phase.box.name}
+              </Text>
+              <Text style={styles.foundMeta} numberOfLines={1}>
+                {phase.box.ip} · service v{phase.box.version || '?'}
+              </Text>
+            </View>
+          </View>
+          <View style={styles.btnRow}>
+            <Pressable
+              onPress={searchAgain}
+              accessibilityRole="button"
+              accessibilityLabel="Not this box — search again"
+              style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}>
+              <Text style={styles.btnGhostText}>NOT THIS ONE</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => void startPair()}
+              accessibilityRole="button"
+              accessibilityLabel={`Pair with ${phase.box.name}`}
+              style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+              <Text style={styles.btnPrimaryText}>PAIR NOW</Text>
+            </Pressable>
+          </View>
+          <Text style={styles.foundHint}>
+            The box will show a 6-digit PIN on its own screen. Nothing is sent until you type it.
+          </Text>
+        </View>
+      )}
+
+      {/* Agent too old for PIN pairing — route to the paths that DO work rather
+          than to an input that would 404. */}
+      {phase.k === 'unsupported' && (
+        <View style={styles.diag}>
+          <Text style={styles.diagTitle}>
+            Found {phase.box.name} at {phase.box.ip}, but its Couchside service (v
+            {phase.box.version || '?'}) is too old to show a PIN.
+          </Text>
+          <Text style={styles.diagItem}>
+            · update the service on the box, then tap Try again
+          </Text>
+          <Text style={styles.diagItem}>
+            · or pair it now with &quot;Scan a pairing code&quot; or &quot;Add by IP&quot; below
+          </Text>
+          <View style={styles.btnRow}>
+            <Pressable
+              onPress={searchAgain}
+              accessibilityRole="button"
+              accessibilityLabel="Search again for a box"
+              style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}>
+              <Text style={styles.btnGhostText}>TRY AGAIN</Text>
+            </Pressable>
+          </View>
+        </View>
+      )}
+
+      {phase.k === 'starting' && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator size="small" color={t.blue} />
+          <Text style={styles.statusText}>Asking {phase.box.name} to show a PIN…</Text>
+        </View>
+      )}
+
+      {(phase.k === 'pin' || phase.k === 'pairing' || phase.k === 'failed') && (
+        <View style={styles.pinWrap}>
+          <Text style={styles.statusText}>
+            {/* Three states, not two (FINDING 2, HIGH). "expired" may only be
+                said about a PIN that was actually SHOWN — `failed` from
+                START_ERR is the pairStart-never-succeeded path, where nothing
+                ever appeared on the TV. Printing "The PIN has expired" there,
+                next to "Could not reach that box", made two contradictory
+                claims about the same moment and sent the user to look at a
+                blank screen. */}
+            {secsLeft > 0
+              ? `A 6-digit PIN is on ${phase.box.name}'s screen. Expires in ${formatCountdown(secsLeft)}.`
+              : phase.k === 'failed' && !phase.shown
+                ? `No PIN was shown on ${phase.box.name}.`
+                : `The PIN on ${phase.box.name} has expired.`}
+          </Text>
+          <TextInput
+            value={pin}
+            onChangeText={(v) => setPin(v.replace(/[^0-9]/g, '').slice(0, 6))}
+            placeholder="6-digit PIN"
+            placeholderTextColor={t.textFaint}
+            keyboardType="number-pad"
+            accessibilityLabel="6-digit PIN from the box"
+            editable={phase.k !== 'pairing' && secsLeft > 0}
+            autoFocus
+            style={styles.input}
+          />
+          {hint && <Text style={styles.err}>{hint}</Text>}
+          {/* The agent's OWN string, verbatim — "wrong PIN", "no active pairing
+              - start it again from the app", "too many wrong PINs - start
+              again". Never matched on: Linux uses an em dash where Windows uses
+              a hyphen. */}
+          {phase.k === 'failed' && <Text style={styles.err}>{phase.msg}</Text>}
+          <View style={styles.btnRow}>
+            <Pressable
+              onPress={back}
+              disabled={phase.k === 'pairing'}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel PIN entry"
+              style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}>
+              <Text style={styles.btnGhostText}>CANCEL</Text>
+            </Pressable>
+            {secsLeft > 0 ? (
+              <Pressable
+                onPress={() => void submitPin()}
+                disabled={phase.k === 'pairing'}
+                accessibilityRole="button"
+                accessibilityLabel="Submit the PIN and pair"
+                style={({ pressed }) => [
+                  styles.btn,
+                  styles.btnPrimary,
+                  (pressed || phase.k === 'pairing') && styles.pressed,
+                ]}>
+                {phase.k === 'pairing' ? (
+                  <ActivityIndicator size="small" color={t.bg} />
+                ) : (
+                  <Text style={styles.btnPrimaryText}>PAIR</Text>
+                )}
+              </Pressable>
+            ) : (
+              /* At zero the old PIN is dead server-side; retrying it can only
+                 fail, so the only forward move is a fresh one. */
+              <Pressable
+                onPress={() => void startPair()}
+                accessibilityRole="button"
+                accessibilityLabel="Show a new PIN on the box"
+                style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+                <Text style={styles.btnPrimaryText}>SHOW A NEW PIN</Text>
+              </Pressable>
+            )}
+          </View>
+        </View>
+      )}
+
+      {phase.k === 'paired' && (
+        <View style={styles.statusRow}>
+          <Ionicons name="checkmark-circle" size={20} color={t.green} />
+          <Text style={styles.statusText}>Paired {phase.box.name}.</Text>
+        </View>
+      )}
+
+      {/* The escape hatch, kept verbatim from the empty state this replaces: the
+          box needs the agent installed before it can be paired at all. */}
+      <Pressable
+        onPress={openGuide}
+        accessibilityRole="button"
+        accessibilityLabel="Open the Couchside setup guide"
+        style={({ pressed }) => [styles.emptyLink, pressed && styles.pressed]}>
+        <Ionicons
+          name="hardware-chip-outline"
+          size={15}
+          color={t.blue}
+          style={styles.emptyLinkIcon}
+        />
+        <Text style={styles.emptyLinkText}>
+          Haven&apos;t installed the Couchside service? Setup guide
+        </Text>
+        <Ionicons name="open-outline" size={13} color={t.blue} style={styles.emptyLinkIcon} />
+      </Pressable>
+    </View>
+  );
+}
+
+/**
+ * One onboarding step. Same structure as setup.tsx's StepRow (mark + label) but
+ * deliberately NOT its style: that one is monospaced because it reports
+ * diagnostics from a connection test, and four human-facing onboarding steps in
+ * a diagnostic typeface read as an error log. It is also module-private there,
+ * and importing it would make setup.tsx <-> SetupProgress a cycle.
+ */
+function StepLine({ n, label, mark }: { n: number; label: string; mark: StepMark }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const glyph = mark === 'done' ? '✓' : mark === 'active' ? '…' : String(n);
+  const color = mark === 'done' ? t.green : mark === 'active' ? t.blue : t.textFaint;
+  return (
+    <View style={styles.stepRow}>
+      <Text style={[styles.stepMark, { color }]}>{glyph}</Text>
+      <Text style={[styles.stepLabel, mark === 'todo' && styles.stepLabelDim]}>{label}</Text>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    // Values copied verbatim from setup.tsx's `card` so this sits IN the screen
+    // rather than on it (that factory is module-private and not importable).
+    card: {
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 14,
+      marginBottom: 12,
+    },
+    lead: { color: t.textDim, fontSize: 13, lineHeight: 19 },
+    steps: { marginTop: 12, gap: 10 },
+    stepRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 10 },
+    stepMark: { fontSize: 14, fontWeight: '800', width: 18, textAlign: 'center', lineHeight: 19 },
+    stepLabel: { color: t.text, fontSize: 13, lineHeight: 19, flex: 1 },
+    stepLabelDim: { color: t.textDim },
+    statusRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginTop: 14 },
+    statusText: { color: t.textDim, fontSize: 13, lineHeight: 19, flex: 1 },
+    diag: { marginTop: 14, gap: 6 },
+    diagTitle: { color: t.text, fontSize: 13, lineHeight: 19 },
+    diagItem: { color: t.textDim, fontSize: 12.5, lineHeight: 18 },
+    err: { color: t.red, fontSize: 13, lineHeight: 18 },
+    foundWrap: { marginTop: 14, gap: 10 },
+    foundRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    foundBody: { flex: 1 },
+    foundName: { color: t.text, fontSize: 15, fontWeight: '700' },
+    foundMeta: { color: t.textDim, fontSize: 12, marginTop: 1 },
+    foundHint: { color: t.textFaint, fontSize: 12, lineHeight: 17 },
+    pinWrap: { marginTop: 14, gap: 10 },
+    input: {
+      backgroundColor: t.inset,
+      borderColor: t.cardBorder,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderRadius: 10,
+      paddingHorizontal: 12,
+      paddingVertical: 11,
+      color: t.text,
+      fontSize: 18,
+      letterSpacing: 4,
+    },
+    btnRow: { flexDirection: 'row', gap: 10, marginTop: 4 },
+    btn: {
+      flex: 1,
+      borderRadius: 10,
+      paddingVertical: 11,
+      minHeight: 44,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    btnPrimary: { backgroundColor: t.blue },
+    btnPrimaryText: { color: t.bg, fontWeight: '800', fontSize: 13 },
+    btnGhost: { backgroundColor: t.inset },
+    btnGhostText: { color: t.textDim, fontWeight: '700', fontSize: 13 },
+    emptyLink: {
+      flexDirection: 'row',
+      // flex-start, not center: once the label wraps to two lines, centred icons
+      // float in the middle of the block instead of sitting on the first line.
+      alignItems: 'flex-start',
+      gap: 6,
+      marginTop: 14,
+    },
+    // Aligns the glyphs with the first line of a wrapped label.
+    emptyLinkIcon: { marginTop: 2 },
+    // flex:1 is load-bearing. Without it the Text takes its INTRINSIC width, so
+    // a label wider than the row pushes the trailing ↗ off the edge rather than
+    // wrapping. It fit on iOS and overflowed on Android, which is exactly the
+    // shape of bug that a single-platform check misses.
+    emptyLinkText: { color: t.blue, fontSize: 13, fontWeight: '600', flex: 1, lineHeight: 18 },
+    pressed: { opacity: 0.7 },
+  });

--- a/app/lib/__tests__/setupPhase.test.ts
+++ b/app/lib/__tests__/setupPhase.test.ts
@@ -1,0 +1,464 @@
+/**
+ * Interactive setup card decisions — lib/setupPhase.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * (CI runs exactly that glob, so this file is picked up with no workflow edit.)
+ *
+ * WHY THESE TESTS AND NOT OTHERS. This card changes state from a network event
+ * the user cannot see, while they are looking at a different screen in another
+ * room. Nothing about it is verifiable by feel. Per CLAUDE.md §11 every rule
+ * below is exercised in BOTH directions and carries a control — an input whose
+ * answer is known independently — because a table that only ever asserts "no"
+ * passes just as well against a function that always says no.
+ *
+ * The version floors in particular are read from the agent sources at the
+ * commits that introduced them, not from memory:
+ *   Linux   2.9.12   commit 1f0952f (agent/couchsided.py, VERSION = "2.9.12")
+ *   Windows 0.4.2-win commit a131bc5 (agent/win/couchsided-win.py, VERSION = "0.4.2-win")
+ * Today's shipping versions are 2.9.61 and 0.4.3-win.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  acceptsSighting,
+  DIAGNOSE_AFTER_MS,
+  formatCountdown,
+  isSearching,
+  netVerdict,
+  nextPhase,
+  PIN_PAIR_MIN_LINUX,
+  PIN_PAIR_MIN_WINDOWS,
+  stepMarks,
+  supportsPinPairing,
+  SWEEP_FAST_WINDOW_MS,
+  SWEEP_GAP_BACKOFF_MS,
+  SWEEP_GAP_MS,
+  SWEEP_GIVE_UP_MS,
+  sweepPolicy,
+  TRANSIENT,
+  ttlRemaining,
+  type SetupBox,
+  type SetupEvent,
+  type SetupPhase,
+} from '../setupPhase.ts';
+
+const box = (version: string, over: Partial<SetupBox> = {}): SetupBox => ({
+  name: 'bazzite',
+  host: 'bazzite.local',
+  ip: '10.1.1.60',
+  port: 8787,
+  version,
+  ...over,
+});
+
+const MODERN = box('2.9.61');
+const ANCIENT = box('2.9.11');
+
+// ---------------------------------------------------------------------------
+// Which agents can PIN-pair
+// ---------------------------------------------------------------------------
+
+test('THE SPEC BUG: a modern Windows agent is NOT unsupported', () => {
+  // The spec said the Windows agent has no PIN pairing at all, from a grep. It
+  // shipped in 0.4.2-win. A single-track semver floor would compare 0.4.3-win
+  // against 2.9.12 and mark EVERY Windows box unsupported.
+  assert.equal(supportsPinPairing('0.4.3-win'), true, 'current Windows agent');
+  assert.equal(supportsPinPairing('0.4.2-win'), true, 'the exact Windows floor');
+  // CONTROL, the other direction: the release BEFORE the floor really is
+  // unsupported — so this cannot pass by accepting every -win string.
+  assert.equal(supportsPinPairing('0.4.1-win'), false, 'predates Windows PIN pairing');
+  assert.equal(supportsPinPairing('0.3.7-win'), false);
+});
+
+test('the Linux floor is exact in both directions', () => {
+  assert.equal(supportsPinPairing('2.9.12'), true, 'the exact Linux floor');
+  assert.equal(supportsPinPairing('2.9.11'), false, 'one release below it');
+  assert.equal(supportsPinPairing('2.9.61'), true, 'current shipping agent');
+  // Numeric, not lexical: a string compare reads '2.9.9' > '2.9.12'.
+  assert.equal(supportsPinPairing('2.9.9'), false);
+  assert.equal(supportsPinPairing('2.10.0'), true);
+  assert.equal(supportsPinPairing('3.0.0'), true);
+  // The declared constants are the ones actually enforced.
+  assert.equal(supportsPinPairing(PIN_PAIR_MIN_LINUX), true);
+  assert.equal(supportsPinPairing(`${PIN_PAIR_MIN_WINDOWS}-win`), true);
+});
+
+test('an unreadable version degrades CLOSED', () => {
+  // pingHost writes '' when the agent sends no version string.
+  for (const v of ['', '   ', 'unknown', 'v2.9.61', 'null', 'win']) {
+    assert.equal(supportsPinPairing(v), false, `${JSON.stringify(v)} was accepted`);
+  }
+  // CONTROL: a well-formed current version still passes, so "closed" is not
+  // "closed to everything".
+  assert.equal(supportsPinPairing('2.9.61'), true);
+});
+
+// ---------------------------------------------------------------------------
+// PIN countdown
+// ---------------------------------------------------------------------------
+
+test('ttlRemaining counts down and stops at zero — never negative', () => {
+  // Anchored to a relative offset, never a literal date: a hardcoded date
+  // fixture with an age cap once turned main red with no code change.
+  const now = Date.now();
+  assert.equal(ttlRemaining(now + 120_000, now), 120);
+  assert.equal(ttlRemaining(now + 1_500, now), 2, 'partial second rounds up, so 1 is not shown as 0');
+  assert.equal(ttlRemaining(now, now), 0, 'exactly expired');
+  // The other direction: past expiry it clamps instead of going negative.
+  assert.equal(ttlRemaining(now - 30_000, now), 0);
+  // Garbage in is zero, not NaN — a NaN countdown renders as "NaN:NaN".
+  assert.equal(ttlRemaining(Number.NaN, now), 0);
+});
+
+test('formatCountdown is m:ss and clamps', () => {
+  assert.equal(formatCountdown(120), '2:00');
+  assert.equal(formatCountdown(119), '1:59');
+  assert.equal(formatCountdown(7), '0:07');
+  assert.equal(formatCountdown(0), '0:00');
+  assert.equal(formatCountdown(-5), '0:00');
+  assert.equal(formatCountdown(Number.NaN), '0:00');
+});
+
+// ---------------------------------------------------------------------------
+// Sweep policy
+// ---------------------------------------------------------------------------
+
+test('sweep cadence backs off, then gives up — both sides of each boundary', () => {
+  assert.deepEqual(sweepPolicy(0), { shouldSweep: true, delayMs: SWEEP_GAP_MS, giveUp: false });
+  assert.equal(sweepPolicy(SWEEP_FAST_WINDOW_MS - 1).delayMs, SWEEP_GAP_MS, 'still fast at 59.999s');
+  assert.equal(sweepPolicy(SWEEP_FAST_WINDOW_MS).delayMs, SWEEP_GAP_BACKOFF_MS, 'backed off at 60s');
+
+  // The give-up boundary, both sides. 254 connection attempts every 6s forever
+  // is battery burn and looks like a port scan to a router.
+  const justBefore = sweepPolicy(SWEEP_GIVE_UP_MS - 1);
+  assert.equal(justBefore.giveUp, false, 'at 4:59.999 it is still sweeping');
+  assert.equal(justBefore.shouldSweep, true);
+  const atLimit = sweepPolicy(SWEEP_GIVE_UP_MS);
+  assert.equal(atLimit.giveUp, true, 'at 5:00 it stops');
+  assert.equal(atLimit.shouldSweep, false);
+
+  // Nonsense elapsed times must not produce a NaN delay or a silent give-up.
+  assert.equal(sweepPolicy(-1).shouldSweep, true);
+  assert.equal(sweepPolicy(Number.NaN).giveUp, false);
+  assert.ok(DIAGNOSE_AFTER_MS < SWEEP_GIVE_UP_MS, 'the honest copy appears before the give-up');
+});
+
+// ---------------------------------------------------------------------------
+// Should we sweep at all
+// ---------------------------------------------------------------------------
+
+test('netVerdict states only what is knowable', () => {
+  // Sweepable — the control. Everything below must be measured against a case
+  // that is known to succeed.
+  assert.deepEqual(netVerdict({ networkType: 'WIFI', isConnected: true, selfIp: '10.1.1.42' }), {
+    k: 'sweepable',
+    subnet: '10.1.1.x',
+  });
+  // Ethernet counts too (a tablet on a dock, a desktop browser).
+  assert.equal(
+    netVerdict({ networkType: 'ETHERNET', isConnected: true, selfIp: '192.168.4.7' }).k,
+    'sweepable',
+  );
+  // Unknown network type is NOT a verdict on its own; the IP still decides.
+  assert.equal(netVerdict({ selfIp: '172.16.0.9' }).k, 'sweepable');
+
+  assert.equal(netVerdict({ isConnected: false, selfIp: '10.1.1.42' }).k, 'offline');
+  assert.equal(netVerdict({ networkType: 'NONE' }).k, 'offline');
+
+  // ORDER MATTERS: a real cellular IP is often CGNAT (100.64/10), which
+  // isValidLanIp accepts. If the cellular test ran second, a phone on mobile
+  // data would sweep the carrier's /24 — 254 connections to strangers.
+  assert.equal(
+    netVerdict({ networkType: 'CELLULAR', isConnected: true, selfIp: '100.72.3.4' }).k,
+    'cellular',
+  );
+  // CONTROL: the same CGNAT address on Wi-Fi (Tailscale lives here) IS swept.
+  assert.equal(
+    netVerdict({ networkType: 'WIFI', isConnected: true, selfIp: '100.72.3.4' }).k,
+    'sweepable',
+  );
+
+  // A public IP is never swept. Measured behaviour on the web target: expo-network
+  // returns the PUBLIC WAN IP there, so without this the app would connect to
+  // 254 hosts on a stranger's /24.
+  assert.equal(netVerdict({ networkType: 'WIFI', selfIp: '216.139.119.131' }).k, 'no-lan-ip');
+  assert.equal(netVerdict({ networkType: 'WIFI' }).k, 'no-lan-ip', 'no IP at all');
+  // The octal escape the LAN gate exists for: 010.1.1.5 resolves to 8.1.1.5.
+  assert.equal(netVerdict({ selfIp: '010.1.1.5' }).k, 'no-lan-ip');
+});
+
+// ---------------------------------------------------------------------------
+// The phase machine
+// ---------------------------------------------------------------------------
+
+/** One of every phase, for cross-product sweeps. */
+const ALL_PHASES: SetupPhase[] = [
+  { k: 'idle' },
+  { k: 'looking', since: 1000, sweeps: 2 },
+  { k: 'stalled', since: 1000, sweeps: 40 },
+  { k: 'nonet', verdict: { k: 'cellular' } },
+  { k: 'found', box: MODERN },
+  { k: 'unsupported', box: ANCIENT },
+  { k: 'starting', box: MODERN },
+  { k: 'pin', box: MODERN, expiresAt: 500_000 },
+  { k: 'pairing', box: MODERN, expiresAt: 500_000 },
+  { k: 'failed', box: MODERN, msg: 'wrong PIN', expiresAt: 500_000, shown: true },
+  { k: 'paired', box: MODERN },
+];
+
+/** One of every event. */
+const ALL_EVENTS: SetupEvent[] = [
+  { t: 'SWEEP_START', now: 2000 },
+  { t: 'SWEEP_EMPTY' },
+  { t: 'FOUND', box: MODERN },
+  { t: 'NO_NET', verdict: { k: 'offline' } },
+  { t: 'GIVE_UP' },
+  { t: 'KEEP_LOOKING', now: 3000 },
+  { t: 'START_PIN' },
+  { t: 'START_OK', ttl: 120, now: 4000 },
+  { t: 'START_ERR', msg: 'boom' },
+  { t: 'UNSUPPORTED' },
+  { t: 'SUBMIT' },
+  { t: 'PAIR_OK' },
+  { t: 'PAIR_ERR', msg: 'wrong PIN' },
+  { t: 'BACK' },
+  { t: 'RESET' },
+];
+
+test('INVARIANT: the machine is total — no (phase x event) pair throws or leaves the union', () => {
+  const kinds = new Set(ALL_PHASES.map((p) => p.k));
+  for (const p of ALL_PHASES) {
+    for (const e of ALL_EVENTS) {
+      const n = nextPhase(p, e);
+      assert.ok(n && typeof n.k === 'string', `${p.k} + ${e.t} produced ${JSON.stringify(n)}`);
+      assert.ok(kinds.has(n.k), `${p.k} + ${e.t} produced unknown phase ${n.k}`);
+    }
+  }
+  assert.equal(kinds.size, 11, 'ALL_PHASES must cover every variant of the union');
+});
+
+test('INVARIANT: RESET returns to idle from every phase — always a way back', () => {
+  for (const p of ALL_PHASES) {
+    assert.equal(nextPhase(p, { t: 'RESET' }).k, 'idle', `no way back from ${p.k}`);
+  }
+});
+
+test('INVARIANT: no in-flight phase is a resting state — each is left by BOTH ok and error', () => {
+  // This is the rule that stops a stuck spinner. Every transient phase must have
+  // a success event and a failure event that move it somewhere else.
+  const exits: Record<string, { ok: SetupEvent; err: SetupEvent }> = {
+    looking: { ok: { t: 'FOUND', box: MODERN }, err: { t: 'GIVE_UP' } },
+    starting: { ok: { t: 'START_OK', ttl: 120, now: 1 }, err: { t: 'START_ERR', msg: 'x' } },
+    pairing: { ok: { t: 'PAIR_OK' }, err: { t: 'PAIR_ERR', msg: 'wrong PIN' } },
+  };
+  for (const k of TRANSIENT) {
+    const p = ALL_PHASES.find((x) => x.k === k);
+    assert.ok(p, `no fixture for transient phase ${k}`);
+    const pair = exits[k];
+    assert.ok(pair, `transient phase ${k} has no declared exits`);
+    assert.notEqual(nextPhase(p, pair.ok).k, k, `${k} does not leave on success`);
+    assert.notEqual(nextPhase(p, pair.err).k, k, `${k} does not leave on failure`);
+  }
+  // CONTROL, the other direction: a RESTING phase legitimately ignores events
+  // that do not apply to it, so "leaves on every event" is not the rule.
+  assert.equal(nextPhase({ k: 'found', box: MODERN }, { t: 'PAIR_OK' }).k, 'found');
+});
+
+test('a late sighting cannot yank the screen out from under a typed PIN', () => {
+  // The sweep is still draining when the user taps Pair now. Its stragglers
+  // arrive seconds later.
+  const committed: SetupPhase[] = [
+    { k: 'found', box: MODERN },
+    { k: 'starting', box: MODERN },
+    { k: 'pin', box: MODERN, expiresAt: 500_000 },
+    { k: 'pairing', box: MODERN, expiresAt: 500_000 },
+    { k: 'failed', box: MODERN, msg: 'wrong PIN', expiresAt: 500_000, shown: true },
+    { k: 'paired', box: MODERN },
+    { k: 'unsupported', box: ANCIENT },
+  ];
+  for (const p of committed) {
+    assert.equal(acceptsSighting(p), false, `${p.k} should refuse a sighting`);
+    assert.deepEqual(nextPhase(p, { t: 'FOUND', box: box('2.9.61', { ip: '10.1.1.99' }) }), p);
+    assert.deepEqual(nextPhase(p, { t: 'NO_NET', verdict: { k: 'cellular' } }), p);
+  }
+  // CONTROL: while searching, the very same event IS acted on — otherwise this
+  // test would pass against a reducer that ignores FOUND entirely.
+  for (const p of ALL_PHASES.filter((x) => acceptsSighting(x))) {
+    assert.equal(nextPhase(p, { t: 'FOUND', box: MODERN }).k, 'found', `${p.k} ignored a sighting`);
+  }
+});
+
+test('a sighting routes by agent version, not by platform', () => {
+  const looking: SetupPhase = { k: 'looking', since: 0, sweeps: 1 };
+  assert.equal(nextPhase(looking, { t: 'FOUND', box: box('2.9.61') }).k, 'found');
+  assert.equal(nextPhase(looking, { t: 'FOUND', box: box('0.4.3-win') }).k, 'found', 'Windows');
+  assert.equal(nextPhase(looking, { t: 'FOUND', box: box('2.9.11') }).k, 'unsupported');
+  assert.equal(nextPhase(looking, { t: 'FOUND', box: box('0.4.1-win') }).k, 'unsupported');
+  assert.equal(nextPhase(looking, { t: 'FOUND', box: box('') }).k, 'unsupported', 'no version');
+});
+
+test('the full happy path, end to end', () => {
+  let p: SetupPhase = { k: 'idle' };
+  p = nextPhase(p, { t: 'SWEEP_START', now: 1_000 });
+  assert.deepEqual(p, { k: 'looking', since: 1_000, sweeps: 0 });
+  p = nextPhase(p, { t: 'SWEEP_EMPTY' });
+  assert.equal((p as { sweeps: number }).sweeps, 1);
+  // A second SWEEP_START must not reset the clock, or the give-up never fires.
+  const before = p;
+  p = nextPhase(p, { t: 'SWEEP_START', now: 9_999 });
+  assert.equal(p, before, 'SWEEP_START while looking is identity');
+
+  p = nextPhase(p, { t: 'FOUND', box: MODERN });
+  assert.deepEqual(p, { k: 'found', box: MODERN });
+  p = nextPhase(p, { t: 'START_PIN' });
+  assert.equal(p.k, 'starting');
+  // The countdown comes from the RETURNED ttl. Inside the agent's 3s debounce
+  // that is the live pairing's REMAINING seconds, not a fresh 120.
+  p = nextPhase(p, { t: 'START_OK', ttl: 119, now: 50_000 });
+  assert.deepEqual(p, { k: 'pin', box: MODERN, expiresAt: 50_000 + 119_000 });
+  p = nextPhase(p, { t: 'SUBMIT' });
+  assert.equal(p.k, 'pairing');
+  p = nextPhase(p, { t: 'PAIR_OK' });
+  assert.deepEqual(p, { k: 'paired', box: MODERN });
+});
+
+test('a wrong PIN keeps the live pairing so retry needs no re-scan', () => {
+  const expiresAt = 500_000;
+  const p = nextPhase({ k: 'pairing', box: MODERN, expiresAt }, {
+    t: 'PAIR_ERR',
+    // The agent's own string, verbatim. Never matched on: Linux writes an em
+    // dash where Windows writes a hyphen for the other two failures.
+    msg: 'wrong PIN',
+  });
+  assert.deepEqual(p, { k: 'failed', box: MODERN, msg: 'wrong PIN', expiresAt, shown: true });
+  // Straight back into the same pairing — no new PIN, no new sweep.
+  assert.equal(nextPhase(p, { t: 'SUBMIT' }).k, 'pairing');
+  // And the other direction: a pairing that is SPENT server-side must not keep
+  // a countdown running over a PIN that can no longer work.
+  const dead = nextPhase({ k: 'pairing', box: MODERN, expiresAt }, {
+    t: 'PAIR_ERR',
+    msg: 'host refused: not a LAN address or local name',
+    dead: true,
+  });
+  assert.equal((dead as { expiresAt: number }).expiresAt, 0);
+});
+
+test('a start that failed offers a new PIN, not a dead text field', () => {
+  const p = nextPhase({ k: 'starting', box: MODERN }, { t: 'START_ERR', msg: 'Timed out after 8s' });
+  assert.deepEqual(p, { k: 'failed', box: MODERN, msg: 'Timed out after 8s', expiresAt: 0,
+                       shown: false });
+  // expiresAt 0 is what makes the card render "SHOW A NEW PIN" instead of PAIR.
+  assert.equal(ttlRemaining((p as { expiresAt: number }).expiresAt, Date.now()), 0);
+  // START_PIN from `failed` is the retry; it must go back through /pair/start.
+  assert.equal(nextPhase(p, { t: 'START_PIN' }).k, 'starting');
+});
+
+test('an agent that answers 401 is routed away from the PIN input', () => {
+  // An agent below the floor whose version we somehow believed. unauthPost
+  // RESOLVES the 401 body rather than throwing, so without this the card would
+  // print the bare word "unauthorized" at the user.
+  assert.equal(nextPhase({ k: 'starting', box: MODERN }, { t: 'UNSUPPORTED' }).k, 'unsupported');
+  assert.equal(nextPhase({ k: 'found', box: MODERN }, { t: 'UNSUPPORTED' }).k, 'unsupported');
+  // CONTROL: it is not a global override — it cannot kill a live PIN entry.
+  const pin: SetupPhase = { k: 'pin', box: MODERN, expiresAt: 1 };
+  assert.deepEqual(nextPhase(pin, { t: 'UNSUPPORTED' }), pin);
+});
+
+test('give up, then keep looking, with a fresh clock', () => {
+  const looking: SetupPhase = { k: 'looking', since: 1_000, sweeps: 47 };
+  const stalled = nextPhase(looking, { t: 'GIVE_UP' });
+  assert.deepEqual(stalled, { k: 'stalled', since: 1_000, sweeps: 47 });
+  assert.equal(isSearching(stalled), false, 'a stalled card must not claim to be looking');
+  const again = nextPhase(stalled, { t: 'KEEP_LOOKING', now: 900_000 });
+  assert.deepEqual(again, { k: 'looking', since: 900_000, sweeps: 0 });
+  assert.equal(isSearching(again), true);
+  // GIVE_UP is only meaningful while looking — it cannot strand a live PIN.
+  const pin: SetupPhase = { k: 'pin', box: MODERN, expiresAt: 9 };
+  assert.deepEqual(nextPhase(pin, { t: 'GIVE_UP' }), pin);
+});
+
+test('BACK returns to the found box without losing it', () => {
+  const pin: SetupPhase = { k: 'pin', box: MODERN, expiresAt: 5 };
+  assert.deepEqual(nextPhase(pin, { t: 'BACK' }), { k: 'found', box: MODERN });
+  const failed: SetupPhase = { k: 'failed', box: MODERN, msg: 'wrong PIN', expiresAt: 5, shown: true };
+  assert.deepEqual(nextPhase(failed, { t: 'BACK' }), { k: 'found', box: MODERN });
+  // CONTROL: BACK does not interrupt an in-flight request.
+  const pairing: SetupPhase = { k: 'pairing', box: MODERN, expiresAt: 5 };
+  assert.deepEqual(nextPhase(pairing, { t: 'BACK' }), pairing);
+});
+
+// ---------------------------------------------------------------------------
+// The four steps
+// ---------------------------------------------------------------------------
+
+test('the card never marks a step done on a guess, and stops claiming to watch', () => {
+  // Steps 1-2 happen on the user's PC and are unverifiable from the phone, so
+  // they go done ONLY once a box has actually answered — which proves both.
+  assert.deepEqual(stepMarks({ k: 'idle' }), ['active', 'todo', 'todo', 'todo']);
+  assert.deepEqual(stepMarks({ k: 'looking', since: 0, sweeps: 0 }), [
+    'active',
+    'active',
+    'active',
+    'todo',
+  ]);
+  assert.deepEqual(stepMarks({ k: 'found', box: MODERN }), ['done', 'done', 'done', 'active']);
+  assert.deepEqual(stepMarks({ k: 'paired', box: MODERN }), ['done', 'done', 'done', 'done']);
+
+  // Step 3 is "watch this screen — it updates by itself". It may be marked
+  // active ONLY while a sweep loop is genuinely running. Both directions:
+  for (const p of ALL_PHASES) {
+    if (isSearching(p)) assert.equal(stepMarks(p)[2], 'active', `${p.k} should be watching`);
+    else assert.notEqual(stepMarks(p)[2], 'active', `${p.k} claims to be watching and is not`);
+  }
+});
+
+test('stepMarks is total and only ever emits the three marks', () => {
+  const allowed = new Set(['todo', 'active', 'done']);
+  for (const p of ALL_PHASES) {
+    const m = stepMarks(p);
+    assert.equal(m.length, 4, `${p.k} did not produce four steps`);
+    for (const x of m) assert.ok(allowed.has(x), `${p.k} emitted ${x}`);
+  }
+});
+
+// ---------------------------------------------------------------- honesty ---
+// Both of these come from the adversarial review of this card. Its entire value
+// is being trusted while someone stands at their PC, so a claim it cannot back
+// is worse than a missing feature.
+
+test('HIGH: a spent PIN kills the countdown, so the card stops advertising a live PIN', () => {
+  // Both agents null PAIR_PIN before raising these two, so the session is GONE
+  // server-side. Carrying expiresAt forward kept rendering "A 6-digit PIN is on
+  // <box>'s screen. Expires in 1:03." with PAIR enabled — every press doomed.
+  // The flagship scenario hits it: the installer restarting the agent mid-pair
+  // (PAIR_PIN is an in-memory global) lands on "no active pairing".
+  // PAIR_ERR only ever arrives from `pairing` — it follows a SUBMIT.
+  const live: SetupPhase = { k: 'pairing', box: MODERN, expiresAt: 500_000 };
+  for (const msg of ['too many wrong PINs — start again',
+                     'no active pairing — start it again from the app']) {
+    const p = nextPhase(live, { t: 'PAIR_ERR', msg, dead: true });
+    assert.equal(p.k, 'failed');
+    assert.equal(p.k === 'failed' && p.expiresAt, 0, `${msg} left a countdown running`);
+  }
+  // CONTROL, the other direction: a merely WRONG pin does not kill the session,
+  // so the countdown must survive and retry must stay possible.
+  const wrong = nextPhase(live, { t: 'PAIR_ERR', msg: 'wrong PIN', dead: false });
+  assert.equal(wrong.k === 'failed' && wrong.expiresAt, 500_000);
+});
+
+test('HIGH: "expired" is never claimed for a PIN that was never shown', () => {
+  // START_ERR is the pairStart-NEVER-SUCCEEDED path — box off Wi-Fi, or the 8s
+  // timeout. Nothing was displayed on the TV, so the card must not say a PIN
+  // expired; that sends the user to look at a blank screen, and sits next to
+  // "Could not reach that box" as a contradiction.
+  const starting: SetupPhase = { k: 'starting', box: MODERN };
+  const p = nextPhase(starting, { t: 'START_ERR', msg: 'Could not reach that box.' });
+  assert.equal(p.k, 'failed');
+  assert.equal(p.k === 'failed' && p.shown, false, 'claimed a PIN was shown');
+  // CONTROL: a failure that arrives AFTER a PIN was shown is marked shown, so
+  // "expired" remains sayable in the one case where it is true.
+  const live: SetupPhase = { k: 'pairing', box: MODERN, expiresAt: 500_000 };
+  const after = nextPhase(live, { t: 'PAIR_ERR', msg: 'wrong PIN', dead: false });
+  assert.equal(after.k === 'failed' && after.shown, true);
+});

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -113,13 +113,56 @@ async function pingHost(ip: string, port: number, timeoutMs: number): Promise<Fo
 }
 
 /**
+ * One-shot-per-IP reporter for `onFound`. Dedupe lives HERE, not in callers.
+ *
+ * Two duplicate sources, both real:
+ *  1. udpProbe sends the same probe to the DIRECTED broadcast AND to
+ *     255.255.255.255 (see broadcastTargets + the send loop below). A box on
+ *     this /24 receives both datagrams and answers TWICE. The Map keyed by IP
+ *     silently swallowed that; reporting per datagram without a guard would
+ *     double-fire for every same-subnet box — the common case, not an edge one.
+ *  2. The HTTP sweep and the UDP probe can both see the same box, arriving down
+ *     two independent code paths.
+ * Every caller would have to reimplement exactly this to avoid rendering one box
+ * twice, so it belongs next to the merge policy it mirrors (scanForBoxes).
+ *
+ * It also swallows anything the callback throws: onFound runs INSIDE a sweep
+ * worker, so a throwing callback would reject the Promise.all and destroy the
+ * whole scan — including results already in hand.
+ */
+function makeReporter(
+  onFound?: (box: FoundBox) => void,
+  signal?: { aborted: boolean },
+): (box: FoundBox) => void {
+  if (!onFound) return () => {};
+  const seen = new Set<string>();
+  return (box) => {
+    if (signal?.aborted) return; // torn down: never call back
+    if (seen.has(box.ip)) return; // first sighting wins
+    seen.add(box.ip);
+    try {
+      onFound(box);
+    } catch {
+      // A caller's render error must not abort discovery.
+    }
+  };
+}
+
+/**
  * HTTP-sweep every host in `base`'s /24 for the agent's /api/ping, `conc` at a
  * time. Dead IPs just time out; live agents answer in milliseconds.
+ *
+ * `report` fires from the worker the INSTANT a host answers. Without it the
+ * caller waits for the whole sweep to drain (254 IPs / 64 workers x 1500 ms
+ * per-host timeout), so a box that answered in ~1 ms is withheld for seconds
+ * with the answer already in hand.
  */
 async function httpSweep(
   base: string,
   port: number,
   perHostTimeoutMs: number,
+  report: (box: FoundBox) => void,
+  signal?: { aborted: boolean },
 ): Promise<FoundBox[]> {
   const ips: string[] = [];
   for (let h = 1; h <= 254; h++) ips.push(base + h);
@@ -128,10 +171,17 @@ async function httpSweep(
   let next = 0;
   const worker = async () => {
     for (;;) {
+      // Checked here, not only before the await: abort() is synchronous, so a
+      // worker suspended in pingHost resumes, sees it, and exits — every worker
+      // is gone within one per-host timeout instead of running all 254 probes.
+      if (signal?.aborted) return;
       const i = next++;
       if (i >= ips.length) return;
       const box = await pingHost(ips[i], port, perHostTimeoutMs);
-      if (box) found.push(box);
+      if (box) {
+        found.push(box);
+        report(box);
+      }
     }
   };
   await Promise.all(Array.from({ length: Math.min(CONC, ips.length) }, worker));
@@ -142,7 +192,12 @@ async function httpSweep(
  * UDP probe: broadcast (directed + global) and collect replies for `timeoutMs`.
  * Resolves an empty list on any failure — the HTTP sweep is the reliable path.
  */
-function udpProbe(myIp: string | undefined, port: number, timeoutMs: number): Promise<FoundBox[]> {
+function udpProbe(
+  myIp: string | undefined,
+  port: number,
+  timeoutMs: number,
+  report: (box: FoundBox) => void,
+): Promise<FoundBox[]> {
   if (!dgram) return Promise.resolve([]);
   const probe = Buffer.from(PROBE);
   const targets = broadcastTargets(myIp);
@@ -177,13 +232,18 @@ function udpProbe(myIp: string | undefined, port: number, timeoutMs: number): Pr
       try {
         const d = JSON.parse(msg.toString());
         if (d && d.couchside) {
-          found.set(rinfo.address, {
+          const box: FoundBox = {
             name: typeof d.name === 'string' ? d.name : rinfo.address,
             host: typeof d.host === 'string' ? d.host : rinfo.address,
             ip: rinfo.address,
             port: typeof d.port === 'number' ? d.port : port,
             version: typeof d.version === 'string' ? d.version : '',
-          });
+          };
+          found.set(rinfo.address, box);
+          // Same drain fix as the HTTP sweep: replies land in milliseconds but
+          // were held until the timer fired. The reporter dedupes the
+          // directed+global double reply.
+          report(box);
         }
       } catch {
         // not our reply; ignore
@@ -216,22 +276,46 @@ function udpProbe(myIp: string | undefined, port: number, timeoutMs: number): Pr
   });
 }
 
+/** Options for {@link scanForBoxes}. The first three are the pre-existing ones,
+ *  unchanged, so `scanForBoxes({ timeoutMs: 3000 })` keeps working verbatim. */
+export type ScanOpts = {
+  ip?: string;
+  port?: number;
+  timeoutMs?: number;
+  /**
+   * Fired ONCE per distinct box, the instant it answers — mid-sweep, seconds
+   * before the returned promise resolves. The resolved array still contains
+   * every box, so a caller may use either or both. Treat the resolved array as
+   * authoritative on completion and reconcile by `ip`: onFound carries the
+   * FIRST sighting, the array carries the HTTP one (see the merge below).
+   */
+  onFound?: (box: FoundBox) => void;
+  /**
+   * Abort an in-flight scan (component unmount, screen blur). Stops dispatching
+   * new probes and silences `onFound`; the promise still resolves with whatever
+   * was found, so a caller must ALSO guard its own `.then`.
+   */
+  signal?: AbortSignal;
+};
+
 /**
  * Discover Couchside boxes on the LAN. Runs the HTTP sweep and the UDP probe
  * together and merges by IP (HTTP wins, since it proves the agent answered).
  * Throws only when no usable local IP could be determined AND UDP is absent.
  */
-export async function scanForBoxes(
-  opts: { ip?: string; port?: number; timeoutMs?: number } = {},
-): Promise<FoundBox[]> {
+export async function scanForBoxes(opts: ScanOpts = {}): Promise<FoundBox[]> {
   const port = opts.port ?? DEFAULT_PORT;
   const timeoutMs = opts.timeoutMs ?? 3000;
   const myIp = opts.ip ?? (await selfIp());
+  if (opts.signal?.aborted) return []; // torn down while selfIp() was in flight
   const base = subnetBase(myIp);
+  // ONE reporter shared by both probes: a box seen by UDP and by HTTP is a
+  // single sighting to the caller.
+  const report = makeReporter(opts.onFound, opts.signal);
 
   const [sweep, udp] = await Promise.all([
-    base ? httpSweep(base, port, 1500) : Promise.resolve([]),
-    udpProbe(myIp, port, Math.min(timeoutMs, 2500)),
+    base ? httpSweep(base, port, 1500, report, opts.signal) : Promise.resolve([]),
+    udpProbe(myIp, port, Math.min(timeoutMs, 2500), report),
   ]);
 
   const found = new Map<string, FoundBox>();

--- a/app/lib/setupPhase.ts
+++ b/app/lib/setupPhase.ts
@@ -1,0 +1,409 @@
+/**
+ * Every DECISION the interactive setup card makes (components/SetupProgress.tsx),
+ * with no React, no timers and no fetch — so it is unit-testable on bare Node.
+ *
+ * WHY IT IS ITS OWN FILE. The card's whole claim is "it advances itself": it
+ * changes state from a network event the user cannot see, on a screen they are
+ * not looking at (they are at their PC watching an installer scroll). That makes
+ * every one of its rules — which sighting wins, when a spinner is allowed to
+ * stop, when a PIN is dead, when to stop burning battery, which agents can even
+ * do this — the kind of thing that must be *proved*, not felt. A component can
+ * only be checked by driving it; a pure reducer can be checked exhaustively,
+ * including the (phase x event) cross product, which is how "never leave a
+ * spinner stuck" stops being a code-review habit and becomes a test.
+ *
+ * The two imports are deliberate and both are themselves import-free, so the
+ * bare-Node runner can load this file (lib/pairLink.ts -> lib/lanIp.ts is the
+ * existing precedent for the explicit `.ts` specifier):
+ *   - cmpVersion  — component-wise numeric compare; a string compare reads
+ *                   2.9.9 > 2.9.21, which is exactly backwards.
+ *   - isValidLanIp — the LAN-shape gate. Single-sourced on purpose: it is the
+ *                   security control that keeps an address learned from an
+ *                   unauthenticated reply from becoming a token destination.
+ */
+import { cmpVersion } from './appUpdate.ts';
+import { isValidLanIp } from './lanIp.ts';
+
+/** Structurally identical to boxDiscovery's FoundBox (kept local so this file
+ *  imports nothing that pulls in react-native / expo). A FoundBox satisfies it. */
+export type SetupBox = {
+  name: string;
+  host: string;
+  ip: string;
+  port: number;
+  version: string;
+};
+
+// ---------------------------------------------------------------------------
+// Which agents can do unauthenticated PIN pairing
+// ---------------------------------------------------------------------------
+
+/**
+ * Linux agent floor. PIN pairing (`pair_pin_start`) landed with agent 2.9.12
+ * (commit 1f0952f, "Couchside 2.9.3 — remote-input, discovery, PIN pairing,
+ * agent 2.9.12"), which is also what lib/api.ts documents on pairStart.
+ */
+export const PIN_PAIR_MIN_LINUX = '2.9.12';
+/**
+ * Windows agent floor. The spec for this card said the Windows agent has NO PIN
+ * pairing at all, from a grep. That claim has EXPIRED: it shipped in 0.4.2-win
+ * (commit a131bc5, "fix(win): PIN pairing + fail the build without
+ * ViGEmClient.dll (0.4.2-win)"), current is 0.4.3-win, and the source header
+ * says "parity with the Linux agent". Verified by reading
+ * agent/win/couchsided-win.py at the commit that introduced pair_pin_start.
+ *
+ * This is why the test is a two-track version floor and NOT a `-win` sniff: a
+ * naive compare of 0.4.3-win against 2.9.12 marks every Windows box
+ * unsupported, which is the exact bug the phase exists to prevent.
+ */
+export const PIN_PAIR_MIN_WINDOWS = '0.4.2';
+
+/**
+ * Can this agent pop a PIN on its own screen for an unauthenticated phone?
+ *
+ * DEGRADES CLOSED (CLAUDE.md §3.7): an empty, malformed or unrecognised version
+ * answers false, which routes the user to the QR / token path rather than to a
+ * PIN input that would answer 401 and print the word "unauthorized" at them.
+ * Cost of a false negative: one extra tap. Cost of a false positive: a dead end.
+ */
+export function supportsPinPairing(version: string): boolean {
+  const v = (version ?? '').trim();
+  if (!v) return false;
+  // A version we cannot even parse the first component of is not a version.
+  if (!/^\d/.test(v)) return false;
+  // Windows builds carry the suffix; anything else is read as the Linux track.
+  // A future `0.5.0-win-rc1` fails endsWith, is read as Linux, and lands
+  // unsupported — wrong but CLOSED, and it costs one tap, not a dead end.
+  return v.toLowerCase().endsWith('-win')
+    ? cmpVersion(v, PIN_PAIR_MIN_WINDOWS) >= 0
+    : cmpVersion(v, PIN_PAIR_MIN_LINUX) >= 0;
+}
+
+// ---------------------------------------------------------------------------
+// PIN countdown
+// ---------------------------------------------------------------------------
+
+/**
+ * Whole seconds left on a PIN, never negative.
+ *
+ * The app already asks for `ttl` and throws it away (BoxScanPair checks only
+ * `r.ok`), so today an expired PIN is discovered by typing it and being told no.
+ * The agent's TTL is 120 s but the RETURNED ttl is not always 120: inside
+ * PAIR_PIN_START_DEBOUNCE (3 s) `/api/pair/start` hands back the LIVE pairing
+ * with its REMAINING seconds. So the countdown is driven by the returned ttl,
+ * never by a hardcoded 120.
+ */
+export function ttlRemaining(expiresAt: number, now: number): number {
+  if (!Number.isFinite(expiresAt) || !Number.isFinite(now)) return 0;
+  return Math.max(0, Math.ceil((expiresAt - now) / 1000));
+}
+
+/** `m:ss`, for a countdown that must not jitter. Clamped at zero. */
+export function formatCountdown(totalSec: number): string {
+  const s = Math.max(0, Math.floor(Number.isFinite(totalSec) ? totalSec : 0));
+  const m = Math.floor(s / 60);
+  return `${m}:${String(s % 60).padStart(2, '0')}`;
+}
+
+// ---------------------------------------------------------------------------
+// Sweep policy — how hard, and for how long, to look
+// ---------------------------------------------------------------------------
+
+/** Gap between sweeps while the install is plausibly still running. */
+export const SWEEP_GAP_MS = 6000;
+/** Gap after the fast window. One sweep is 254 connection attempts; at 6 s
+ *  forever that is ~2,500 per minute, which costs battery and looks like a port
+ *  scan to a router/IDS. The install is normally over inside a minute. */
+export const SWEEP_GAP_BACKOFF_MS = 15000;
+/** How long the fast cadence lasts. */
+export const SWEEP_FAST_WINDOW_MS = 60000;
+/** Total time before the card stops on its own and offers "Keep looking". */
+export const SWEEP_GIVE_UP_MS = 300000;
+/** When the honest "here is what it is usually" list replaces "looking…".
+ *  Long enough that a normal install-then-find never sees it. */
+export const DIAGNOSE_AFTER_MS = 25000;
+
+export type SweepDecision = {
+  /** Run another sweep now. */
+  shouldSweep: boolean;
+  /** Wait this long before the sweep after that one. */
+  delayMs: number;
+  /** Stop and hand the user the button. */
+  giveUp: boolean;
+};
+
+/** `elapsedMs` is time since the search started, not since the last sweep. */
+export function sweepPolicy(elapsedMs: number): SweepDecision {
+  const e = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+  if (e >= SWEEP_GIVE_UP_MS) return { shouldSweep: false, delayMs: 0, giveUp: true };
+  return {
+    shouldSweep: true,
+    delayMs: e < SWEEP_FAST_WINDOW_MS ? SWEEP_GAP_MS : SWEEP_GAP_BACKOFF_MS,
+    giveUp: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Should we sweep at all, and if not, what is honestly known
+// ---------------------------------------------------------------------------
+
+export type NetFacts = {
+  /** expo-network's NetworkStateType as a string, or undefined if unknown. */
+  networkType?: string;
+  isConnected?: boolean;
+  /** The device's own IPv4 per expo-network, or undefined if unusable. */
+  selfIp?: string;
+};
+
+export type NetVerdict =
+  | { k: 'sweepable'; subnet: string }
+  | { k: 'offline' }
+  | { k: 'cellular' }
+  | { k: 'no-lan-ip'; ip?: string };
+
+/**
+ * Whether a /24 sweep is even meaningful, and what the card may state as FACT.
+ *
+ * There is NO API in Expo SDK 57 (or in RN's fetch) that reports iOS Local
+ * Network permission — checked against the v57 docs for expo-network, whose
+ * whole surface is useNetworkState / getIpAddressAsync / getNetworkStateAsync /
+ * isAirplaneModeEnabledAsync / addNetworkStateListener; "local network" does not
+ * appear. whatwg-fetch rejects with a flat `TypeError('Network request failed')`,
+ * so a permission denial is byte-identical to a timeout, a dead host and a wrong
+ * subnet. A `blocked` phase therefore CANNOT be entered from evidence, and this
+ * function does not pretend otherwise: it returns only what is actually known.
+ * The two things that ARE known — no connection, and cellular / not-LAN-shaped —
+ * get their own verdicts; everything else is left to honest differential copy.
+ *
+ * Order matters: a real cellular IP is often CGNAT (100.64/10), which
+ * isValidLanIp accepts, so the cellular test has to come first or a phone on
+ * mobile data sweeps the carrier's /24.
+ */
+export function netVerdict(f: NetFacts): NetVerdict {
+  if (f.isConnected === false) return { k: 'offline' };
+  const type = (f.networkType ?? '').toUpperCase();
+  if (type === 'NONE') return { k: 'offline' };
+  // NOTE (unverified): with iOS Personal Hotspot on, the phone may report
+  // CELLULAR while a box IS reachable on its shared network. Such a user can
+  // still pair with "Scan for boxes" / QR / add-by-IP below, all unchanged.
+  if (type === 'CELLULAR') return { k: 'cellular' };
+  const ip = f.selfIp;
+  if (!ip || !isValidLanIp(ip)) return { k: 'no-lan-ip', ip };
+  return { k: 'sweepable', subnet: ip.replace(/\.\d+$/, '.x') };
+}
+
+// ---------------------------------------------------------------------------
+// The phase machine
+// ---------------------------------------------------------------------------
+
+export type SetupPhase =
+  /** Nothing started yet. */
+  | { k: 'idle' }
+  /** A sweep is running (or the gap between two). */
+  | { k: 'looking'; since: number; sweeps: number }
+  /** Stopped after SWEEP_GIVE_UP_MS with nothing found. */
+  | { k: 'stalled'; since: number; sweeps: number }
+  /** Not sweeping because sweeping cannot work from here. */
+  | { k: 'nonet'; verdict: NetVerdict }
+  /** A box answered /api/ping while the fleet was empty. THE payoff moment. */
+  | { k: 'found'; box: SetupBox }
+  /** Agent too old (or non-conforming) for PIN pairing — route to QR/token. */
+  | { k: 'unsupported'; box: SetupBox }
+  /** POST /api/pair/start in flight. */
+  | { k: 'starting'; box: SetupBox }
+  /** PIN is on the box's TV; awaiting entry. */
+  | { k: 'pin'; box: SetupBox; expiresAt: number }
+  /** POST /api/pair/finish in flight. */
+  | { k: 'pairing'; box: SetupBox; expiresAt: number }
+  /** Pairing refused. `msg` is the AGENT'S OWN string, verbatim. */
+  /** `shown` records whether a PIN was ever actually put on the box's screen.
+   *  Without it the card cannot tell "the PIN expired" from "there was never a
+   *  PIN", and it printed the former for the latter — see START_ERR below. */
+  | { k: 'failed'; box: SetupBox; msg: string; expiresAt: number; shown: boolean }
+  /** Token in hand and stored. */
+  | { k: 'paired'; box: SetupBox };
+
+export type SetupEvent =
+  | { t: 'SWEEP_START'; now: number }
+  | { t: 'SWEEP_EMPTY' }
+  | { t: 'FOUND'; box: SetupBox }
+  | { t: 'NO_NET'; verdict: NetVerdict }
+  | { t: 'GIVE_UP' }
+  | { t: 'KEEP_LOOKING'; now: number }
+  | { t: 'START_PIN' }
+  | { t: 'START_OK'; ttl: number; now: number }
+  | { t: 'START_ERR'; msg: string }
+  /**
+   * Runtime backstop for an agent whose version claimed PIN support but whose
+   * /api/pair/start hit the bearer gate and answered 401. unauthPost resolves
+   * that body instead of throwing, so without this the card would print the
+   * bare word "unauthorized" at the user. This is the ONE place the
+   * surface-the-agent's-error-verbatim rule is deliberately overridden.
+   */
+  | { t: 'UNSUPPORTED' }
+  | { t: 'SUBMIT' }
+  | { t: 'PAIR_OK' }
+  /** `dead` means the pairing is spent server-side, so no countdown may survive
+   *  it — e.g. the agent accepted the PIN and something after that failed. */
+  | { t: 'PAIR_ERR'; msg: string; dead?: boolean }
+  /** Back to the found box without losing it (explicit escape from PIN entry). */
+  | { t: 'BACK' }
+  /** Back to the very start (explicit escape from anywhere). */
+  | { t: 'RESET' };
+
+/** Phases with an operation in flight. None of these may be a resting state:
+ *  every one of them must be left by BOTH an ok and an error event. */
+export const TRANSIENT: readonly SetupPhase['k'][] = ['looking', 'starting', 'pairing'];
+
+/** Phases from which a fresh sighting is welcome. Anything else means the user
+ *  has already committed to a box, and a straggler sighting from the sweep that
+ *  was still draining must NOT yank the screen out from under them. */
+const SIGHTING_OK: readonly SetupPhase['k'][] = ['idle', 'looking', 'stalled', 'nonet'];
+
+/**
+ * The whole state machine. Pure, total (never throws for any phase x event) and
+ * IDENTITY for any event that does not apply — an unexpected event is ignored,
+ * never a crash and never a silent jump to a wrong phase.
+ */
+export function nextPhase(p: SetupPhase, e: SetupEvent): SetupPhase {
+  // Always available, from everywhere: the explicit path back to idle.
+  if (e.t === 'RESET') return { k: 'idle' };
+
+  switch (e.t) {
+    case 'SWEEP_START':
+      if (p.k === 'looking') return p; // already looking; keep `since`
+      if (p.k === 'idle' || p.k === 'stalled' || p.k === 'nonet') {
+        return { k: 'looking', since: e.now, sweeps: 0 };
+      }
+      return p;
+
+    case 'SWEEP_EMPTY':
+      return p.k === 'looking' ? { ...p, sweeps: p.sweeps + 1 } : p;
+
+    case 'FOUND':
+      if (!SIGHTING_OK.includes(p.k)) return p;
+      return supportsPinPairing(e.box.version)
+        ? { k: 'found', box: e.box }
+        : { k: 'unsupported', box: e.box };
+
+    case 'NO_NET':
+      // Only while searching. A verdict arriving mid-pairing is not a reason to
+      // throw away a live PIN.
+      return SIGHTING_OK.includes(p.k) ? { k: 'nonet', verdict: e.verdict } : p;
+
+    case 'GIVE_UP':
+      return p.k === 'looking' ? { k: 'stalled', since: p.since, sweeps: p.sweeps } : p;
+
+    case 'KEEP_LOOKING':
+      if (p.k === 'stalled' || p.k === 'nonet' || p.k === 'idle') {
+        return { k: 'looking', since: e.now, sweeps: 0 };
+      }
+      return p;
+
+    case 'START_PIN':
+      // From `found` (first time), from `failed` or `pin` ("Show a new PIN").
+      if (p.k === 'found' || p.k === 'pin' || p.k === 'failed') {
+        return { k: 'starting', box: p.box };
+      }
+      return p;
+
+    case 'START_OK':
+      if (p.k !== 'starting') return p;
+      return { k: 'pin', box: p.box, expiresAt: e.now + Math.max(0, e.ttl) * 1000 };
+
+    case 'START_ERR':
+      // expiresAt 0: there is no live PIN, so the card must offer a new one
+      // rather than a text field that can only fail.
+      //
+      // shown:false is the load-bearing half (FINDING 2, HIGH). This is the
+      // pairStart-NEVER-SUCCEEDED path — the box dropped off Wi-Fi, or the 8s
+      // timeout fired — so nothing was ever displayed on the TV. Reporting
+      // "The PIN on <box> has expired" here states a PIN existed, alongside
+      // "Could not reach that box", which are contradictory claims about the
+      // same moment. The user goes looking at a TV showing nothing.
+      return p.k === 'starting'
+        ? { k: 'failed', box: p.box, msg: e.msg, expiresAt: 0, shown: false }
+        : p;
+
+    case 'UNSUPPORTED':
+      return p.k === 'starting' || p.k === 'found' ? { k: 'unsupported', box: p.box } : p;
+
+    case 'SUBMIT':
+      if (p.k === 'pin' || p.k === 'failed') {
+        return { k: 'pairing', box: p.box, expiresAt: p.expiresAt };
+      }
+      return p;
+
+    case 'PAIR_OK':
+      return p.k === 'pairing' ? { k: 'paired', box: p.box } : p;
+
+    case 'PAIR_ERR':
+      // Carry expiresAt: a wrong PIN (attempts 1-4) is retryable against the
+      // SAME pairing, so retry must need no re-scan and no new PIN.
+      return p.k === 'pairing'
+        ? { k: 'failed', box: p.box, msg: e.msg, expiresAt: e.dead ? 0 : p.expiresAt,
+           shown: true }
+        : p;
+
+    case 'BACK':
+      return p.k === 'pin' || p.k === 'failed' || p.k === 'unsupported'
+        ? { k: 'found', box: p.box }
+        : p;
+  }
+}
+
+/** Is a sweep loop supposed to be running in this phase? */
+export function isSearching(p: SetupPhase): boolean {
+  return p.k === 'looking';
+}
+
+/**
+ * May a sweep run, and may a sighting be acted on, from this phase?
+ *
+ * The same predicate gates the reducer's FOUND rule and the component's loop, on
+ * purpose: "the user has committed to a box" must mean one thing. False here is
+ * what stops a straggler sighting — from the sweep that was still draining when
+ * they tapped Pair now — from yanking the screen out from under a typed PIN.
+ */
+export function acceptsSighting(p: SetupPhase): boolean {
+  return SIGHTING_OK.includes(p.k);
+}
+
+// ---------------------------------------------------------------------------
+// The four steps
+// ---------------------------------------------------------------------------
+
+/** `todo` renders `·`, `active` renders `…`, `done` renders `✓`. */
+export type StepMark = 'todo' | 'active' | 'done';
+
+/**
+ * The four onboarding steps' marks for a phase — i.e. the literal meaning of
+ * "the card advances itself", as a function.
+ *
+ * Steps 1 and 2 happen on the user's PC and are UNVERIFIABLE from here, so they
+ * are never marked done on a guess: they go done only once a box has actually
+ * answered, which proves both. Step 3 ("watch this screen") is active only while
+ * a sweep loop is genuinely running — when the card gives up, or cannot sweep,
+ * it stops claiming to be watching.
+ */
+export function stepMarks(p: SetupPhase): [StepMark, StepMark, StepMark, StepMark] {
+  switch (p.k) {
+    case 'idle':
+      return ['active', 'todo', 'todo', 'todo'];
+    case 'looking':
+      return ['active', 'active', 'active', 'todo'];
+    case 'stalled':
+    case 'nonet':
+      return ['active', 'active', 'todo', 'todo'];
+    case 'found':
+    case 'starting':
+    case 'pin':
+    case 'pairing':
+    case 'failed':
+      return ['done', 'done', 'done', 'active'];
+    case 'unsupported':
+      return ['done', 'done', 'done', 'todo'];
+    case 'paired':
+      return ['done', 'done', 'done', 'done'];
+  }
+}

--- a/docs/memory/project_interactive-setup-card.md
+++ b/docs/memory/project_interactive-setup-card.md
@@ -1,0 +1,194 @@
+# Project — Interactive setup card
+
+Status: **SPEC / not built.** Written 2026-07-21.
+Motivation: measured funnel — ~9-15 distinct strangers downloaded the phone app in the first
+six days, and ~0 of them got an agent running on a box. Everything upstream of the install
+works; the drop-off is at "now go install a daemon on your gaming PC."
+See the maintainer-side metrics note for the baseline this is measured against.
+
+---
+
+## 1. What it is
+
+The no-box empty state stops being a paragraph of instructions and becomes a **live card that
+advances itself**. The user reads four short steps, walks to their PC, runs the installer —
+and the card on their phone changes on its own the moment the agent starts answering on the
+LAN, before they have typed anything. It ends by putting a PIN on the box's own TV, so the
+last mile needs no terminal, no token, and no typing on the box.
+
+The point is not decoration. It is **proof of progress**: the single hardest moment in the
+funnel is the user standing at their PC with no idea whether anything worked.
+
+---
+
+## 2. Why this is possible (mechanisms, all read from source)
+
+| Fact | Where | Consequence |
+|---|---|---|
+| `GET /api/ping` is pre-auth, returns `{ok, app, version, ip, host}` | `agent/couchsided.py:10375-10393` (gate at `:10399`) | The app can see a box and read its **hostname + version** with no token. |
+| `POST /api/pair/start` and `/api/pair/finish` are the only unauthenticated POSTs, **not** loopback-gated | `agent/couchsided.py:10686-10714` | Any phone on the LAN can start a pairing. This is the zero-terminal path. |
+| `/api/pair/start` pops the PIN **full-screen on the box's own TV** and returns only `{ok, ttl}` — never the PIN | `agent/couchsided.py:10022-10041`, `:10691-10700` | Physical-presence proof, Android-TV style. The secret never crosses the network. |
+| `GET /pair` and `/api/pair/status` are **loopback-only** (`/pair` also Host-header checked) | `agent/couchsided.py:10348-10373` | The phone can never read these. The asymmetry is the design — do not "fix" it. |
+| `PAIR_PIN_TTL = 120`, `MAX_ATTEMPTS = 5`, `START_DEBOUNCE = 3` | `agent/couchsided.py:9968-9973` | The card can and should show a real countdown. |
+| The agent **binds at the midpoint of `install.sh`** — ~850 more lines run afterwards | `install.sh:880-889`, QR at `:1708-1728` | **The box answers `/api/ping` well before the terminal finishes.** The card can say "found it" while the installer is still scrolling. |
+| The agent has **no** first-run / unpaired / paired flag anywhere | verified live vs 10.1.1.60 | Cannot ask the box "are you new?" — but see §3. |
+
+**The one that matters most:** the agent binds long before the installer prints its QR, so the
+card reaches "found your box" *while the user is still watching the terminal*. That is the
+moment worth engineering for.
+
+### The "is it new?" problem, solved phone-side
+
+The agent cannot say "I was just installed." It does not need to. **The card only ever runs
+when the local fleet is empty**, so any agent discovered in that state is new *to this phone* —
+which is the only sense that matters. No agent change, no new `/api/ping` field, no protocol
+bump. (Adding a field would be additive-only per CLAUDE.md §4 anyway, but it is not needed.)
+
+---
+
+## 3. Required code changes
+
+### 3a. `app/lib/boxDiscovery.ts` — incremental results (the only non-trivial change)
+
+Today `scanForBoxes()` awaits `Promise.all` over 64 workers and returns **only when the entire
+sweep drains** (`:227-235`). A box at `.5` is not reported until the last worker finishes —
+up to ~6 s of dead air with the answer already in hand. For a card whose whole value is
+immediacy, that is the bug.
+
+Add an **optional** callback, fired from the worker the instant `pingHost` returns non-null:
+
+```ts
+export type ScanOpts = {
+  timeoutMs?: number;
+  onFound?: (box: FoundBox) => void;   // NEW — called per hit, mid-sweep
+};
+```
+
+Additive. The existing return contract is unchanged, so `BoxScanPair.tsx:36` keeps working
+untouched. Constants that stay as they are: range `.1`-`.254`, `CONC = 64`, per-host timeout
+1500 ms (note: currently hardcoded at the call site and **not** reachable from `opts.timeoutMs`
+— leave that alone, it is out of scope).
+
+### 3b. `app/components/SetupProgress.tsx` — new component
+
+Follows the **discriminated-union phase machine** already used by `BoxScanPair.tsx:21-26` —
+that is the house pattern for a wizard, and the new card should be indistinguishable in style:
+
+```ts
+type Phase =
+  | { k: 'idle' }                                         // never scanned yet
+  | { k: 'looking'; since: number }                       // sweep in flight
+  | { k: 'found'; box: FoundBox }                         // /api/ping answered, fleet empty
+  | { k: 'pin'; box: FoundBox; ttl: number; expiresAt: number }
+  | { k: 'pairing'; box: FoundBox }
+  | { k: 'failed'; box: FoundBox; msg: string }           // agent's own error string
+  | { k: 'unsupported'; box: FoundBox }                   // Windows agent, no PIN flow
+  | { k: 'blocked' };                                     // iOS Local Network denied
+```
+
+Rules carried over from `BoxScanPair`: every async handler sets a terminal phase in **both**
+the ok and catch branches (never leave a spinner stuck), and there is always an explicit path
+back to `idle`.
+
+Styling: `useTheme()` + `useThemedStyles(makeStyles)` with a module-scope
+`const makeStyles = (t: Palette) => StyleSheet.create({...})` factory — the current pattern per
+CONVENTIONS.md:215-227. **Do not** write against the legacy static `theme` export. Reuse
+`setup.tsx`'s existing `card` / `emptyText` / `emptyLink` / `sectionLabel` styles
+(`:1539-1545`, `:1616-1631`, `:1802`) so the card sits in the screen rather than on it.
+
+Step rendering: reuse the existing `StepState` / `StepRow` idiom already in `setup.tsx` (the
+`· … ✓ ✗` mark + label + colored detail line used by the CONNECTION TEST card). It already
+exists, it already matches, and it needs no new dependency.
+
+**No Reanimated.** It is a dependency (`app/package.json:30`) but is imported in exactly three
+files, none of them under `app/components/`. Introducing it here buys a pulse animation and
+costs the entire animation-verification trap surface (§5). **State changes are the feedback.**
+
+### 3c. `app/app/(tabs)/setup.tsx` — swap the empty state
+
+Replace the `boxes.length === 0` branch at `:882-902` with `<SetupProgress />`. Keep the
+"Haven't installed the Couchside service? Setup guide" link **inside** the new card — it is the
+escape hatch for anyone who wants the full page, and its deep link is verified working.
+
+### 3d. Polling policy
+
+Poll only when **all** of: `boxes.length === 0`, the Setup tab is focused, and
+`AppState === 'active'`. Sweep, wait ~6 s, sweep again. Stop after 5 minutes of nothing and
+show a "Keep looking" button rather than burning battery forever. Cancel in flight on unmount.
+
+---
+
+## 4. The states, and what each one says
+
+1. **`idle` / `looking`** — the four steps, with step 1 marked running:
+   *1. On your PC, switch to Desktop Mode and open a terminal. 2. Open couchside.tv and run
+   the install command. 3. Watch this screen — it updates by itself. 4. A PIN appears on your
+   TV; type it here.* Plus a live "Looking for your box on the network…" line.
+2. **`found`** — *"Found **bazzite** at 10.1.1.60 · service v2.9.36"* and a single **Pair now**
+   button. This is the payoff moment and it can fire while the installer is still running.
+3. **`pin`** — fires `POST /api/pair/start`, which pops the PIN on the TV. Shows the 6-digit
+   input **and a countdown from the returned `ttl`**. Today the app requests `ttl` and throws
+   it away (`BoxScanPair.tsx:66-73` only checks `r.ok`), so an expired PIN is discovered only
+   on submit. The card should fix that: show the countdown, and offer "Show a new PIN" at zero.
+4. **`failed`** — surface the **agent's own** error string verbatim (`wrong PIN`,
+   `no active pairing — start it again from the app`, `too many wrong PINs — start again`),
+   exactly as `BoxScanPair.tsx:84-110` already does. Return to `pin` so retry needs no re-scan.
+5. **`unsupported`** — the Windows agent has **no PIN pairing at all** (Linux-only; grep of
+   `agent/win/couchsided-win.py` finds no `pair_pin`). Discriminate on the `version` string
+   from `/api/ping` (Windows builds carry a `-win` suffix) and route those users to the QR /
+   token path instead of a PIN input that would 404.
+6. **`blocked`** — **iOS Local Network permission denied.** The sweep then finds nothing,
+   forever, silently, and a card that says "still looking…" is actively lying. Needs its own
+   state with a "Open Settings" affordance. This is the highest-risk state to omit.
+
+---
+
+## 5. Verification plan (and the three ways the harness will lie)
+
+From CONVENTIONS.md §"Verifying app UI" — all three apply directly here:
+
+1. **`AppState` is mapped to document visibility in RN Web**, and the browser pane is
+   permanently `visibilityState: hidden`. A card gated on `AppState === 'active'` **will never
+   poll in the harness.** Required shim, harness-side only:
+   `Object.defineProperty(document,'visibilityState',{get:()=>'visible'})` then dispatch
+   `visibilitychange`. Without this the card looks dead and the bug is in the test rig.
+2. **`requestAnimationFrame` runs at 0 fps** there. Irrelevant if §3b's no-animation rule
+   holds — which is a second reason to hold it.
+3. **`localStorage` is per-origin AND per-browser.** Reseed after any port change.
+
+Also: RN Web `Pressable`s expose no a11y role, so `read_page`/`find` cannot reach them — drive
+taps by coordinate or by dispatching pointer events on the ancestor.
+
+**Observe both states.** A detector is unverified until it has been seen to fire *and* not
+fire. Concretely: the card must be watched finding a box **and** correctly staying in `looking`
+when none exists. One half is how a card shipped advertising a dead session for 27 minutes.
+
+**Harness gap, stated plainly:** the web harness's own IP is loopback, so an HTTP `/24` sweep
+has nothing real to find. Discovery timing and the `found` transition **cannot be proven in the
+harness** and must be exercised on a device against a real box (10.1.1.60 answers pre-auth
+today). Do not mark this feature complete on harness evidence alone.
+
+---
+
+## 6. What must not change
+
+- `/pair` and `/api/pair/status` stay **loopback-only**. The LAN-reachable route never reveals
+  a secret; the secret-revealing route is loopback-only. That asymmetry is the security model.
+- No new agent endpoint is required. No `/api/ping` field is required.
+- No client-supplied string may reach `subprocess`. `pair_show_on_box` builds its URL from
+  `self.port`, a server-side attribute — it must stay that way.
+- Response shapes are additive-only (CLAUDE.md §4).
+
+---
+
+## 7. Open questions
+
+- **Sweep cost.** 254 connection attempts every ~6 s, repeatedly. Battery impact unmeasured;
+  may also look like port-scanning to a router/IDS. Consider backing off after the first
+  minute, or sweeping a narrower range first (`.1-.60` covers most DHCP pools).
+- **Time-to-listening is inferred, not measured** — ~10-25 s from pressing enter, dominated by
+  human prompts (sudo password, plus an interactive screensaver y/N that blocks *before* any
+  download, `install.sh:456-459`) and ~630 KB of downloads, not by compute. Worth timing once
+  for real before promising "watch this screen" in copy.
+- Whether the four steps should also appear on couchside.tv, so the phone and the web page
+  tell the same story.


### PR DESCRIPTION
**Measured funnel:** ~9–15 strangers downloaded the app in the first six days after launch; **~0 got an agent paired.** Until now a new user got the Setup tab forced, a paragraph of text, and two links to a website. The app's own comment named it: *"the app is useless without the box-side agent, and a store download gives no hint one exists."*

Now the no-box state is four steps that **advance on their own**. The user walks to their PC, runs the installer, and the card changes by itself the moment the agent answers on the LAN — then pops a PIN on the box's TV. No terminal, no token, no typing on the box.

The moment being engineered for is measured: **the agent binds at the midpoint of `install.sh`, ~850 lines before the terminal prints its QR** — so "found your box" can land *while the installer is still scrolling*. That's where the funnel dies.

App-only. No agent change, no new endpoint, no protocol bump. The security asymmetry is used as designed and untouched: `/api/ping` + `/api/pair/start` unauthenticated and LAN-reachable, `/pair` + `/api/pair/status` loopback-only — the phone triggers a PIN it can never read.

## Two spec corrections, verified from source

- **The Windows agent DOES have PIN pairing now** (`0.4.3-win`, routes wired). The spec's "none at all" expired. It's a two-track version floor, not a `-win` sniff — a naive compare of `0.4.3-win` against `2.9.12` marks *every* Windows box unsupported, the exact bug that state exists to prevent.
- **There is no `blocked` state, because iOS Local Network denial cannot be detected.** SDK 57's expo-network exposes no such API, and RN's fetch collapses denial/timeout/dead-host into one identical `TypeError`. So the card gives a differential diagnosis rather than claiming to know. Ordering is a test: **cellular is checked before the LAN check**, because a real cellular IP is usually CGNAT which `isValidLanIp` accepts — reversed, a phone on mobile data would sweep the carrier's /24.

## Two HIGH findings from adversarial review — fixed, pinned by tests

1. **The countdown kept running after the agent destroyed the pairing.** Both agents null `PAIR_PIN` before raising "no active pairing" / "too many wrong PINs", so the card advertised a live PIN on the user's TV for up to two more minutes, `PAIR` enabled, every press doomed. The flagship scenario hits it — the installer restarting the agent mid-pair.
2. **"The PIN has expired" printed when no PIN was ever shown** — the pairStart-never-succeeded path — rendered beside "Could not reach that box". Two contradictory claims about the same moment, sending the user to look at a blank screen.

**Mutation-checked:** reverting either fix fails exactly 2 tests. 125/125 app tests, `tsc` clean.

Also: `boxDiscovery` gains an additive `onFound` so a hit reports the instant `pingHost` answers instead of after the sweep drains (~8.5s of dead air with the answer in hand). Dedupe is centralised because `broadcastTargets` hits directed *and* global broadcast, so a box genuinely answers twice.

## Verified in the harness

With the AppState shim (**test-rig only** — RN Web maps AppState to document visibility and the pane is permanently `hidden`, so the card would never poll and would look dead): renders in the empty state, all four steps, step 1 running, the setup-guide escape hatch preserved inside the card, existing pairing options still below, a11y labels on every control, TRY AGAIN pressable.

Observed honest negative: with no LAN address the card says *"This phone has no local-network address, so there is no network to search."* rather than claiming to still be looking.

## NOT VERIFIED — and it is the feature's entire claim

**The `looking → found` transition, its timing, the PIN flow and the pairing handoff have never run.** The harness's own IP is loopback so a `/24` sweep has nothing to find, and stubbing the IP source didn't take because `selfIp()` had already resolved. **This needs a device against a real box before it can be called done.**

Also unobserved: the negative half of the AppState gate (background → sweeping stops), and the cellular verdict's effect on iOS Personal Hotspot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)