### PR TITLE
chore(agent): 2.9.69 — the release that ships the privileged helper

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.68"
+VERSION = "2.9.69"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -32,8 +32,16 @@ agent="$root/agent"
 # The exact files install.sh fetches. couchsided.py + couchside.service are
 # REQUIRED; qr.py + the two add-on scripts are optional at install time but
 # always shipped + signed here.
+#
+# The three couchside-helper files ship as a SET (agent >= 2.9.69): the helper
+# is ROOT code, so install.sh refuses one that is present but not listed in the
+# signed SHA256SUMS, and drops the set if any of the three failed to fetch.
+# Publishing them here is what lets a fetch-mode install gain the helper at
+# all — a release without them simply installs the sudo-only agent, which
+# keeps working (the shim detects absence and falls back).
 files=(couchsided.py couchside.service qr.py couchside-screensaver.sh \
-       couchside-player.sh)
+       couchside-player.sh couchside-helper.py couchside-helper.socket \
+       couchside-helper.service)
 for f in "${files[@]}"; do
     [ -f "$agent/$f" ] || { echo "error: missing agent/$f" >&2; exit 2; }
 done


### PR DESCRIPTION
VERSION 2.9.68 → 2.9.69 and release-agent.sh gains the three helper assets
(couchside-helper.py / .socket / .service) in the signed set.

Why both matter:
- Unchanged VERSION = silent no-op update (recorded trap): boxes compare
  agent-version.txt and would never fetch.
- install.sh (shipped in #326) refuses a helper that is present but not listed
  in the **signed** SHA256SUMS, and drops a partial set — so until the release
  chain publishes these three files, no fetch-mode box can gain the helper.
  A release without them stays sudo-only and keeps working; this PR is what
  makes phase 1 reach hardware through the normal channel.

No agent logic changes; the helper + shim merged in #326 and were
hardware-proven there (real reboot on bazzite, refusal battery against the
root helper over the live socket).

NOTE this branch includes the #327 roadmap commit (branched from it); if #327
merges first this PR rebases to just the two release files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)