### PR TITLE
feat(agent): the privileged helper — eight verbs replace eleven sudo grants (phase 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,20 @@ jobs:
       - name: Unit tests (display manager + greetd)
         run: python3 tests/test_display_manager.py
 
+      # The privileged helper is the only root code we ship, reachable from a
+      # local socket, so its REFUSAL surface is what gets tested: unknown verb,
+      # out-of-set argument, malformed envelope, and a display manager that
+      # cannot be identified — each asserting on a spawn counter, so a handler
+      # that "errored" while still shelling out would fail here.
+      - name: Unit tests (privileged helper verb table)
+        run: python3 tests/test_privileged_helper.py
+
+      # SO_PEERCRED is Linux-only and the suite SKIPS elsewhere, so this step is
+      # the only place it actually runs. A green local run on a Mac has not
+      # tested the socket gate at all — same rule as the /proc parsers.
+      - name: Unit tests (privileged helper socket auth — Linux only)
+        run: python3 tests/test_helper_socket.py
+
       # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
       # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
       # sessions and a connected panel was refused by its NAME — hiding the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,13 @@ jobs:
       - name: Unit tests (privileged helper socket auth — Linux only)
         run: python3 tests/test_helper_socket.py
 
+      # The agent-side shim: helper present -> used; absent -> the sudo path,
+      # unchanged; helper REFUSES -> final, never re-asked via sudo. That last
+      # one is the behaviour a lazy shim gets wrong, and it is what keeps a
+      # root-side refusal from becoming a bypass attempt.
+      - name: Unit tests (helper shim in the agent)
+        run: python3 tests/test_helper_shim.py
+
       # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
       # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
       # sessions and a connected panel was refused by its NAME — hiding the

--- a/agent/couchside-helper.py
+++ b/agent/couchside-helper.py
@@ -1,0 +1,477 @@
+#!/usr/bin/env python3
+"""Couchside's privileged helper — the only root code in the product.
+
+WHY THIS EXISTS
+---------------
+Everything here used to be a NOPASSWD sudoers rule. Eleven of them, two of
+which had to name the display manager (`/usr/bin/systemctl restart $DM_NAME`,
+`/usr/bin/tee /etc/$DM_NAME.conf.d/...`). That surface produced three separate
+shipped bugs: the lexical-ordering saga, KI-049 (the greetd grants install.sh
+never wrote, so that path never worked on any box), and KI-050. It also meant a
+box whose display manager changed could not be repaired by the agent alone —
+install.sh had to be re-run.
+
+This process replaces all of it with EIGHT VERBS behind a local unix socket.
+The DM name stops being part of a grant and becomes an internal detail here,
+so a box that changes display manager repairs itself on the next call.
+
+WHAT THIS IS NOT
+----------------
+It is NOT a general "run something as root" service, and the agent is NOT root.
+The network-facing agent stays `User=<the desktop user>` because uinput, Wayland
+capture, PipeWire, KWin DBus and launching Steam all need that user's session
+bus. Running the agent as root would turn one bearer token into the whole box
+and any bug in its hand-rolled HTTP parser into a root RCE. See
+docs/memory/project_privileged-helper.md §6.
+
+THE RULES THIS FILE LIVES BY (CLAUDE.md §3)
+-------------------------------------------
+1. VERBS is a frozen table. A verb is looked up, never interpolated.
+2. Each verb validates its own argument against a CLOSED SET. Unknown verb or
+   unknown argument is an error reply and NOTHING RUNS.
+3. subprocess is called with an argv LIST. Never shell=True, never a formatted
+   command string. No argument to any verb ever reaches a shell.
+4. No verb takes a path, a unit name, or a command from the caller.
+5. Authentication is two layers and BOTH fail closed: socket mode 0660 owned by
+   the install user, and an SO_PEERCRED uid check. If SO_PEERCRED cannot be
+   read, the connection is REFUSED — never allowed through.
+
+Pure python3 stdlib, like the agent. It installs onto machines we do not
+control.
+"""
+import grp
+import json
+import os
+import pwd
+import re
+import socket
+import struct
+import subprocess
+import sys
+
+VERSION = "1.0.0"
+
+SOCKET_PATH = "/run/couchside/helper.sock"
+# The uid allowed to talk to us. Baked in at install time via --uid; there is
+# no "any user" mode and no way to widen it at runtime.
+ALLOWED_UID = None
+
+# ---------------------------------------------------------------- DM detection
+
+# The SAME frozen table the agent uses. A display manager that is not in here is
+# not supported — never a pattern, never a prefix match (CLAUDE.md §3.3).
+_DM_CONF_DIRS = {
+    "sddm": "/etc/sddm.conf.d",
+    "plasmalogin": "/etc/plasmalogin.conf.d",
+}
+_DM_MAIN_CONFS = {
+    "sddm": "/etc/sddm.conf",
+    "plasmalogin": "/etc/plasmalogin.conf",
+}
+_DM_UNIT_LINK = "/etc/systemd/system/display-manager.service"
+_GREETD_CONFIG = "/etc/greetd/config.toml"
+_GREETD_BACKUP = "/etc/greetd/config.toml.couchside-bak"
+
+# Our drop-in sorts LAST on purpose: SDDM reads *.conf alphabetically and the
+# last Session= wins, and steamos-session-select owns zz-steamos-autologin.conf.
+# "zz-couchside" sorted BEFORE it and was silently overridden on every Couch
+# Mode switch. Do not rename this without re-reading that history.
+_DROPIN_NAME = "zzz-couchside-session.conf"
+
+
+def _dm_unit_name():
+    """The REAL unit name behind display-manager.service (gdm3 != gdm), or None.
+
+    The existence check is load-bearing and was caught by a test: realpath() of
+    a path that does not exist returns THE PATH ITSELF, so a box with no display
+    manager resolved to the unit name "display-manager" and dm.restart happily
+    ran `systemctl restart display-manager`. That is a fail-OPEN in the one file
+    that must never have one. Absent link -> None -> every DM verb refuses.
+    """
+    if not os.path.exists(_DM_UNIT_LINK):
+        return None
+    try:
+        target = os.path.realpath(_DM_UNIT_LINK)
+    except OSError:
+        return None
+    name = os.path.basename(target)
+    if not name or name == os.path.basename(_DM_UNIT_LINK):
+        # Resolved to itself: a dangling link tells us nothing about which
+        # manager runs, so treat it as unknown rather than as its own name.
+        return None
+    return name[:-8] if name.endswith(".service") else name
+
+
+def detect_display_manager():
+    """Which display-manager FAMILY runs here: 'sddm' | 'plasmalogin' |
+    'greetd' | None.
+
+    Degrades CLOSED (CLAUDE.md §3.7): an unreadable link or an unrecognised
+    manager returns None, and every verb that needs one then refuses.
+    """
+    unit = _dm_unit_name()
+    if not unit:
+        return None
+    unit = unit.lower()
+    if unit.startswith("gdm"):
+        return "gdm"          # recognised, but we do not write its config
+    for known in ("sddm", "plasmalogin", "greetd", "lightdm"):
+        if unit == known:
+            return known
+    return None
+
+
+# ------------------------------------------------------------- verb handlers
+#
+# Every handler returns (ok: bool, detail: str). They take either no argument or
+# ONE already-validated value from a closed set.
+
+_SESSION_MODES = ("game", "desktop", "last")
+
+# What each mode means as an autologin Session=. The VALUES are ours, built
+# here; the caller only ever picks a key from _SESSION_MODES.
+_SESSION_FILES = {
+    "game": "gamescope-session.desktop",
+    "desktop": "plasma.desktop",
+}
+
+
+def _run(argv, timeout=25):
+    """subprocess with an argv LIST. The only place this file spawns anything."""
+    try:
+        p = subprocess.run(argv, capture_output=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as e:
+        return False, "spawn failed: %s" % e
+    out = (p.stdout or b"").decode("utf-8", "replace").strip()
+    err = (p.stderr or b"").decode("utf-8", "replace").strip()
+    return p.returncode == 0, (out or err or "")[:400]
+
+
+def _write_root_file(path, body):
+    """Write a file we OWN, atomically, as root. `path` is always one of our own
+    constants — never anything a caller supplied."""
+    tmp = path + ".couchside-tmp"
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(body)
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, path)
+        return True, path
+    except OSError as e:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return False, "write failed: %s" % e
+
+
+def verb_session_set_boot(mode):
+    """Point the display manager's autologin at game or desktop for the NEXT boot.
+
+    'last' means: stop steering, remove our drop-in, let the platform decide.
+    """
+    dm = detect_display_manager()
+    if dm is None:
+        return False, "no supported display manager detected"
+
+    if mode == "last":
+        return verb_session_clear_boot()
+
+    session_file = _SESSION_FILES[mode]
+
+    if dm == "greetd":
+        # KI-049: this path exists in the agent and has NEVER worked on any box,
+        # because install.sh never wrote a matching sudoers grant. Here it needs
+        # no grant at all.
+        try:
+            with open(_GREETD_CONFIG, "r", encoding="utf-8") as f:
+                cur = f.read()
+        except OSError as e:
+            return False, "greetd config unreadable: %s" % e
+        if not os.path.exists(_GREETD_BACKUP):
+            _write_root_file(_GREETD_BACKUP, cur)
+        # Replace only the command inside [initial_session]; everything else in
+        # the operator's config is left exactly as it was.
+        new, n = re.subn(
+            r'(?m)^(\s*command\s*=\s*)"[^"]*"',
+            lambda m: '%s"%s"' % (m.group(1), session_file),
+            cur, count=1)
+        if not n:
+            return False, "greetd config has no [initial_session] command"
+        ok, detail = _write_root_file(_GREETD_CONFIG, new)
+        return ok, ("greetd -> %s (%s)" % (session_file, detail))
+
+    conf_dir = _DM_CONF_DIRS.get(dm)
+    if not conf_dir:
+        return False, "%s is detected but not configurable by couchside" % dm
+
+    # A Session= in the MAIN conf beats every drop-in on SDDM — the reverse of
+    # the systemd convention, and the trap that made the first version of this
+    # feature fail open. If the operator set one there, say so rather than
+    # writing a file that will be silently ignored.
+    main = _DM_MAIN_CONFS.get(dm)
+    if main and os.path.exists(main):
+        try:
+            with open(main, "r", encoding="utf-8") as f:
+                if re.search(r"(?mi)^\s*Session\s*=", f.read()):
+                    return False, ("%s names a Session in %s, which overrides "
+                                   "drop-ins" % (dm, main))
+        except OSError:
+            return False, "%s unreadable; refusing to steer blind" % main
+
+    body = ("# Written by couchside-helper. Remove this file to restore the\n"
+            "# box's original boot behaviour exactly.\n"
+            "[Autologin]\nSession=%s\n" % session_file)
+    ok, detail = _write_root_file(os.path.join(conf_dir, _DROPIN_NAME), body)
+    return ok, ("%s -> %s (%s)" % (dm, session_file, detail))
+
+
+def verb_session_clear_boot():
+    """Remove our steering so the platform decides again. Never an error when
+    there is nothing to remove — clearing twice is success both times."""
+    removed = []
+    for conf_dir in _DM_CONF_DIRS.values():
+        p = os.path.join(conf_dir, _DROPIN_NAME)
+        try:
+            os.unlink(p)
+            removed.append(p)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            return False, "could not remove %s: %s" % (p, e)
+    if os.path.exists(_GREETD_BACKUP):
+        try:
+            with open(_GREETD_BACKUP, "r", encoding="utf-8") as f:
+                body = f.read()
+            _write_root_file(_GREETD_CONFIG, body)
+            os.unlink(_GREETD_BACKUP)
+            removed.append(_GREETD_CONFIG + " (restored)")
+        except OSError as e:
+            return False, "greetd restore failed: %s" % e
+    return True, ("cleared: %s" % ", ".join(removed) if removed else "nothing to clear")
+
+
+def verb_dm_restart():
+    """Restart the display manager — the real unit name, whatever it is."""
+    unit = _dm_unit_name()
+    if not unit:
+        return False, "no display-manager.service to restart"
+    return _run(["/usr/bin/systemctl", "restart", unit])
+
+
+_POWER_ACTIONS = ("reboot", "poweroff", "suspend")
+
+
+def verb_power(action):
+    return _run(["/usr/bin/systemctl", action], timeout=15)
+
+
+# A CLOSED set of units, mapped to their real names here. The caller sends a
+# key, never a unit name, so no verb can restart an arbitrary service.
+_RESTARTABLE = {
+    "plugin_loader": ["/usr/bin/systemctl", "restart", "plugin_loader"],
+    # --no-block is load-bearing: the detached updater lives inside this unit's
+    # own cgroup, so a blocking restart would SIGTERM the updater mid-wait.
+    "couchside": ["/usr/bin/systemctl", "restart", "--no-block",
+                  "couchside.service"],
+}
+
+
+def verb_unit_restart(unit_key):
+    return _run(_RESTARTABLE[unit_key], timeout=20)
+
+
+_UNIT_SUFFIXES = (".service", ".socket", ".target", ".timer", ".mount",
+                  ".scope", ".slice", ".path", ".device", ".swap", ".automount")
+
+
+def verb_logs_journal(arg):
+    """Read a unit's journal. The unit is validated by SHAPE and the option set
+    is fixed here, so --file/--directory injection (arbitrary root file read)
+    is impossible — that is why the old sudoers rule granted a wrapper rather
+    than journalctl itself."""
+    unit = arg.get("unit")
+    lines = arg.get("lines", 200)
+    if not isinstance(unit, str) or not unit.endswith(_UNIT_SUFFIXES):
+        return False, "invalid unit"
+    if re.search(r"[^A-Za-z0-9@._\-\\:]", unit):
+        return False, "invalid unit"
+    try:
+        lines = int(lines)
+    except (TypeError, ValueError):
+        lines = 200
+    lines = max(1, min(2000, lines))
+    return _run(["/usr/bin/journalctl", "-u", unit, "-n", str(lines),
+                 "--no-pager", "-o", "short-iso"], timeout=30)
+
+
+_FLATPAK_WRAPPER = "/usr/local/libexec/couchside-flatpak-update"
+_OS_WRAPPER = "/usr/local/libexec/couchside-os-update"
+
+
+def verb_update_flatpak():
+    if not os.path.exists(_FLATPAK_WRAPPER):
+        return False, "flatpak updater not installed"
+    return _run([_FLATPAK_WRAPPER], timeout=600)
+
+
+def verb_update_os():
+    if not os.path.exists(_OS_WRAPPER):
+        return False, "os updater not installed"
+    return _run([_OS_WRAPPER, "apply"], timeout=900)
+
+
+# ------------------------------------------------------------------ the table
+#
+# THE WHOLE PRIVILEGED SURFACE, on one screen. Each entry is
+# (handler, argument validator or None). A verb not in here is a 404.
+
+def _one_of(choices):
+    return lambda v: v if isinstance(v, str) and v in choices else None
+
+
+def _journal_arg(v):
+    return v if isinstance(v, dict) else None
+
+
+VERBS = {
+    "session.set-boot":   (verb_session_set_boot, _one_of(_SESSION_MODES)),
+    "session.clear-boot": (verb_session_clear_boot, None),
+    "dm.restart":         (verb_dm_restart, None),
+    "power":              (verb_power, _one_of(_POWER_ACTIONS)),
+    "unit.restart":       (verb_unit_restart, _one_of(tuple(_RESTARTABLE))),
+    "logs.journal":       (verb_logs_journal, _journal_arg),
+    "update.flatpak":     (verb_update_flatpak, None),
+    "update.os":          (verb_update_os, None),
+}
+
+
+def dispatch(req):
+    """One request in, one reply dict out. The single entry point, and the only
+    place a client-supplied string is ever compared against the table."""
+    if not isinstance(req, dict):
+        return {"ok": False, "error": "malformed request"}
+    verb = req.get("verb")
+    if not isinstance(verb, str) or verb not in VERBS:
+        # Looked up, never interpolated. Unknown verb runs NOTHING.
+        return {"ok": False, "error": "unknown verb"}
+    handler, validate = VERBS[verb]
+    if validate is None:
+        ok, detail = handler()
+    else:
+        arg = validate(req.get("arg"))
+        if arg is None:
+            return {"ok": False, "error": "invalid argument for %s" % verb}
+        ok, detail = handler(arg)
+    return {"ok": bool(ok), "detail": detail}
+
+
+# ------------------------------------------------------------------- serving
+
+def peer_uid(conn):
+    """The connecting process's uid via SO_PEERCRED, or None if unreadable.
+
+    None means REFUSE. A helper that cannot identify its caller must not act —
+    'unknown' is never 'allowed' (CLAUDE.md §3.7)."""
+    try:
+        creds = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED,
+                                struct.calcsize("3i"))
+        _pid, uid, _gid = struct.unpack("3i", creds)
+        return uid
+    except (OSError, struct.error, AttributeError):
+        # AttributeError matters: SO_PEERCRED is Linux-only, and on a platform
+        # without it this raised mid-connection and killed the handler instead
+        # of answering. Boxes are Linux so production always has it, but the
+        # failure mode of an unidentifiable caller must be a clean REFUSAL,
+        # never a crash and never a pass-through.
+        return None
+
+
+def serve_one(conn):
+    try:
+        uid = peer_uid(conn)
+        if uid is None or ALLOWED_UID is None or uid != ALLOWED_UID:
+            conn.sendall(json.dumps(
+                {"ok": False, "error": "not authorized"}).encode() + b"\n")
+            return
+        conn.settimeout(30)
+        buf = b""
+        while b"\n" not in buf and len(buf) < 65536:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        try:
+            req = json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            reply = {"ok": False, "error": "malformed request"}
+        else:
+            reply = dispatch(req)
+        conn.sendall(json.dumps(reply).encode() + b"\n")
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def _listen_socket(path, owner_uid, owner_gid):
+    """Our own socket when not socket-activated. 0660 and owned by the install
+    user, so the filesystem is the first of the two auth layers."""
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o755, exist_ok=True)
+        os.unlink(path)
+    except OSError:
+        pass
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(path)
+    os.chown(path, owner_uid, owner_gid)
+    os.chmod(path, 0o660)
+    s.listen(8)
+    return s
+
+
+def main(argv=None):
+    global ALLOWED_UID
+    argv = list(sys.argv[1:] if argv is None else argv)
+    user = None
+    path = SOCKET_PATH
+    for i, a in enumerate(argv):
+        if a == "--user" and i + 1 < len(argv):
+            user = argv[i + 1]
+        elif a == "--socket" and i + 1 < len(argv):
+            path = argv[i + 1]
+        elif a == "--version":
+            print(VERSION)
+            return 0
+    if not user:
+        print("error: --user <name> is required", file=sys.stderr)
+        return 2
+    try:
+        pw = pwd.getpwnam(user)
+    except KeyError:
+        print("error: no such user: %s" % user, file=sys.stderr)
+        return 2
+    ALLOWED_UID = pw.pw_uid
+    if os.geteuid() != 0:
+        print("error: couchside-helper must run as root", file=sys.stderr)
+        return 2
+
+    try:
+        gid = grp.getgrnam(user).gr_gid
+    except KeyError:
+        gid = pw.pw_gid
+    srv = _listen_socket(path, pw.pw_uid, gid)
+    while True:
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            continue
+        serve_one(conn)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/couchside-helper.py
+++ b/agent/couchside-helper.py
@@ -69,8 +69,6 @@ _DM_MAIN_CONFS = {
     "plasmalogin": "/etc/plasmalogin.conf",
 }
 _DM_UNIT_LINK = "/etc/systemd/system/display-manager.service"
-_GREETD_CONFIG = "/etc/greetd/config.toml"
-_GREETD_BACKUP = "/etc/greetd/config.toml.couchside-bak"
 
 # Our drop-in sorts LAST on purpose: SDDM reads *.conf alphabetically and the
 # last Session= wins, and steamos-session-select owns zz-steamos-autologin.conf.
@@ -124,16 +122,19 @@ def detect_display_manager():
 # ------------------------------------------------------------- verb handlers
 #
 # Every handler returns (ok: bool, detail: str). They take either no argument or
-# ONE already-validated value from a closed set.
+# ONE already-validated value.
 
-_SESSION_MODES = ("game", "desktop", "last")
-
-# What each mode means as an autologin Session=. The VALUES are ours, built
-# here; the caller only ever picks a key from _SESSION_MODES.
-_SESSION_FILES = {
-    "game": "gamescope-session.desktop",
-    "desktop": "plasma.desktop",
-}
+# Where sessions live. The set of acceptable Session= values is DERIVED FROM
+# THESE DIRECTORIES at call time — a box-owned closed set, not a caller-owned
+# one. The caller names a basename; if it is not a file in one of these dirs,
+# the verb refuses. This is deliberate and load-bearing: a hardcoded
+# mode->file table here would re-create the 2026-07-27 stranding, where
+# "plasmax11.desktop" (a SteamOS name) was written on a Bazzite box that ships
+# no such session — SDDM logged "Autologin failed!" and the box came up at the
+# GREETER, with no agent and no way for the phone to undo it. The agent owns
+# the mode->file selection because its version is the one that learned that
+# lesson; the helper only verifies and writes.
+_SESSION_DIRS = ("/usr/share/wayland-sessions", "/usr/share/xsessions")
 
 
 def _run(argv, timeout=25):
@@ -166,41 +167,47 @@ def _write_root_file(path, body):
         return False, "write failed: %s" % e
 
 
-def verb_session_set_boot(mode):
-    """Point the display manager's autologin at game or desktop for the NEXT boot.
+def _session_installed(name):
+    """True when `name` is a session file that exists on THIS box.
 
-    'last' means: stop steering, remove our drop-in, let the platform decide.
-    """
+    The validation is by membership in a directory listing, never by cleaning
+    the input (CLAUDE.md §3.6): a basename containing a separator or a dot-dot
+    can never equal a listdir() entry, so traversal is structurally impossible
+    rather than filtered."""
+    if not isinstance(name, str) or not name.endswith(".desktop"):
+        return False
+    for d in _SESSION_DIRS:
+        try:
+            if name in os.listdir(d):
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def verb_session_set_boot(session_file):
+    """Point the display manager's autologin at an INSTALLED session for the
+    next boot. The caller (the agent) picks which; we verify it exists and
+    build the file body ourselves — nothing from the caller lands in the file
+    except the verified basename."""
     dm = detect_display_manager()
     if dm is None:
         return False, "no supported display manager detected"
 
-    if mode == "last":
-        return verb_session_clear_boot()
-
-    session_file = _SESSION_FILES[mode]
-
     if dm == "greetd":
-        # KI-049: this path exists in the agent and has NEVER worked on any box,
-        # because install.sh never wrote a matching sudoers grant. Here it needs
-        # no grant at all.
-        try:
-            with open(_GREETD_CONFIG, "r", encoding="utf-8") as f:
-                cur = f.read()
-        except OSError as e:
-            return False, "greetd config unreadable: %s" % e
-        if not os.path.exists(_GREETD_BACKUP):
-            _write_root_file(_GREETD_BACKUP, cur)
-        # Replace only the command inside [initial_session]; everything else in
-        # the operator's config is left exactly as it was.
-        new, n = re.subn(
-            r'(?m)^(\s*command\s*=\s*)"[^"]*"',
-            lambda m: '%s"%s"' % (m.group(1), session_file),
-            cur, count=1)
-        if not n:
-            return False, "greetd config has no [initial_session] command"
-        ok, detail = _write_root_file(_GREETD_CONFIG, new)
-        return ok, ("greetd -> %s (%s)" % (session_file, detail))
+        # DELIBERATELY UNSUPPORTED for now (KI-049 stays open). The agent's own
+        # greetd writer validates the session's Exec and composes around the
+        # operator's config; duplicating a lesser version of that here would be
+        # a worse copy of code that has never run on any real box — there is no
+        # greetd machine on this LAN to verify against. Refusing is honest;
+        # Phase 2 owns it.
+        return False, "greetd: not yet supported by the helper"
+
+    if not _session_installed(session_file):
+        # The 2026-07-27 stranding rule: never write an autologin for a session
+        # this box does not have. SDDM fails the autologin and parks the box at
+        # the greeter — where there is no agent and no way back from the phone.
+        return False, "session %r is not installed on this box" % (session_file,)
 
     conf_dir = _DM_CONF_DIRS.get(dm)
     if not conf_dir:
@@ -240,15 +247,10 @@ def verb_session_clear_boot():
             pass
         except OSError as e:
             return False, "could not remove %s: %s" % (p, e)
-    if os.path.exists(_GREETD_BACKUP):
-        try:
-            with open(_GREETD_BACKUP, "r", encoding="utf-8") as f:
-                body = f.read()
-            _write_root_file(_GREETD_CONFIG, body)
-            os.unlink(_GREETD_BACKUP)
-            removed.append(_GREETD_CONFIG + " (restored)")
-        except OSError as e:
-            return False, "greetd restore failed: %s" % e
+    # greetd is DELIBERATELY not touched here. The helper never writes greetd
+    # (see verb_session_set_boot), and "restore a backup we did not make" could
+    # clobber operator edits made since the agent's own writer took it. Phase 2
+    # owns greetd end to end.
     return True, ("cleared: %s" % ", ".join(removed) if removed else "nothing to clear")
 
 
@@ -335,8 +337,20 @@ def _journal_arg(v):
     return v if isinstance(v, dict) else None
 
 
+def _session_file_arg(v):
+    """A session-file BASENAME. Shape only — existence is checked by the verb
+    against the box's own session dirs. A separator or a traversal component
+    can never match a listdir() entry, but reject the shape here too so the
+    refusal is visible at the boundary."""
+    if not isinstance(v, str) or not v.endswith(".desktop"):
+        return None
+    if "/" in v or "\\" in v or v.startswith("."):
+        return None
+    return v
+
+
 VERBS = {
-    "session.set-boot":   (verb_session_set_boot, _one_of(_SESSION_MODES)),
+    "session.set-boot":   (verb_session_set_boot, _session_file_arg),
     "session.clear-boot": (verb_session_clear_boot, None),
     "dm.restart":         (verb_dm_restart, None),
     "power":              (verb_power, _one_of(_POWER_ACTIONS)),
@@ -460,11 +474,20 @@ def main(argv=None):
         print("error: couchside-helper must run as root", file=sys.stderr)
         return 2
 
-    try:
-        gid = grp.getgrnam(user).gr_gid
-    except KeyError:
-        gid = pw.pw_gid
-    srv = _listen_socket(path, pw.pw_uid, gid)
+    # systemd socket activation: the socket unit owns the listening socket and
+    # hands it to us as fd 3 (LISTEN_FDS). Binding our own here would UNLINK
+    # systemd's socket out from under it and the two would fight over the path.
+    # The env check is the standard sd_listen_fds contract, pure stdlib.
+    srv = None
+    if os.environ.get("LISTEN_PID") == str(os.getpid()) and \
+            int(os.environ.get("LISTEN_FDS", "0") or 0) >= 1:
+        srv = socket.socket(fileno=3)
+    if srv is None:
+        try:
+            gid = grp.getgrnam(user).gr_gid
+        except KeyError:
+            gid = pw.pw_gid
+        srv = _listen_socket(path, pw.pw_uid, gid)
     while True:
         try:
             conn, _ = srv.accept()

--- a/agent/couchside-helper.service
+++ b/agent/couchside-helper.service
@@ -1,0 +1,31 @@
+; Couchside privileged helper: SERVICE unit TEMPLATE.
+; install.sh substitutes __USER__ and __HELPER__ (the resolved helper path) and
+; installs the result as /etc/systemd/system/couchside-helper.service.
+;
+; This is the ONLY root process in the product. Its entire surface is the
+; eight-verb table in couchside-helper.py — read that file's header before
+; touching this one. The agent stays User=__USER__; see
+; docs/memory/project_privileged-helper.md §6 for why running the agent as
+; root was rejected.
+[Unit]
+Description=Couchside privileged helper
+Requires=couchside-helper.socket
+After=couchside-helper.socket
+
+[Service]
+; Root on purpose, and locked down everywhere root is not needed:
+User=root
+ExecStart=/usr/bin/python3 __HELPER__ --user __USER__ --socket /run/couchside/helper.sock
+Restart=always
+RestartSec=2
+; Hardening. The helper writes /etc/<dm>.conf.d, /etc/greetd and /run, and
+; calls systemctl; everything else is closed off.
+NoNewPrivileges=yes
+ProtectHome=yes
+PrivateTmp=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictSUIDSGID=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/agent/couchside-helper.socket
+++ b/agent/couchside-helper.socket
@@ -1,0 +1,46 @@
+; Couchside privileged helper: SOCKET unit TEMPLATE.
+; install.sh substitutes __USER__ and installs the result as
+; /etc/systemd/system/couchside-helper.socket.
+;
+; The socket's filesystem permissions are the FIRST of the helper's two auth
+; layers: 0660, owned by the install user's group, so only that user (and root)
+; can even connect. The second layer is the SO_PEERCRED uid check inside the
+; helper, which refuses anything that is not exactly the install user. Both
+; fail closed.
+[Unit]
+Description=Couchside privileged helper socket
+
+; NO ordering edge against couchside.service HERE — the edge lives on the
+; SERVICE side (couchside.service: After=couchside-helper.socket), and getting
+; that wrong took out a real box's shutdown. The first version put
+; After=couchside.service on THIS unit, reasoning it would keep the socket
+; alive through the agent's ExecStop arm. Measured on hardware (bazzite,
+; 2026-07-31), it did the opposite twice over: After= orders STARTUP, so at
+; shutdown (reverse order) the socket stopped FIRST — and worse, the edge
+; closed a loop through sockets.target/basic.target and systemd broke the
+; cycle by DELETING couchside.service's stop job entirely:
+;
+;   Found ordering cycle: couchside.service/stop after
+;     couchside-helper.socket/stop after sockets.target/stop after
+;     basic.target/stop - after couchside.service
+;   Job couchside.service/stop deleted to break ordering cycle
+;
+; ExecStop never ran at all — no arm, no drop-in, the box booted last-session
+; with the preference silently ignored, and firewalld's and NetworkManager's
+; stop jobs were collateral. The service-side After= gives the correct stop
+; order (agent first, socket after) with no cycle, because sockets start early
+; and ordering in that direction is the natural one.
+
+[Socket]
+ListenStream=/run/couchside/helper.sock
+SocketUser=root
+SocketGroup=__USER__
+SocketMode=0660
+DirectoryMode=0755
+; One serving process, not one per connection (Accept=no is the default, but
+; the spec calls it out, so say it): a per-connection fork would multiply the
+; root surface for no gain.
+Accept=no
+
+[Install]
+WantedBy=sockets.target

--- a/agent/couchside.service
+++ b/agent/couchside.service
@@ -9,6 +9,28 @@
 Description=Couchside box agent
 After=network-online.target
 Wants=network-online.target
+; KI-051 REGRESSION GUARD. The ExecStop below arms the boot preference, and on
+; a helper-equipped box that call goes over couchside-helper.socket — so the
+; socket must outlive this service's stop. After= on THIS unit gives exactly
+; that: we start after the socket, therefore we STOP BEFORE it (reverse order),
+; and the socket is still accepting while ExecStop runs. The edge must live on
+; this side; putting it on the socket unit instead created a shutdown ordering
+; CYCLE through sockets.target that made systemd DELETE this service's stop job
+; — ExecStop never ran and the preference was silently ignored (measured on
+; bazzite, 2026-07-31; the socket template's header has the full journal).
+; Ordering against a unit that does not exist is ignored, so this line is
+; harmless on a box that has no helper installed.
+;
+; BOTH units, deliberately. Reboot #2 (bazzite 2026-07-31) proved the socket
+; edge alone is not enough: the helper SERVICE stopped at the first instant of
+; shutdown, systemd refuses socket re-activation while shutting down, and the
+; ExecStop arm quietly succeeded via the SUDO FALLBACK instead — invisible
+; today, fatal in phase 3 when the sudoers file goes away. Ordering after the
+; service too keeps the helper process alive through our stop; it is running
+; at shutdown because our own startup disarm activates it at boot.
+; PHASE-2 PROOF DEBT: helper-served arm at shutdown (journal shows the helper
+; serving during the stop window) is NOT yet demonstrated on hardware.
+After=couchside-helper.socket couchside-helper.service
 
 [Service]
 User=__USER__

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4537,6 +4537,49 @@ def session_default_get():
     return {"available": True, "backend": backend, "mode": mode}
 
 
+# --------------------------------------------------------- privileged helper
+#
+# The root-side companion (agent/couchside-helper.py) replaces the sudoers
+# surface verb by verb. DETECTED AND OPTIONAL, never assumed: quick updates
+# ship this file WITHOUT the installer, so a new agent must keep working on a
+# box that has no helper, possibly for months. The shape is always
+#   try the helper -> on "helper not present", fall back to sudo
+# and a helper that is PRESENT BUT REFUSES is a real answer, not a cue to
+# retry via sudo — retrying would turn every helper refusal into a second
+# attempt through the path the helper exists to retire.
+
+HELPER_SOCKET = "/run/couchside/helper.sock"
+
+
+def _helper_call(verb, arg=None, timeout=10):
+    """One verb over the helper socket. Returns the reply dict, or None when
+    the helper is NOT PRESENT (no socket / nothing listening) — the only case
+    the caller may treat as "use the sudo fallback"."""
+    if not os.path.exists(HELPER_SOCKET):
+        return None
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(HELPER_SOCKET)
+        req = {"verb": verb}
+        if arg is not None:
+            req["arg"] = arg
+        s.sendall(json.dumps(req).encode("utf-8") + b"\n")
+        buf = b""
+        while b"\n" not in buf and len(buf) < 65536:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        s.close()
+        return json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+    except (OSError, ValueError):
+        # Socket file present but dead/garbled: treat as not present. The sudo
+        # fallback still enforces every original constraint, so degrading to it
+        # never widens anything.
+        return None
+
+
 def _dm_write(dm, session_file):
     """Write our drop-in via a sudo tee whose PATH IS FIXED IN THE SUDOERS RULE.
 
@@ -4568,6 +4611,20 @@ def _dm_write(dm, session_file):
         print("[session] refusing to write autologin for missing session %r"
               % (session_file,), flush=True)
         return False
+    # HELPER FIRST (agent >= 2.9.69): every refusal above still applied — the
+    # guards live before the transport on purpose, so no future transport can
+    # route around them. A helper refusal is FINAL: it re-validated against the
+    # box's own session dirs as root and said no; retrying via sudo would just
+    # re-ask the question through the surface the helper exists to retire.
+    reply = _helper_call("session.set-boot", session_file)
+    if reply is not None:
+        ok = bool(reply.get("ok"))
+        if not ok:
+            print("[session] helper refused set-boot: %s"
+                  % reply.get("detail", reply.get("error", "")), flush=True)
+        if ok:
+            _dm_neutralise_legacy(dm)
+        return ok
     body = ("# Written by Couchside. Delete this file to restore the box's\n"
             "# original boot behaviour; nothing else was modified.\n"
             "[Autologin]\n"
@@ -4619,6 +4676,14 @@ def _dm_disarm(dm):
         return True
     if not _last_session_line(dropin):
         return True  # already blank; don't spend a sudo call
+    # HELPER FIRST. clear-boot REMOVES the file rather than blanking it — the
+    # sudo path blanks only because its grant is tee-at-one-path and deletion
+    # was never grantable. Removal is the better end state (the drop-in's own
+    # comment tells users "delete this file"), and both leave zero [Autologin]
+    # contribution, which is all disarm means.
+    reply = _helper_call("session.clear-boot")
+    if reply is not None:
+        return bool(reply.get("ok"))
     try:
         r = subprocess.run(["sudo", "-n", "tee", dropin],
                            input=_DISARMED_DROPIN_BODY, capture_output=True,

--- a/install.sh
+++ b/install.sh
@@ -562,6 +562,13 @@ if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/agent/couchsided.py" ]; then
     cp "$SCRIPT_DIR/agent/couchside.service" "$WORK_DIR/couchside.service"
     # Optional QR helper: present in a checkout, harmless if not.
     [ -f "$SCRIPT_DIR/agent/qr.py" ] && cp "$SCRIPT_DIR/agent/qr.py" "$WORK_DIR/qr.py"
+    # Privileged helper + its units. Optional as a SET: the (g2) block installs
+    # only when all three are present, and the agent falls back to sudo when
+    # the helper is absent — so a checkout that predates the helper installs
+    # exactly as before.
+    for f in couchside-helper.py couchside-helper.socket couchside-helper.service; do
+        [ -f "$SCRIPT_DIR/agent/$f" ] && cp "$SCRIPT_DIR/agent/$f" "$WORK_DIR/$f"
+    done
     # Optional Couchside Player tile + its branded art, only when wanted.
     if [ "$WANT_PLAYER" = 1 ]; then
         [ -f "$SCRIPT_DIR/agent/couchside-player.sh" ] && \
@@ -592,6 +599,21 @@ else
     curl -fsSL "$UNIT_URL" -o "$WORK_DIR/couchside.service"
     # Optional: don't abort the install if only the QR helper fails to fetch.
     curl -fsSL "$QR_URL" -o "$WORK_DIR/qr.py" 2>/dev/null || true
+    # Privileged helper + units — optional as a SET, and all-or-nothing: a
+    # release that predates the helper simply has no such assets, and (g2)
+    # skips. A PARTIAL fetch must not install (a socket unit pointing at a
+    # helper that failed to download would leave a dead root service), so if
+    # any of the three is missing, drop the set.
+    curl -fsSL "${AGENT_BASE}/couchside-helper.py" -o "$WORK_DIR/couchside-helper.py" 2>/dev/null || true
+    curl -fsSL "${AGENT_BASE}/couchside-helper.socket" -o "$WORK_DIR/couchside-helper.socket" 2>/dev/null || true
+    curl -fsSL "${AGENT_BASE}/couchside-helper.service" -o "$WORK_DIR/couchside-helper.service" 2>/dev/null || true
+    if [ ! -s "$WORK_DIR/couchside-helper.py" ] || \
+       [ ! -s "$WORK_DIR/couchside-helper.socket" ] || \
+       [ ! -s "$WORK_DIR/couchside-helper.service" ]; then
+        rm -f "$WORK_DIR/couchside-helper.py" \
+              "$WORK_DIR/couchside-helper.socket" \
+              "$WORK_DIR/couchside-helper.service"
+    fi
     # Optional Couchside Player tile + art, same policy. The tile is CODE, so it
     # goes through the same signature + checksum gate as everything else below;
     # the art is plain PNG.
@@ -646,6 +668,31 @@ else
             exit 1
         fi
     ) || die "agent checksum verification FAILED (corrupt/tampered/missing) — refusing to install."
+fi
+# The helper is ROOT CODE, so it gets a STRICTER rule than the other optional
+# files: present-but-not-listed in the signed SHA256SUMS means DROP IT, not
+# "install unverified". The general hash loop above only checks files that are
+# both landed and listed, which is right for art but would let a file injected
+# alongside an older release (whose signed sums predate the helper) through.
+# A fetch-mode install with no SHA256SUMS at all also drops it — a local
+# checkout (SIG skipped for everything) is the only unverified path, same as
+# the agent itself.
+if [ -f "$WORK_DIR/couchside-helper.py" ]; then
+    if [ ! -f "$WORK_DIR/SHA256SUMS" ] && [ -z "$SCRIPT_DIR" ]; then
+        note "helper present but no signed manifest; dropping it (agent keeps its sudo path)."
+        rm -f "$WORK_DIR"/couchside-helper.py "$WORK_DIR"/couchside-helper.socket \
+              "$WORK_DIR"/couchside-helper.service
+    elif [ -f "$WORK_DIR/SHA256SUMS" ] && \
+         ! grep -qF ' couchside-helper.py' "$WORK_DIR/SHA256SUMS"; then
+        note "helper not in the signed manifest; dropping it (agent keeps its sudo path)."
+        rm -f "$WORK_DIR"/couchside-helper.py "$WORK_DIR"/couchside-helper.socket \
+              "$WORK_DIR"/couchside-helper.service
+    fi
+fi
+# And root code must compile, same as the agent.
+if [ -f "$WORK_DIR/couchside-helper.py" ]; then
+    python3 -m py_compile "$WORK_DIR/couchside-helper.py" \
+        || die "downloaded couchside-helper.py does not compile, aborting."
 fi
 # Secondary sanity gate: even a correctly-signed file must actually parse (a
 # git-checkout install skips the crypto above, and this catches a bad local
@@ -1205,6 +1252,47 @@ if ! grep -q -- '--config' "$WORK_DIR/couchside.service.rendered"; then
         "$WORK_DIR/couchside.service.rendered"
 fi
 sudo install -m 0644 -o root -g root "$WORK_DIR/couchside.service.rendered" "$UNIT_DST"
+
+# ---------------------------------------------------------------------------
+# (g2) privileged helper — replaces the sudoers surface, one verb at a time
+# ---------------------------------------------------------------------------
+# The helper is the ONLY root process in the product: eight frozen verbs behind
+# a 0660 unix socket + SO_PEERCRED uid check (agent/couchside-helper.py has the
+# full rules). The agent DETECTS it and falls back to sudo when absent, so this
+# block is additive: nothing else in this installer changes behaviour because
+# of it, and the sudoers file keeps being written until the fallback is retired
+# (project_privileged-helper.md, phase 2). Fetched alongside the agent and
+# subject to the same signature verification upstream of here.
+if [ -f "$WORK_DIR/couchside-helper.py" ] && \
+   [ -f "$WORK_DIR/couchside-helper.socket" ] && \
+   [ -f "$WORK_DIR/couchside-helper.service" ]; then
+    say "Installing privileged helper (socket-gated, replaces sudo one verb at a time)"
+    # ROOT-OWNED PATH, deliberately NOT $INSTALL_DIR: the helper runs as root,
+    # and root code in a user-writable directory is a privilege escalation (the
+    # user swaps the file, the root service runs it). Same home as the other
+    # root-run wrappers. The service unit's ProtectHome=yes enforces this — a
+    # helper left in $HOME is unreadable to its own service, measured live.
+    HELPER_PATH="/usr/local/libexec/couchside-helper.py"
+    # ostree boxes ship no /usr/local/libexec; create it (root-owned) first.
+    sudo install -d -m 0755 -o root -g root /usr/local/libexec
+    sudo install -m 0755 -o root -g root "$WORK_DIR/couchside-helper.py" "$HELPER_PATH"
+    sed -e "s|__USER__|$USER_NAME|g" \
+        "$WORK_DIR/couchside-helper.socket" > "$WORK_DIR/couchside-helper.socket.rendered"
+    sed -e "s|__HELPER__|$HELPER_PATH|g" -e "s|__USER__|$USER_NAME|g" \
+        "$WORK_DIR/couchside-helper.service" > "$WORK_DIR/couchside-helper.service.rendered"
+    sudo install -m 0644 -o root -g root \
+        "$WORK_DIR/couchside-helper.socket.rendered" \
+        /etc/systemd/system/couchside-helper.socket
+    sudo install -m 0644 -o root -g root \
+        "$WORK_DIR/couchside-helper.service.rendered" \
+        /etc/systemd/system/couchside-helper.service
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now couchside-helper.socket >/dev/null 2>&1 || true
+else
+    # A quick update fetched only the agent binary: no helper files, no change.
+    # The agent's sudo fallback keeps working exactly as before.
+    :
+fi
 sudo systemctl daemon-reload
 # Decky co-existence: when Decky Loader is present, the Couchside Decky plugin
 # owns the agent — it installs its own (no-downgrade) bundle to the SAME run

--- a/tests/test_helper_shim.py
+++ b/tests/test_helper_shim.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""The agent-side helper shim: helper first, sudo fallback, refusals are final.
+
+Run: python3 tests/test_helper_shim.py
+
+The spec (project_privileged-helper.md §7) names three behaviours and this file
+pins all of them:
+
+  1. helper PRESENT  -> used, and the sudo path is NOT touched
+  2. helper ABSENT   -> the sudo fallback runs, unchanged
+  3. helper REFUSES  -> the refusal is final; sudo is NOT tried as a second ask
+
+(3) is the one a lazy shim gets wrong. A helper refusal means root-side
+validation said no; falling back to sudo would re-ask the same question through
+the exact surface the helper exists to retire, and would turn every refusal
+into a bypass attempt.
+"""
+import importlib.util
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+SUDO_CALLS = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class FakeRun:
+    """Stands in for subprocess.run on the SUDO path only."""
+    def __init__(self):
+        self.returncode = 0
+        self.stdout = ""
+        self.stderr = ""
+
+
+def fake_subprocess_run(argv, **kw):
+    SUDO_CALLS.append(list(argv))
+    return FakeRun()
+
+
+cs.subprocess.run = fake_subprocess_run
+
+
+def fake_helper(replies):
+    """A one-shot helper: serves len(replies) connections then stops. Returns
+    the socket path and a list that accumulates the requests it saw."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "helper.sock")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(path)
+    srv.listen(4)
+    seen = []
+
+    def serve():
+        for reply in replies:
+            conn, _ = srv.accept()
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            try:
+                seen.append(json.loads(buf.split(b"\n", 1)[0].decode()))
+            except ValueError:
+                seen.append(None)
+            conn.sendall(json.dumps(reply).encode() + b"\n")
+            conn.close()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return path, seen
+
+
+# _dm_write needs its guards satisfied: a writable-looking dm, a session that
+# counts as installed, and a silent main conf.
+saved = {
+    "installed": cs._installed_session_files,
+    "main": dict(cs._DM_MAIN_CONFS),
+    "socket": cs.HELPER_SOCKET,
+    "neutralise": cs._dm_neutralise_legacy,
+}
+cs._installed_session_files = lambda: {"plasma.desktop",
+                                       "gamescope-session.desktop"}
+cs._DM_MAIN_CONFS = {"sddm": "/nonexistent-couchside-test/sddm.conf",
+                     "plasmalogin": "/nonexistent-couchside-test/pl.conf"}
+cs._dm_neutralise_legacy = lambda dm: None
+
+try:
+    print("1. helper PRESENT -> used; sudo untouched")
+    path, seen = fake_helper([{"ok": True, "detail": "written"}])
+    cs.HELPER_SOCKET = path
+    SUDO_CALLS.clear()
+    ok = cs._dm_write("sddm", "plasma.desktop")
+    check("write succeeds through the helper", ok, True)
+    check("helper saw the verb", seen[0].get("verb"), "session.set-boot")
+    check("helper saw the session file", seen[0].get("arg"), "plasma.desktop")
+    check("sudo was NOT called", SUDO_CALLS, [])
+
+    print()
+    print("2. helper ABSENT -> sudo fallback, unchanged")
+    cs.HELPER_SOCKET = "/nonexistent-couchside-test/helper.sock"
+    SUDO_CALLS.clear()
+    ok = cs._dm_write("sddm", "plasma.desktop")
+    check("write succeeds via sudo", ok, True)
+    check("exactly one sudo call", len(SUDO_CALLS), 1)
+    check("...and it is the fixed-path tee",
+          SUDO_CALLS[0][:3], ["sudo", "-n", "tee"])
+
+    print()
+    print("3. helper REFUSES -> final; sudo NOT tried as a second ask")
+    path, seen = fake_helper([{"ok": False,
+                               "detail": "session 'x' is not installed"}])
+    cs.HELPER_SOCKET = path
+    SUDO_CALLS.clear()
+    ok = cs._dm_write("sddm", "plasma.desktop")
+    check("the refusal is returned", ok, False)
+    check("sudo was NOT tried afterwards", SUDO_CALLS, [])
+
+    print()
+    print("4. disarm: same three behaviours through clear-boot")
+    # Present:
+    path, seen = fake_helper([{"ok": True, "detail": "cleared"}])
+    cs.HELPER_SOCKET = path
+    SUDO_CALLS.clear()
+    # _dm_disarm returns early unless the drop-in exists with a Session= line,
+    # so point the dropin resolver at a real file for this test.
+    d = tempfile.mkdtemp()
+    dropin = os.path.join(d, "zzz-couchside-session.conf")
+    with open(dropin, "w") as f:
+        f.write("[Autologin]\nSession=plasma.desktop\n")
+    saved_dropin = cs._dm_dropin
+    cs._dm_dropin = lambda dm: dropin
+    try:
+        ok = cs._dm_disarm("sddm")
+        check("disarm via helper", ok, True)
+        check("helper saw clear-boot", seen[0].get("verb"), "session.clear-boot")
+        check("sudo untouched", SUDO_CALLS, [])
+
+        # Absent:
+        with open(dropin, "w") as f:
+            f.write("[Autologin]\nSession=plasma.desktop\n")
+        cs.HELPER_SOCKET = "/nonexistent-couchside-test/helper.sock"
+        SUDO_CALLS.clear()
+        ok = cs._dm_disarm("sddm")
+        check("disarm via sudo when absent", ok, True)
+        check("the sudo call is the blanking tee",
+              SUDO_CALLS and SUDO_CALLS[0][:3], ["sudo", "-n", "tee"])
+    finally:
+        cs._dm_dropin = saved_dropin
+
+    print()
+    print("5. a dead socket FILE is 'absent', not an error")
+    # The stale-socket lesson from screen capture (2.9.56): a file that exists
+    # but has no listener must mean fallback, never a hang or a crash.
+    d = tempfile.mkdtemp()
+    stale = os.path.join(d, "helper.sock")
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(stale)
+    s.close()  # bound then closed: the path exists, nothing listens
+    cs.HELPER_SOCKET = stale
+    SUDO_CALLS.clear()
+    ok = cs._dm_write("sddm", "plasma.desktop")
+    check("falls back to sudo on a dead socket", ok, True)
+    check("exactly one sudo call", len(SUDO_CALLS), 1)
+
+finally:
+    cs._installed_session_files = saved["installed"]
+    cs._DM_MAIN_CONFS = saved["main"]
+    cs.HELPER_SOCKET = saved["socket"]
+    cs._dm_neutralise_legacy = saved["neutralise"]
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all helper-shim tests passed")

--- a/tests/test_helper_socket.py
+++ b/tests/test_helper_socket.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""The helper's SOCKET gate: SO_PEERCRED decides, and it fails closed.
+
+Run: python3 tests/test_helper_socket.py
+
+LINUX ONLY, and it says so rather than passing vacuously. SO_PEERCRED does not
+exist on macOS, so a developer machine cannot exercise this at all — same
+situation as the /proc parsers, and the same rule applies: **check CI before
+releasing**, because a green run on a Mac has not tested any of this.
+
+The dispatch-level tests in test_privileged_helper.py prove the verb table
+refuses bad input. This file proves an unauthorized CALLER never reaches the
+verb table in the first place.
+"""
+import importlib.util
+import json
+import os
+import platform
+import socket
+import sys
+import tempfile
+import threading
+
+if platform.system() != "Linux":
+    print("SKIP: SO_PEERCRED is Linux-only; this suite is meaningless on %s."
+          % platform.system())
+    print("      It runs for real in CI (ubuntu-latest). Do not read a local")
+    print("      pass as evidence — there was nothing to pass.")
+    sys.exit(0)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchside_helper", os.path.join(ROOT, "agent", "couchside-helper.py"))
+H = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(H)
+
+FAILURES = []
+SPAWNS = []
+H._run = lambda argv, timeout=25: (SPAWNS.append(list(argv)) or (True, "ok"))
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+d = tempfile.mkdtemp()
+path = os.path.join(d, "helper.sock")
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(path)
+srv.listen(8)
+
+
+def _serve(n):
+    for _ in range(n):
+        conn, _addr = srv.accept()
+        H.serve_one(conn)
+
+
+threading.Thread(target=_serve, args=(6,), daemon=True).start()
+
+
+def call(req):
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.connect(path)
+    s.sendall(json.dumps(req).encode() + b"\n")
+    data = b""
+    while b"\n" not in data:
+        chunk = s.recv(4096)
+        if not chunk:
+            break
+        data += chunk
+    s.close()
+    return json.loads(data.decode().split("\n")[0])
+
+
+print("an unauthorized caller never reaches the verb table")
+
+# Never configured. "Unknown" must mean refuse, not "allow anybody".
+H.ALLOWED_UID = None
+SPAWNS.clear()
+r = call({"verb": "power", "arg": "reboot"})
+check("unconfigured ALLOWED_UID refuses", r.get("error"), "not authorized")
+check("...and nothing ran", SPAWNS, [])
+
+# A different uid.
+H.ALLOWED_UID = os.getuid() + 12345
+SPAWNS.clear()
+r = call({"verb": "power", "arg": "reboot"})
+check("a uid that is not ours is refused", r.get("error"), "not authorized")
+check("...and nothing ran", SPAWNS, [])
+
+# The refusal must come BEFORE parsing, so even a malformed body is rejected
+# as unauthorized rather than being decoded first.
+SPAWNS.clear()
+r = call({"verb": "session.clear-boot"})
+check("refusal applies to every verb, not just power",
+      r.get("error"), "not authorized")
+check("...and nothing ran", SPAWNS, [])
+
+print()
+print("the authorized caller does get through")
+H.ALLOWED_UID = os.getuid()
+SPAWNS.clear()
+r = call({"verb": "power", "arg": "reboot"})
+check("matching uid is allowed", r.get("ok"), True)
+check("...and ran exactly the allowlisted argv",
+      SPAWNS, [["/usr/bin/systemctl", "reboot"]])
+
+# Authorized, but still subject to the verb table.
+SPAWNS.clear()
+r = call({"verb": "power", "arg": "halt"})
+check("an authorized caller STILL cannot invent an argument", r.get("ok"), False)
+check("...and nothing ran", SPAWNS, [])
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all helper socket tests passed")

--- a/tests/test_privileged_helper.py
+++ b/tests/test_privileged_helper.py
@@ -60,8 +60,13 @@ print("a KNOWN verb still refuses an argument outside its closed set")
 for verb, bad in (
         ("power", "halt"), ("power", "reboot; rm -rf /"), ("power", ""),
         ("power", None), ("power", ["reboot"]),
-        ("session.set-boot", "plasma.desktop"),  # a real file, still not a mode
+        # Mode words were v1's argument; the rework moved mode->file selection
+        # into the agent, so bare words must be REFUSED at the shape gate.
+        ("session.set-boot", "game"), ("session.set-boot", "desktop"),
         ("session.set-boot", "GAME"), ("session.set-boot", None),
+        ("session.set-boot", "../evil.desktop"),
+        ("session.set-boot", "a/b.desktop"),
+        ("session.set-boot", ".hidden.desktop"),
         ("unit.restart", "sshd"), ("unit.restart", "couchside.service"),
         ("unit.restart", "plugin_loader; id"),
 ):
@@ -157,7 +162,17 @@ try:
     H._DM_MAIN_CONFS["sddm"] = main_conf
     H._DM_CONF_DIRS["sddm"] = os.path.join(d, "sddm.conf.d")
     H.detect_display_manager = lambda: "sddm"
-    r = H.dispatch({"verb": "session.set-boot", "arg": "game"})
+    # A fake session dir stands in for /usr/share/wayland-sessions with the two
+    # files a real box carries. The validator is a listdir membership check, so
+    # this drives the REAL code path rather than stubbing it out.
+    sess_dir = os.path.join(d, "wayland-sessions")
+    os.makedirs(sess_dir)
+    for f_ in ("plasma.desktop", "gamescope-session.desktop"):
+        with open(os.path.join(sess_dir, f_), "w") as fh:
+            fh.write("[Desktop Entry]\n")
+    saved_sess = H._SESSION_DIRS
+    H._SESSION_DIRS = (sess_dir,)
+    r = H.dispatch({"verb": "session.set-boot", "arg": "gamescope-session.desktop"})
     check("refused when the main conf names a Session", r.get("ok"), False)
     check("...and no drop-in was written",
           os.path.exists(os.path.join(d, "sddm.conf.d", H._DROPIN_NAME)), False)
@@ -165,10 +180,15 @@ try:
     # With the main conf silent, the write is allowed and lands in the right file.
     with open(main_conf, "w") as f:
         f.write("[General]\n")
-    r = H.dispatch({"verb": "session.set-boot", "arg": "desktop"})
+    r = H.dispatch({"verb": "session.set-boot", "arg": "plasma.desktop"})
     check("allowed when the main conf is silent", r.get("ok"), True)
     body = open(os.path.join(d, "sddm.conf.d", H._DROPIN_NAME)).read()
     check("drop-in names the desktop session", "plasma.desktop" in body, True)
+    # The stranding rule survives the transport: a session the box does not
+    # have refuses even with the main conf silent.
+    r = H.dispatch({"verb": "session.set-boot", "arg": "plasmax11.desktop"})
+    check("a session missing from the box refuses (the stranding rule)",
+          r.get("ok"), False)
     check("drop-in is the zzz- name (sorts after zz-steamos-autologin)",
           H._DROPIN_NAME.startswith("zzz-"), True)
 
@@ -182,6 +202,7 @@ finally:
     H._DM_MAIN_CONFS.clear(); H._DM_MAIN_CONFS.update(saved_main)
     H._DM_CONF_DIRS.clear(); H._DM_CONF_DIRS.update(saved_dirs)
     H.detect_display_manager = saved_detect
+    H._SESSION_DIRS = saved_sess
 
 print()
 print("gdm3 vs gdm: the FAMILY is collapsed, the real unit name is not")
@@ -195,7 +216,7 @@ try:
           SPAWNS, [["/usr/bin/systemctl", "restart", "gdm3"]])
     # gdm is recognised but we do not write its autologin config.
     H.detect_display_manager_saved = H.detect_display_manager
-    r = H.dispatch({"verb": "session.set-boot", "arg": "game"})
+    r = H.dispatch({"verb": "session.set-boot", "arg": "gamescope-session.desktop"})
     check("set-boot refuses on gdm rather than guessing", r.get("ok"), False)
 finally:
     H._dm_unit_name = saved_unit
@@ -211,7 +232,7 @@ for verb, (handler, validate) in H.VERBS.items():
         continue
     for probe in ("/etc/shadow", "sh", "systemctl", "reboot ", " reboot"):
         if validate(probe) is not None and probe not in (
-                H._SESSION_MODES + H._POWER_ACTIONS + tuple(H._RESTARTABLE)):
+                H._POWER_ACTIONS + tuple(H._RESTARTABLE)):
             check("%s must not accept %r" % (verb, probe), probe, "rejected")
 print("  PASS  no closed-set verb accepts a path or a bare binary name")
 

--- a/tests/test_privileged_helper.py
+++ b/tests/test_privileged_helper.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""The privileged helper's refusal surface.
+
+Run: python3 tests/test_privileged_helper.py
+
+This is root-side code reachable from a process on the box, so the tests that
+matter are the ones proving it says NO. Per CLAUDE.md §6, anything taking a
+client id owes a test that a non-allowlisted id is refused AND that nothing
+runs — so every refusal case below asserts on a spawn counter, not just on the
+return value. A handler that returned "error" while still having shelled out
+would pass a naive test and fail this one.
+"""
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchside_helper", os.path.join(ROOT, "agent", "couchside-helper.py"))
+H = importlib.util.module_from_spec(_spec)
+sys.modules["couchside_helper"] = H
+_spec.loader.exec_module(H)
+
+FAILURES = []
+SPAWNS = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def fake_run(argv, timeout=25):
+    """Record instead of spawning. Every refusal test asserts this stays empty."""
+    SPAWNS.append(list(argv))
+    return True, "fake-ok"
+
+
+H._run = fake_run
+
+
+print("the verb table refuses what is not in it")
+for bad in ("", "nope", "session.set-bootx", "SESSION.SET-BOOT", "power;reboot",
+            "../../bin/sh", "update.os ", None, 42, {"a": 1}):
+    SPAWNS.clear()
+    r = H.dispatch({"verb": bad})
+    ok = (r.get("ok") is False and r.get("error") == "unknown verb"
+          and SPAWNS == [])
+    if not ok:
+        check("unknown verb %r refused and nothing ran" % (bad,), r, "refusal")
+print("  PASS  every unknown verb refused, zero spawns")
+
+print()
+print("a KNOWN verb still refuses an argument outside its closed set")
+for verb, bad in (
+        ("power", "halt"), ("power", "reboot; rm -rf /"), ("power", ""),
+        ("power", None), ("power", ["reboot"]),
+        ("session.set-boot", "plasma.desktop"),  # a real file, still not a mode
+        ("session.set-boot", "GAME"), ("session.set-boot", None),
+        ("unit.restart", "sshd"), ("unit.restart", "couchside.service"),
+        ("unit.restart", "plugin_loader; id"),
+):
+    SPAWNS.clear()
+    r = H.dispatch({"verb": verb, "arg": bad})
+    if not (r.get("ok") is False and SPAWNS == []):
+        check("%s(%r) refused with no spawn" % (verb, bad), r, "refusal")
+print("  PASS  every out-of-set argument refused, zero spawns")
+
+print()
+print("the allowlisted arguments DO run — and run the right argv")
+SPAWNS.clear()
+H.dispatch({"verb": "power", "arg": "reboot"})
+check("power reboot spawns systemctl reboot",
+      SPAWNS, [["/usr/bin/systemctl", "reboot"]])
+
+SPAWNS.clear()
+H.dispatch({"verb": "unit.restart", "arg": "couchside"})
+check("couchside restart keeps --no-block",
+      SPAWNS, [["/usr/bin/systemctl", "restart", "--no-block",
+                "couchside.service"]])
+
+SPAWNS.clear()
+H.dispatch({"verb": "unit.restart", "arg": "plugin_loader"})
+check("plugin_loader restart argv",
+      SPAWNS, [["/usr/bin/systemctl", "restart", "plugin_loader"]])
+
+print()
+print("journal: shape-validated, and the option set is ours")
+SPAWNS.clear()
+r = H.dispatch({"verb": "logs.journal", "arg": {"unit": "couchside.service"}})
+check("a real unit runs", SPAWNS and SPAWNS[0][:3],
+      ["/usr/bin/journalctl", "-u", "couchside.service"])
+check("...with --no-pager", "--no-pager" in SPAWNS[0], True)
+
+for bad in ("couchside", "../../etc/shadow", "a b.service", "x.service;id",
+            "--file=/etc/shadow", "", None, 5):
+    SPAWNS.clear()
+    r = H.dispatch({"verb": "logs.journal", "arg": {"unit": bad}})
+    if not (r.get("ok") is False and SPAWNS == []):
+        check("journal unit %r refused" % (bad,), r, "refusal")
+print("  PASS  every malformed unit refused, zero spawns")
+
+# THE POINT of granting a wrapper rather than journalctl itself: no caller can
+# reach --file / --directory, which would be arbitrary root file read.
+SPAWNS.clear()
+H.dispatch({"verb": "logs.journal",
+            "arg": {"unit": "couchside.service", "lines": 10**9}})
+check("line count clamped to 2000", "2000" in SPAWNS[0], True)
+SPAWNS.clear()
+H.dispatch({"verb": "logs.journal",
+            "arg": {"unit": "couchside.service", "lines": "nonsense"}})
+check("non-numeric line count falls back, still runs", len(SPAWNS), 1)
+check("no --file reaches journalctl",
+      any(a.startswith("--file") or a.startswith("--directory")
+          for a in SPAWNS[0]), False)
+
+print()
+print("malformed envelopes never reach a handler")
+for req in (None, [], "power", 7, {"arg": "reboot"}, {}):
+    SPAWNS.clear()
+    r = H.dispatch(req)
+    if not (r.get("ok") is False and SPAWNS == []):
+        check("envelope %r refused" % (req,), r, "refusal")
+print("  PASS  every malformed envelope refused, zero spawns")
+
+print()
+print("display-manager detection degrades CLOSED")
+saved_link = H._DM_UNIT_LINK
+try:
+    H._DM_UNIT_LINK = "/nonexistent-couchside-test/display-manager.service"
+    check("no link -> None", H.detect_display_manager(), None)
+    SPAWNS.clear()
+    r = H.dispatch({"verb": "session.set-boot", "arg": "game"})
+    check("set-boot refuses with no DM", r.get("ok"), False)
+    check("...and nothing ran", SPAWNS, [])
+    r = H.dispatch({"verb": "dm.restart"})
+    check("dm.restart refuses with no DM", r.get("ok"), False)
+    check("...and nothing ran", SPAWNS, [])
+finally:
+    H._DM_UNIT_LINK = saved_link
+
+print()
+print("SDDM's main conf OVERRIDES drop-ins — refuse rather than write a file")
+print("that will be silently ignored (the trap that made v1 fail open)")
+d = tempfile.mkdtemp()
+main_conf = os.path.join(d, "sddm.conf")
+with open(main_conf, "w") as f:
+    f.write("[Autologin]\nSession=plasma.desktop\n")
+saved_main, saved_dirs = dict(H._DM_MAIN_CONFS), dict(H._DM_CONF_DIRS)
+saved_detect = H.detect_display_manager
+try:
+    H._DM_MAIN_CONFS["sddm"] = main_conf
+    H._DM_CONF_DIRS["sddm"] = os.path.join(d, "sddm.conf.d")
+    H.detect_display_manager = lambda: "sddm"
+    r = H.dispatch({"verb": "session.set-boot", "arg": "game"})
+    check("refused when the main conf names a Session", r.get("ok"), False)
+    check("...and no drop-in was written",
+          os.path.exists(os.path.join(d, "sddm.conf.d", H._DROPIN_NAME)), False)
+
+    # With the main conf silent, the write is allowed and lands in the right file.
+    with open(main_conf, "w") as f:
+        f.write("[General]\n")
+    r = H.dispatch({"verb": "session.set-boot", "arg": "desktop"})
+    check("allowed when the main conf is silent", r.get("ok"), True)
+    body = open(os.path.join(d, "sddm.conf.d", H._DROPIN_NAME)).read()
+    check("drop-in names the desktop session", "plasma.desktop" in body, True)
+    check("drop-in is the zzz- name (sorts after zz-steamos-autologin)",
+          H._DROPIN_NAME.startswith("zzz-"), True)
+
+    # clear-boot removes it, and clearing twice is success both times.
+    r = H.dispatch({"verb": "session.clear-boot"})
+    check("clear removes the drop-in",
+          os.path.exists(os.path.join(d, "sddm.conf.d", H._DROPIN_NAME)), False)
+    r2 = H.dispatch({"verb": "session.clear-boot"})
+    check("clearing again is still ok", r2.get("ok"), True)
+finally:
+    H._DM_MAIN_CONFS.clear(); H._DM_MAIN_CONFS.update(saved_main)
+    H._DM_CONF_DIRS.clear(); H._DM_CONF_DIRS.update(saved_dirs)
+    H.detect_display_manager = saved_detect
+
+print()
+print("gdm3 vs gdm: the FAMILY is collapsed, the real unit name is not")
+saved_unit = H._dm_unit_name
+try:
+    H._dm_unit_name = lambda: "gdm3"
+    check("gdm3 -> family gdm", H.detect_display_manager(), "gdm")
+    SPAWNS.clear()
+    H.dispatch({"verb": "dm.restart"})
+    check("dm.restart uses the REAL unit name, not the family",
+          SPAWNS, [["/usr/bin/systemctl", "restart", "gdm3"]])
+    # gdm is recognised but we do not write its autologin config.
+    H.detect_display_manager_saved = H.detect_display_manager
+    r = H.dispatch({"verb": "session.set-boot", "arg": "game"})
+    check("set-boot refuses on gdm rather than guessing", r.get("ok"), False)
+finally:
+    H._dm_unit_name = saved_unit
+
+print()
+print("no verb accepts a path, a unit name, or a command from the caller")
+# Structural: every validator either takes no argument, or maps into a closed
+# set, or (journal) validates by shape and builds the argv itself.
+for verb, (handler, validate) in H.VERBS.items():
+    if validate is None:
+        continue
+    if verb == "logs.journal":
+        continue
+    for probe in ("/etc/shadow", "sh", "systemctl", "reboot ", " reboot"):
+        if validate(probe) is not None and probe not in (
+                H._SESSION_MODES + H._POWER_ACTIONS + tuple(H._RESTARTABLE)):
+            check("%s must not accept %r" % (verb, probe), probe, "rejected")
+print("  PASS  no closed-set verb accepts a path or a bare binary name")
+
+print()
+print("the verb table is small enough to audit")
+check("eight verbs, no more", len(H.VERBS), 8)
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all privileged-helper tests passed")


### PR DESCRIPTION
Phase 1 of `docs/memory/project_privileged-helper.md`: the helper, its units,
the agent shim, installer wiring, and four test suites. **Dual-path by design**
— the sudoers file is still written and still works; the helper is detected and
optional, because quick updates ship the agent without the installer.

## What's here

- `agent/couchside-helper.py` — the only root code in the product. Eight frozen
  verbs behind a 0660 unix socket + SO_PEERCRED uid check (unidentifiable
  caller = refused). Argv lists only; no verb takes a path, unit name, or
  command from the caller. `session.set-boot` validates the session file
  against the box's **own** session dirs — the mode→file choice stays in the
  agent, whose version learned the plasmax11 stranding lesson.
- greetd is **deliberately refused** by the helper for now; KI-049 stays open.
  The agent's greetd writer validates `Exec` and composes around the operator's
  config; a lesser duplicate that no box on this LAN can verify would be worse.
- Agent shim: helper first; absent → sudo fallback unchanged; **a helper
  refusal is final** and never re-asked via sudo.
- install.sh: root-owned `/usr/local/libexec` (root code in `$HOME` is
  user-replaceable = privilege escalation), all-or-nothing on the three files,
  and a helper not listed in the **signed** SHA256SUMS is dropped, never
  installed unverified.

## What the tests caught before hardware did

- `realpath()` on a missing `display-manager.service` returns the path itself →
  a box with **no** DM "detected" a unit called `display-manager` and
  `dm.restart` would have run it. Fail-open in root code; now absent/dangling
  → None → every DM verb refuses.
- `SO_PEERCRED` is Linux-only and an uncaught `AttributeError` crashed the
  handler mid-connection instead of refusing.

## What only a real reboot caught

The shutdown ordering was wrong **twice**:

1. v1 put `After=couchside.service` on the socket. `After=` orders startup, so
   the socket stopped FIRST — and the edge closed a cycle through
   `sockets.target` that systemd broke by **deleting couchside.service's stop
   job**. ExecStop never ran; the box booted last-session with the preference
   silently ignored; firewalld's and NetworkManager's stop jobs were collateral.
2. v2 puts `After=couchside-helper.socket` on the service. Reboot #2, bazzite:
   no cycle, arm at 21:08:43, socket alive until 21:08:48, box booted the
   chosen desktop session, drop-in consumed at startup, pref intact.

## Hardware-verified (bazzite 10.1.1.60, root helper over the real socket)

Refusals: unknown verb; `plasmax11.desktop` (not installed — the stranding
session); traversal shape; bad power arg; **root itself** (uid 0 ≠ install
user). Positive: set-boot wrote the root-owned drop-in, clear-boot removed it,
idempotent on repeat. Both test suites also pass on the box, including the
SO_PEERCRED gate that SKIPS loudly on macOS.

## Stated proof debt (in the unit comments too)

- Reboot #2's arm ran through the **sudo fallback**: the helper *service* had
  already stopped and systemd refuses socket re-activation during shutdown.
  Fine in phase 1; fatal in phase 3. `After=couchside-helper.service` is added
  and boot-time activation keeps the helper alive, but **helper-served arm at
  shutdown is not yet demonstrated on hardware.**
- CachyOS/plasmalogin: only the deploy was exercised (no passwordless sudo for
  arbitrary commands there); its DM path is covered by table tests.
- The release chain does not yet publish the three helper assets; until then
  fetch-mode installs simply skip the helper block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)