### PR TITLE
fix(session): detect the display manager, and offer Couch Mode by capability — plasmalogin support, fail-closed backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,14 @@ jobs:
       - name: Unit tests (display manager + greetd)
         run: python3 tests/test_display_manager.py
 
+      # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
+      # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
+      # sessions and a connected panel was refused by its NAME — hiding the
+      # toggle, the desktop cluster and the guide hold together. Now it probes
+      # the tools plus both switch targets; these pin both directions.
+      - name: Unit tests (couch mode gate)
+        run: python3 tests/test_couchmode_gate.py
+
       # Flatpak update completion (KI-036). "Done" must be the update PROCESS
       # finishing, not `remote-ls` count reaching zero — an EOL runtime pins the
       # count above zero forever, which stranded the card on "Updating…" and

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,32 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.66
+
+Machines that aren't SteamOS or Bazzite get features they should have had all
+along, and one setting stops pretending to work.
+
+- **"Boots into" works on newer KDE login screens.** KDE is moving from SDDM to
+  plasmalogin, and CachyOS handheld images already ship it. On those boxes the
+  card appeared, said "unknown", and quietly did nothing — every change was
+  written to a folder the machine does not have. It now finds the login manager
+  your box actually runs and writes where that manager reads, so the setting
+  takes effect on the next boot.
+
+- **"Restart session" aims at the right service.** The fix-a-black-screen button
+  was hardcoded to SDDM. On a box running something else it either failed or,
+  worse, could have started a second login manager on top of your live session.
+
+- **Couch Mode, the desktop controls and the controller shortcut show up on more
+  machines.** They were offered based on the name in your box's OS file, so a
+  CachyOS or ChimeraOS machine carrying exactly the same session tooling as a
+  Steam Deck was refused for its name alone. Couchside now checks whether the
+  box can actually make the switch.
+
+- **A box whose login manager can't be identified hides the boot setting**
+  instead of showing one that silently does nothing. A missing control is
+  better than one that lies.
+
 ## 2.9.65
 
 Three fixes, all found by testing against real boxes rather than reading code.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3566,16 +3566,37 @@ def couchmode_info():
     }
 
 
-def desktop_available():
-    """True on a Couch-Mode-capable box currently in the DESKTOP session —
-    gates the app's desktop-nav cluster (Start menu / pointer / overview), which
-    only makes sense in the desktop, not in Game Mode. Session-aware so the
-    buttons appear when you're on the desktop and hide once you fling to Game
-    Mode. The keys themselves ride the existing /ws/gamepad uinput keyboard.
+def _desktop_session_installed():
+    """True when this box has a real desktop session to drive, any DE.
 
-    Shares couchmode's platform predicate rather than the old distro-name grep,
-    so the same box that can fling to the TV can also drive its desktop."""
-    return _couchmode_platform_ok() and _couchmode_session() == "desktop"
+    Deliberately NOT _couchmode_platform_ok() and NOT _DESKTOP_SESSIONS: that
+    table lists the PLASMA sessions the autologin writer may name, and Couch
+    Mode's predicate additionally demands a Game Mode target. Neither describes
+    what the desktop cluster needs, and gating on them cost real function — a
+    Bazzite GNOME image (gnome.desktop, no plasma*.desktop) would have lost the
+    trackpad surface toggle, the nav cluster and the file-drop "Show on box",
+    while `inGameMode = !hasDesktop` in the app flipped ON a Steam-menus
+    segment whose steam:// links do nothing outside Game Mode. The cluster
+    itself is DE-agnostic: Meta opens Activities as readily as the Plasma
+    launcher, and the pointer keys are uinput.
+
+    Degrades CLOSED, unlike the couchmode probe: an empty enumeration here
+    means a headless box (no session dirs at all — an HTPC, a Proxmox guest,
+    the "any systemd machine" the README sells), and there the cluster would be
+    a whole panel of dead controls. couchmode can afford the opposite default
+    because its four-tool requirement still gates; this has no second gate."""
+    return any(not name.startswith("gamescope-session")
+               for name in _installed_session_files())
+
+
+def desktop_available():
+    """True on a box with a desktop session, currently IN it — gates the app's
+    desktop-nav cluster (Start menu / pointer / overview) and the file-drop
+    reveal, which only make sense on the desktop, not in Game Mode.
+    Session-aware so the buttons appear when you're on the desktop and hide
+    once you fling to Game Mode. The keys themselves ride the existing
+    /ws/gamepad uinput keyboard."""
+    return _desktop_session_installed() and _couchmode_session() == "desktop"
 
 
 def _couch_run(cmd, timeout=25, max_out=1500):

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.65"
+VERSION = "2.9.66"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -723,6 +723,62 @@ def _inject_session_actions():
             ACTIONS[aid] = spec
             if aid not in ACTION_ORDER:
                 ACTION_ORDER.append(aid)
+
+
+def _is_stock_restart_session_cmd(cmd):
+    """True for the installer/DEFAULT_ACTIONS shape of the restart-session
+    argv: `sudo systemctl restart <conf-dir manager>`. Every config through
+    agent 2.9.65 wrote the sddm spelling; newer installers write the detected
+    manager. Both are "stock" — anything else is owner-customised and never
+    touched. Membership in _DM_CONF_DIRS keeps this a frozen-set comparison,
+    not a pattern."""
+    return (isinstance(cmd, list) and len(cmd) == 4
+            and cmd[:3] == ["sudo", "systemctl", "restart"]
+            and cmd[3] in _DM_CONF_DIRS)
+
+
+def _retarget_restart_session(mock):
+    """Aim the restart-session action at the display manager ACTUALLY enabled.
+
+    The stock action hardcodes `systemctl restart sddm`. On a plasmalogin box
+    that unit either does not exist — the signature fix-a-black-screen button
+    fails — or, worse, the sddm PACKAGE is installed while plasmalogin is the
+    enabled manager, and the button would START a second display manager over
+    the live session. Detection reuses the same display-manager.service
+    symlink the boot-session feature reads (VERIFIED on CachyOS hardware
+    2026-07-30: plasmalogin.service enabled, no sddm unit anywhere).
+
+    Degrades closed (§3.7): when the manager cannot be identified, or sudoers
+    has no NOPASSWD grant for restarting the one that was detected, the stock
+    action is REMOVED — a dead rescue button on the screen people reach for
+    when the TV is black costs more trust than a missing one. Only the
+    untouched stock argv is ever rewritten or removed; an owner-customised
+    command is not ours to second-guess. Idempotent, called after
+    load_config."""
+    global WATCHLIST, WATCHLIST_NAMES
+    if mock:
+        return  # --mock keeps the stock action so the app is exercisable
+    act = ACTIONS.get("restart-session")
+    if not act or not _is_stock_restart_session_cmd(act.get("cmd")):
+        return
+    dm = detect_display_manager()
+    if dm and _sudo_nopasswd_allows("systemctl restart %s" % dm):
+        if act["cmd"][3] != dm:
+            # Copy before editing: ACTIONS shallow-copies DEFAULT_ACTIONS, so
+            # editing `act` in place would silently rewrite the shipped spec.
+            act = dict(act)
+            act["cmd"] = ["sudo", "systemctl", "restart", dm]
+            act["description"] = ("Restart the display session (%s), fixes a "
+                                  "wedged/black screen" % dm)
+            ACTIONS["restart-session"] = act
+            stale = {"%s.service" % k for k in _DM_CONF_DIRS if k != dm}
+            WATCHLIST = [(("%s.service" % dm) if n in stale else n, s)
+                         for n, s in WATCHLIST]
+            WATCHLIST_NAMES = {name for name, _scope in WATCHLIST}
+        return
+    ACTIONS.pop("restart-session", None)
+    if "restart-session" in ACTION_ORDER:
+        ACTION_ORDER.remove("restart-session")
 
 
 def _nopasswd_last_match(rules_text, needle):
@@ -3726,29 +3782,57 @@ def _installed_session_files():
 
 # Closed set. A client selects one of these; it never reaches a command line.
 SESSION_DEFAULT_MODES = ("game", "desktop", "last")
-# Our SDDM autologin drop-in.
+
+# The conf-dir display managers we can write a boot session for: SDDM, and
+# plasmalogin — KDE's SDDM successor (CachyOS deckify ships it today; Bazzite
+# will follow as Plasma migrates). plasmalogin keeps SDDM's config scheme — a
+# drop-in dir whose *.conf files are read ALPHABETICALLY, last wins — so the
+# two share one reader and one writer. VERIFIED on a real CachyOS box
+# 2026-07-30: display-manager.service -> plasmalogin.service, /etc/sddm.conf.d
+# ABSENT, /etc/plasmalogin.conf.d holding the distro's own
+# zz-steamos-autologin.conf.
+#
+# A frozen dict, never a pattern (§3.3): extending it means adding a conf dir
+# we have VERIFIED that manager actually reads.
+_DM_CONF_DIRS = {
+    "sddm": "/etc/sddm.conf.d",
+    "plasmalogin": "/etc/plasmalogin.conf.d",
+}
+
+
+# Our autologin drop-in, inside the DETECTED manager's conf dir.
 #
 # THE NAME IS LOAD-BEARING, and it is why this is "zzz" and not "zz".
-# SDDM reads /etc/sddm.conf.d/*.conf in ALPHABETICAL order and the last file
-# wins. SteamOS and Bazzite both ship `steamos-session-select`, which writes its
-# own autologin drop-in at zz-steamos-autologin.conf -- and "zz-couchside"
-# sorts BEFORE "zz-steamos", so our setting was silently overridden by theirs.
-# Worse, that script runs on every Couch Mode switch and every switch-to-desktop
-# action, so it rewrote the winning file routinely and the user's "Boots into"
-# choice quietly stopped applying. MEASURED 2026-07-27 on a real box: our file
-# and theirs both present, theirs last, effective session theirs.
+# SDDM and plasmalogin read <confdir>/*.conf in ALPHABETICAL order and the last
+# file wins. SteamOS, Bazzite and CachyOS all ship `steamos-session-select`,
+# which writes its own autologin drop-in at zz-steamos-autologin.conf -- and
+# "zz-couchside" sorts BEFORE "zz-steamos", so our setting was silently
+# overridden by theirs. Worse, that script runs on every Couch Mode switch and
+# every switch-to-desktop action, so it rewrote the winning file routinely and
+# the user's "Boots into" choice quietly stopped applying. MEASURED 2026-07-27
+# on a real box: our file and theirs both present, theirs last, effective
+# session theirs.
 #
 # We do NOT call steamos-session-select to set this instead: it ends with an
-# unconditional `systemctl restart sddm` (verified by running it), which kills
-# the user's current session. A preference about the NEXT boot must never log
-# somebody out of the session they are in.
-SDDM_DROPIN = "/etc/sddm.conf.d/zzz-couchside-session.conf"
-# The pre-2.9.64 name. Still written -- as an inert comment -- so a box that
-# updates does not keep an old [Autologin] stanza competing with the new file.
-# Kept as a constant rather than deleted so the migration is explicit.
-SDDM_DROPIN_LEGACY = "/etc/sddm.conf.d/zz-couchside-session.conf"
+# unconditional restart of the display manager (verified by running it), which
+# kills the user's current session. A preference about the NEXT boot must never
+# log somebody out of the session they are in.
+def _dm_dropin(dm):
+    """OUR autologin drop-in path for `dm`, or "" for a DM with no conf dir."""
+    d = _DM_CONF_DIRS.get(dm)
+    return d + "/zzz-couchside-session.conf" if d else ""
+
+
+def _dm_dropin_legacy(dm):
+    """The pre-2.9.64 drop-in name. Still written -- as an inert comment -- so
+    a box that updates does not keep an old [Autologin] stanza competing with
+    the new file. Only SDDM boxes ever had one, but deriving it per-DM is
+    harmless: the neutraliser skips a file that does not exist."""
+    d = _DM_CONF_DIRS.get(dm)
+    return d + "/zz-couchside-session.conf" if d else ""
+
+
 GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"
-SDDM_STATE = "/var/lib/sddm/state.conf"
 
 
 def _steamosctl_session_ok():
@@ -3768,10 +3852,21 @@ def _steamosctl_session_ok():
     return out.split()[0] in ("game", "desktop")
 
 
-def _sddm_session_ok():
-    """True when sudoers really lets us write our own sddm drop-in."""
-    return (_sudo_nopasswd_allows(SDDM_DROPIN)
-            or _sudo_nopasswd_allows(SDDM_DROPIN_LEGACY))
+def _dm_session_ok(dm):
+    """True when sudoers really lets us write the DETECTED manager's drop-in.
+
+    The grant is per-path, so it only proves anything about the manager whose
+    conf dir it names. install.sh (through agent 2.9.65) wrote the SDDM grant
+    UNCONDITIONALLY, and the old probe treated that grant as proof SDDM was in
+    charge — so a plasmalogin box advertised backend "sddm" and wrote into
+    /etc/sddm.conf.d, a directory that box does not even have (VERIFIED on
+    CachyOS hardware 2026-07-30). The caller must pass the manager it actually
+    detected; this function never guesses one."""
+    dropin = _dm_dropin(dm)
+    if not dropin:
+        return False
+    return (_sudo_nopasswd_allows(dropin)
+            or _sudo_nopasswd_allows(_dm_dropin_legacy(dm)))
 
 
 # ---------------------------------------------------------------------------
@@ -3806,8 +3901,9 @@ DISPLAY_MANAGER_UNIT = "/etc/systemd/system/display-manager.service"
 
 # Display managers we can READ or WRITE a boot session for. The value is the
 # short name used throughout; extending this set means adding a real writer,
-# never a pattern match.
-_KNOWN_DMS = ("sddm", "greetd", "gdm", "lightdm")
+# never a pattern match. plasmalogin is KDE's SDDM successor and shares the
+# SDDM writer via _DM_CONF_DIRS.
+_KNOWN_DMS = ("sddm", "plasmalogin", "greetd", "gdm", "lightdm")
 
 
 def detect_display_manager():
@@ -4002,8 +4098,9 @@ def _greetd_write(session_file):
 
 
 def session_default_backend():
-    """"steamosctl" | "sddm" | None. steamosctl first: on a real Deck it is the
-    supported path and keeps Valve's own state consistent."""
+    """"steamosctl" | "sddm" | "plasmalogin" | "greetd" | None. steamosctl
+    first: on a real Deck it is the supported path and keeps Valve's own state
+    consistent."""
     if _steamosctl_session_ok():
         return "steamosctl"
     # Pick the backend that matches the DM this box ACTUALLY runs, rather than
@@ -4013,34 +4110,69 @@ def session_default_backend():
     dm = detect_display_manager()
     if dm == "greetd":
         return "greetd" if _greetd_session_ok() else None
-    if dm == "sddm" or dm is None:
-        # dm is None on a box we cannot identify; SDDM stays the fallback there
-        # because it is what shipped and its writer refuses on its own if the
-        # grant or the session file is missing.
-        return "sddm" if _sddm_session_ok() else None
-    return None  # gdm / lightdm: detected, but no writer yet — honest absence
+    if dm in _DM_CONF_DIRS:
+        return dm if _dm_session_ok(dm) else None
+    # dm is None (unreadable symlink, or a manager with no writer here —
+    # plasmalogin was exactly that until 2026-07-30). The old code fell back to
+    # "sddm, if the sudoers grant exists" — but install.sh wrote that grant
+    # unconditionally, so a plasmalogin box advertised a working sddm backend
+    # aimed at a directory that did not exist: the card rendered and every
+    # write was a silent no-op (VERIFIED on CachyOS hardware). A box whose
+    # boot path we cannot identify gets NO capability (§3.7); gdm/lightdm are
+    # detected but have no writer yet — the same honest absence.
+    return None
 
 
 def session_default_available():
     return session_default_backend() is not None
 
 
-def _sddm_current_session_file():
-    """The session file SDDM will actually use, best-effort.
+def _last_session_line(path, found=""):
+    """Last `Session=` value in `path` (same line-scan the old reader used —
+    the key only occurs under [Autologin] in practice), or `found` unchanged
+    when the file is unreadable or names none."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                line = line.strip()
+                if line.lower().startswith("session="):
+                    found = os.path.basename(line.split("=", 1)[1].strip())
+    except OSError:
+        pass
+    return found
 
-    Reads OUR drop-in first (it sorts last, so it wins), then falls back to
-    SDDM's recorded last session. Returns "" when neither is readable —
-    degrading to "unknown" rather than claiming a mode we did not verify."""
-    for path in (SDDM_DROPIN, SDDM_DROPIN_LEGACY, SDDM_STATE):
-        try:
-            with open(path, "r", encoding="utf-8", errors="replace") as f:
-                for line in f:
-                    line = line.strip()
-                    if line.lower().startswith("session="):
-                        return os.path.basename(line.split("=", 1)[1].strip())
-        except OSError:
-            continue
-    return ""
+
+def _dm_current_session_file(dm):
+    """The session file the display manager will autologin into, best-effort.
+
+    Reproduces the manager's own merge order: the main /etc/<dm>.conf, then
+    <confdir>/*.conf ALPHABETICALLY, and the LAST Session= wins — that ordering
+    is the whole reason our drop-in is zzz- (see _dm_dropin). Earlier versions
+    read only OUR drop-in and then /var/lib/sddm/state.conf; on a box where the
+    user had not yet set anything through Couchside the state file is root-only
+    (MEASURED on both Bazzite and CachyOS, 2026-07-30), so the card said
+    "unknown" while the distro's own zz-steamos-autologin.conf named the answer
+    in plain sight.
+
+    Returns "" when nothing readable names a session — "unknown" beats a
+    guess."""
+    confdir = _DM_CONF_DIRS.get(dm)
+    if not confdir:
+        return ""
+    found = _last_session_line("/etc/%s.conf" % dm)
+    try:
+        names = sorted(fn for fn in os.listdir(confdir) if fn.endswith(".conf"))
+    except OSError:
+        names = []
+    for fn in names:
+        found = _last_session_line(os.path.join(confdir, fn), found)
+    if found:
+        return found
+    # Last resort: the manager's record of the LAST session. Autologin config
+    # beats it when both exist (mirrored above by trying it only when no config
+    # named a session), and it is root-only on every box measured so far — kept
+    # because it costs nothing when it is readable.
+    return _last_session_line("/var/lib/%s/state.conf" % dm)
 
 
 def session_default_get():
@@ -4080,7 +4212,8 @@ def session_default_get():
             m = ""
         return {"available": True, "backend": backend,
                 "mode": m if m in ("game", "desktop") else "unknown"}
-    name = _sddm_current_session_file()
+    # backend is "sddm" or "plasmalogin" here: same conf-dir scheme, same read.
+    name = _dm_current_session_file(backend)
     if name == GAMESCOPE_SESSION_FILE:
         mode = "game"
     elif name in _DESKTOP_SESSIONS:
@@ -4090,11 +4223,13 @@ def session_default_get():
     return {"available": True, "backend": backend, "mode": mode}
 
 
-def _sddm_write(session_file):
+def _dm_write(dm, session_file):
     """Write our drop-in via a sudo tee whose PATH IS FIXED IN THE SUDOERS RULE.
 
-    session_file is chosen by the agent from a frozen table — never client
-    input — and the whole file body is composed here.
+    `dm` is the DETECTED manager (a _DM_CONF_DIRS key — the caller dispatches on
+    it), so the tee path is one of two frozen strings; session_file is chosen by
+    the agent from a frozen table — never client input — and the whole file body
+    is composed here.
 
     REFUSES to write a session that is not installed. An autologin entry naming
     a missing session does not degrade gracefully: SDDM logs "Unable to find
@@ -4102,6 +4237,9 @@ def _sddm_write(session_file):
     whose agent is a user service. Measured 2026-07-27 — this guard is the
     reason that cannot happen again, and it sits HERE, at the single write, so
     no future caller can route around it."""
+    dropin = _dm_dropin(dm)
+    if not dropin:
+        return False
     installed = _installed_session_files()
     if installed and session_file not in installed:
         print("[session] refusing to write autologin for missing session %r"
@@ -4112,17 +4250,17 @@ def _sddm_write(session_file):
             "[Autologin]\n"
             "Session=%s\n" % session_file)
     try:
-        r = subprocess.run(["sudo", "-n", "tee", SDDM_DROPIN],
+        r = subprocess.run(["sudo", "-n", "tee", dropin],
                            input=body, capture_output=True, text=True, timeout=8)
         ok = r.returncode == 0
     except Exception:
         return False
     if ok:
-        _sddm_neutralise_legacy()
+        _dm_neutralise_legacy(dm)
     return ok
 
 
-def _sddm_neutralise_legacy():
+def _dm_neutralise_legacy(dm):
     """Blank the pre-2.9.64 drop-in so it cannot compete with the new one.
 
     Overwritten with a comment rather than deleted: the sudoers grant permits
@@ -4130,14 +4268,16 @@ def _sddm_neutralise_legacy():
     have there, and an empty file contributes no [Autologin] stanza. Silent and
     best-effort -- a box whose grant predates this simply keeps a stale file
     that now sorts BEFORE the new one and therefore loses, which is the
-    behaviour we want anyway."""
-    if not os.path.exists(SDDM_DROPIN_LEGACY):
+    behaviour we want anyway. Only SDDM boxes ever had the legacy file, so on
+    plasmalogin the exists-check simply never fires."""
+    legacy = _dm_dropin_legacy(dm)
+    if not legacy or not os.path.exists(legacy):
         return
     body = ("# Superseded by zzz-couchside-session.conf (Couchside >= 2.9.64).\n"
             "# Left blank deliberately: this name sorted BEFORE the display\n"
             "# manager's own drop-in and so could never win. Safe to delete.\n")
     try:
-        subprocess.run(["sudo", "-n", "tee", SDDM_DROPIN_LEGACY],
+        subprocess.run(["sudo", "-n", "tee", legacy],
                        input=body, capture_output=True, text=True, timeout=8)
     except Exception:
         pass
@@ -4160,10 +4300,15 @@ def session_default_set(mode):
         return done(False, "no session backend on this box")
 
     if mode == "last":
-        # SDDM already records the last session; what defeats it is the
-        # Autologin override. So "last" means: point the override at whatever
-        # is running NOW, and keep doing so as the session changes.
-        current = _sddm_current_session_file() or GAMESCOPE_SESSION_FILE
+        # The display manager already records the last session; what defeats
+        # it is the Autologin override. So "last" means: point the override at
+        # whatever is running NOW, and keep doing so as the session changes.
+        # Read through the DETECTED manager's config (a steamosctl Deck still
+        # runs sddm underneath); a greetd/unidentifiable box reads "" and
+        # falls back to Game Mode, exactly as it did before.
+        dm = detect_display_manager()
+        current = (_dm_current_session_file(dm) if dm in _DM_CONF_DIRS else "") \
+            or GAMESCOPE_SESSION_FILE
         target = current if current in _DESKTOP_SESSIONS else GAMESCOPE_SESSION_FILE
     elif mode == "game":
         target = GAMESCOPE_SESSION_FILE
@@ -4189,7 +4334,17 @@ def session_default_set(mode):
             return done(False, out.strip()[:160])
         return done(session_default_get().get("mode") == arg)
 
-    return done(_sddm_write(target))
+    if backend == "greetd":
+        # RESTORED. The 2.9.65 getter fix MOVED this dispatch out of the setter
+        # instead of copying it, so a greetd box rendered the card, read the
+        # mode correctly, and then every set fell through to the SDDM writer —
+        # which the old unconditional install.sh grant could even let SUCCEED,
+        # into a conf dir greetd never reads.
+        return done(_greetd_write(target))
+
+    # backend is "sddm" or "plasmalogin": the shared drop-in writer, aimed at
+    # the conf dir of the manager that was actually detected.
+    return done(_dm_write(backend, target))
 
 
 def _default_desktop_session():
@@ -16893,6 +17048,7 @@ def main():
     load_config(args.config)
     if not args.mock:
         check_config_writable()  # warn loudly if pairings/launchers can't persist
+    _retarget_restart_session(args.mock)
     _inject_session_actions()
     _inject_suspend_action(args.mock)
     _inject_decky_action(args.mock)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -762,17 +762,24 @@ def _retarget_restart_session(mock):
     if not act or not _is_stock_restart_session_cmd(act.get("cmd")):
         return
     dm = detect_display_manager()
-    if dm and _sudo_nopasswd_allows("systemctl restart %s" % dm):
-        if act["cmd"][3] != dm:
+    # The REAL unit name, not the collapsed family: detect_display_manager
+    # folds gdm3.service into "gdm", but sudoers matches arguments exactly, so
+    # probing "restart gdm" against a gdm3 grant (substring-matched) and then
+    # running "restart gdm" would advertise a rescue button sudo refuses on
+    # every press. Probe and rewrite must use the same spelling the grant and
+    # the unit actually have.
+    unit = _display_manager_unit_name()
+    if dm and unit and _sudo_nopasswd_allows("systemctl restart %s" % unit):
+        if act["cmd"][3] != unit:
             # Copy before editing: ACTIONS shallow-copies DEFAULT_ACTIONS, so
             # editing `act` in place would silently rewrite the shipped spec.
             act = dict(act)
-            act["cmd"] = ["sudo", "systemctl", "restart", dm]
+            act["cmd"] = ["sudo", "systemctl", "restart", unit]
             act["description"] = ("Restart the display session (%s), fixes a "
-                                  "wedged/black screen" % dm)
+                                  "wedged/black screen" % unit)
             ACTIONS["restart-session"] = act
-            stale = {"%s.service" % k for k in _DM_CONF_DIRS if k != dm}
-            WATCHLIST = [(("%s.service" % dm) if n in stale else n, s)
+            stale = {"%s.service" % k for k in _DM_CONF_DIRS if k != unit}
+            WATCHLIST = [(("%s.service" % unit) if n in stale else n, s)
                          for n, s in WATCHLIST]
             WATCHLIST_NAMES = {name for name, _scope in WATCHLIST}
         return
@@ -3861,9 +3868,23 @@ def _dm_session_ok(dm):
     charge — so a plasmalogin box advertised backend "sddm" and wrote into
     /etc/sddm.conf.d, a directory that box does not even have (VERIFIED on
     CachyOS hardware 2026-07-30). The caller must pass the manager it actually
-    detected; this function never guesses one."""
+    detected; this function never guesses one.
+
+    Two more degrade-closed gates, each closing a specific dead-button hole:
+    * the conf dir must EXIST — `sudo tee` cannot create parent directories,
+      the grant names only the file, and vanilla Arch SDDM installs often ship
+      without /etc/sddm.conf.d until an admin creates it (the new install.sh
+      creates it, but a grant can outlive that);
+    * the classic main conf must NOT name a Session — the manager applies
+      /etc/<dm>.conf LAST, over every drop-in (see the layer constants below),
+      so on a hand-configured box our zzz- file can never win and a rendered
+      card would confirm settings that never take effect."""
     dropin = _dm_dropin(dm)
     if not dropin:
+        return False
+    if not os.path.isdir(_DM_CONF_DIRS[dm]):
+        return False
+    if _last_session_line(_DM_MAIN_CONFS.get(dm, "")):
         return False
     return (_sudo_nopasswd_allows(dropin)
             or _sudo_nopasswd_allows(_dm_dropin_legacy(dm)))
@@ -3924,6 +3945,30 @@ def detect_display_manager():
     if unit.startswith("gdm"):
         return "gdm"
     return unit if unit in _KNOWN_DMS else None
+
+
+def _display_manager_unit_name():
+    """The REAL unit name behind the symlink ("gdm3", "sddm", ...), or "".
+
+    detect_display_manager answers "which FAMILY" and deliberately collapses
+    gdm3 -> gdm; anything that builds a `systemctl restart <x>` argv or probes
+    sudoers for one must use this instead. Probing the collapsed name would
+    substring-match a gdm3 grant while the rewritten argv said "gdm" — which
+    sudo (exact-argument matching) then refuses: an advertised rescue button
+    that fails every press. Same read, same degrade-closed shape: unreadable
+    or non-.service means ""."""
+    try:
+        target = os.path.realpath(DISPLAY_MANAGER_UNIT)
+    except OSError:
+        return ""
+    base = os.path.basename(target or "")
+    if not base.endswith(".service"):
+        return ""
+    name = base[: -len(".service")].lower()
+    # The alias itself means the symlink was missing (realpath returns the
+    # unresolved path) — that is "no manager", not a unit called
+    # "display-manager".
+    return "" if name == "display-manager" else name
 
 
 # ---------------------------------------------------------------------------
@@ -4142,37 +4187,66 @@ def _last_session_line(path, found=""):
     return found
 
 
+# The other config layers each conf-dir manager merges, as module constants so
+# tests can repoint them at fixtures (CONVENTIONS §Naming). ORDER IS THE
+# BUG-PRONE PART: SDDM loads the sys conf.d, then /etc/<dm>.conf.d, and applies
+# the classic /etc/<dm>.conf LAST — the MAIN FILE OVERRIDES EVERY DROP-IN, the
+# reverse of the systemd convention. Verified in SDDM's own source
+# (ConfigReader's ConfigBase::load: "order of priority from least influence to
+# most influence ... m_path" — the main file is appended last) after v1 of this
+# reader shipped that order backwards and would have reported a hand-configured
+# /etc/sddm.conf box wrong. For plasmalogin, /etc/plasmalogin.conf.d last-wins
+# is confirmed by CachyOS's own tooling (os-session-select's zz- drop-in
+# overrides steam-deckify.conf, and the distro's comment in that file says so),
+# and the sys layer is the SDDM path: MEASURED on the CachyOS box 2026-07-30,
+# cachyos-kde-settings ships plasmalogin's greeter defaults at
+# /usr/lib/sddm/sddm.conf.d ([Autologin] Session=plasma there, overridden by
+# /etc). A missing layer simply reads empty.
+_DM_SYS_CONF_DIRS = {"sddm": "/usr/lib/sddm/sddm.conf.d",
+                     "plasmalogin": "/usr/lib/sddm/sddm.conf.d"}
+_DM_MAIN_CONFS = {"sddm": "/etc/sddm.conf", "plasmalogin": "/etc/plasmalogin.conf"}
+_DM_STATE_FILES = {"sddm": "/var/lib/sddm/state.conf",
+                   "plasmalogin": "/var/lib/plasmalogin/state.conf"}
+
+
 def _dm_current_session_file(dm):
     """The session file the display manager will autologin into, best-effort.
 
-    Reproduces the manager's own merge order: the main /etc/<dm>.conf, then
-    <confdir>/*.conf ALPHABETICALLY, and the LAST Session= wins — that ordering
-    is the whole reason our drop-in is zzz- (see _dm_dropin). Earlier versions
-    read only OUR drop-in and then /var/lib/sddm/state.conf; on a box where the
-    user had not yet set anything through Couchside the state file is root-only
-    (MEASURED on both Bazzite and CachyOS, 2026-07-30), so the card said
-    "unknown" while the distro's own zz-steamos-autologin.conf named the answer
-    in plain sight.
+    Reproduces the manager's own merge order (see the layer constants above):
+    sys conf.d, then /etc conf.d — each alphabetically, last Session= wins,
+    which is why our drop-in is zzz- — then the classic main conf, which
+    OVERRIDES all drop-ins. Earlier versions read only OUR drop-in and then
+    /var/lib/sddm/state.conf; on a box where the user had not yet set anything
+    through Couchside the state file is root-only (MEASURED on both Bazzite and
+    CachyOS, 2026-07-30), so the card said "unknown" while the distro's own
+    zz-steamos-autologin.conf named the answer in plain sight.
 
     Returns "" when nothing readable names a session — "unknown" beats a
     guess."""
     confdir = _DM_CONF_DIRS.get(dm)
     if not confdir:
         return ""
-    found = _last_session_line("/etc/%s.conf" % dm)
-    try:
-        names = sorted(fn for fn in os.listdir(confdir) if fn.endswith(".conf"))
-    except OSError:
-        names = []
-    for fn in names:
-        found = _last_session_line(os.path.join(confdir, fn), found)
+    found = ""
+    for d in (_DM_SYS_CONF_DIRS.get(dm), confdir):
+        if not d:
+            continue
+        try:
+            names = sorted(fn for fn in os.listdir(d) if fn.endswith(".conf"))
+        except OSError:
+            names = []
+        for fn in names:
+            found = _last_session_line(os.path.join(d, fn), found)
+    # The classic main conf is applied LAST by the manager itself, so it wins
+    # here too. When it names a Session, autologin through drop-ins is dead —
+    # _dm_session_ok refuses the whole capability in that case.
+    found = _last_session_line(_DM_MAIN_CONFS.get(dm, ""), found)
     if found:
         return found
     # Last resort: the manager's record of the LAST session. Autologin config
     # beats it when both exist (mirrored above by trying it only when no config
     # named a session), and it is root-only on every box measured so far — kept
     # because it costs nothing when it is readable.
-    return _last_session_line("/var/lib/%s/state.conf" % dm)
+    return _last_session_line(_DM_STATE_FILES.get(dm, ""))
 
 
 def session_default_get():
@@ -4239,6 +4313,15 @@ def _dm_write(dm, session_file):
     no future caller can route around it."""
     dropin = _dm_dropin(dm)
     if not dropin:
+        return False
+    # Backstop for the availability gate in _dm_session_ok: the classic main
+    # conf overrides every drop-in, so a write it would defeat must refuse
+    # rather than return ok and let the next GET "confirm" a setting that
+    # never applies.
+    if _last_session_line(_DM_MAIN_CONFS.get(dm, "")):
+        print("[session] refusing %s write: %s sets its own Session=, which "
+              "overrides every conf.d drop-in" % (dm, _DM_MAIN_CONFS.get(dm)),
+              flush=True)
         return False
     installed = _installed_session_files()
     if installed and session_file not in installed:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3340,11 +3340,14 @@ def real_action(action_id):
 # gamescope session override we don't ship yet, so `output` is advisory and the
 # app's picker (shown only with 2+ externals) is best-effort there.
 #
-# SteamOS/Bazzite only (shared tooling: gamescope, steamos-session-select,
-# kscreen-doctor, wpctl). Gated to boxes with 2+ connected outputs, so a
-# single-display box (a handheld with nothing plugged in, or a dedicated Game
-# Mode box) never shows the button. Outputs are read from DRM sysfs, which works
-# regardless of the current session (kscreen-doctor only answers inside Plasma).
+# Offered on any box carrying the SteamOS-style session tooling (gamescope,
+# steamos-session-select, kscreen-doctor, wpctl) with both switch targets
+# installed — SteamOS, Bazzite, CachyOS deckify, ChimeraOS. See
+# _couchmode_platform_ok: the old gate grepped the distro NAME out of
+# /etc/os-release and hid the feature on capable boxes. Gated to boxes with at
+# least one connected output (an undocked handheld qualifies; headless does
+# not). Outputs are read from DRM sysfs, which works regardless of the current
+# session (kscreen-doctor only answers inside Plasma).
 #
 # The switch (couchmode_start / desktop_mode) runs entirely from the agent's own
 # service env: it's a SYSTEM service running as the desktop user with
@@ -3360,13 +3363,42 @@ _INTERNAL_OUTPUT_PREFIXES = ("eDP", "LVDS", "DSI")
 _COUCHMODE_TOOLS = ("gamescope", "steamos-session-select", "kscreen-doctor", "wpctl")
 
 
-def _is_steamos_like():
-    """True on SteamOS or Bazzite — the only platforms Couch Mode targets."""
-    try:
-        rel = open("/etc/os-release").read().lower()
-    except OSError:
+def _couchmode_platform_ok():
+    """True when this box actually HAS the session machinery Couch Mode drives.
+
+    This used to be `_is_steamos_like()` — a grep of /etc/os-release for the
+    strings "steamos" or "bazzite". That hid Couch Mode, the `desktop` cap and
+    the guide-button hold on every other box that ships Valve's session
+    tooling. MEASURED on a real CachyOS deckify box 2026-07-30 (ID=cachyos,
+    ID_LIKE=arch): all four _COUCHMODE_TOOLS present at real paths, eDP-1
+    connected, `steamos-session-select` accepting the gamescope/plasma verbs
+    through a polkit rule granted with no password prompt — a box fully able to
+    do the handoff, refused because of its name. ChimeraOS and any Arch box
+    running the deckify packaging are in the same position.
+
+    So the gate asks what the switch NEEDS instead of who made the distro:
+
+      1. the four tools (checked by the caller, unchanged), and
+      2. both switch TARGETS installed — `gamescope-session.desktop` to fling
+         to, and some known desktop session to come back to.
+
+    (2) is the KI-038 lesson applied to a gate rather than a write: it is not
+    enough that a *command* exists, the thing it switches to has to be really
+    installed, or the button lands you nowhere. It also answers the "bare Arch
+    box with gamescope but no session" case — though that box is already
+    excluded by needing `steamos-session-select`, which vanilla Arch has no
+    package for.
+
+    Session enumeration degrades the same way `_dm_write` does: a dir we cannot
+    read yields an empty set, which is "unknown", NOT "absent" — refusing there
+    would hide Couch Mode on a working box over an unreadable directory, and
+    the tool requirement is doing the real work anyway."""
+    installed = _installed_session_files()
+    if not installed:
+        return True  # cannot enumerate: fall back to the tool requirement
+    if GAMESCOPE_SESSION_FILE not in installed:
         return False
-    return "steamos" in rel or "bazzite" in rel
+    return any(name in installed for name in _DESKTOP_SESSIONS)
 
 
 def _connected_outputs():
@@ -3393,8 +3425,8 @@ def _connected_outputs():
 
 
 def couchmode_available():
-    """True when this box can switch desktop↔Game Mode: SteamOS/Bazzite, the
-    session tools present, and ANY connected display to land Game Mode on.
+    """True when this box can switch desktop↔Game Mode: the session tools and
+    both switch targets present, and ANY connected display to land Game Mode on.
 
     An external TV/monitor gives the full handoff (display pin, TV wake, audio
     routing). An INTERNAL-ONLY box — an undocked Steam Deck / Legion Go — now
@@ -3406,7 +3438,7 @@ def couchmode_available():
 
     Headless (no display at all) stays hidden: gamescope with nothing to render
     on is a box you can no longer reach."""
-    if not _is_steamos_like():
+    if not _couchmode_platform_ok():
         return False
     if not all(shutil.which(t) for t in _COUCHMODE_TOOLS):
         return False
@@ -3535,12 +3567,15 @@ def couchmode_info():
 
 
 def desktop_available():
-    """True on a SteamOS/Bazzite box currently in the Plasma DESKTOP session —
+    """True on a Couch-Mode-capable box currently in the DESKTOP session —
     gates the app's desktop-nav cluster (Start menu / pointer / overview), which
     only makes sense in the desktop, not in Game Mode. Session-aware so the
     buttons appear when you're on the desktop and hide once you fling to Game
-    Mode. The keys themselves ride the existing /ws/gamepad uinput keyboard."""
-    return _is_steamos_like() and _couchmode_session() == "desktop"
+    Mode. The keys themselves ride the existing /ws/gamepad uinput keyboard.
+
+    Shares couchmode's platform predicate rather than the old distro-name grep,
+    so the same box that can fling to the TV can also drive its desktop."""
+    return _couchmode_platform_ok() and _couchmode_session() == "desktop"
 
 
 def _couch_run(cmd, timeout=25, max_out=1500):

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1079,7 +1079,12 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
 export type SessionDefaultMode = 'game' | 'desktop' | 'last';
 export type SessionDefault = {
   available: boolean;
-  backend: 'steamosctl' | 'sddm' | null;
+  /** What the agent detected: 'greetd' since 2.9.58 (custom Steam machines),
+   *  'plasmalogin' since 2.9.66 (KDE's SDDM successor — CachyOS deckify today,
+   *  Bazzite eventually). The card never branches on this, so an unknown
+   *  string from a NEWER agent must stay representable — hence the open
+   *  fallback arm. */
+  backend: 'steamosctl' | 'sddm' | 'plasmalogin' | 'greetd' | (string & {}) | null;
   mode: 'game' | 'desktop' | 'unknown';
 };
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -373,7 +373,21 @@ recommendation was wrong, not merely superseded.
   a time), NVIDIA never as the first box.
 - **Unverified:** SELinux mode on Nobara, whether Steam-HTPC provides a `steamos-session-select`
   equivalent, gdm-variant behaviour, and every row of the flavor table (derived from what each
-  desktop ships, not from running the agent). CachyOS is a separate, un-researched target.
+  desktop ships, not from running the agent). CachyOS was researched separately on real
+  hardware 2026-07-30 — see `docs/memory/project_cachyos-support.md` and the CachyOS entry
+  below.
+
+### CachyOS: remaining installer pass
+- **priority:** P2 · **risk:** low · **affects:** installer only · **depends_on:** the
+  10.7.1.92 test box (temporary — owner will tear it down)
+- The hard part shipped with the display-manager detection fix (agent 2.9.66): caps,
+  Couch Mode's polkit-granted session switch, gamepad, steam, media, tv, screen and the
+  boot-session feature all verified on hardware — see
+  `docs/memory/project_cachyos-support.md`.
+- Remaining: recognise `ID_LIKE=arch`; pacman for any deps; skip the firewall step when
+  neither firewalld nor ufw exists (this box has neither). Optional and arguably-never:
+  a pacman OS-update path — rolling-release updates are a different risk profile than
+  atomic ones, and hiding the button is honest.
 
 ### macOS agent (beta) — Macs as a supported box
 - **priority:** P2 · **risk:** MEDIUM — new OS surface, TCC unknowns · **affects:** new agent
@@ -438,6 +452,27 @@ recommendation was wrong, not merely superseded.
 ---
 
 ## ✅ Completed
+
+### Display-manager detection: plasmalogin + fail-closed session backend — agent 2.9.66 (PR pending)
+- **priority:** P1 (blocked the queued "Boots into" release on plasmalogin boxes) · **risk:**
+  medium · **affects:** agent + install.sh · **depends_on:** none
+- The agent proved "SDDM is in charge" by probing for a sudoers grant `install.sh` wrote
+  unconditionally — a plasmalogin box (CachyOS deckify today; Bazzite as KDE migrates)
+  advertised `{"available": true, "backend": "sddm", "mode": "unknown"}` and wrote into
+  `/etc/sddm.conf.d`, which does not exist there. Verified on real hardware (ASUS G14,
+  CachyOS, 10.7.1.92) before and after.
+- Backend now requires a DETECTED manager (display-manager.service symlink); the
+  dm-is-None → sddm-grant fallback is gone. plasmalogin joins `_KNOWN_DMS`; conf dir,
+  drop-in and restart unit derive from the frozen `_DM_CONF_DIRS` table. Mode read
+  reproduces the manager's own merge order (conf.d alphabetical, last `Session=` wins) —
+  fixes mode:"unknown" on boxes never configured through Couchside. greetd dispatch in
+  `session_default_set` RESTORED (lost in the 2.9.65 getter fix). `restart-session`
+  retargets to the detected manager at startup and is removed without a matching grant.
+  `install.sh` allowlists the detected manager (sddm|plasmalogin) before it touches
+  config.json or sudoers.
+- Both directions verified live: CachyOS (old grants) now fails closed end-to-end over
+  HTTP; Bazzite/SDDM unchanged (`backend "sddm", mode "desktop"`, stock action kept).
+  Fixtures in tests are verbatim from both boxes.
 
 ### Couchside Player — a media-player tile, phone-driven — SHIPPED 2026-07-28 (agent 2.9.64)
 - **priority:** P1 · **risk:** medium · **affects:** new box program + agent + app ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -399,8 +399,10 @@ recommendation was wrong, not merely superseded.
   persistent "Boots into" drop-in defeats one-shot session switches — a one-shot
   switch is a re-autologin, and our `zzz-` file sorts last by design — and
   `couchmode_exit()` fake-greens because it trusts exit 0 instead of verifying like
-  the ceremony does. Proven both directions on hardware; Bazzite/SteamOS scope
-  unverified. Fix before the next release that touches this area.
+  the ceremony does. Proven both directions on the CachyOS box and REPRODUCED on the
+  living-room Bazzite box — it is the 2.9.64 `zzz-` rename's twin (that rename fixed
+  "Boots into" and created this), so the fleet splits by install age. **Fix before
+  releasing 2.9.66.**
 
 ### macOS agent (beta) — Macs as a supported box
 - **priority:** P2 · **risk:** MEDIUM — new OS surface, TCC unknowns · **affects:** new agent

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -388,6 +388,13 @@ recommendation was wrong, not merely superseded.
   neither firewalld nor ufw exists (this box has neither). Optional and arguably-never:
   a pacman OS-update path — rolling-release updates are a different risk profile than
   atomic ones, and hiding the button is honest.
+- **Couch Mode toggle hidden on CachyOS by one string check** (owner-reported
+  2026-07-30): `_is_steamos_like()` greps os-release for "steamos"/"bazzite" and gates
+  `couchmode_available()`, the `desktop` cap and guide-hold — while every real gate
+  passes on the box (all four `_COUCHMODE_TOOLS` at real paths, eDP-1 connected,
+  session-select verbs + no-prompt polkit verified live). Fix = capability probe with a
+  session-select sanity check, not a distro name. Same disease the 2.9.66
+  display-manager fix cured.
 
 ### macOS agent (beta) — Macs as a supported box
 - **priority:** P2 · **risk:** MEDIUM — new OS surface, TCC unknowns · **affects:** new agent

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -388,13 +388,19 @@ recommendation was wrong, not merely superseded.
   neither firewalld nor ufw exists (this box has neither). Optional and arguably-never:
   a pacman OS-update path — rolling-release updates are a different risk profile than
   atomic ones, and hiding the button is honest.
-- **Couch Mode toggle hidden on CachyOS by one string check** (owner-reported
-  2026-07-30): `_is_steamos_like()` greps os-release for "steamos"/"bazzite" and gates
-  `couchmode_available()`, the `desktop` cap and guide-hold — while every real gate
-  passes on the box (all four `_COUCHMODE_TOOLS` at real paths, eDP-1 connected,
-  session-select verbs + no-prompt polkit verified live). Fix = capability probe with a
-  session-select sanity check, not a distro name. Same disease the 2.9.66
-  display-manager fix cured.
+- ~~Couch Mode toggle hidden on CachyOS by one string check~~ **FIXED 2026-07-30**
+  (same release): `_is_steamos_like()` grepped os-release for "steamos"/"bazzite" and
+  gated `couchmode_available()`, the `desktop` cap and guide-hold. Now
+  `_couchmode_platform_ok()` — the four tools plus both switch targets installed.
+  Live-proven on the box: real `/api/desktop-mode` landed it in Plasma, real
+  `/api/couch-mode` ceremony flung it back to Game Mode. Same disease the
+  display-manager fix cured, one function over.
+- **Pressing that newly visible button exposed KI-051** (see KNOWN_ISSUES): the
+  persistent "Boots into" drop-in defeats one-shot session switches — a one-shot
+  switch is a re-autologin, and our `zzz-` file sorts last by design — and
+  `couchmode_exit()` fake-greens because it trusts exit 0 instead of verifying like
+  the ceremony does. Proven both directions on hardware; Bazzite/SteamOS scope
+  unverified. Fix before the next release that touches this area.
 
 ### macOS agent (beta) — Macs as a supported box
 - **priority:** P2 · **risk:** MEDIUM — new OS surface, TCC unknowns · **affects:** new agent

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -92,6 +92,18 @@ _POWER_SUPPLY_DIR = "/sys/class/power_supply"
 New code that reads a path under `/sys`, `/proc`, or a cache dir **must** route through a
 module-level constant, or it cannot be tested without root and real hardware.
 
+### Display-manager paths derive from `_DM_CONF_DIRS` — never hardcode SDDM
+
+Since 2.9.66, anything touching the boot-session config or the restart-session rescue
+action goes through `detect_display_manager()` (the `display-manager.service` symlink)
+and the frozen `_DM_CONF_DIRS` table (`sddm`, `plasmalogin`) — conf dir, drop-in path
+(`_dm_dropin`), and restart unit all derive from the DETECTED manager. Hardcoding
+`/etc/sddm.conf.d` or `systemctl restart sddm` is the fail-open bug that shipped a dead
+"Boots into" card on CachyOS (2026-07-30, real hardware): a sudoers grant that
+`install.sh` wrote unconditionally was read as proof SDDM was in charge. The grant proves
+only itself; the symlink proves which manager runs. No detected manager (or no grant for
+the detected one) = no capability, no action — never a fallback to SDDM.
+
 ---
 
 ## 2. Tests (`tests/test_*.py`)

--- a/install.sh
+++ b/install.sh
@@ -827,6 +827,14 @@ case "$DM_NAME" in
     *)
         DM_NAME="" ;;
 esac
+# The drop-in dir must EXIST before the boot-session feature can work: the
+# sudoers grant names only the file, and `sudo tee` cannot create parent
+# directories. SteamOS/Bazzite/CachyOS ship the dir; vanilla Arch SDDM installs
+# often do not until an admin creates it. The agent refuses the capability when
+# the dir is missing, so creating it here is what arms the feature.
+if [ -n "$DM_NAME" ]; then
+    sudo install -d -m 0755 "/etc/${DM_NAME}.conf.d"
+fi
 
 # ---------------------------------------------------------------------------
 # (e) Initial config.json (only if absent)

--- a/install.sh
+++ b/install.sh
@@ -803,42 +803,66 @@ if sudo test -s "$LEGACY_CONFIG" && ! sudo test -s "$CONFIG_FILE"; then
 fi
 
 # ---------------------------------------------------------------------------
+# (e0) Which display manager is actually ENABLED?
+#
+# systemd maintains the answer for us: display-manager.service is an alias
+# symlink to the enabled manager's unit — the same probe CachyOS's own
+# steamos-session-select uses. The old probe (`systemctl cat sddm.service`)
+# answered "is the sddm PACKAGE installed", which lies on a plasmalogin box
+# that still carries sddm on disk: the restart-session action then aimed
+# `systemctl restart sddm` at a manager that was not running, i.e. STARTED a
+# second display manager over the live session. VERIFIED on real CachyOS
+# hardware 2026-07-30 (enabled: plasmalogin.service, /etc/sddm.conf.d absent).
+#
+# The name is ALLOWLISTED before it goes anywhere near sudoers or config.json
+# (§ reject rather than sanitise): anything but the two conf-dir managers the
+# agent can drive collapses to "no manager", which skips the grants and the
+# action entirely — the agent degrades closed and the card/button never appear.
+# ---------------------------------------------------------------------------
+DM_UNIT="$(systemctl show -p Id --value display-manager 2>/dev/null || true)"
+DM_NAME="${DM_UNIT%.service}"
+case "$DM_NAME" in
+    sddm|plasmalogin)
+        note "display manager: $DM_NAME" ;;
+    *)
+        DM_NAME="" ;;
+esac
+
+# ---------------------------------------------------------------------------
 # (e) Initial config.json (only if absent)
 # ---------------------------------------------------------------------------
 if sudo test -s "$CONFIG_FILE"; then
     say "Config $CONFIG_FILE already exists, keeping it"
 else
     say "Generating initial $CONFIG_FILE"
-    HAVE_SDDM=0
-    if systemctl cat sddm.service >/dev/null 2>&1; then
-        HAVE_SDDM=1
-        note "found sddm.service, adding it to the watchlist + restart-session action"
+    if [ -n "$DM_NAME" ]; then
+        note "adding $DM_NAME.service to the watchlist + restart-session action"
     else
-        note "no sddm.service on this box, skipping session-restart action"
+        note "no supported display manager on this box, skipping the session-restart action"
     fi
     HAVE_KODI=0
     if command -v flatpak >/dev/null 2>&1 && flatpak info tv.kodi.Kodi >/dev/null 2>&1; then
         HAVE_KODI=1
         note "found Kodi flatpak, adding a stop-kodi action"
     fi
-    HAVE_SDDM="$HAVE_SDDM" HAVE_KODI="$HAVE_KODI" python3 - > "$WORK_DIR/config.json" <<'PYEOF'
+    DM_NAME="$DM_NAME" HAVE_KODI="$HAVE_KODI" python3 - > "$WORK_DIR/config.json" <<'PYEOF'
 import json, os
 
-have_sddm = os.environ.get("HAVE_SDDM") == "1"
+dm = os.environ.get("DM_NAME", "")
 have_kodi = os.environ.get("HAVE_KODI") == "1"
 
 units = []
-if have_sddm:
-    units.append({"name": "sddm.service", "scope": "system"})
+if dm:
+    units.append({"name": "%s.service" % dm, "scope": "system"})
 units.append({"name": "couchside.service", "scope": "system"})
 
 actions, order = {}, []
-if have_sddm:
+if dm:
     actions["restart-session"] = {
         "label": "Restart Session",
-        "description": "Restart the display session (sddm), fixes a wedged/black screen",
+        "description": "Restart the display session (%s), fixes a wedged/black screen" % dm,
         "danger": "high",
-        "cmd": ["sudo", "systemctl", "restart", "sddm"],
+        "cmd": ["sudo", "systemctl", "restart", dm],
         "user_env": False, "detached": False,
     }
     order.append("restart-session")
@@ -912,26 +936,45 @@ JWRAP
     cat > "$WORK_DIR/couchside-sudoers" <<SUDOERS
 # couchside: allow the Couchside agent (running as $USER_NAME, no TTY) to run
 # exactly the privileged commands it needs, without a password.
-$USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart sddm
+SUDOERS
+    # Display-manager grants: written ONLY for the manager this box actually
+    # enables ($DM_NAME, allowlisted above). Through agent 2.9.65 the sddm
+    # grants were written unconditionally, and the agent treated their mere
+    # presence as proof SDDM was in charge — on a plasmalogin box it then
+    # advertised a working boot-session backend that wrote into a directory
+    # the box does not have. The grant now names the detected manager, and a
+    # box with no supported manager gets NO grant: the agent degrades closed
+    # and the card/button never render.
+    if [ -n "$DM_NAME" ]; then
+        cat >> "$WORK_DIR/couchside-sudoers" <<SUDOERS
+# Restart the enabled display manager ($DM_NAME) — the fix-a-black-screen
+# rescue action. Fixed unit, detected at install time, never client input.
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl restart $DM_NAME
 # Boot session default (game / desktop / last). The PATH IS FIXED IN THE RULE,
 # so this grants writing exactly one file and nothing else -- not tee in
 # general. The agent composes the whole body from its own frozen table; the
 # phone only ever selects a mode from a closed set. Our own drop-in sorts after
-# the distro's steamos.conf, so removing this one file restores the box's
+# the distro's own *.conf files, so removing this one file restores the box's
 # original boot behaviour exactly, with nothing of theirs edited.
-# Boot session default. TWO fixed paths, and the pair is deliberate.
 #
-# zzz- is the live one: SDDM reads /etc/sddm.conf.d/*.conf alphabetically and
-# the LAST file wins, and steamos-session-select (both SteamOS and Bazzite)
-# owns zz-steamos-autologin.conf -- so "zz-couchside" sorted BEFORE it and was
+# zzz- is load-bearing: SDDM and plasmalogin read <confdir>/*.conf
+# alphabetically and the LAST file wins, and steamos-session-select owns
+# zz-steamos-autologin.conf -- so "zz-couchside" sorted BEFORE it and was
 # silently overridden every time that script ran, which is on every Couch Mode
 # switch. zzz- sorts after it and therefore actually applies.
-#
-# The old zz- path stays granted so an updating box can BLANK its stale file;
-# without the grant that orphaned [Autologin] stanza would linger forever.
-# Each grant is one exact path -- never a directory, never a glob.
-$USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/sddm.conf.d/zzz-couchside-session.conf
+$USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/$DM_NAME.conf.d/zzz-couchside-session.conf
+SUDOERS
+    fi
+    if [ "$DM_NAME" = "sddm" ]; then
+        cat >> "$WORK_DIR/couchside-sudoers" <<SUDOERS
+# The old zz- path stays granted so an updating SDDM box can BLANK its stale
+# pre-2.9.64 file; without the grant that orphaned [Autologin] stanza would
+# linger forever. Each grant is one exact path -- never a directory, never a
+# glob. (Only SDDM boxes ever had the legacy file.)
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/tee /etc/sddm.conf.d/zz-couchside-session.conf
+SUDOERS
+    fi
+    cat >> "$WORK_DIR/couchside-sudoers" <<SUDOERS
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 $USER_NAME ALL=(root) NOPASSWD: /usr/bin/systemctl suspend

--- a/tests/test_couchmode_gate.py
+++ b/tests/test_couchmode_gate.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Who is OFFERED Couch Mode — the capability probe that replaced a distro name.
+
+Run: python3 tests/test_couchmode_gate.py
+
+THE BUG (owner-reported, 2026-07-30). The Couch Mode toggle never appeared on a
+CachyOS deckify box. Nothing was broken there: MEASURED live on that machine
+(10.1.1.235, ID=cachyos / ID_LIKE=arch, kernel 7.1.5-1-cachyos-deckify),
+
+    gamescope               /usr/bin/gamescope
+    steamos-session-select  /usr/bin/steamos-session-select
+    kscreen-doctor          /usr/bin/kscreen-doctor
+    wpctl                   /usr/bin/wpctl
+    connected output        card1-eDP-1
+    sessions installed      gamescope-session.desktop, plasma.desktop
+
+...and its `steamos-session-select` takes the same gamescope/plasma verbs the
+agent sends, through a polkit rule granted allow_any=yes (no password prompt).
+The box could do the handoff in every way that matters. It was refused by
+`_is_steamos_like()`, which grepped /etc/os-release for the literal strings
+"steamos" or "bazzite" — so the distro's NAME, not its ability, decided. That
+one check also gated the `desktop` capability and the guide-button hold, so
+three features vanished together on every capable non-Valve-branded box
+(CachyOS deckify, ChimeraOS, Arch running the deckify packaging).
+
+The replacement asks what the switch needs: the four tools, plus BOTH switch
+targets really installed — somewhere to fling to (gamescope-session.desktop)
+and something to come back to (a known desktop session). The second half is the
+KI-038 lesson applied to a gate instead of a write: a command existing does not
+mean the thing it switches to does.
+
+Both directions are exercised here, with controls in each — a probe you have
+only seen say yes is not verified (CLAUDE.md §11.2/§11.3).
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def session_dir(names):
+    """A fake /usr/share/wayland-sessions holding exactly `names`."""
+    d = tempfile.mkdtemp()
+    for n in names:
+        with open(os.path.join(d, n), "w") as f:
+            f.write("[Desktop Entry]\nExec=/bin/true\n")
+    return d
+
+
+# Session sets copied from the real boxes.
+CACHYOS = ["gamescope-session.desktop", "plasma.desktop"]          # 10.1.1.235
+BAZZITE = ["gamescope-session.desktop", "gamescope-session-steam.desktop",
+           "plasma.desktop", "plasma-steamos-wayland-oneshot.desktop",
+           "plasma-steamos-oneshot.desktop"]                       # 10.7.0.200
+STEAMOS = ["gamescope-session.desktop", "plasma.desktop", "plasmax11.desktop"]
+
+
+def setup(sessions, tools=True, outputs=True, session="desktop"):
+    """Point the probe at fixtures. Returns the temp dir so it can be removed."""
+    d = session_dir(sessions)
+    cs._SESSION_DIRS = (d,)
+    cs.shutil.which = (lambda t: "/usr/bin/" + t) if tools else (lambda t: None)
+    cs._connected_outputs = lambda: (
+        [{"name": "eDP-1", "internal": True}] if outputs else [])
+    cs._couchmode_session = lambda: session
+    return d
+
+
+def main():
+    real_dirs = cs._SESSION_DIRS
+    real_which = cs.shutil.which
+    real_outputs = cs._connected_outputs
+    real_session = cs._couchmode_session
+    dirs = []
+    try:
+        print("the box that reported the bug, and the fleet that already worked")
+        for label, sessions in (("cachyos deckify", CACHYOS),
+                                ("bazzite", BAZZITE),
+                                ("steamos", STEAMOS)):
+            dirs.append(setup(sessions))
+            check("%-16s offers Couch Mode" % label,
+                  cs.couchmode_available(), True)
+            check("%-16s offers the desktop cluster (in the desktop)" % label,
+                  cs.desktop_available(), True)
+
+        print()
+        print("...and it is the SESSIONS that decide, not the distro name")
+        # The old gate read /etc/os-release. Nothing here does, so a box that
+        # calls itself steamos but ships no session machinery is refused, and
+        # the fixtures above pass with no os-release involvement at all. If the
+        # distro string ever creeps back, one of these two fails.
+        dirs.append(setup([], tools=False))
+        check("no session tooling -> refused", cs.couchmode_available(), False)
+        dirs.append(setup(["plasma.desktop"]))
+        check("desktop session but NO gamescope-session -> refused",
+              cs.couchmode_available(), False)
+        dirs.append(setup(["gamescope-session.desktop"]))
+        check("gamescope-session but NO desktop session -> refused",
+              cs.couchmode_available(), False)
+        dirs.append(setup(["kiosk.desktop", "sway.desktop"]))
+        check("neither target installed -> refused",
+              cs.couchmode_available(), False)
+
+        print()
+        print("the other two gates still hold (they were never the bug)")
+        dirs.append(setup(CACHYOS, tools=False))
+        check("tools missing -> refused", cs.couchmode_available(), False)
+        dirs.append(setup(CACHYOS, outputs=False))
+        check("headless (no connected output) -> refused",
+              cs.couchmode_available(), False)
+        dirs.append(setup(CACHYOS, session="gamescope"))
+        check("desktop cluster hides once you are IN Game Mode",
+              cs.desktop_available(), False)
+        check("...while Couch Mode itself stays offered (Back to Desktop)",
+              cs.couchmode_available(), True)
+
+        print()
+        print("unreadable session dirs are UNKNOWN, not ABSENT")
+        # _installed_session_files() returns an empty set both when a box has no
+        # sessions and when the dirs cannot be read — the same ambiguity
+        # _dm_write handles by only refusing on a POSITIVE miss. Refusing here
+        # instead would hide a working handheld's Couch button over an
+        # unreadable directory, and the tool requirement is the real gate.
+        cs._SESSION_DIRS = ("/nonexistent-couchside-test",)
+        cs.shutil.which = lambda t: "/usr/bin/" + t
+        cs._connected_outputs = lambda: [{"name": "eDP-1", "internal": True}]
+        check("cannot enumerate + tools present -> still offered",
+              cs.couchmode_available(), True)
+        cs.shutil.which = lambda t: None
+        check("...but cannot enumerate + no tools -> refused (control)",
+              cs.couchmode_available(), False)
+
+        print()
+        print("guide-hold rides the same gate")
+        # It is the reason relaxing this matters twice: the hold-to-couch
+        # trigger was invisible on CachyOS for the same reason the button was.
+        dirs.append(setup(CACHYOS))
+        real_access = cs.os.access
+        try:
+            cs.os.access = lambda *a, **k: True
+            check("capable box -> guide hold offered",
+                  cs.guide_hold_available(), True)
+            dirs.append(setup(["plasma.desktop"]))
+            check("box with no Game Mode target -> guide hold refused",
+                  cs.guide_hold_available(), False)
+        finally:
+            cs.os.access = real_access
+    finally:
+        cs._SESSION_DIRS = real_dirs
+        cs.shutil.which = real_which
+        cs._connected_outputs = real_outputs
+        cs._couchmode_session = real_session
+        import shutil as _sh
+        for d in dirs:
+            _sh.rmtree(d, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        return 1
+    print("all couch-mode gate tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_couchmode_gate.py
+++ b/tests/test_couchmode_gate.py
@@ -68,8 +68,14 @@ def session_dir(names):
 CACHYOS = ["gamescope-session.desktop", "plasma.desktop"]          # 10.1.1.235
 BAZZITE = ["gamescope-session.desktop", "gamescope-session-steam.desktop",
            "plasma.desktop", "plasma-steamos-wayland-oneshot.desktop",
-           "plasma-steamos-oneshot.desktop"]                       # 10.7.0.200
+           "plasma-steamos-oneshot.desktop"]                       # 10.1.1.60
 STEAMOS = ["gamescope-session.desktop", "plasma.desktop", "plasmax11.desktop"]
+# Bazzite publishes GNOME variants too, and they carry "bazzite" in os-release
+# so the OLD gate said yes to them. Plasma is absent; the desktop cluster must
+# NOT depend on it (see _desktop_session_installed).
+BAZZITE_GNOME = ["gamescope-session.desktop", "gamescope-session-steam.desktop",
+                 "gnome.desktop", "gnome-xorg.desktop"]
+GAME_ONLY = ["gamescope-session.desktop"]   # a dedicated Game Mode box
 
 
 def setup(sessions, tools=True, outputs=True, session="desktop"):
@@ -132,6 +138,24 @@ def main():
               cs.couchmode_available(), True)
 
         print()
+        print("the desktop cluster is DE-agnostic and has its OWN gate")
+        # It rides a different predicate than Couch Mode on purpose. Sharing
+        # couchmode's would have taken the trackpad toggle, the nav cluster and
+        # the file-drop reveal away from Bazzite's GNOME images, which the OLD
+        # distro-string gate happily allowed — a regression hidden inside a fix.
+        dirs.append(setup(BAZZITE_GNOME))
+        check("bazzite GNOME keeps the desktop cluster",
+              cs.desktop_available(), True)
+        check("...even though it has no Plasma session at all",
+              any(n.startswith("plasma") for n in cs._installed_session_files()),
+              False)
+        check("...and Couch Mode is a separate question there",
+              cs.couchmode_available(), False)
+        dirs.append(setup(GAME_ONLY))
+        check("a Game-Mode-only box has no desktop to drive",
+              cs.desktop_available(), False)
+
+        print()
         print("unreadable session dirs are UNKNOWN, not ABSENT")
         # _installed_session_files() returns an empty set both when a box has no
         # sessions and when the dirs cannot be read — the same ambiguity
@@ -146,6 +170,17 @@ def main():
         cs.shutil.which = lambda t: None
         check("...but cannot enumerate + no tools -> refused (control)",
               cs.couchmode_available(), False)
+        # The desktop cluster takes the OPPOSITE default, because it has no
+        # second gate: no session dirs at all is a headless box (HTPC, Proxmox
+        # guest, "any systemd machine"), where the whole cluster would be dead
+        # controls. Both stub states are checked so this cannot pass by
+        # accident of the tool lambda above.
+        cs._couchmode_session = lambda: "desktop"
+        check("headless (no session dirs) -> desktop cluster HIDDEN",
+              cs.desktop_available(), False)
+        cs.shutil.which = lambda t: "/usr/bin/" + t
+        check("...still hidden with every tool present (no second gate here)",
+              cs.desktop_available(), False)
 
         print()
         print("guide-hold rides the same gate")

--- a/tests/test_display_manager.py
+++ b/tests/test_display_manager.py
@@ -72,12 +72,17 @@ STOCK = {"label": "Restart Session",
          "danger": "high", "cmd": ["sudo", "systemctl", "restart", "sddm"],
          "user_env": False, "detached": False}
 real_detect, real_sudo = cs.detect_display_manager, cs._sudo_nopasswd_allows
-def reset(detect, grant_units):
+real_unit = cs._display_manager_unit_name
+def reset(detect, grant_units, unit=None):
     cs.ACTIONS = {"restart-session": dict(STOCK, cmd=list(STOCK["cmd"]))}
     cs.ACTION_ORDER = ["restart-session", "reboot"]
     cs.WATCHLIST = [("sddm.service", "system"), ("couchside.service", "system")]
     cs.WATCHLIST_NAMES = {n for n, _ in cs.WATCHLIST}
     cs.detect_display_manager = lambda: detect
+    # The real unit name usually equals the family name; gdm3 is the exception
+    # the `unit` override exists for.
+    cs._display_manager_unit_name = lambda: (unit if unit is not None
+                                             else (detect or ""))
     cs._sudo_nopasswd_allows = lambda needle: needle in grant_units
 try:
     # The CachyOS shape: plasmalogin enabled, NEW installer grant present.
@@ -124,12 +129,59 @@ try:
           cs.ACTIONS["restart-session"]["cmd"],
           ["sudo", "systemctl", "restart", "my-kiosk"])
 
+    # THE PLASMALOGIN STOCK SPELLING is stock too: a fresh new-installer box
+    # writes ["sudo","systemctl","restart","plasmalogin"] into config.json, and
+    # if that box later flips back to SDDM the action must retarget the other
+    # way, not be classed owner-customised.
+    reset("sddm", {"systemctl restart sddm"})
+    cs.ACTIONS["restart-session"]["cmd"] = ["sudo", "systemctl", "restart", "plasmalogin"]
+    cs._retarget_restart_session(False)
+    check("plasmalogin-stock cmd retargets BACK to sddm",
+          cs.ACTIONS["restart-session"]["cmd"], ["sudo", "systemctl", "restart", "sddm"])
+    reset(None, {"systemctl restart sddm", "systemctl restart plasmalogin"})
+    cs.ACTIONS["restart-session"]["cmd"] = ["sudo", "systemctl", "restart", "plasmalogin"]
+    cs._retarget_restart_session(False)
+    check("plasmalogin-stock cmd removed when no manager detected",
+          "restart-session" in cs.ACTIONS, False)
+
+    # gdm3: the FAMILY is "gdm" but the unit (and any real grant) says gdm3.
+    # Probe and argv must both use the real spelling — probing the collapsed
+    # name substring-matches a gdm3 grant and then aims sudo at "gdm", which
+    # exact-argument matching refuses: a rescue button that fails every press.
+    reset("gdm", {"systemctl restart gdm3"}, unit="gdm3")
+    cs._retarget_restart_session(False)
+    check("gdm3 box: argv uses the REAL unit",
+          cs.ACTIONS["restart-session"]["cmd"], ["sudo", "systemctl", "restart", "gdm3"])
+    check("gdm3 box: watchlist uses the real unit too",
+          ("gdm3.service", "system") in cs.WATCHLIST, True)
+    reset("gdm", {"systemctl restart gdm"}, unit="gdm3")
+    cs._retarget_restart_session(False)
+    check("grant naming only 'gdm' on a gdm3 box -> action removed (fail closed)",
+          "restart-session" in cs.ACTIONS, False)
+
     # --mock keeps the stock action so the app stays exercisable off-box.
     reset(None, set())
     cs._retarget_restart_session(True)
     check("mock keeps the action", "restart-session" in cs.ACTIONS, True)
 finally:
     cs.detect_display_manager, cs._sudo_nopasswd_allows = real_detect, real_sudo
+    cs._display_manager_unit_name = real_unit
+
+print()
+print("_display_manager_unit_name: the real spelling, no family collapse")
+d2=tempfile.mkdtemp()
+def link2(target):
+    p=os.path.join(d2,"display-manager.service")
+    if os.path.lexists(p): os.remove(p)
+    if target: os.symlink(target, p)
+    cs.DISPLAY_MANAGER_UNIT=p
+link2("/lib/systemd/system/gdm3.service")
+check("gdm3 stays gdm3", cs._display_manager_unit_name(), "gdm3")
+check("...while the family collapses", cs.detect_display_manager(), "gdm")
+link2("/usr/lib/systemd/system/plasmalogin.service")
+check("plasmalogin unit", cs._display_manager_unit_name(), "plasmalogin")
+link2(None)
+check("no symlink -> empty, not 'display-manager'", cs._display_manager_unit_name(), "")
 
 print()
 print("greetd config rewrite PRESERVES everything else")

--- a/tests/test_display_manager.py
+++ b/tests/test_display_manager.py
@@ -42,6 +42,12 @@ def link(target):
     if target: os.symlink(target, p)
     cs.DISPLAY_MANAGER_UNIT=p
 for unit,want in [("/usr/lib/systemd/system/sddm.service","sddm"),
+                  # VERBATIM from the CachyOS box (10.7.1.92, 2026-07-30):
+                  # readlink -f -> /usr/lib/systemd/system/plasmalogin.service.
+                  # plasmalogin not being detected here is the root of the
+                  # fail-open bug: the backend fell back to "sddm if the grant
+                  # exists", and install.sh wrote that grant unconditionally.
+                  ("/usr/lib/systemd/system/plasmalogin.service","plasmalogin"),
                   ("/usr/lib/systemd/system/greetd.service","greetd"),
                   ("/usr/lib/systemd/system/gdm.service","gdm"),
                   ("/lib/systemd/system/gdm3.service","gdm"),
@@ -50,6 +56,80 @@ for unit,want in [("/usr/lib/systemd/system/sddm.service","sddm"),
     os.makedirs(os.path.dirname(unit), exist_ok=True) if False else None
     link(unit); check("%-42s -> %s"%(os.path.basename(unit),want), cs.detect_display_manager(), want)
 link(None); check("no symlink at all -> None (refuse, don't guess)", cs.detect_display_manager(), None)
+
+print()
+print("per-manager paths derive from the DETECTED manager, never a hardcode")
+check("sddm drop-in dir", cs._dm_dropin("sddm"),
+      "/etc/sddm.conf.d/zzz-couchside-session.conf")
+check("plasmalogin drop-in dir", cs._dm_dropin("plasmalogin"),
+      "/etc/plasmalogin.conf.d/zzz-couchside-session.conf")
+check("unknown manager -> no path at all", cs._dm_dropin("ly"), "")
+
+print()
+print("restart-session retargets to the DETECTED manager (or disappears)")
+STOCK = {"label": "Restart Session",
+         "description": "Restart the display session (sddm), fixes a wedged/black screen",
+         "danger": "high", "cmd": ["sudo", "systemctl", "restart", "sddm"],
+         "user_env": False, "detached": False}
+real_detect, real_sudo = cs.detect_display_manager, cs._sudo_nopasswd_allows
+def reset(detect, grant_units):
+    cs.ACTIONS = {"restart-session": dict(STOCK, cmd=list(STOCK["cmd"]))}
+    cs.ACTION_ORDER = ["restart-session", "reboot"]
+    cs.WATCHLIST = [("sddm.service", "system"), ("couchside.service", "system")]
+    cs.WATCHLIST_NAMES = {n for n, _ in cs.WATCHLIST}
+    cs.detect_display_manager = lambda: detect
+    cs._sudo_nopasswd_allows = lambda needle: needle in grant_units
+try:
+    # The CachyOS shape: plasmalogin enabled, NEW installer grant present.
+    reset("plasmalogin", {"systemctl restart plasmalogin"})
+    cs._retarget_restart_session(False)
+    check("cmd now restarts plasmalogin",
+          cs.ACTIONS["restart-session"]["cmd"],
+          ["sudo", "systemctl", "restart", "plasmalogin"])
+    check("watchlist follows the manager",
+          ("plasmalogin.service", "system") in cs.WATCHLIST, True)
+    check("sddm.service left the watchlist",
+          ("sddm.service", "system") in cs.WATCHLIST, False)
+    check("description names the real manager",
+          "plasmalogin" in cs.ACTIONS["restart-session"]["description"], True)
+
+    # The CachyOS shape TODAY (old installer): plasmalogin enabled, only the
+    # stale sddm grant. Firing `systemctl restart sddm` there would START a
+    # second display manager over the live session — the button must vanish.
+    reset("plasmalogin", {"systemctl restart sddm"})
+    cs._retarget_restart_session(False)
+    check("stale sddm grant does NOT keep the button (fail closed)",
+          "restart-session" in cs.ACTIONS, False)
+    check("...and it leaves the action order",
+          "restart-session" in cs.ACTION_ORDER, False)
+
+    # Bazzite regression control: sddm detected, sddm grant -> untouched.
+    reset("sddm", {"systemctl restart sddm"})
+    cs._retarget_restart_session(False)
+    check("sddm box keeps the stock action verbatim",
+          cs.ACTIONS["restart-session"]["cmd"], STOCK["cmd"])
+    check("sddm box keeps its watchlist",
+          ("sddm.service", "system") in cs.WATCHLIST, True)
+
+    # Unidentifiable manager: no unit worth aiming a rescue action at.
+    reset(None, {"systemctl restart sddm"})
+    cs._retarget_restart_session(False)
+    check("unknown manager -> action removed", "restart-session" in cs.ACTIONS, False)
+
+    # An owner-customised command is not ours to second-guess.
+    reset("plasmalogin", {"systemctl restart plasmalogin"})
+    cs.ACTIONS["restart-session"]["cmd"] = ["sudo", "systemctl", "restart", "my-kiosk"]
+    cs._retarget_restart_session(False)
+    check("customised cmd untouched",
+          cs.ACTIONS["restart-session"]["cmd"],
+          ["sudo", "systemctl", "restart", "my-kiosk"])
+
+    # --mock keeps the stock action so the app stays exercisable off-box.
+    reset(None, set())
+    cs._retarget_restart_session(True)
+    check("mock keeps the action", "restart-session" in cs.ACTIONS, True)
+finally:
+    cs.detect_display_manager, cs._sudo_nopasswd_allows = real_detect, real_sudo
 
 print()
 print("greetd config rewrite PRESERVES everything else")

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -127,10 +127,15 @@ def test_autologin_session_must_exist():
         setup({"gamescope-session.desktop"}, "plasmax11.desktop")
         check("no desktop session at all -> refuse", cs._desktop_session_for_autologin(), None)
 
-        # The write itself is guarded, so no future caller can route around it.
+        # The write itself is guarded, so no future caller can route around it
+        # — on BOTH conf-dir managers.
         cs._installed_session_files = lambda: BAZZITE
-        check("_sddm_write refuses a session that is not installed",
-              cs._sddm_write("plasmax11.desktop"), False)
+        check("_dm_write(sddm) refuses a session that is not installed",
+              cs._dm_write("sddm", "plasmax11.desktop"), False)
+        check("_dm_write(plasmalogin) refuses it too",
+              cs._dm_write("plasmalogin", "plasmax11.desktop"), False)
+        check("_dm_write refuses an unknown manager outright",
+              cs._dm_write("ly", cs.GAMESCOPE_SESSION_FILE), False)
     finally:
         cs._installed_session_files = saved_inst
         cs._default_desktop_session = saved_cfg
@@ -157,39 +162,52 @@ def test_dropin_outranks_the_platforms_own():
     This test is a sort comparison because that is literally the mechanism.
     """
     print("test_dropin_outranks_the_platforms_own")
-    ours = os.path.basename(cs.SDDM_DROPIN)
     theirs = "zz-steamos-autologin.conf"
-    check("our drop-in sorts AFTER steamos-session-select's", ours > theirs, True)
-    # CONTROL: the old name genuinely lost — proving the test can fail, and
-    # documenting the bug rather than just asserting the fix.
-    legacy = os.path.basename(cs.SDDM_DROPIN_LEGACY)
-    check("...and the OLD name genuinely lost", legacy > theirs, False)
-    # Both still beat the distro's base config, which is what we always relied on.
-    for base in ("steamos.conf", "steamdeck.conf", "virtualkbd.conf"):
-        check("beats %s" % base, ours > base, True)
-    # The live path must not be the legacy path.
-    check("live path differs from legacy", cs.SDDM_DROPIN != cs.SDDM_DROPIN_LEGACY, True)
+    for dm in ("sddm", "plasmalogin"):
+        ours = os.path.basename(cs._dm_dropin(dm))
+        check("[%s] our drop-in sorts AFTER steamos-session-select's" % dm,
+              ours > theirs, True)
+        # CONTROL: the old name genuinely lost — proving the test can fail, and
+        # documenting the bug rather than just asserting the fix.
+        legacy = os.path.basename(cs._dm_dropin_legacy(dm))
+        check("[%s] ...and the OLD name genuinely lost" % dm,
+              legacy > theirs, False)
+        # Both still beat the distro's base config, which is what we always
+        # relied on ("cachyos.conf" and "steam-deckify.conf" are verbatim from
+        # the CachyOS plasmalogin box, 2026-07-30).
+        for base in ("steamos.conf", "steamdeck.conf", "virtualkbd.conf",
+                     "cachyos.conf", "steam-deckify.conf"):
+            check("[%s] beats %s" % (dm, base), ours > base, True)
+        # The live path must not be the legacy path.
+        check("[%s] live path differs from legacy" % dm,
+              cs._dm_dropin(dm) != cs._dm_dropin_legacy(dm), True)
+        # ...and both live inside the DETECTED manager's own conf dir.
+        check("[%s] drop-in lives in that manager's conf dir" % dm,
+              cs._dm_dropin(dm).startswith(cs._DM_CONF_DIRS[dm] + "/"), True)
+    check("an unknown manager has NO drop-in path", cs._dm_dropin("ly"), "")
     # Reading the current session must still consult the legacy file, so a box
     # that has not re-run install.sh is reported correctly. Asserted by actually
-    # reading one, not by inspecting a docstring.
+    # reading one, not by inspecting a docstring. The mechanism is now the same
+    # alphabetical last-wins scan the manager itself does, so the win is the
+    # SORT ORDER, exercised for real via a synthetic manager whose conf dir is
+    # a temp dir (name chosen so /etc/testdm.conf and /var/lib/testdm/ cannot
+    # exist on any box this test runs on).
     import tempfile
     tmp = tempfile.mkdtemp()
-    live, legacy_p = os.path.join(tmp, "zzz.conf"), os.path.join(tmp, "zz.conf")
-    saved = (cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY, cs.SDDM_STATE)
+    saved_dirs = cs._DM_CONF_DIRS
     try:
-        cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY = live, legacy_p
-        cs.SDDM_STATE = os.path.join(tmp, "missing.conf")
-        with open(legacy_p, "w") as f:
+        cs._DM_CONF_DIRS = dict(saved_dirs, testdm=tmp)
+        with open(os.path.join(tmp, "zz-couchside-session.conf"), "w") as f:
             f.write("[Autologin]\nSession=plasma.desktop\n")
         check("a legacy-only box still reports its session",
-              cs._sddm_current_session_file(), "plasma.desktop")
+              cs._dm_current_session_file("testdm"), "plasma.desktop")
         # ...and the live file WINS when both exist.
-        with open(live, "w") as f:
+        with open(os.path.join(tmp, "zzz-couchside-session.conf"), "w") as f:
             f.write("[Autologin]\nSession=gamescope-session.desktop\n")
         check("the live drop-in wins over the legacy one",
-              cs._sddm_current_session_file(), "gamescope-session.desktop")
+              cs._dm_current_session_file("testdm"), "gamescope-session.desktop")
     finally:
-        cs.SDDM_DROPIN, cs.SDDM_DROPIN_LEGACY, cs.SDDM_STATE = saved
+        cs._DM_CONF_DIRS = saved_dirs
         import shutil
         shutil.rmtree(tmp, ignore_errors=True)
 
@@ -257,6 +275,68 @@ def test_greetd_get_reads_never_writes(tmp):
         cs._sudo_nopasswd_allows = real_sudo
 
 
+def test_setter_dispatches_per_backend():
+    """set() must write through the backend that was DETECTED.
+
+    Two regressions pinned:
+      * greetd: the 2.9.65 getter fix MOVED the greetd dispatch out of the
+        setter instead of copying it, so a greetd box read fine and then every
+        set fell through to the SDDM writer — which the old unconditional
+        install.sh grant could even let SUCCEED, into a dir greetd never reads.
+      * plasmalogin: the write must aim at /etc/plasmalogin.conf.d, not the
+        hardcoded SDDM path (the 2026-07-30 CachyOS bug).
+    """
+    print("test_setter_dispatches_per_backend")
+    real_run = cs.subprocess.run
+    real_sudo = cs._sudo_nopasswd_allows
+    real_detect = cs.detect_display_manager
+    real_gwrite = cs._greetd_write
+    real_inst = cs._installed_session_files
+    try:
+        cs._sudo_nopasswd_allows = lambda needle: True
+        cs._installed_session_files = lambda: {cs.GAMESCOPE_SESSION_FILE,
+                                               "plasma.desktop"}
+        # steamosctl must keep failing so the DM path is chosen.
+        cs.subprocess.run = FakeRun(stderr="Error: UnknownInterface", rc=0)
+
+        cs.detect_display_manager = lambda: "greetd"
+        gcalls = []
+        cs._greetd_write = lambda sf: (gcalls.append(sf), True)[1]
+        r = cs.session_default_set("game")
+        check("greetd set() reaches the greetd writer", gcalls,
+              [cs.GAMESCOPE_SESSION_FILE])
+        check("greetd set() reports ok", r["ok"], True)
+
+        # plasmalogin: capture the tee argv end-to-end through set().
+        cs.detect_display_manager = lambda: "plasmalogin"
+        cs._greetd_write = lambda sf: (_ for _ in ()).throw(
+            AssertionError("greetd writer must not run for plasmalogin"))
+        teed = []
+
+        def fake_run(argv, **kw):
+            class R:
+                pass
+            r = R()
+            r.returncode, r.stdout, r.stderr = 0, "", ""
+            if argv[:3] == ["sudo", "-n", "tee"]:
+                teed.append(list(argv))
+            elif argv[:1] == ["steamosctl"]:
+                r.stdout, r.stderr = "", "Error: UnknownInterface"
+            return r
+
+        cs.subprocess.run = fake_run
+        r = cs.session_default_set("game")
+        check("plasmalogin set() reports ok", r["ok"], True)
+        check("plasmalogin set() tees into PLASMALOGIN's conf dir",
+              teed, [["sudo", "-n", "tee", cs._dm_dropin("plasmalogin")]])
+    finally:
+        cs.subprocess.run = real_run
+        cs._sudo_nopasswd_allows = real_sudo
+        cs.detect_display_manager = real_detect
+        cs._greetd_write = real_gwrite
+        cs._installed_session_files = real_inst
+
+
 def main():
     real_run = cs.subprocess.run
     real_sudo = cs._sudo_nopasswd_allows
@@ -277,16 +357,40 @@ def main():
     check("empty output is refused", cs._steamosctl_session_ok(), False)
 
     print("backend selection")
+    real_detect = cs.detect_display_manager
     cs.subprocess.run = FakeRun(stdout="desktop\n", rc=0)
     cs._sudo_nopasswd_allows = lambda needle: True
+    cs.detect_display_manager = lambda: "sddm"
     check("steamosctl wins when both are usable",
           cs.session_default_backend(), "steamosctl")
     cs.subprocess.run = FakeRun(stderr="Error: UnknownInterface", rc=0)
-    check("falls back to sddm on Bazzite", cs.session_default_backend(), "sddm")
+    check("Bazzite: detected sddm + grant -> sddm",
+          cs.session_default_backend(), "sddm")
+    cs.detect_display_manager = lambda: "plasmalogin"
+    check("CachyOS: detected plasmalogin + grant -> plasmalogin",
+          cs.session_default_backend(), "plasmalogin")
     cs._sudo_nopasswd_allows = lambda needle: False
     check("no grant -> NO backend (degrade closed)",
           cs.session_default_backend(), None)
     check("...so the capability is absent", cs.session_default_available(), False)
+
+    # THE 2026-07-30 BUG, pinned. install.sh wrote the SDDM tee grant
+    # UNCONDITIONALLY, and an unidentifiable display manager fell back to
+    # "sddm if the grant exists" — so a plasmalogin box (not yet in
+    # _KNOWN_DMS then) advertised {"available": true, "backend": "sddm"}
+    # and wrote into /etc/sddm.conf.d, which did not exist. VERIFIED on real
+    # CachyOS hardware. The grant being present must prove NOTHING when the
+    # manager is unknown.
+    cs._sudo_nopasswd_allows = lambda needle: True
+    cs.detect_display_manager = lambda: None
+    check("unidentifiable DM + sddm grant -> NO backend (fail closed)",
+          cs.session_default_backend(), None)
+    check("...capability absent, card never renders",
+          cs.session_default_available(), False)
+    # Detected-but-unwritable managers are the same honest absence.
+    cs.detect_display_manager = lambda: "gdm"
+    check("gdm: detected, no writer -> None", cs.session_default_backend(), None)
+    cs.detect_display_manager = real_detect
 
     print("the route's allowlist")
     # Membership is what the route checks; anything outside is a 400.
@@ -303,14 +407,9 @@ def main():
 
     test_autologin_session_must_exist()
     test_dropin_outranks_the_platforms_own()
+    test_setter_dispatches_per_backend()
 
-    print("the sddm drop-in body")
-    # We must NEVER edit the box's own steamos.conf; we write our own file.
-    check("drop-in sorts after the distro's own file",
-          os.path.basename(cs.SDDM_DROPIN) > "steamos.conf", True)
-    check("drop-in is a separate file from the distro's",
-          cs.SDDM_DROPIN.endswith("zz-couchside-session.conf"), True)
-
+    print("the drop-in body (both conf-dir managers)")
     written = {}
 
     def fake_tee(argv, **kw):
@@ -325,41 +424,128 @@ def main():
 
     cs.subprocess.run = fake_tee
     cs._sudo_nopasswd_allows = lambda needle: True
-    # force the sddm path
-    ok = cs._sddm_write(cs.GAMESCOPE_SESSION_FILE)
-    check("write returns ok", ok, True)
-    check("writes via sudo tee at the FIXED path",
-          written["argv"], ["sudo", "-n", "tee", cs.SDDM_DROPIN])
-    check("body sets the gamescope session",
-          "Session=%s" % cs.GAMESCOPE_SESSION_FILE in written["body"], True)
-    check("body says how to undo it",
-          "Delete this file" in written["body"], True)
+    for dm in ("sddm", "plasmalogin"):
+        written.clear()
+        ok = cs._dm_write(dm, cs.GAMESCOPE_SESSION_FILE)
+        check("[%s] write returns ok" % dm, ok, True)
+        check("[%s] writes via sudo tee at that manager's FIXED path" % dm,
+              written["argv"], ["sudo", "-n", "tee", cs._dm_dropin(dm)])
+        check("[%s] body sets the gamescope session" % dm,
+              "Session=%s" % cs.GAMESCOPE_SESSION_FILE in written["body"], True)
+        check("[%s] body says how to undo it" % dm,
+              "Delete this file" in written["body"], True)
 
-    print("reading the current mode")
-    tmp = tempfile.mkdtemp()
-    drop = os.path.join(tmp, "zz.conf")
-    with open(drop, "w") as f:
-        f.write("[Autologin]\nSession=gamescope-session.desktop\n")
-    old = cs.SDDM_DROPIN
-    cs.SDDM_DROPIN = drop
+    print("reading the current mode — VERBATIM fixtures from real hardware")
+    # Every file body below is byte-for-byte what the named box serves
+    # (CLAUDE.md §6: fixtures copied verbatim). Captured 2026-07-30.
+    CACHYOS_PLASMALOGIN = {
+        # ASUS G14, CachyOS deckify, 10.7.1.92 — /etc/plasmalogin.conf.d/
+        "cachyos.conf": (
+            "[General]\n"
+            "HaltCommand=/usr/bin/systemctl poweroff\n"
+            "RebootCommand=/usr/bin/systemctl reboot\n"
+            "\n"
+            "[Theme]\n"
+            "Current=breeze\n"
+            "\n"
+            "[Users]\n"
+            "MaximumUid=60000\n"
+            "MinimumUid=1000\n"),
+        "steam-deckify.conf": (
+            "[Autologin]\n"
+            "Relogin=true\n"
+            "# This is only for first boot as a file that overrides this gets"
+            " created once /usr/lib/os-session-select runs\n"
+            "Session=gamescope-session.desktop\n"
+            "User=deck\n"),
+        "zz-steamos-autologin.conf": (
+            "[Autologin]\n"
+            "Session=gamescope-session.desktop\n"),
+    }
+    BAZZITE_SDDM = {
+        # lenovodesktop, Bazzite, 10.7.0.200 — /etc/sddm.conf.d/
+        "steamos.conf": (
+            "[General]\n"
+            "DisplayServer=wayland\n"
+            "\n"
+            "[Autologin]\n"
+            "Relogin=true\n"
+            "Session=gamescope-session.desktop\n"
+            "User=bazzite\n"
+            "\n"
+            "[X11]\n"
+            "# Janky workaround for wayland sessions not stopping in sddm, kills\n"
+            "# all active sddm-helper sessions on teardown\n"
+            "DisplayStopCommand=/usr/bin/gamescope-wayland-teardown-workaround\n"),
+        "virtualkbd.conf": (
+            "[General]\n"
+            "InputMethod=qtvirtualkeyboard\n"),
+        "zzz-couchside-session.conf": (
+            "# Written by Couchside. Delete this file to restore the box's\n"
+            "# original boot behaviour; nothing else was modified.\n"
+            "[Autologin]\n"
+            "Session=plasma.desktop\n"),
+    }
+
+    def fixture_dir(files):
+        d = tempfile.mkdtemp()
+        for name, body in files.items():
+            with open(os.path.join(d, name), "w") as f:
+                f.write(body)
+        return d
+
+    saved_dirs = cs._DM_CONF_DIRS
+    dirs = []
     try:
-        check("reads game from our drop-in",
-              cs._sddm_current_session_file(), "gamescope-session.desktop")
-        with open(drop, "w") as f:
-            f.write("[Autologin]\nSession=/usr/share/wayland-sessions/plasma.desktop\n")
-        check("basenames a full path", cs._sddm_current_session_file(),
-              "plasma.desktop")
-        with open(drop, "w") as f:
-            f.write("[Autologin]\n")
-        cs.SDDM_STATE = os.path.join(tmp, "missing.conf")
+        # The plasmalogin box that exposed the bug: the distro's own drop-in
+        # names the answer, and the old reader (our-drop-in-or-sddm-state-file)
+        # reported "unknown" on it. Both states are observed: game as shipped,
+        # then desktop once OUR later-sorting file lands (§11.2).
+        d = fixture_dir(CACHYOS_PLASMALOGIN)
+        dirs.append(d)
+        cs._DM_CONF_DIRS = dict(saved_dirs, testdm=d)
+        check("CachyOS/plasmalogin fixture reads game (was: unknown)",
+              cs._dm_current_session_file("testdm"), "gamescope-session.desktop")
+        with open(os.path.join(d, "zzz-couchside-session.conf"), "w") as f:
+            f.write("[Autologin]\nSession=plasma.desktop\n")
+        check("...and OUR drop-in wins once written (alphabetical last-wins)",
+              cs._dm_current_session_file("testdm"), "plasma.desktop")
+
+        # The Bazzite regression control: a box where Couchside already set
+        # desktop must keep reading desktop, and without our file must read
+        # the distro's game default — fires AND not-fires.
+        d2 = fixture_dir(BAZZITE_SDDM)
+        dirs.append(d2)
+        cs._DM_CONF_DIRS = dict(saved_dirs, testdm=d2)
+        check("Bazzite fixture reads desktop (our zzz file present)",
+              cs._dm_current_session_file("testdm"), "plasma.desktop")
+        os.remove(os.path.join(d2, "zzz-couchside-session.conf"))
+        check("Bazzite without our file reads the distro's game default",
+              cs._dm_current_session_file("testdm"), "gamescope-session.desktop")
+
+        # Full-path values are basenamed; a dir with no Session= at all reads
+        # empty, never a guess.
+        d3 = fixture_dir({"zzz-couchside-session.conf":
+                          "[Autologin]\nSession=/usr/share/wayland-sessions/"
+                          "plasma.desktop\n"})
+        dirs.append(d3)
+        cs._DM_CONF_DIRS = dict(saved_dirs, testdm=d3)
+        check("basenames a full path",
+              cs._dm_current_session_file("testdm"), "plasma.desktop")
+        d4 = fixture_dir({"cachyos.conf": CACHYOS_PLASMALOGIN["cachyos.conf"]})
+        dirs.append(d4)
+        cs._DM_CONF_DIRS = dict(saved_dirs, testdm=d4)
         check("no Session anywhere -> empty, not a guess",
-              cs._sddm_current_session_file(), "")
+              cs._dm_current_session_file("testdm"), "")
+        check("unknown manager -> empty, not a guess",
+              cs._dm_current_session_file(None), "")
     finally:
-        cs.SDDM_DROPIN = old
+        cs._DM_CONF_DIRS = saved_dirs
         cs.subprocess.run = real_run
         cs._sudo_nopasswd_allows = real_sudo
         import shutil
-        shutil.rmtree(tmp, ignore_errors=True)
+        for d in dirs:
+            shutil.rmtree(d, ignore_errors=True)
 
     print()
     print("greetd getter (reads, never writes)")

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -292,7 +292,20 @@ def test_setter_dispatches_per_backend():
     real_detect = cs.detect_display_manager
     real_gwrite = cs._greetd_write
     real_inst = cs._installed_session_files
+    saved_layers = (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+                    cs._DM_STATE_FILES)
+    base = tempfile.mkdtemp()
     try:
+        # Hermetic conf dirs: availability now requires the dir to exist and
+        # the main conf to be silent.
+        dirs = {dm: os.path.join(base, dm + ".conf.d")
+                for dm in ("sddm", "plasmalogin")}
+        for d in dirs.values():
+            os.makedirs(d)
+        cs._DM_CONF_DIRS = dirs
+        cs._DM_SYS_CONF_DIRS = {}
+        cs._DM_MAIN_CONFS = {}
+        cs._DM_STATE_FILES = {}
         cs._sudo_nopasswd_allows = lambda needle: True
         cs._installed_session_files = lambda: {cs.GAMESCOPE_SESSION_FILE,
                                                "plasma.desktop"}
@@ -307,6 +320,13 @@ def test_setter_dispatches_per_backend():
               [cs.GAMESCOPE_SESSION_FILE])
         check("greetd set() reports ok", r["ok"], True)
 
+        # greetd + mode "last": no conf-dir manager to read, so the target
+        # falls back to Game Mode — through the greetd writer, never the tee.
+        gcalls[:] = []
+        r = cs.session_default_set("last")
+        check("greetd set('last') falls back to gamescope via the greetd writer",
+              gcalls, [cs.GAMESCOPE_SESSION_FILE])
+
         # plasmalogin: capture the tee argv end-to-end through set().
         cs.detect_display_manager = lambda: "plasmalogin"
         cs._greetd_write = lambda sf: (_ for _ in ()).throw(
@@ -320,6 +340,7 @@ def test_setter_dispatches_per_backend():
             r.returncode, r.stdout, r.stderr = 0, "", ""
             if argv[:3] == ["sudo", "-n", "tee"]:
                 teed.append(list(argv))
+                r.stdout = kw.get("input", "")
             elif argv[:1] == ["steamosctl"]:
                 r.stdout, r.stderr = "", "Error: UnknownInterface"
             return r
@@ -329,12 +350,40 @@ def test_setter_dispatches_per_backend():
         check("plasmalogin set() reports ok", r["ok"], True)
         check("plasmalogin set() tees into PLASMALOGIN's conf dir",
               teed, [["sudo", "-n", "tee", cs._dm_dropin("plasmalogin")]])
+
+        # mode "last" on a conf-dir box: the target is whatever the MERGED
+        # config says is running now — here the distro drop-in names the
+        # desktop session, so "last" must write plasma.desktop, not gamescope.
+        with open(os.path.join(dirs["plasmalogin"],
+                               "zz-steamos-autologin.conf"), "w") as f:
+            f.write("[Autologin]\nSession=plasma.desktop\n")
+        teed[:] = []
+        wrote = {}
+        def fake_run2(argv, **kw):
+            class R:
+                pass
+            r = R()
+            r.returncode, r.stdout, r.stderr = 0, "", ""
+            if argv[:3] == ["sudo", "-n", "tee"]:
+                wrote["argv"], wrote["body"] = list(argv), kw.get("input", "")
+            elif argv[:1] == ["steamosctl"]:
+                r.stdout, r.stderr = "", "Error: UnknownInterface"
+            return r
+        cs.subprocess.run = fake_run2
+        r = cs.session_default_set("last")
+        check("plasmalogin set('last') reports ok", r["ok"], True)
+        check("...and writes the session the merged config names",
+              "Session=plasma.desktop" in wrote.get("body", ""), True)
     finally:
         cs.subprocess.run = real_run
         cs._sudo_nopasswd_allows = real_sudo
         cs.detect_display_manager = real_detect
         cs._greetd_write = real_gwrite
         cs._installed_session_files = real_inst
+        (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+         cs._DM_STATE_FILES) = saved_layers
+        import shutil
+        shutil.rmtree(base, ignore_errors=True)
 
 
 def main():
@@ -358,6 +407,18 @@ def main():
 
     print("backend selection")
     real_detect = cs.detect_display_manager
+    # Hermetic conf-dir layout: _dm_session_ok requires the conf dir to EXIST
+    # and the classic main conf to be silent, so the real /etc must not leak in.
+    saved_layers = (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+                    cs._DM_STATE_FILES)
+    bdir = tempfile.mkdtemp()
+    sddm_dir, pl_dir = os.path.join(bdir, "sddm.conf.d"), os.path.join(bdir, "plasmalogin.conf.d")
+    os.makedirs(sddm_dir); os.makedirs(pl_dir)
+    cs._DM_CONF_DIRS = {"sddm": sddm_dir, "plasmalogin": pl_dir}
+    cs._DM_SYS_CONF_DIRS = {}
+    cs._DM_MAIN_CONFS = {"sddm": os.path.join(bdir, "sddm.conf"),
+                         "plasmalogin": os.path.join(bdir, "plasmalogin.conf")}
+    cs._DM_STATE_FILES = {}
     cs.subprocess.run = FakeRun(stdout="desktop\n", rc=0)
     cs._sudo_nopasswd_allows = lambda needle: True
     cs.detect_display_manager = lambda: "sddm"
@@ -390,6 +451,46 @@ def main():
     # Detected-but-unwritable managers are the same honest absence.
     cs.detect_display_manager = lambda: "gdm"
     check("gdm: detected, no writer -> None", cs.session_default_backend(), None)
+
+    # THE GRANT IS PER-PATH — a needle-blind stub cannot pin that. This is the
+    # real CachyOS box TODAY: the old installer wrote only the sddm-path tee
+    # grants, the new agent detects plasmalogin. An implementation that checks
+    # the SDDM path regardless of dm (the pre-fix shape, one refactor away)
+    # fails here and only here.
+    sddm_grants = {cs._dm_dropin("sddm"), cs._dm_dropin_legacy("sddm")}
+    cs._sudo_nopasswd_allows = lambda needle: needle in sddm_grants
+    cs.detect_display_manager = lambda: "plasmalogin"
+    check("CachyOS today: sddm-path grants only + plasmalogin detected -> None",
+          cs.session_default_backend(), None)
+    cs.detect_display_manager = lambda: "sddm"
+    check("...same grants on a real sddm box -> sddm (control)",
+          cs.session_default_backend(), "sddm")
+
+    # The conf dir must EXIST: the grant names one file and `sudo tee` cannot
+    # create parent directories — vanilla Arch SDDM ships without the dir.
+    cs._sudo_nopasswd_allows = lambda needle: True
+    cs.detect_display_manager = lambda: "plasmalogin"
+    import shutil as _sh
+    _sh.rmtree(pl_dir)
+    check("conf dir missing + full grants -> NO backend (tee cannot mkdir)",
+          cs.session_default_backend(), None)
+    os.makedirs(pl_dir)
+    check("...and it returns once the dir exists (control)",
+          cs.session_default_backend(), "plasmalogin")
+
+    # The classic main conf OVERRIDES every drop-in (SDDM applies it last), so
+    # a box hand-configured there can never honor our zzz- file: capability off.
+    cs.detect_display_manager = lambda: "sddm"
+    with open(cs._DM_MAIN_CONFS["sddm"], "w") as f:
+        f.write("[Autologin]\nSession=plasma.desktop\n")
+    check("main conf names a Session -> NO backend (drop-ins can never win)",
+          cs.session_default_backend(), None)
+    os.remove(cs._DM_MAIN_CONFS["sddm"])
+    check("...and returns once it is silent (control)",
+          cs.session_default_backend(), "sddm")
+
+    (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+     cs._DM_STATE_FILES) = saved_layers
     cs.detect_display_manager = real_detect
 
     print("the route's allowlist")
@@ -546,6 +647,55 @@ def main():
         import shutil
         for d in dirs:
             shutil.rmtree(d, ignore_errors=True)
+
+    print("merge order: sys conf.d < /etc conf.d < classic main conf; state last")
+    # SDDM applies the classic /etc/sddm.conf LAST — it OVERRIDES every
+    # drop-in, the reverse of the systemd convention (verified in SDDM's
+    # ConfigReader; v1 of this reader shipped the order backwards). The sys
+    # layer body is VERBATIM /usr/lib/sddm/sddm.conf.d/general.conf's
+    # [Autologin] group from the CachyOS box (note: bare "plasma", no
+    # .desktop — real distros do that).
+    lay = tempfile.mkdtemp()
+    sysd = os.path.join(lay, "sys.conf.d")
+    etcd = os.path.join(lay, "etc.conf.d")
+    os.makedirs(sysd)
+    os.makedirs(etcd)
+    main_conf = os.path.join(lay, "testdm.conf")
+    state_conf = os.path.join(lay, "state.conf")
+    saved_layers = (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+                    cs._DM_STATE_FILES)
+    try:
+        cs._DM_CONF_DIRS = dict(saved_layers[0], testdm=etcd)
+        cs._DM_SYS_CONF_DIRS = {"testdm": sysd}
+        cs._DM_MAIN_CONFS = {"testdm": main_conf}
+        cs._DM_STATE_FILES = {"testdm": state_conf}
+        with open(os.path.join(sysd, "general.conf"), "w") as f:
+            f.write("[Autologin]\nRelogin=false\nSession=plasma\n")
+        check("sys conf.d alone is read (lowest layer)",
+              cs._dm_current_session_file("testdm"), "plasma")
+        with open(os.path.join(etcd, "zz-steamos-autologin.conf"), "w") as f:
+            f.write("[Autologin]\nSession=gamescope-session.desktop\n")
+        check("/etc conf.d overrides the sys layer",
+              cs._dm_current_session_file("testdm"), "gamescope-session.desktop")
+        with open(main_conf, "w") as f:
+            f.write("[Autologin]\nSession=plasmax11.desktop\n")
+        check("the classic MAIN conf overrides every drop-in (SDDM applies it last)",
+              cs._dm_current_session_file("testdm"), "plasmax11.desktop")
+        # state.conf is a LAST resort: consulted only when no config names one.
+        with open(state_conf, "w") as f:
+            f.write("[Last]\nSession=/usr/share/wayland-sessions/plasma.desktop\n")
+        check("state.conf ignored while any config names a session",
+              cs._dm_current_session_file("testdm"), "plasmax11.desktop")
+        os.remove(main_conf)
+        os.remove(os.path.join(etcd, "zz-steamos-autologin.conf"))
+        os.remove(os.path.join(sysd, "general.conf"))
+        check("state.conf answers only when nothing else does",
+              cs._dm_current_session_file("testdm"), "plasma.desktop")
+    finally:
+        (cs._DM_CONF_DIRS, cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS,
+         cs._DM_STATE_FILES) = saved_layers
+        import shutil
+        shutil.rmtree(lay, ignore_errors=True)
 
     print()
     print("greetd getter (reads, never writes)")

--- a/tests/test_update_grant.py
+++ b/tests/test_update_grant.py
@@ -41,11 +41,19 @@ def check(name, got, want):
 
 
 def _sudoers_block():
-    """The couchside-sudoers heredoc body (the rules that become the file)."""
-    m = re.search(r'cat > "\$WORK_DIR/couchside-sudoers" <<SUDOERS\n(.*?)\nSUDOERS\n',
-                  SRC, re.S)
-    assert m, "could not find the couchside-sudoers heredoc"
-    return m.group(1)
+    """The couchside-sudoers heredoc bodies, concatenated in order.
+
+    Since 2.9.66 the file is assembled from several appends — the
+    display-manager grants are conditional on the manager DETECTED at install
+    time — and what lands in /etc/sudoers.d is the concatenation, so the shape
+    tests read that same union. (The conditional lines carry $DM_NAME, which is
+    allowlisted to sddm|plasmalogin before the heredoc runs; these tests treat
+    it as the literal text it is.)"""
+    parts = re.findall(
+        r'cat >>? "\$WORK_DIR/couchside-sudoers" <<SUDOERS\n(.*?)\nSUDOERS\n',
+        SRC, re.S)
+    assert parts, "could not find the couchside-sudoers heredocs"
+    return "\n".join(parts)
 
 
 def test_restart_grant_is_present_and_exact():

--- a/tests/test_update_grant.py
+++ b/tests/test_update_grant.py
@@ -113,11 +113,48 @@ def test_fastpath_is_gated_and_short_circuits_before_root_setup():
     check("fast-path exits before the root setup", "exit 0" in between, True)
 
 
+def test_dm_name_is_allowlisted_before_it_reaches_sudoers():
+    """The $DM_NAME sudoers lines are safe ONLY because of shell control flow:
+    a `case` allowlist collapses anything but sddm|plasmalogin to "", and a
+    non-empty guard keeps the whole grant heredoc out when it is "". That
+    control flow IS the security property (§3: reject, don't sanitise), so it
+    gets pinned as text exactly like the grants themselves — a future edit that
+    loosens the case to a pattern or drops the empty arm must fail here."""
+    print("test_dm_name_is_allowlisted_before_it_reaches_sudoers")
+    check("detection uses the systemd alias probe",
+          "systemctl show -p Id --value display-manager" in SRC, True)
+    m = re.search(r'case "\$DM_NAME" in\n(.*?)\nesac', SRC, re.S)
+    check("the case allowlist exists", bool(m), True)
+    body = m.group(1) if m else ""
+    check("it allowlists exactly sddm|plasmalogin", "sddm|plasmalogin)" in body, True)
+    check("everything else collapses to EMPTY (no pass-through)",
+          'DM_NAME=""' in body, True)
+    check("no pattern arm in the allowlist", "*dm)" in body or "*login)" in body, False)
+    i_case = SRC.index('case "$DM_NAME" in')
+    i_grant = SRC.index("NOPASSWD: /usr/bin/systemctl restart $DM_NAME")
+    check("allowlist runs before the grant heredoc", i_case < i_grant, True)
+    i_guard = SRC.rfind('if [ -n "$DM_NAME" ]', 0, i_grant)
+    check("the grant heredoc sits inside a non-empty guard",
+          i_guard != -1 and i_guard > i_case, True)
+    # And nothing ELSE unexpanded may reach a granted command: the only
+    # variables inside NOPASSWD command text are the allowlisted DM name and
+    # the fixed journal-wrapper path.
+    cmds = [ln for ln in _sudoers_block().splitlines()
+            if "NOPASSWD:" in ln and not ln.lstrip().startswith("#")]
+    seen = set()
+    for ln in cmds:
+        seen |= set(re.findall(r"\$[A-Za-z_][A-Za-z0-9_]*",
+                               ln.split("NOPASSWD:", 1)[1]))
+    check("only $DM_NAME and $JOURNAL_WRAPPER expand inside granted commands",
+          seen <= {"$DM_NAME", "$JOURNAL_WRAPPER"}, True)
+
+
 if __name__ == "__main__":
     for fn in (test_restart_grant_is_present_and_exact,
                test_no_wildcard_in_any_couchside_grant,
                test_restart_is_no_block,
-               test_fastpath_is_gated_and_short_circuits_before_root_setup):
+               test_fastpath_is_gated_and_short_circuits_before_root_setup,
+               test_dm_name_is_allowlisted_before_it_reaches_sudoers):
         fn()
     if FAILURES:
         print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))


### PR DESCRIPTION
## The bug

The agent proved "SDDM is in charge" by checking for a sudoers grant `install.sh` wrote **unconditionally** — so a plasmalogin box (CachyOS deckify today; Bazzite as KDE migrates off SDDM) advertised a working boot-session backend aimed at `/etc/sddm.conf.d`, a directory it does not have, and the restart-session rescue action pointed `systemctl restart sddm` at a manager that was not running. Verified on real hardware before the fix (ASUS G14, CachyOS, agent 2.9.65):

    /api/session/default -> {"available": true, "backend": "sddm", "mode": "unknown"}
    display-manager      -> plasmalogin.service ; /etc/sddm.conf.d MISSING

## The fix

- `session_default_backend()` requires a **detected** manager (the `display-manager.service` symlink); the dm-is-None → sddm-grant fallback is gone. **Fail closed** (§3.7): no identified manager, no capability, no card.
- plasmalogin joins `_KNOWN_DMS`; conf dir, drop-in path, and restart unit derive from the frozen `_DM_CONF_DIRS` table. `backend` reports what was detected (`"plasmalogin"` is a new *value*, no shape change; the app never branches on it — its TS union was widened with an open fallback arm).
- Mode read reproduces the manager's real merge order — sys conf.d < `/etc/<dm>.conf.d` (alphabetical, last `Session=` wins — why our drop-in stays `zzz-`) < **the classic `/etc/<dm>.conf`, which SDDM applies LAST, over every drop-in** (verified in SDDM's ConfigReader source; the reverse of the systemd convention). The old root-only state-file fallback never worked on either measured box; it remains as a config-less last resort.
- A main conf that names its own `Session=` disables the capability (and the writer refuses as a backstop) — our drop-in could never win there, and set() would otherwise "confirm" a setting that never applies.
- Availability also requires the conf dir to **exist** (`sudo tee` cannot mkdir); install.sh creates it for the detected manager.
- greetd dispatch in `session_default_set` **restored** — the 2.9.65 getter fix moved it out of the setter instead of copying it, so every greetd set silently wrote the SDDM path.
- `restart-session` retargets to the detected manager's **real unit name** (gdm3 stays gdm3 — probing the collapsed family name substring-matched a gdm3 grant while the argv said `gdm`, which sudo's exact-argument matching refuses) and is **removed** when there is no matching grant: a dead fix-a-black-screen button costs more trust than a missing one.
- `install.sh` detects the enabled manager via `systemctl show -p Id --value display-manager` and **allowlists the name** (`case … sddm|plasmalogin`) before it reaches config.json or the sudoers heredoc; anything else collapses to "no manager, no grants". The old probe (`systemctl cat sddm.service`) matched an *installed-but-disabled* sddm package, which would have aimed the rescue button at starting a second display manager over the live session.

## Allowlist verification

No new client input reaches a command or path. The client still selects only a mode from `SESSION_DEFAULT_MODES`; the manager name comes from a root-owned systemd symlink, is looked up in a frozen dict (agent) / case allowlist (installer), and an unknown name yields absence, never pass-through. Sudoers grants got *narrower*: DM grants are now written only for the detected manager (the sddm `zz-` legacy grant only on sddm). `tests/test_update_grant.py` now pins the installer allowlist and that only `$DM_NAME`/`$JOURNAL_WRAPPER` ever expand inside granted commands; generated sudoers for all three cases (`sddm`/`plasmalogin`/none) validated with `visudo -cf`.

## Review

Multi-agent adversarial review over the diff (5 lenses, 17 findings, 8 confirmed after refutation passes) — all 8 fixed in the second commit, including the SDDM main-conf precedence inversion and the gdm3 unit-name mismatch.

## Verified on hardware

- **CachyOS/plasmalogin (10.7.1.92), agent 2.9.66 test instance, end-to-end over HTTP:** `/api/session/default` → `{"available": false}` (old grants present — the fail-closed direction, observed live), caps `session_default: false`, `restart-session` absent from `/api/actions`, POST refuses `"no session backend"`, unauth still 401. Mode read against the real filesystem returns `game` from the distro's own drop-in (was `unknown`).
- **CachyOS, simulated post-new-install** (only the sudo probe stubbed to the grants the new installer writes; filesystem + detection real): backend `plasmalogin`, mode `game`, restart-session retargets to `["sudo","systemctl","restart","plasmalogin"]`, watchlist follows.
- **Bazzite/SDDM (10.7.0.200), regression:** backend `sddm`, mode `desktop` (matches its `zzz-couchside-session.conf`), stock action and watchlist untouched, prod agent undisturbed. Its `/etc/sddm.conf` is the commented template, so the new main-conf gate correctly passes it.
- `--mock` boots and keeps the stock card/action.

## Verified after opening (owner ran the new installer on the CachyOS box, 2026-07-30)

- **Sudoers landed exactly as designed:** `restart plasmalogin` + the plasmalogin `zzz-` tee grant present, every old sddm grant gone, no sddm legacy line (plasmalogin box).
- **The real write path, end-to-end over HTTP with no stubs:** backend `plasmalogin`, set desktop → root write through the new tee grant → drop-in content correct → GET reads `desktop`; set game → restored. 
- **Both boot states observed across real reboots:** with `Session=plasma.desktop` the box came up in Plasma (`plasmalogin-helper --autologin` → `startplasma-wayland`, no gamescope); with `Session=gamescope-session.desktop` it came up in Game Mode (`gamescope … -O '*',eDP-1`, no plasma). The drop-in is honored in both directions on plasmalogin hardware — the feature's whole claim.
- **The rescue action fired for real:** `POST /api/actions/restart-session` → exit 0, `plasmalogin.service` ActiveEnterTimestamp advanced, unit active after. Retargeted argv + grant agree.
- `restart-session` appears on the box with the plasmalogin description/argv via the startup retarget (its config has no `actions` key, so defaults + retarget apply).

## Second change on this branch: Couch Mode offered by capability, not by distro name

Same disease, one function over. `_is_steamos_like()` grepped `/etc/os-release` for the strings "steamos"/"bazzite" and gated `couchmode_available()`, the `desktop` cap and `guide_hold_available()` — so a CachyOS deckify box with every session tool at a real path, a connected panel, both sessions installed, and a `steamos-session-select` that takes the same verbs through a no-prompt polkit rule was refused **by its name**. Three features hidden at once (owner-reported; ChimeraOS and any Arch box on the deckify packaging are in the same position).

`_couchmode_platform_ok()` asks what the switch needs: the four tools (unchanged) plus both switch **targets** really installed — `gamescope-session.desktop` to fling to, a known desktop session to come back to. The second half is the KI-038 lesson applied to a gate rather than a write: a command existing does not mean the thing it switches to does. Session dirs that cannot be enumerated stay **UNKNOWN, not ABSENT** (the `_dm_write` convention), so no shipped box can lose the feature over an unreadable directory — the tool requirement still gates there. `desktop_available()` shares the predicate.

**Verified by pressing the control, not rendering it** (CLAUDE.md §6), live on the CachyOS box: `couchmode` and `guide_hold` true; the `desktop` cap observed in **both** states (false in Game Mode, true in Plasma); a real `POST /api/desktop-mode` landed the box in Plasma; a real `POST /api/couch-mode` ceremony reported `done` with gamescope back up. Box restored to Game Mode with its boot preference intact. New `tests/test_couchmode_gate.py` (+ CI step) pins both directions with controls, and was mutation-checked: restoring the old gate fails 10 of its assertions.

**Review round on that commit** (3 lenses, adversarial verify) caught a regression I had introduced: sharing couchmode's predicate with `desktop_available()` demanded a Game Mode target *and* a Plasma session, neither of which that cap ever needed — a Bazzite **GNOME** image would have lost the trackpad surface toggle, the nav cluster and the file-drop "Show on box", and gained a dead Steam-menus segment through the app's `inGameMode = !hasDesktop`; a headless box would have reported `desktop: true` and shown a panel of dead controls. Fixed in `5edefa4`: `_desktop_session_installed()` asks whether any non-gamescope session is installed, DE-agnostic, degrading **closed** on no session dirs. Old-vs-new across the fleet with controls — SteamOS Deck, Bazzite KDE, bazzite-deck-gnome, bazzite-gnome, CachyOS all keep the cap; a plain GNOME box gains it (the cluster works there); a Game-Mode-only box loses it (nothing to drive).

## KI-051 — found by pressing that newly visible button (logged, NOT fixed here)

The first `POST /api/desktop-mode` returned `{"ok": true, "session": "desktop"}` and the box came back up in **Game Mode**. Two defects, one cause:

1. **A one-shot session switch is a re-autologin.** CachyOS's `steamos-session-select plasma` writes the distro's `zz-steamos-autologin.conf` and stops `gamescope-session.target`; the display manager autologins again and merges `conf.d` alphabetically — so our `zzz-couchside-session.conf`, which sorts last *by design* so the "Boots into" preference wins, also overrides the switch the user just asked for. Proven both directions on hardware: with our drop-in naming gamescope the switch bounces back; blanked, the identical call lands in Plasma.
2. **`couchmode_exit()` reports ok on exit 0** without verifying the session changed — the exact lie the to-game *ceremony* was built to stop, on the path that never got the same treatment.

The two features are in genuine tension: a standing autologin override makes "switch now" impossible, because every session start looks like a boot to the display manager. **REPRODUCED ON BAZZITE** (living-room box, Kinoite/bazzite-deck, sddm). Its `steamos-session-select` is a different script with the same shape — writes `/etc/sddm.conf.d/zz-steamos-autologin.conf`, then `systemctl restart sddm`. With a `zzz-` drop-in naming gamescope in place, `POST /api/desktop-mode` returned `{"ok": true, "session": "desktop"}` with the script's own stdout reading *"Updated system autologin session to plasma-steamos-wayland-oneshot.desktop / Restarted SDDM"* — and sddm came back up as `sddm-helper --start gamescope-session-plus steam --autologin`. Box restored to its exact prior state afterwards.

**The bite:** this is the 2.9.64 `zzz-` rename's twin. That rename FIXED "Boots into" (`zz-couchside` sorted *before* `zz-steamos` and lost) and in the same stroke created this collision (`zzz-couchside` sorts *after* and wins) — same mechanism, opposite direction. The fleet splits by install age: a box still on the legacy `zz-` name has a useless boot preference but working one-shot switches; a box that re-ran install.sh at ≥2.9.64 **and** set a boot preference gets the reverse. Renaming back is not a fix — it just restores the old bug. Full write-up in KI-051; needs a design call (neutralise-and-restore across a switch / restore-at-boot preference / refuse the switch with an honest reason) plus a verifying `couchmode_exit()`.

## NOT verified

- greetd end-to-end (no greetd box has ever existed here — and see KI-049: install.sh still writes no greetd grant, so that backend remains unreachable in practice).
- gdm3 behavior on a real Debian box (fixture-tested only).
- `/proc`-independent, but per house rule: local green on macOS is not trusted — CI must pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


