### PR TITLE
fix(app): one caps writer, not two — a session switch hung the app on iOS

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "109",
+      "buildNumber": "110",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1580,6 +1580,19 @@ function PadScreen() {
           setPref('padTrackpadLarge', !trackpadLarge);
           hapticSelection();
         }}
+        // The SECOND door to the diagnostics panel, and in large-pad mode the
+        // only one: the header pill that carries the other long-press is inside
+        // `{!largePad && ...}`, so enlarging the pad -- the natural thing to do
+        // for trackpad use, and therefore the state you are in when the cursor
+        // dies -- removed every way to read the counters. Shrinking the pad to
+        // reach the pill is not an acceptable workaround: it is one more
+        // interaction with the touch layer whose state is the thing under
+        // investigation.
+        onLongPress={() => {
+          hapticLight();
+          setDiagOpen(true);
+        }}
+        delayLongPress={700}
         style={styles.tpToggleChip}
         hitSlop={12}
         accessibilityLabel={trackpadLarge ? 'Exit large pad' : 'Enlarge pad'}>

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -7,7 +7,7 @@ import { CouchModeSheet } from '@/components/CouchModeSheet';
 import { ScreensaverSheet } from '@/components/ScreensaverSheet';
 import { SleepTimerSheet } from '@/components/SleepTimerSheet';
 import { usePoll } from '@/hooks/usePoll';
-import { api, capsEqual, Displays, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
+import { api, Displays, hostKey, PowerSchedule, Screensaver, Status, Tv, TvOp, VolumeTarget } from '@/lib/api';
 import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { getPref, usePref } from '@/lib/prefs';
 import { normalizeMac, isValidLanIp } from '@/lib/settings';
@@ -230,11 +230,30 @@ export function RemotePowerBar({ compact = false }: { compact?: boolean }) {
   // so the tab bar can hide gaming tabs on a server box immediately on next
   // launch. Value-equality gate (caps is a fresh object every poll) so it
   // writes storage once per real change, not once per poll.
-  React.useEffect(() => {
-    if (s?.caps && !capsEqual(s.caps, settings.caps)) {
-      void update({ caps: s.caps });
-    }
-  }, [s?.caps, settings.caps, update]);
+  // The caps learner USED TO LIVE HERE and has moved to useCapsSync (KI-054).
+  //
+  // Having two of them was a hang. This component polls status every 8s and
+  // useCapsSync polls it every 30s, so each held its own snapshot; whenever
+  // those two snapshots disagreed about a SESSION-VOLATILE cap -- `desktop`,
+  // which flips on every Game Mode <-> desktop switch -- each write set
+  // settings.caps to its own view, which made the OTHER learner's
+  // value-equality check false, and it wrote straight back from its stale
+  // snapshot. Neither had to refetch for that to continue, so the two ran a
+  // synchronous write loop at render speed until they happened to refetch and
+  // agree, which at a 30s cadence is a very long time.
+  //
+  // Measured against a mock whose `desktop` flipped on a timer:
+  //   [KI-054] capsEqual=false; diffs=desktop: box=false stored=true
+  //   [KI-054] capsEqual=false; diffs=desktop: box=true  stored=false
+  // -- one key, alternating, exactly the two writers fighting. On real
+  // hardware (bazzite, a live session switch) it produced "Maximum update
+  // depth exceeded" and pinned the JS thread for 8+ minutes: the app stopped
+  // polling the box 4 seconds after the switch and never recovered, which is
+  // the trackpad-dies-after-a-session-switch report (KI-053).
+  //
+  // ONE writer, always mounted, is the invariant. Do not re-add a second one
+  // here or anywhere else -- the fix is not "add a better guard", it is that
+  // two independent writers of the same persisted value cannot both be right.
 
   // TV/audio backend + mute state. Polled (not probed once per connect) so the
   // mute indicator self-heals when the box is muted out of band (controller,


### PR DESCRIPTION
Fixes **KI-054**, and the evidence says it is the cause of **KI-053** — the
trackpad dying after a Game Mode ↔ desktop switch, which has been open for
weeks and had survived two wrong diagnoses.

## The bug

Two components persisted the box's caps: `RemotePowerBar` off its 8s status
poll, and `useCapsSync` off its own 30s poll. Each held its own snapshot.
Whenever those snapshots disagreed about a session-volatile cap — `desktop`,
which flips on every session switch — each write set `settings.caps` to its own
view, which made the other's value-equality check false, and it wrote straight
back from its stale snapshot. **Neither had to refetch for that to continue**,
so the two ran a synchronous write loop at render speed.

## How it was found, and what it is not

Measured on hardware first. bazzite 10.1.1.60, a real session switch at
16:01:23; the app's last request to the box at 16:01:28; then `Maximum update
depth exceeded` still accumulating **8 minutes later** (230 → 238 in 20s, 887
total) with no further polling. That is the field report exactly: green pill,
healthy socket, dead input, recoverable only by switching boxes or tabs (both
remount) or force-quitting.

Then reproduced **deterministically** against a mock whose `desktop` flipped on
a timer. One key, alternating — the two writers fighting:

```
[KI-054] capsEqual=false; diffs=desktop: box=false stored=true
[KI-054] capsEqual=false; diffs=desktop: box=true  stored=false
```

Ruled out, so nobody re-derives them:
- **NOT the §4 five-edit-sites trap.** `normalizeCaps` and `capsEqual` list the
  same 19 keys, and bazzite sends 18, every one a real `bool` — checked the live
  payload's value *types*, not just key presence.
- **NOT the touch layer.** During a real episode the gesture counters read
  grants 17 = releases 17, unclosed 0, moves 890 = onMoveCalls 890.
- **NOT `update` being unmemoised**, which was my first guess and was wrong: it
  is memoised all the way down (`[activeId, updateBox]` → `[commit]` → `[]`).

## Verification

| | before | after |
|---|---|---|
| harness, cap flipping every 20s | hundreds of writes/sec | **1 write in 90s** |
| iOS build 112, real session switch on hardware | app hung | **owner confirms fixed** |

Both states observed: the loop reproduced on demand, then stopped.

157 input-path tests pass. Typecheck clean.

## The iOS-only asymmetry, measured rather than assumed

The owner noted this never happens on Android. Tested it: razr 2023 (app 2.9.31)
against the CachyOS box, flipped **both** directions — `caps.desktop` confirmed
changing on the box, logcat capture confirmed live — **0** `Maximum update
depth`, and the app kept polling at 110–117 req/60s. iOS stopped at +4s.

`git show 54249d1` confirms **both writers are present in the 2.9.31 build
Android is running**, so this is not a version difference. Why the same
defective code loops on iOS and not Android is **unexplained**; a keychain-cost
hypothesis is recorded in KNOWN_ISSUES as a guess, explicitly not a finding.
It does not change the fix: two independent writers of one persisted value is a
defect on every platform, and the platform profile matches (loop iOS-only,
KI-053 iOS-only).

## Also here

`fix(pad)`: the diagnostics panel was unreachable in large-pad mode — the
long-press lived on the header pill, which is inside `{!largePad && …}`, so the
one mode where the counters matter had no way to open them. The floating size
chip gets the same `onLongPress`. Exercised in the harness both ways: long-press
opens the panel, short press still toggles the pad and does **not** open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)