### PR TITLE
fix(iap): stop the StoreKit re-delivery storm (dead trackpad, app killed every minute)

### DIFF
--- a/app/lib/entitlement.ts
+++ b/app/lib/entitlement.ts
@@ -156,8 +156,21 @@ async function firstLaunchMs(): Promise<number> {
   return now;
 }
 
-/** Record a completed unlock purchase (called after buy()/restore() succeed). */
+/** Record a completed unlock purchase (called after buy()/restore() succeed).
+
+    Read-before-write, for two reasons measured on the same device (iOS 27
+    beta, 2026-07-30): a keychain write is ~two securityd round-trips
+    (SecItemAdd -> duplicate -> SecItemUpdate), and on that beta the item can
+    get into a state where reads miss it while adds collide — so a caller loop
+    (the StoreKit re-delivery storm) turned this into ~100 keychain writes per
+    second. The storm is fixed at its source in purchase.ts; this guard makes
+    the write path idempotent regardless of caller behaviour. */
 export async function markPurchased(): Promise<void> {
+  try {
+    if ((await storageGet(PURCHASED_KEY)) === '1') return;
+  } catch {
+    // unreadable cache: fall through and write
+  }
   await storageSet(PURCHASED_KEY, '1');
 }
 

--- a/app/lib/purchase.ts
+++ b/app/lib/purchase.ts
@@ -33,6 +33,10 @@ export type RestoreResult =
 type IapPurchase = {
   productId: string;
   purchaseState: 'pending' | 'purchased' | 'unknown';
+  // Transaction identity, when the platform provides one. Used ONLY to dedupe
+  // re-deliveries of the same transaction (see the listener); never required.
+  id?: string;
+  transactionId?: string;
   // Original transaction time (ms since epoch). Open IAP surfaces this as
   // `transactionDate`; some platforms also carry a StoreKit
   // `originalPurchaseDate`. Both optional: never depend on either existing.
@@ -88,6 +92,13 @@ function iap(): IapModule | null {
 
 let connectPromise: Promise<boolean> | null = null;
 let listenersAttached = false;
+// Transactions already granted this session, keyed by the best identity the
+// platform gives us. Module level: the listener survives provider remounts,
+// and StoreKit re-delivery of an unfinished transaction must never re-grant
+// (the 2026-07-30 CPU storm — see the listener). Bounded: one entry per real
+// transaction, and a session sees a handful at most.
+const grantedTxIds = new Set<string>();
+let finishFailureLogged = false;
 
 /**
  * Registered by EntitlementProvider; fired whenever the store reports a
@@ -139,7 +150,39 @@ async function connect(): Promise<boolean> {
               return;
             }
             // Non-consumable: acknowledge/finish so the store stops retrying.
-            m.finishTransaction({ purchase, isConsumable: false }).catch(() => {});
+            //
+            // THE STORM GUARD (2026-07-30, measured on the owner's iPhone,
+            // iOS 27 beta). When finishTransaction FAILS, StoreKit re-delivers
+            // the unfinished transaction to this listener immediately and
+            // forever. Ungated, every re-delivery granted again: a keychain
+            // write (~100/s measured), a fresh entitlement object, a full
+            // context re-render — 87% CPU sustained until iOS killed the app
+            // for CPU abuse, every ~30-120s, every launch. A pegged JS thread
+            // also stops pumping trackpad frames, which is what "the mouse
+            // dies until I restart the app" actually was.
+            //
+            // So: keep RETRYING the finish on every delivery (that is the only
+            // path to making StoreKit stop), but grant AT MOST ONCE per
+            // transaction identity — and log the finish failure instead of
+            // swallowing it, because a silent `.catch(() => {})` is how this
+            // ran undiagnosed on a shipped build.
+            const txId =
+              purchase.id ?? purchase.transactionId ??
+              (purchase.transactionDate != null ? String(purchase.transactionDate) : null);
+            m.finishTransaction({ purchase, isConsumable: false }).catch((e) => {
+              if (!finishFailureLogged) {
+                finishFailureLogged = true;
+                console.warn(
+                  '[iap] finishTransaction failed; StoreKit will re-deliver ' +
+                    'this transaction until it succeeds:',
+                  e instanceof Error ? e.message : e,
+                );
+              }
+            });
+            if (txId != null && grantedTxIds.has(txId)) {
+              return; // re-delivery of a transaction we already granted
+            }
+            if (txId != null) grantedTxIds.add(txId);
             onPurchased?.(purchaseDateOf(purchase));
             settleBuy({ ok: true });
           });


### PR DESCRIPTION
Field-diagnosed live on the owner's iPhone with three synchronized streams — device syslog (pymobiledevice3 over network), the agent journal, and an independent WS+ping canary riding the same network path — after presenting for days as *"the trackpad dies after a session switch until I force-restart the app."*

## What was actually happening

~12s after **every** app launch, StoreKit finishes connecting and replays the owner's **unfinished** unlock transaction. `finishTransaction()` fails on iOS 27 beta (24A5370h) and the failure was swallowed by `.catch(() => {})` — so StoreKit re-delivers the transaction immediately, forever. Each re-delivery re-granted the purchase:

- `markPurchased()` → a SecureStore keychain write — **~100/s measured** (`SecItemAdd` → `-25299 duplicate` → `SecItemUpdate`, against an item reads couldn't see — beta keychain weirdness)
- a fresh entitlement object → full context re-render

The iOS resource monitor caught it: **87% CPU for 103 seconds** in a single Hermes callback (limit 50%/180s). A pegged JS thread stops pumping trackpad frames — the dead mouse — and iOS then kills the process for CPU abuse, which the agent sees as a mass `ECONNRESET` storm. Four app instances lived and died in six minutes of capture.

**Every prior theory was eliminated by measurement**: the box's Wi-Fi (canary ran clean through each death), the agent (its journal shows the phone going totally silent — even API polls starve), the session switch itself (the correlation is that you open the app *to* switch, and the storm lands ~12-30s post-launch, right while testing the trackpad afterwards), and the old WS-keepalive diagnosis (that fix shipped and works — this was never a keepalive problem).

## The fix, three layers

1. **Grant at most once per transaction identity** (module-level dedupe set, survives provider remounts) — while still retrying `finishTransaction` on every re-delivery, because a successful finish is the only thing that makes StoreKit stop.
2. **Log the finish failure once** instead of swallowing it — a silent `.catch(() => {})` is how this shipped and ran undiagnosed.
3. **`markPurchased()` is read-before-write** — the keychain path is idempotent regardless of caller behaviour.

## Verified / NOT verified

- `tsc` clean; the changed logic is dependency-light but lives against the native `expo-iap` surface, so **the web harness cannot exercise it**.
- **NOT verified on the failing device.** That requires a TestFlight build on the owner's phone — the only device here on the iOS 27 beta. The evidence chain (onset timing, write cadence, keychain signature, CPU report, kill/relaunch cycle) is all measurement, but the fix's effect must be confirmed the same way: capture device syslog after updating and watch for the absence of the 12s-post-launch write storm.
- Root cause of the *finish failure itself* (expo-iap vs iOS 27 beta StoreKit) is unresolved — the new log line will name it. Tracked as a known issue; if iOS 27 ships with this behavior, every beta-adopter with an unlock hits the redelivery path, and this guard is what keeps the app usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)