### PR TITLE
fix(pad): one-tap hard reset (the owner's box-switch recovery)

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1152,9 +1152,12 @@ function PadScreen() {
         noPad: keyboardMode,
       });
     } else if (stale) {
-      // Connected on paper but the socket has gone silent: force a fresh one.
-      // connect() would no-op here (its guard sees the still-OPEN socket).
-      client.reconnect();
+      // Connected on paper but the socket has gone silent. hardReset() rather
+      // than reconnect(): a plain socket rebuild demonstrably does NOT revive a
+      // dead cursor in the field, while switching boxes and back does — and the
+      // difference is the released buttons + cleared address-fallback that only
+      // the switch path performs. See GamepadClient.hardReset.
+      client.hardReset();
     }
   }, [client, settings, status, stale, canForce, askToSwitch, keyboardMode]);
 

--- a/app/lib/__tests__/gamepad.lifecycle.test.ts
+++ b/app/lib/__tests__/gamepad.lifecycle.test.ts
@@ -181,6 +181,36 @@ test('reconnect(): forces a fresh socket even while still OPEN (pill tap-to-retr
   c.close();
 });
 
+test('hardReset(): rebuilds the socket AND releases held buttons (the box-switch recovery)', () => {
+  const c = freshClient();
+  c.connect(CONN);
+  MockWebSocket.instances[0].openAndHello();
+  const ws0 = MockWebSocket.instances[0];
+  // Hold a mouse button, then lose the cursor. A stuck BTN_LEFT turns every
+  // move into a drag, which is one of the two things only the box-switch path
+  // (close -> releaseAll) clears; reconnect() leaves it held.
+  c.sendMouseButton('l', 1);
+  const sentBefore = ws0.sent.length;
+  c.hardReset();
+  assert.equal(MockWebSocket.instances.length, 2, 'hardReset opens a fresh socket');
+  // The release must go out on the OLD socket, before it is torn down —
+  // otherwise the agent keeps the button latched.
+  const released = ws0.sent
+    .slice(sentBefore)
+    .some((raw) => {
+      const m = JSON.parse(raw) as { t?: string; k?: string; v?: number };
+      return m.t === 'mb' && m.k === 'l' && m.v === 0;
+    });
+  assert.ok(released, 'hardReset releases the held mouse button on the way out');
+  c.close();
+});
+
+test('hardReset(): no-op when the client has no connection yet', () => {
+  const c = freshClient();
+  c.hardReset();
+  assert.equal(MockWebSocket.instances.length, 0, 'nothing to reset before a first connect');
+});
+
 test('reconnect(): no-op when not active', () => {
   const c = freshClient();
   c.reconnect();

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -637,6 +637,48 @@ export class GamepadClient {
     this.open();
   }
 
+  /**
+   * The recovery the OWNER found by hand: switch to another box and back, which
+   * restores a dead cursor INSTANTLY where the plain retry above does not.
+   *
+   * That difference is the whole reason this exists. `reconnect()` calls
+   * `open()` and nothing else; switching boxes runs `close()` then
+   * `connect(otherConn)` then `connect(thisConn)`, which additionally
+   *
+   *   1. releaseAll()s the PAD state (buttons/triggers/sticks — note it does
+   *      NOT cover mouse buttons, so this method releases those explicitly: a
+   *      pointer button left down turns every move into a drag, which reads as
+   *      "the mouse does nothing"), and
+   *   2. clears `useFallback`, because connect() sees a DIFFERENT conn — so the
+   *      next dial goes back to the IP-first address instead of staying pinned
+   *      to whichever alternate a past failure selected. This is the candidate
+   *      that actually fits a MOUSE fault; the pad-release half does not.
+   *
+   * Neither is reachable from reconnect(), and both survive a socket rebuild —
+   * which is exactly the shape of a bug that a force-quit or a box-switch cures
+   * and a retry does not. So do the same thing the owner does, in one call,
+   * without inventing a placeholder box to bounce off.
+   *
+   * Deliberately NOT automatic: this is the tap-to-retry escalation, and it is
+   * still symptom treatment. The root cause is under investigation (KI-053) —
+   * whatever it turns out to be, having the known-good recovery one tap away
+   * beats making people navigate twice.
+   */
+  hardReset(): void {
+    const conn = this.conn;
+    if (conn == null) return;
+    this.releaseAll();
+    // releaseAll() is pad-only; a held pointer button would otherwise survive
+    // the reset and keep dragging on the far side.
+    for (const b of ['l', 'r', 'm'] as MouseButton[]) this.sendMouseButton(b, 0);
+    this.useFallback = false;
+    this.attempt = 0;
+    this.clearReconnect();
+    this.teardownSocket(true);
+    this.active = true;
+    this.open();
+  }
+
   sendButton(k: ButtonKey, v: 0 | 1): void {
     this.sendRaw({ t: 'b', k, v });
   }
@@ -1189,6 +1231,11 @@ export class GamepadClient {
       Date.now() - this.lastInbound > PING_INTERVAL_MS * 2.5
     ) {
       wsTrace.recoveries += 1;
+      // reconnect(), NOT hardReset(): this runs INSIDE sendRaw, and hardReset
+      // releases held inputs — which calls sendRaw again, once per key, each
+      // re-entering this very branch. Tried it; three lifecycle tests caught the
+      // recursion immediately. The heavier reset stays on the explicit user tap,
+      // where nothing is mid-send.
       this.reconnect();
       return; // can't land on a dead socket; the rebuilt one carries the next frame
     }


### PR DESCRIPTION
A dead cursor is cured by switching boxes and back, but not by the retry pill. hardReset() does what the switch does — release held inputs, clear the address-fallback, rebuild — in one tap. Symptom treatment; root cause still open (KI-053).

Two self-corrections in the commit message: the auto-recovery stays on reconnect() (hardReset inside sendRaw recurses — caught by existing tests), and releaseAll() is pad-only, so hardReset releases mouse buttons explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)