### PR TITLE
fix(agent): don't show the OS version twice when PRETTY_NAME bakes it in

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -954,10 +954,20 @@ def read_os_release():
     except OSError:
         vals = {}
     name = vals.get("PRETTY_NAME") or vals.get("NAME")
-    if name:
-        out["name"] = name
     # VERSION_ID is the point release; a rolling distro has only BUILD_ID.
     version = vals.get("VERSION_ID") or vals.get("BUILD_ID")
+    # Some distros bake the release INTO PRETTY_NAME — Nobara 43 ships
+    # PRETTY_NAME="Nobara Linux 43 (KDE Plasma Desktop Edition)" (VERBATIM from
+    # nobara-xps, 2026-08-01) — and the app header renders "<name> <version>",
+    # which would show the 43 twice with an edition string in between. When the
+    # pretty name already carries the version, fall back to the bare NAME
+    # ("Nobara Linux" + "43" -> "Nobara Linux 43"). Word-boundary match so a
+    # version like "4" cannot false-positive on "F43" inside a build string.
+    if (name and version and vals.get("NAME")
+            and re.search(r"(?<![\w.])%s(?![\w.])" % re.escape(version), name)):
+        name = vals.get("NAME")
+    if name:
+        out["name"] = name
     if version:
         out["version"] = version
     build = vals.get("BUILD_ID")

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,6 +70,29 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   under gamescope (a TV that blanks mid-movie is a bug we have never tested for), and which of
   those apps ship usable Actions.
 
+### Couch Mode fallback: Big Picture on gamescope-less boxes
+- **priority:** P2 · **risk:** medium · **affects:** agent + app · **depends_on:** nothing
+  (measured feasible 2026-08-01)
+- **Owner ask:** "if gamescope isn't installed could the couchmode button just launch
+  Steam Big Picture mode?" On a desktop-only box (Nobara, generic distros) Big Picture IS
+  the couch experience, and it slots in as a degraded couchmode backend — the ceremony
+  keeps its TV stages (power, input, audio); only the session stage changes.
+- **MEASURED on Nobara hardware (nobara-xps, 2026-08-01), screen-captured both ways:**
+  `steam steam://open/bigpicture` with Steam running brought BPM up FULLSCREEN, and
+  `steam://close/bigpicture` returned cleanly to the desktop — the exit URL is real, not
+  folklore. Fired from a bare env with only XDG_RUNTIME_DIR set (IPC to the running
+  client; no display env needed warm).
+- **Unmeasured, owned by the build:** the COLD path (`steam -gamepadui` with Steam down)
+  — over ssh it dies on session env, and the agent's own launch path is the correct test
+  environment, not an ssh reconstruction. Multi-monitor placement also unmeasured (the
+  test box has one display); a monitor+TV desktop needs kscreen-doctor thought.
+- **Shape:** extend couchmode with a `bigpicture` backend (additive field, no shape
+  change; couchmode cap already exists so no five-site dance). App toggle labels
+  honestly — "Big Picture", not "Game Mode". Gate: steam root present AND no gamescope
+  session. Allowlist: fixed argv, zero new privileges, zero client input.
+- Both-directions rule applies to the build: the toggle must be proven to ENTER and
+  EXIT on hardware before it ships, cold and warm.
+
 ### Note mode — jot a clue on the phone while the game runs
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** the drag stroke (shipped)
 - **Full spec: `docs/memory/project_note-mode.md`.** Read it first.

--- a/tests/test_os_release.py
+++ b/tests/test_os_release.py
@@ -57,6 +57,18 @@ ANSI_COLOR="38;2;23;147;209"
 HOME_URL="https://cachyos.org/"
 '''
 
+# Nobara bakes the release AND edition into PRETTY_NAME — the case that made
+# the header show "…43 (KDE Plasma Desktop Edition) 43". VERBATIM from
+# nobara-xps (Nobara 43 KDE), 2026-08-01.
+NOBARA = '''NAME="Nobara Linux"
+VERSION="43 (KDE Plasma Desktop Edition)"
+ID=nobara
+ID_LIKE="fedora"
+VERSION_ID=43
+PRETTY_NAME="Nobara Linux 43 (KDE Plasma Desktop Edition)"
+LOGO=fedora-logo-icon
+'''
+
 # SteamOS ships a VERSION_ID and a build; the Deck is the reference handheld.
 STEAMOS = '''NAME="SteamOS"
 PRETTY_NAME="SteamOS"
@@ -91,6 +103,21 @@ check("cachyos name", c.get("name"), "CachyOS")
 # THE TRAP: no VERSION_ID at all. A VERSION_ID-only reader shows nothing here.
 check("cachyos falls back to BUILD_ID", c.get("version"), "rolling")
 check("...and does not duplicate it into build", "build" in c, False)
+
+n = read_with(NOBARA)
+check("nobara: version baked into PRETTY_NAME falls back to NAME",
+      n.get("name"), "Nobara Linux")
+check("nobara version", n.get("version"), "43")
+# The app header joins name + version, so the pair must not repeat the release:
+check("nobara: header would read cleanly",
+      ("%s %s" % (n.get("name"), n.get("version"))), "Nobara Linux 43")
+
+# CONTROL: Bazzite's PRETTY_NAME ("Bazzite") does NOT contain its version, so
+# the fallback must NOT fire there — b was read above.
+check("bazzite still uses PRETTY_NAME (control)", b.get("name"), "Bazzite")
+# CONTROL 2: a one-digit version must not match inside a build-ish token.
+q2 = read_with('NAME="X"\nPRETTY_NAME="X F43 edition"\nVERSION_ID=4\n')
+check("version 4 does not false-positive on F43", q2.get("name"), "X F43 edition")
 
 s = read_with(STEAMOS)
 check("steamos name", s.get("name"), "SteamOS")


### PR DESCRIPTION
First real-hardware Nobara finding. PRETTY_NAME on Nobara 43 is `Nobara Linux 43 (KDE Plasma Desktop Edition)`; the header renders `<name> <version>` and would show the 43 twice. Fall back to bare NAME when the pretty name already contains the version — word-boundary matched, with controls both directions (Bazzite unaffected; a version of `4` doesn't fire on `F43`). Verbatim fixture from the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)