### PR TITLE
fix(pad): stop rendering PASTE/DONE where the iOS keyboard covers them

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -649,10 +649,23 @@ function KeyboardBar({ autoOpenSignal, onText, onBackspace, onEnter, onSwipeMode
           {!open && <Text style={styles.kbSwipeCue}>›</Text>}
         </Pressable>
         {!open && onSearch && searchSide === 'right' && searchBtn}
-        {open && (
+        {open && Platform.OS !== 'ios' && (
           <>
-            {/* Android has no InputAccessoryView, so PASTE has to live here too
-                or half the users never get it. */}
+            {/* ANDROID ONLY. Android has no InputAccessoryView, so PASTE has to
+                live here or half the users never get it.
+                
+                On iOS these are DUPLICATES of the InputAccessoryView below, and
+                rendering them here actively hurt: this row sits in normal
+                layout flow with no keyboard lift, so the raised keyboard covered
+                it — reported from a device as "the keyboard covers up the paste
+                button and something else I can't see". The user saw two pills
+                sliced in half at the bottom of the screen and had no way to
+                reach them, while the working PASTE/DONE sat on the accessory bar
+                they could not see past the keyboard.
+                
+                iOS keeps its accessory (pinned to the keyboard's top edge, which
+                is the whole reason it exists); Android keeps this row. Neither
+                platform now renders a control it cannot reach. */}
             <Pressable
               onPress={pasteFromClipboard}
               hitSlop={8}


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE YET** — one specific thing is unverified and it can make this worse than the bug. See the bottom.

Reported from a device: *"keyboard covers up the paste button and something else I can't see in iOS."* The screenshot shows two pills sliced in half at the bottom edge, unreachable behind the keyboard.

## Cause

PASTE/DONE render **twice** on iOS:

1. the in-layout `kbBarRow` — sits in **normal layout flow with no keyboard lift**, so the raised keyboard covers it
2. an `InputAccessoryView` — which exists *precisely because* the in-layout bar gets covered (its own comment says so)

The in-layout copies are there for **Android**, which has no `InputAccessoryView`. So on iOS they were duplicates whose only effect was to look broken.

Now Android-only. iOS keeps the accessory pinned to the keyboard's top edge; Android keeps the row. Neither platform renders a control it cannot reach.

## NOT VERIFIED — and it's the thing that matters

**I could not confirm the `InputAccessoryView` actually renders.** CoreSimulator died (`Connection refused`) mid-check.

The reporter's screenshot doesn't show an accessory bar above the keyboard either, which fits **two** explanations:
- it renders, and the absolutely-positioned compose field (`bottom: 10 + kbLift`) is drawn **over** it — the field is lifted to exactly where the accessory sits
- it doesn't render at all

**If it doesn't render, this change removes the last reachable PASTE on iOS** — strictly worse than the bug being fixed.

**The 5-second check that settles it:** open the app, tap the keyboard bar on the Pad tab, and look at the strip directly above the keyboard. If a `PASTE` / `DONE` bar is there, this is correct and safe to merge. If it isn't, the fix is different — the accessory needs repairing first, or the in-layout row needs lifting instead of removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)