### PR TITLE
fix(session): our autologin drop-in must outrank the platform's own

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -40,6 +40,15 @@ The Couchside Player arrives — an optional, experimental add-on.
   A box that never asks for it is unchanged, and the app hides the whole feature
   on any box without it.
 
+Also in this release:
+
+- **"Boots into" no longer quietly reverts.** SteamOS and Bazzite both ship a
+  script that writes the same login setting Couchside was writing — and its file
+  took priority over ours, so anything that ran it (switching to Desktop from the
+  phone, or Couch Mode) put the setting back without telling you. Ours now takes
+  priority and survives. Setting it still never disturbs the session you are in;
+  it applies at the next boot.
+
 ## 2.9.63
 
 A boot-session fix for Bazzite, and early groundwork for other kinds of box.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3617,7 +3617,27 @@ def _installed_session_files():
 
 # Closed set. A client selects one of these; it never reaches a command line.
 SESSION_DEFAULT_MODES = ("game", "desktop", "last")
-SDDM_DROPIN = "/etc/sddm.conf.d/zz-couchside-session.conf"
+# Our SDDM autologin drop-in.
+#
+# THE NAME IS LOAD-BEARING, and it is why this is "zzz" and not "zz".
+# SDDM reads /etc/sddm.conf.d/*.conf in ALPHABETICAL order and the last file
+# wins. SteamOS and Bazzite both ship `steamos-session-select`, which writes its
+# own autologin drop-in at zz-steamos-autologin.conf -- and "zz-couchside"
+# sorts BEFORE "zz-steamos", so our setting was silently overridden by theirs.
+# Worse, that script runs on every Couch Mode switch and every switch-to-desktop
+# action, so it rewrote the winning file routinely and the user's "Boots into"
+# choice quietly stopped applying. MEASURED 2026-07-27 on a real box: our file
+# and theirs both present, theirs last, effective session theirs.
+#
+# We do NOT call steamos-session-select to set this instead: it ends with an
+# unconditional `systemctl restart sddm` (verified by running it), which kills
+# the user's current session. A preference about the NEXT boot must never log
+# somebody out of the session they are in.
+SDDM_DROPIN = "/etc/sddm.conf.d/zzz-couchside-session.conf"
+# The pre-2.9.64 name. Still written -- as an inert comment -- so a box that
+# updates does not keep an old [Autologin] stanza competing with the new file.
+# Kept as a constant rather than deleted so the migration is explicit.
+SDDM_DROPIN_LEGACY = "/etc/sddm.conf.d/zz-couchside-session.conf"
 GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"
 SDDM_STATE = "/var/lib/sddm/state.conf"
 
@@ -3641,7 +3661,8 @@ def _steamosctl_session_ok():
 
 def _sddm_session_ok():
     """True when sudoers really lets us write our own sddm drop-in."""
-    return _sudo_nopasswd_allows(SDDM_DROPIN)
+    return (_sudo_nopasswd_allows(SDDM_DROPIN)
+            or _sudo_nopasswd_allows(SDDM_DROPIN_LEGACY))
 
 
 # ---------------------------------------------------------------------------
@@ -3901,7 +3922,7 @@ def _sddm_current_session_file():
     Reads OUR drop-in first (it sorts last, so it wins), then falls back to
     SDDM's recorded last session. Returns "" when neither is readable —
     degrading to "unknown" rather than claiming a mode we did not verify."""
-    for path in (SDDM_DROPIN, SDDM_STATE):
+    for path in (SDDM_DROPIN, SDDM_DROPIN_LEGACY, SDDM_STATE):
         try:
             with open(path, "r", encoding="utf-8", errors="replace") as f:
                 for line in f:
@@ -3968,9 +3989,33 @@ def _sddm_write(session_file):
     try:
         r = subprocess.run(["sudo", "-n", "tee", SDDM_DROPIN],
                            input=body, capture_output=True, text=True, timeout=8)
-        return r.returncode == 0
+        ok = r.returncode == 0
     except Exception:
         return False
+    if ok:
+        _sddm_neutralise_legacy()
+    return ok
+
+
+def _sddm_neutralise_legacy():
+    """Blank the pre-2.9.64 drop-in so it cannot compete with the new one.
+
+    Overwritten with a comment rather than deleted: the sudoers grant permits
+    `tee` at that exact path and nothing else, so writing is the only tool we
+    have there, and an empty file contributes no [Autologin] stanza. Silent and
+    best-effort -- a box whose grant predates this simply keeps a stale file
+    that now sorts BEFORE the new one and therefore loses, which is the
+    behaviour we want anyway."""
+    if not os.path.exists(SDDM_DROPIN_LEGACY):
+        return
+    body = ("# Superseded by zzz-couchside-session.conf (Couchside >= 2.9.64).\n"
+            "# Left blank deliberately: this name sorted BEFORE the display\n"
+            "# manager's own drop-in and so could never win. Safe to delete.\n")
+    try:
+        subprocess.run(["sudo", "-n", "tee", SDDM_DROPIN_LEGACY],
+                       input=body, capture_output=True, text=True, timeout=8)
+    except Exception:
+        pass
 
 
 def session_default_set(mode):

--- a/install.sh
+++ b/install.sh
@@ -919,6 +919,18 @@ $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm
 # phone only ever selects a mode from a closed set. Our own drop-in sorts after
 # the distro's steamos.conf, so removing this one file restores the box's
 # original boot behaviour exactly, with nothing of theirs edited.
+# Boot session default. TWO fixed paths, and the pair is deliberate.
+#
+# zzz- is the live one: SDDM reads /etc/sddm.conf.d/*.conf alphabetically and
+# the LAST file wins, and steamos-session-select (both SteamOS and Bazzite)
+# owns zz-steamos-autologin.conf -- so "zz-couchside" sorted BEFORE it and was
+# silently overridden every time that script ran, which is on every Couch Mode
+# switch. zzz- sorts after it and therefore actually applies.
+#
+# The old zz- path stays granted so an updating box can BLANK its stale file;
+# without the grant that orphaned [Autologin] stanza would linger forever.
+# Each grant is one exact path -- never a directory, never a glob.
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/sddm.conf.d/zzz-couchside-session.conf
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/sddm.conf.d/zz-couchside-session.conf
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -136,6 +136,64 @@ def test_autologin_session_must_exist():
         cs._default_desktop_session = saved_cfg
 
 
+
+def test_dropin_outranks_the_platforms_own():
+    """Our drop-in must WIN against steamos-session-select's (2026-07-27).
+
+    SDDM reads /etc/sddm.conf.d/*.conf alphabetically and the LAST file wins.
+    Both SteamOS and Bazzite ship `steamos-session-select`, which writes its own
+    autologin drop-in at zz-steamos-autologin.conf. Our old name, zz-couchside-
+    session.conf, sorts BEFORE that ("c" < "s") — so the platform's file won and
+    the user's "Boots into" choice silently stopped applying. That script runs
+    on every Couch Mode switch and every switch-to-desktop action, so it rewrote
+    the winning file routinely. MEASURED on a real box: both files present,
+    theirs last, effective session theirs.
+
+    We do NOT call steamos-session-select instead: it ends with an unconditional
+    `systemctl restart sddm` (verified by running it), which kills the user's
+    current session. A preference about the NEXT boot must never log somebody
+    out of the one they are in.
+
+    This test is a sort comparison because that is literally the mechanism.
+    """
+    print("test_dropin_outranks_the_platforms_own")
+    ours = os.path.basename(cs.SDDM_DROPIN)
+    theirs = "zz-steamos-autologin.conf"
+    check("our drop-in sorts AFTER steamos-session-select's", ours > theirs, True)
+    # CONTROL: the old name genuinely lost — proving the test can fail, and
+    # documenting the bug rather than just asserting the fix.
+    legacy = os.path.basename(cs.SDDM_DROPIN_LEGACY)
+    check("...and the OLD name genuinely lost", legacy > theirs, False)
+    # Both still beat the distro's base config, which is what we always relied on.
+    for base in ("steamos.conf", "steamdeck.conf", "virtualkbd.conf"):
+        check("beats %s" % base, ours > base, True)
+    # The live path must not be the legacy path.
+    check("live path differs from legacy", cs.SDDM_DROPIN != cs.SDDM_DROPIN_LEGACY, True)
+    # Reading the current session must still consult the legacy file, so a box
+    # that has not re-run install.sh is reported correctly. Asserted by actually
+    # reading one, not by inspecting a docstring.
+    import tempfile
+    tmp = tempfile.mkdtemp()
+    live, legacy_p = os.path.join(tmp, "zzz.conf"), os.path.join(tmp, "zz.conf")
+    saved = (cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY, cs.SDDM_STATE)
+    try:
+        cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY = live, legacy_p
+        cs.SDDM_STATE = os.path.join(tmp, "missing.conf")
+        with open(legacy_p, "w") as f:
+            f.write("[Autologin]\nSession=plasma.desktop\n")
+        check("a legacy-only box still reports its session",
+              cs._sddm_current_session_file(), "plasma.desktop")
+        # ...and the live file WINS when both exist.
+        with open(live, "w") as f:
+            f.write("[Autologin]\nSession=gamescope-session.desktop\n")
+        check("the live drop-in wins over the legacy one",
+              cs._sddm_current_session_file(), "gamescope-session.desktop")
+    finally:
+        cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY, cs.SDDM_STATE = saved
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
 def main():
     real_run = cs.subprocess.run
     real_sudo = cs._sudo_nopasswd_allows
@@ -181,6 +239,7 @@ def main():
     check("set() reports failure", cs.session_default_set("game")["ok"], False)
 
     test_autologin_session_must_exist()
+    test_dropin_outranks_the_platforms_own()
 
     print("the sddm drop-in body")
     # We must NEVER edit the box's own steamos.conf; we write our own file.


### PR DESCRIPTION
**"Boots into" was being silently reverted.**

SDDM reads `/etc/sddm.conf.d/*.conf` alphabetically and the **last file wins**. Both SteamOS and Bazzite ship `steamos-session-select`, which writes its own autologin drop-in at `zz-steamos-autologin.conf` — and ours was `zz-couchside-session.conf`, which sorts **before** it (`c` < `s`). So theirs won.

That script runs on **every Couch Mode switch and every switch-to-desktop action**, so it rewrote the winning file routinely and the user's choice quietly stopped applying. Measured on a real box: both files present, theirs last, effective session theirs.

Ours is now `zzz-couchside-session.conf`.

## Why not just call the platform's tool

Tempting, and it's what the deprecation notice gestures at — but `steamos-session-select` ends with an unconditional `systemctl restart sddm`. **Verified by running it**; the box printed *"Restarted SDDM"*. A preference about the **next** boot must never log somebody out of the session they're in.

## The migration trap

The sudoers grant names **one exact path**, so a new agent with an old grant couldn't write the new file. Handled: `install.sh` grants **both** paths, the agent blanks the legacy file to a comment after a successful write (so no orphaned `[Autologin]` stanza lingers), and reading the current mode consults both — a box that hasn't re-run install.sh still reports correctly.

## Credit where due

Prompted by an r/SteamOS commenter noting `steamos-session-select` is deprecated in favour of `steamosctl`. **Verified verbatim on a Legion Go S, SteamOS 3.8.16:**

```
# This script is now deprecated, please use steamosctl.
```

They were right — and our code already prefers `steamosctl`. Measured live on that box: backend resolves to `steamosctl`, mode reads back `game`. Chasing their point is what surfaced the precedence bug, which is the bigger one.

## Noted, not fixed here

SteamOS names its gamescope session `gamescope-wayland.desktop`, while `GAMESCOPE_SESSION_FILE` hardcodes `gamescope-session.desktop`. **Latent only** — SteamOS takes the steamosctl path, and KI-038's guard would refuse rather than strand a box if it ever fell back. Same hardcoded-filename class as KI-038; worth probing later.

## Verified

Session-default suite green, including a new test asserting the sort order **and** that the old name genuinely lost (so the test can fail), plus real file reads proving legacy-only boxes still report and the live file wins when both exist. DM/greetd and Decky guard suites still green. Live read-only check on SteamOS. `bash -n` clean.

Agent → **2.9.64**; changelog folded into the existing section rather than opening a duplicate heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)