### PR TITLE
feat(console): show which OS and version the box runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,13 @@ jobs:
       - name: Unit tests (couch mode gate)
         run: python3 tests/test_couchmode_gate.py
 
+      # Which OS the Console header claims the box runs. The shape differs by
+      # distro and the reader must not assume one: a ROLLING release (CachyOS)
+      # has no VERSION_ID at all, a point release (Bazzite/SteamOS) has both.
+      # Fixtures are verbatim from real boxes.
+      - name: Unit tests (os-release reader)
+        run: python3 tests/test_os_release.py
+
       # Flatpak update completion (KI-036). "Done" must be the update PROCESS
       # finishing, not `remote-ls` count reaching zero — an EOL runtime pins the
       # count above zero forever, which stranded the card on "Updating…" and

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,12 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.68
+
+- **The Console now shows which OS your box runs**, under the service version —
+  "Bazzite 43", "CachyOS rolling", "SteamOS 3.8.21". Handy when you have more
+  than one box, and the first thing worth knowing in a bug report.
+
 ## 2.9.67
 
 The "Boots into" setting was breaking your box's own session switching. It

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.67"
+VERSION = "2.9.68"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -916,6 +916,58 @@ def read_uptime_s():
             return int(float(f.read().split()[0]))
     except Exception:
         return 0
+
+
+# The distro identity file, as a module constant so tests can point it at
+# fixtures (same pattern as _DRM_DIR / _PROC_INPUT_DEVICES).
+_OS_RELEASE = "/etc/os-release"
+
+
+def read_os_release():
+    """{"name","version","build","kernel"} for the Console header, or {}.
+
+    Every field is independently optional and OMITTED when unreadable, so the
+    app can treat absence as "this box did not say" without telling it apart
+    from a null — the same contract as `battery` and `display`.
+
+    The fields differ by distro and that is the whole reason more than one is
+    sent rather than a single pre-formatted string. VERBATIM from the two boxes
+    here (2026-07-31):
+
+        Bazzite   PRETTY_NAME="Bazzite"  VERSION_ID=43
+                  BUILD_ID="Stable (F43.20260420)"
+        CachyOS   PRETTY_NAME="CachyOS"  BUILD_ID=rolling   (no VERSION_ID)
+
+    So a rolling distro has only BUILD_ID, a point release has both, and the
+    build string carries the part support actually needs. `kernel` is free from
+    uname and is the single most useful line in a bug report about a handheld.
+
+    Values may be quoted; strip both quote styles. Never raises."""
+    out = {}
+    vals = {}
+    try:
+        with open(_OS_RELEASE, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                key, sep, val = line.strip().partition("=")
+                if sep:
+                    vals[key] = val.strip().strip('"').strip("'")
+    except OSError:
+        vals = {}
+    name = vals.get("PRETTY_NAME") or vals.get("NAME")
+    if name:
+        out["name"] = name
+    # VERSION_ID is the point release; a rolling distro has only BUILD_ID.
+    version = vals.get("VERSION_ID") or vals.get("BUILD_ID")
+    if version:
+        out["version"] = version
+    build = vals.get("BUILD_ID")
+    if build and build != out.get("version"):
+        out["build"] = build
+    try:
+        out["kernel"] = os.uname().release
+    except Exception:
+        pass
+    return out
 
 
 # --- primary-interface network facts (for the app's Wake-on-LAN power path) --
@@ -3173,6 +3225,7 @@ def _history_snapshot():
 
 
 def real_status():
+    osrel = read_os_release()
     load = read_load()
     temp = read_cpu_temp_c()
     mem = read_mem()
@@ -3185,6 +3238,10 @@ def real_status():
         "hostname": socket.gethostname().split(".")[0],
         "time": now,
         "uptime_s": read_uptime_s(),
+        # Which OS the box runs. ADDITIVE and omitted entirely when
+        # /etc/os-release cannot be read, so an old app ignores it and a new one
+        # treats absence as "the box did not say".
+        **({"os": osrel} if osrel else {}),
         "load": load,
         "cpu_temp_c": temp,
         "mem": mem,
@@ -5559,6 +5616,11 @@ def mock_status():
         "audio": mock_audio_info(),
         "net": {"iface": "eth0", "mac": "de:ad:be:ef:00:01",
                 "wired": True, "wol_armed": True},
+        # A POINT-RELEASE distro (name + version + a separate build string) —
+        # the shape with the most fields, so the harness renders the busiest
+        # case. A rolling box sends only name + version.
+        "os": {"name": "Bazzite", "version": "43",
+               "build": "Stable (F43.20260420)", "kernel": "6.17.4-204.fc43.x86_64"},
         "agent_version": VERSION,
         "caps": CAPS,
         "config_writable": True,

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -126,9 +126,23 @@ function ConsoleScreen() {
           <Text style={styles.hostname}>
             {s?.hostname ?? (configured ? settings.host : 'Couchside')}
           </Text>
-          <Text style={styles.headerSub}>
-            {reachable ? `service v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
-          </Text>
+          <View style={styles.headerRight}>
+            <Text style={styles.headerSub}>
+              {reachable ? `service v${s?.agent_version}` : configured ? 'offline' : 'not set up'}
+            </Text>
+            {/* Which OS the box runs (agent >= 2.9.34). Absent on older agents
+                and on any box that could not read /etc/os-release, so it is
+                rendered only when the box actually said — never a placeholder.
+                `version` already falls back to BUILD_ID agent-side, so a
+                rolling distro reads "CachyOS rolling" and a point release
+                "Bazzite 43". numberOfLines guards a long PRETTY_NAME (Fedora
+                ships "Fedora Linux 43 (KDE Plasma)") from shoving the row. */}
+            {reachable && !!s?.os?.name && (
+              <Text style={styles.headerOs} numberOfLines={1}>
+                {[s.os.name, s.os.version].filter(Boolean).join(' ')}
+              </Text>
+            )}
+          </View>
         </View>
 
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
@@ -364,7 +378,11 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   dot: { width: 14, height: 14, borderRadius: 7 },
   hostname: { color: t.text, fontSize: 26, fontWeight: '700', fontFamily: mono },
-  headerSub: { color: t.textDim, fontSize: 13, marginLeft: 'auto' },
+  headerRight: { marginLeft: 'auto', alignItems: 'flex-end', flexShrink: 1 },
+  headerSub: { color: t.textDim, fontSize: 13 },
+  // Dimmer and smaller than the service line: useful when you need it, quiet
+  // when you do not.
+  headerOs: { color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 1 },
   emptyCard: {
     backgroundColor: t.card,
     borderColor: t.cardBorder,

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -420,6 +420,21 @@ export type Status = {
       and works for boxes added by hostname. */
   ip?: string;
   agent_version: string;
+  /** Which OS the box runs (agent >= 2.9.34). Absent on older agents and on any
+   *  box whose /etc/os-release could not be read — omission, never a null.
+   *  Shapes differ by distro: a rolling release (CachyOS) has no VERSION_ID and
+   *  reports `version` from BUILD_ID with no separate `build`; a point release
+   *  (Bazzite, SteamOS) sends both. */
+  os?: {
+    /** PRETTY_NAME, falling back to NAME. e.g. "Bazzite", "CachyOS". */
+    name?: string;
+    /** VERSION_ID, falling back to BUILD_ID. e.g. "43", "rolling", "3.8.21". */
+    version?: string;
+    /** BUILD_ID when it differs from `version`. e.g. "Stable (F43.20260420)". */
+    build?: string;
+    /** uname release — the single most useful line in a handheld bug report. */
+    kernel?: string;
+  };
   /** Optional-feature summary (agent >= 2.8.2); undefined on older agents. See BoxCaps. */
   caps?: BoxCaps;
   /** Recent-vitals ring for sparklines (agent >= 2.8.3); undefined on older agents. */

--- a/tests/test_os_release.py
+++ b/tests/test_os_release.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""What the Console header says the box is running.
+
+Run: python3 tests/test_os_release.py
+
+Every fixture below is VERBATIM from a real box (CLAUDE.md §6). The point of
+the test is that the SHAPE differs by distro and the reader must not assume one
+of them:
+
+    Bazzite   PRETTY_NAME="Bazzite"  VERSION_ID=43  BUILD_ID="Stable (F43...)"
+    CachyOS   PRETTY_NAME="CachyOS"  BUILD_ID=rolling      (NO VERSION_ID)
+
+A rolling release has no VERSION_ID at all, so a reader that only looks there
+shows a nameless blank on CachyOS; one that only looks at BUILD_ID loses
+Bazzite's clean "43". Both are sent, and absence is always omission — never a
+null the app has to special-case.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+BAZZITE = '''NAME="Bazzite"
+VERSION="43.20260420 (Forty Three)"
+ID=bazzite
+ID_LIKE="fedora"
+VERSION_ID=43
+PRETTY_NAME="Bazzite"
+BUILD_ID="Stable (F43.20260420)"
+HOME_URL="https://bazzite.gg"
+'''
+
+CACHYOS = '''NAME="CachyOS Linux"
+PRETTY_NAME="CachyOS"
+ID=cachyos
+ID_LIKE=arch
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://cachyos.org/"
+'''
+
+# SteamOS ships a VERSION_ID and a build; the Deck is the reference handheld.
+STEAMOS = '''NAME="SteamOS"
+PRETTY_NAME="SteamOS"
+ID=steamos
+ID_LIKE=arch
+VERSION_ID=3.8.21
+BUILD_ID=20260318.1
+'''
+
+
+def read_with(text):
+    d = tempfile.mkdtemp()
+    p = os.path.join(d, "os-release")
+    with open(p, "w") as f:
+        f.write(text)
+    saved = cs._OS_RELEASE
+    try:
+        cs._OS_RELEASE = p
+        return cs.read_os_release()
+    finally:
+        cs._OS_RELEASE = saved
+
+
+print("real fixtures, three distro shapes")
+b = read_with(BAZZITE)
+check("bazzite name", b.get("name"), "Bazzite")
+check("bazzite version prefers VERSION_ID", b.get("version"), "43")
+check("bazzite keeps the build string too", b.get("build"), "Stable (F43.20260420)")
+
+c = read_with(CACHYOS)
+check("cachyos name", c.get("name"), "CachyOS")
+# THE TRAP: no VERSION_ID at all. A VERSION_ID-only reader shows nothing here.
+check("cachyos falls back to BUILD_ID", c.get("version"), "rolling")
+check("...and does not duplicate it into build", "build" in c, False)
+
+s = read_with(STEAMOS)
+check("steamos name", s.get("name"), "SteamOS")
+check("steamos version", s.get("version"), "3.8.21")
+check("steamos build", s.get("build"), "20260318.1")
+
+print()
+print("kernel comes from uname, not the file")
+check("kernel present", bool(b.get("kernel")), True)
+
+print()
+print("degrades to omission, never to a null")
+missing = read_with("")  # empty file: nothing to report but uname
+check("no name key when the file says nothing", "name" in missing, False)
+check("no version key either", "version" in missing, False)
+saved = cs._OS_RELEASE
+try:
+    cs._OS_RELEASE = "/nonexistent-couchside-test/os-release"
+    gone = cs.read_os_release()
+    check("unreadable file -> no name", "name" in gone, False)
+finally:
+    cs._OS_RELEASE = saved
+
+print()
+print("quoting is stripped (values arrive quoted on every real distro)")
+q = read_with('PRETTY_NAME="Quoted Name"\nVERSION_ID=\'7\'\n')
+check("double quotes stripped", q.get("name"), "Quoted Name")
+check("single quotes stripped", q.get("version"), "7")
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all os-release tests passed")


### PR DESCRIPTION
Console header gains a quiet line under the service version: "Bazzite 43", "CachyOS rolling". Additive `os` block on /api/status, omitted when unreadable.

Verified on both real boxes — the rolling-vs-point-release shapes differ and both are handled (CachyOS has no VERSION_ID at all). Fixtures verbatim, CI step added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)