### PR TITLE
docs: scope the privileged helper, and Player Phase 7 from flex-launcher

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,6 +40,36 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### The privileged helper — retire the sudoers surface
+- **priority:** P1 · **risk:** high (new root-side code) · **affects:** agent + install.sh +
+  new helper binary · **depends_on:** none
+- **Full spec: `docs/memory/project_privileged-helper.md`.** Read it first.
+- Eight verbs over a root-owned unix socket (`SO_PEERCRED` uid check, frozen verb table) replace
+  all eleven NOPASSWD rules. The agent stays `User=__USER__` — uinput, Wayland capture, PipeWire,
+  KWin DBus and launching Steam all need the user session bus, so running it as root is rejected
+  outright and the spec records why.
+- **Closes KI-049** (the greetd grants are never written by install.sh, so that path has never
+  worked on any box) and **KI-050**. Also ends the DM-name-in-the-grant problem: a box whose
+  display manager changes repairs itself instead of needing install.sh re-run.
+- **Two traps the spec calls out:** the `ExecStop=--arm-boot-session` hook will need the helper
+  at shutdown, so unit ordering must be explicit or KI-051 silently regresses; and because quick
+  updates ship the agent binary WITHOUT the installer, the helper must be detected and optional
+  with the sudo path kept for a full release cycle.
+
+### Couchside Player Phase 7 — native media apps via `.desktop` + Actions
+- **priority:** P2 · **risk:** medium · **affects:** tile + agent + app · **depends_on:**
+  Player Phases 0–6 (shipped)
+- **Full spec: `docs/memory/project_media-player.md` §1c, §5b, Phase 7.** Read those first.
+- Every service the Player reaches today is a web URL. Kodi, Plex HTPC, Jellyfin, Moonlight, VLC
+  and Spotify are installed natively on plenty of boxes and cannot be launched at all. XDG
+  Desktop **Actions** are the mechanism — and the thing that opens a native app in TV mode
+  rather than a desktop window.
+- Design taken from flex-launcher's entry syntax; its launch path (`sh -c` for every entry,
+  `.desktop` files included) is explicitly rejected. Curated ids, argv-split `Exec`, no globs.
+- Two cheap unknowns to measure first: whether Chrome already inhibits the box's idle timer
+  under gamescope (a TV that blanks mid-movie is a bug we have never tested for), and which of
+  those apps ship usable Actions.
+
 ### Note mode — jot a clue on the phone while the game runs
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** the drag stroke (shipped)
 - **Full spec: `docs/memory/project_note-mode.md`.** Read it first.

--- a/docs/memory/project_media-player.md
+++ b/docs/memory/project_media-player.md
@@ -74,6 +74,64 @@ knowing when pricing this against a paid unlock.
 Phone-as-navigation-layer is not in that product, because it does not have the problem. The
 inspiration supplies the *shape*; the differentiator is bigger than the first draft claimed.
 
+## 1c. Reconciled against flex-launcher (repo read in full, 2026-07-31)
+
+[complexlogic/flex-launcher](https://github.com/complexlogic/flex-launcher) — a controller-driven
+10-foot launcher, ~4k LOC of C plus SDL. The owner asked what it has that we should take. The
+repo was cloned and read (`src/platform/unix.c`, `src/launcher.c`, `docs/configuration.md`), not
+skimmed from its README.
+
+**Adopt**
+
+- **Desktop Actions.** Its entry syntax is `Entry1=Steam;icon.png;/usr/share/applications/steam.desktop;BigPicture`
+  — the trailing token names an **Action inside** the `.desktop` file rather than a command.
+  That indirection is exactly our lookup model, and it is the piece that turns "launch Kodi"
+  into "launch Kodi in TV mode". Becomes Phase 7.
+- **`InhibitOSScreensaver`.** Names a bug class we have not tested. See Phase 7.
+
+**Adapt**
+
+- **`Exec` field-code stripping.** A real XDG detail any `.desktop` consumer must handle, but
+  **do not port their implementation** — `strip_field_codes()` in `src/platform/unix.c` does an
+  overlapping `strcpy` (undefined behaviour) and drops the character before the `%`. Take the
+  requirement, write it against the spec, fixture-test it.
+- **`OnLaunch=Blank`.** A black frame while the app initialises. We have no launcher window,
+  but the tile can do the same thing.
+
+**Reject — and the reason matters more than the verdict**
+
+- **Its entire launch path.** Every entry, `.desktop` files included, ends at:
+
+  ```c
+  const char *args[] = { "sh", "-c", cmd, NULL };
+  execvp(file, (char* const*) args);
+  ```
+
+  That is correct for a program whose config file the user hand-writes on the machine in front
+  of them. It is fatal for a daemon reachable over the LAN behind one bearer token. **If Phase 7
+  ever parses an `Exec` line, it is argv-split and exec'd as a list — never handed to a shell.**
+- **`:fork`, `StartupCmd`, `QuitCmd`** — three separate "run this arbitrary string" features.
+- **`:shutdown` / `:restart` / `:sleep`** — we already have these behind fixed-argument grants,
+  which is strictly better than what they do.
+- **Per-entry icons and selected-icon overrides** — we already ship branded grid art.
+- **Its screensaver, clock widget, menu tree, `ControllerMappingsFile`** — the screensaver
+  shipped in 2.8.4, and the rest assume the UI lives on the box. Ours lives on the phone.
+
+## 5b. Security rules for Phase 7 (`.desktop` handling)
+
+Written down separately because this is the first time the Player would launch something that
+is not a URL.
+
+1. **The client never supplies a path, an `Exec` line, or a command** — only an `app_id` and an
+   optional `action_id`, both of which index a table the agent built.
+2. **Curated ids, not blanket discovery.** Offering every `.desktop` file found on the box is a
+   glob by another name, and the attack is concrete: anything that can drop a file into
+   `~/.local/share/applications` — a browser download, a flatpak, a game's installer — would
+   become code execution the moment a phone taps the tile. Adding an app is adding an entry.
+3. **`Exec` is argv-split, never shelled.** See §1c.
+4. **Degrade closed.** An unparseable `.desktop`, a missing `Exec`, or an action that is not in
+   the file ⇒ the entry is not offered. Never "offer it and hope".
+
 ## 2. Shape: this is the SCREENSAVER pattern, second instance
 
 The owner's instinct ("custom program, registered as a non-Steam app") is not just correct,
@@ -473,6 +531,52 @@ this reason.
 
   **`_pl_relaunch()` extracted** so `open`, `search` and `hub` share ONE launch path. Three
   copies of the fresh-registration double-fire would be three places for it to drift.
+
+- **Phase 7 — native media apps (`.desktop` + Actions). 📋 PLANNED, scoped 2026-07-31.**
+  See §1c for where the design came from and §5b for the security rules it must obey.
+
+  **The gap it closes:** every service the Player can reach today is a *web* service —
+  `_PLAYER_SERVICES` is populated from the tile and each entry is a URL. Kodi, Plex HTPC,
+  Jellyfin, Moonlight, VLC and Spotify are installed natively on plenty of boxes and the
+  Player cannot launch any of them. This is the single largest thing missing from "Couchside
+  media".
+
+  **The mechanism:** an XDG `.desktop` entry, optionally with a named **Action**. The agent
+  scans, builds the table, and mints the ids; the phone sends `{app_id, action_id}` and both
+  are looked up. Nothing the client sends is ever a path, an `Exec` line, or a command.
+
+  Shape, matching the existing `_pl_validate()` pattern:
+
+  - `_MEDIA_APPS = {id: {name, desktop_path, actions: {...}, icon}}`, built at startup by the
+    same probe-and-appear rule as the rest of the tile. Empty table ⇒ the capability is absent.
+  - Ids come from a **curated known-media list** (kodi, plex, plexhtpc, jellyfin, moonlight,
+    vlc, spotify), not from "everything discovered". Blanket discovery is a pattern, which
+    CLAUDE.md §3.3 forbids, and it has a concrete attack — see §5b.
+  - `Exec=` is read, field codes (`%f %F %u %U %i %c %k`) stripped per the XDG spec,
+    `shlex.split()`, run as an **argv list**. Never a shell string.
+  - Actions are the reason this is worth doing at all: `kodi.desktop` and friends expose their
+    TV/fullscreen mode as a named action, so the action is what gets a native app onto the TV
+    correctly instead of in a desktop window.
+
+  **Also adopted from flex-launcher, both small:**
+  - **Screensaver inhibit while playing.** Their `InhibitOSScreensaver` names a bug class we
+    have never checked: if the box's idle timer or DPMS fires mid-movie, the TV blanks during
+    playback. **Verify first** — Chrome may already inhibit under gamescope — and only add an
+    inhibit if the measurement says it does not. Both states must be observed (§11.2).
+  - **A blank frame while an app starts** (their `OnLaunch=Blank`). Chrome takes seconds to
+    come up and the TV currently shows the Steam UI and then a flash. Cosmetic, cheap.
+
+  **Tests this phase owes:** a non-allowlisted `app_id` and a non-allowlisted `action_id` each
+  refused with nothing launched; a `.desktop` fixture copied VERBATIM from a real box for each
+  app in the curated list; a field-code fixture proving `%U` is stripped and an argument
+  containing a legitimate `%` is not; a planted `~/.local/share/applications` entry proving it
+  is NOT offered; and the launch itself screen-captured off the TV, because it is only
+  observable there.
+
+  **NOT yet verified, and both are cheap:** whether Chrome already inhibits idle under
+  gamescope on our boxes, and which of those six apps actually ship usable Actions in their
+  `.desktop` files. Neither could be checked when this was scoped — the CachyOS box was
+  offline and the Bazzite box was on the other subnet.
 
 ### Picture controls: BUILT, THEN CUT 2026-07-27 — and why
 

--- a/docs/memory/project_media-player.md
+++ b/docs/memory/project_media-player.md
@@ -573,10 +573,41 @@ this reason.
   is NOT offered; and the launch itself screen-captured off the TV, because it is only
   observable there.
 
-  **NOT yet verified, and both are cheap:** whether Chrome already inhibits idle under
-  gamescope on our boxes, and which of those six apps actually ship usable Actions in their
-  `.desktop` files. Neither could be checked when this was scoped — the CachyOS box was
-  offline and the Bazzite box was on the other subnet.
+  **MEASURED on bazzite 10.1.1.60, 2026-07-31** — the survey that was pending when this was
+  scoped. Numbers are from 232 real `.desktop` files in `/usr/share/applications` and
+  `/var/lib/flatpak/exports/share/applications`:
+
+  | fact | count | what it means for Phase 7 |
+  |---|---|---|
+  | files with `Exec` field codes | 46 / 232 (20%) | stripping is **mandatory**, not an edge case |
+  | files with an `Actions=` line | 11 / 232 (5%) | Actions are a **bonus, not the mechanism** |
+  | `~/.local/share/applications` exists, user-writable | yes | the §5b attack surface is real on a stock box |
+
+  **The media apps actually installed, verbatim:**
+
+  - `tv.kodi.Kodi.desktop` — **`Actions=Fullscreen;Standalone;`**, with
+    `[Desktop Action Fullscreen]` / `Name=Open in fullscreen`. This is the Phase 7 use case
+    confirmed on hardware.
+  - `tv.plex.PlexHTPC.desktop` — **no `Actions` line.**
+  - `com.moonlight_stream.Moonlight.desktop` — **no `Actions` line.**
+
+  **Two corrections to the scoping draft, from that data:**
+  1. Actions are *not* how most native apps reach TV mode — one of the three media apps on the
+     box has them. Phase 7 must launch plain `Exec` well first and treat an action as an
+     optional refinement, not build the feature around actions.
+  2. Every `Exec` here is a flatpak wrapper
+     (`/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=kodi tv.kodi.Kodi`). Fine
+     for an argv list, but it means the parser must not assume `Exec[0]` is the app.
+
+  **Quoting is load-bearing.** A real line on that box:
+  `Exec=kde-geo-uri-handler --coordinate-template "https://www.google.com/maps/@<LAT>,<LON>,<Z>z" ... %u`
+  — quoted arguments containing commas and angle brackets. A naive `split()` mangles it; use
+  `shlex.split()` and fixture-test against this exact line.
+
+  **STILL NOT verified:** whether Chrome already inhibits idle under gamescope. That needs a
+  live playback session, which takes over the TV, so it was not run unasked. It also must
+  observe **both** states (§11.2) — idle firing without playback, and not firing with it —
+  or it proves nothing.
 
 ### Picture controls: BUILT, THEN CUT 2026-07-27 — and why
 

--- a/docs/memory/project_privileged-helper.md
+++ b/docs/memory/project_privileged-helper.md
@@ -1,0 +1,168 @@
+# Project: the privileged helper (retiring the sudoers surface)
+
+**Status:** 📋 Scoped, not started. Depends on nothing; safe to start any time.
+**Risk:** high — this is new root-side code on a LAN-reachable box. Every rule in
+CLAUDE.md §3 applies to the helper with no exceptions.
+
+---
+
+## 1. Why
+
+Three separate shipped bugs came out of the sudoers surface, not out of the
+features themselves:
+
+- the NOPASSWD lexical-ordering saga (`zz-couchside`, last-match-wins probing),
+- **KI-049** — the greetd grants are *never written by install.sh*, so the agent's
+  greetd path calls `sudo -n` against rules that do not exist and fails closed on
+  every greetd box,
+- **KI-050** — the Decky bootstrap may write stale `sddm`-shaped grants on a box
+  whose display manager is not sddm.
+
+The grants are also now *dynamic* (`$DM_NAME`), which means the installer has to
+be re-run to fix a box whose DM changed — the agent alone cannot repair it.
+
+Root-running the agent is rejected: see §6.
+
+## 2. What exists today (shipped, agent 2.9.68)
+
+Eleven NOPASSWD rules, from `install.sh`:
+
+| # | rule | note |
+|---|------|------|
+| 1 | `systemctl restart $DM_NAME` | dynamic — `sddm` or `plasmalogin` |
+| 2 | `tee /etc/$DM_NAME.conf.d/zzz-couchside-session.conf` | dynamic path |
+| 3 | `tee /etc/sddm.conf.d/zz-couchside-session.conf` | legacy, blank-only |
+| 4 | `systemctl reboot` | |
+| 5 | `systemctl poweroff` | |
+| 6 | `systemctl suspend` | |
+| 7 | `systemctl restart plugin_loader` | Decky recovery |
+| 8 | `systemctl restart --no-block couchside.service` | app-triggered update |
+| 9 | `$JOURNAL_WRAPPER` | root-owned, validates unit + line count |
+| 10 | `$WRAP` (flatpak update wrapper) | conditional on `-x` |
+| 11 | `$OSWRAP` (OS update wrapper) | conditional on `-x` |
+
+Plus two agent call sites with **no matching grant at all** (KI-049):
+`sudo -n cp -n $GREETD_CONFIG $GREETD_BACKUP` and `sudo -n tee $GREETD_CONFIG`.
+
+## 3. The helper
+
+A separate root process, socket-activated, that the network-facing agent talks to
+over a local unix socket. The agent keeps running as `User=__USER__` — it must,
+because uinput, Wayland capture, PipeWire, KWin DBus and launching Steam all need
+the user session bus.
+
+```
+/usr/libexec/couchside-helper          root:root 0755, pure stdlib
+/run/couchside/helper.sock             SocketMode=0660, SocketUser=<install user>
+couchside-helper.socket                systemd socket unit
+couchside-helper.service               Type=simple, root, Accept=no
+```
+
+**Protocol.** One JSON object per line in, one out. No streaming, no shell.
+
+```json
+{"verb": "session.set-boot", "arg": "desktop"}
+{"ok": true, "detail": "plasmalogin: zzz-couchside-session.conf written"}
+```
+
+**Authentication is two-layer and both layers fail closed:**
+1. socket mode 0660 owned by the install user;
+2. `SO_PEERCRED` on the accepted connection — the peer uid must equal the uid
+   baked in at install time. If `SO_PEERCRED` is unavailable, **refuse**, do not
+   fall through to "allow".
+
+**The verb table is a frozen dict in the helper.** The verb selects a Python
+function; the arg is validated against that verb's own closed set. An unknown
+verb or an unknown arg is an error reply and nothing runs. No verb takes a path,
+a unit name, or any string that reaches a shell. `subprocess` is argv-list only.
+
+| verb | arg (closed set) | replaces |
+|------|------------------|----------|
+| `session.set-boot` | `game` \| `desktop` \| `last` | 2, 3, + greetd writes |
+| `session.clear-boot` | — | 2 |
+| `dm.restart` | — | 1 |
+| `power` | `reboot` \| `poweroff` \| `suspend` | 4, 5, 6 |
+| `unit.restart` | `plugin_loader` \| `couchside` | 7, 8 |
+| `logs.journal` | `{unit, lines}`, unit from the units table | 9 |
+| `update.flatpak` | — | 10 |
+| `update.os` | — | 11 |
+
+Eight verbs for eleven grants plus the two ungranted greetd calls. The DM name
+stops being part of the *grant* and becomes an internal detail of the helper,
+which detects it the same way the agent does today — so a box whose DM changes
+repairs itself on the next call instead of needing install.sh re-run.
+
+## 4. Rollout — the constraint that shapes everything
+
+**The agent updates independently of the installer.** The quick-update path
+prints, verbatim:
+
+> Quick update: agent binary only. If the service file or sudo grants also
+> changed, re-run this installer from a terminal to apply those.
+
+So a 2.9.7x agent will run on boxes that have no helper, possibly for months.
+The helper is therefore **optional and detected**, never assumed:
+
+```
+_privileged(verb, arg):
+    if helper socket present and answers  -> use it
+    else                                  -> existing sudo argv path
+```
+
+Phase order:
+1. Ship the helper + the agent shim, with sudoers **unchanged**. Both paths live.
+   Any box that runs the installer gains the helper; every other box is untouched.
+2. Once telemetry-free confidence is there (both test boxes on the helper path,
+   one full release cycle), stop writing the migrated sudoers lines in a new
+   installer run and remove the stale file.
+3. Delete the sudo fallback only after the minimum supported agent has the shim.
+
+## 5. Traps to design against
+
+- **Shutdown ordering.** `couchside.service` has
+  `ExecStop=… --arm-boot-session`, which will now want the helper. If
+  `couchside-helper.socket` is torn down first, arming silently fails and the
+  KI-051 fix regresses on every shutdown. The units need explicit ordering, and
+  the arming test must be run against a *real* reboot, not a mocked one — that is
+  how the original bug was caught.
+- **Socket activation at boot.** The agent can start before the socket is up; the
+  detection must treat "not yet there" as "use fallback", not as a hard error.
+- **The helper is root code reading a socket.** It gets the same review bar as the
+  HTTP allowlist: a reviewer should be able to read the whole verb table on one
+  screen.
+- **`Accept=no`,** so one long-lived process handles connections; a per-connection
+  fork would multiply the root surface for no gain.
+
+## 6. Rejected: run the agent as root
+
+It would delete the sudoers file outright, and it is still the wrong trade.
+
+- The agent is a hand-rolled HTTP/WebSocket server reachable on the LAN behind one
+  bearer token. Today a token compromise yields the desktop account plus a fixed
+  argv allowlist; as root it yields the whole box, and any bug in that parser
+  becomes a root RCE.
+- It does not simplify as much as it looks. `User=__USER__` and
+  `XDG_RUNTIME_DIR=/run/user/__UID__` are load-bearing for uinput, Wayland
+  capture, PipeWire, KWin DBus and Steam. A root daemon would immediately need to
+  re-enter the user session, trading sudoers complexity for privilege-dropping
+  complexity — the harder of the two to get right.
+- Root would not have prevented any of the recent display-manager work. It does
+  not tell you which DM is installed, does not change that `/etc/sddm.conf`
+  overrides `conf.d`, and would not have prevented KI-051. Those are platform
+  semantics, identical at every privilege level.
+
+## 7. Tests required (CLAUDE.md §6)
+
+- unknown verb refused **and nothing runs** (the standard non-allowlisted-id test);
+- unknown arg for a known verb refused;
+- `SO_PEERCRED` mismatch refused; missing `SO_PEERCRED` refused (fail closed);
+- agent shim: helper present -> helper used; helper absent -> sudo fallback;
+  helper present but erroring -> reported, **not** silently retried as sudo;
+- shutdown arming through the helper, proven on a real reboot of a real box, both
+  directions (game and desktop), the way KI-051 was proven;
+- greetd: the path that has never worked now works — this is the KI-049 close.
+
+## 8. Size
+
+Helper ~200 lines. Agent shim ~60 plus deleting the sudo argv builders. install.sh
+~40 (install units, stop writing migrated rules in phase 2). Four test files.


### PR DESCRIPTION
Two planned specs. **No code, no behaviour change** — three docs files.

## The privileged helper — `docs/memory/project_privileged-helper.md`

The sudoers surface has produced three separate shipped bugs: the NOPASSWD
lexical-ordering saga, KI-049, and KI-050. The grants are also now DM-dynamic
(`$DM_NAME`), so a box whose display manager changes cannot be repaired by the
agent alone — install.sh has to be re-run.

Proposal: **eight verbs replace all eleven NOPASSWD rules**, over a root-owned
unix socket (mode 0660, `SO_PEERCRED` uid check, frozen verb table, argv lists
only, unknown verb or arg refused).

The agent **stays `User=__USER__`**. Running it as root would delete the sudoers
file, and is rejected in §6 with the reasoning recorded: it is a hand-rolled
HTTP/WebSocket server reachable on the LAN behind one bearer token, so a token
compromise would go from "the desktop account plus a fixed argv allowlist" to
the whole box; and `XDG_RUNTIME_DIR` is load-bearing for uinput, Wayland
capture, PipeWire, KWin DBus and launching Steam, so a root daemon would
immediately have to re-enter the user session anyway.

Closes **KI-049** — the greetd grants are never written by install.sh, so the
agent's two greetd call sites have never worked on any box. Verified by reading
the shipped installer's grant list, not inferred.

Two traps the spec calls out up front:
- `ExecStop=--arm-boot-session` will need the helper at shutdown. If the socket
  tears down first, KI-051 silently regresses on every shutdown. Unit ordering
  must be explicit, and the arming test must run against a real reboot.
- Quick updates ship the agent binary **without** the installer, so the helper
  must be detected and optional, with the sudo path kept for a full release
  cycle.

## Player Phase 7 — `docs/memory/project_media-player.md` §1c, §5b, Phase 7

The flex-launcher repo was cloned and read (~4k LOC C plus its config docs), not
skimmed from the README. Recorded as §1c in the same adopt/adapt/reject format
as the existing §1b.

**The gap Phase 7 closes:** every service the Player reaches today is a web URL.
Kodi, Plex HTPC, Jellyfin, Moonlight, VLC and Spotify are installed natively on
plenty of boxes and cannot be launched at all. XDG Desktop **Actions** are the
mechanism, and the thing that opens a native app in TV mode rather than a
desktop window.

**Rejected, and quoted in the spec so it is never copied** — every flex-launcher
entry, `.desktop` files included, ends at `sh -c`. Correct for a config file the
user hand-writes locally; fatal for a LAN-reachable daemon. Phase 7 argv-splits
`Exec`. Also rejected: `:fork`, `StartupCmd`, `QuitCmd`.

**Curated ids, not blanket discovery** (§5b). Offering every `.desktop` found is
a glob by another name, and the attack is concrete: anything that can write to
`~/.local/share/applications` — a download, a flatpak, a game installer — would
become code execution the moment a phone taps the tile. One required test plants
exactly that file and asserts it is not offered.

Their `strip_field_codes()` is explicitly **not** to be ported: it does an
overlapping `strcpy` and drops the character before the `%`. Take the
requirement, write it against the XDG spec.

## Verified / not verified

Docs only, so there is nothing to run. What informed them was read directly: the
shipped `install.sh` grant list, the agent's sudo call sites, `_pl_validate()`
and the Player service tables, and flex-launcher's `src/platform/unix.c`.

**Not verified, both flagged in the spec and both cheap:** whether Chrome already
inhibits the box's idle timer under gamescope (a TV that blanks mid-movie is a
bug class we have never tested for), and which of those six apps ship usable
Actions in their `.desktop` files. Neither could be checked while scoping — the
CachyOS box went offline and the Bazzite box is on the other subnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)