### PR TITLE
feat(couch): Big Picture as Couch Mode's degraded tier

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1568,7 +1568,8 @@ def set_caps(mock):
     if mock:
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
-                 "screensaver", "couchmode", "desktop", "steamlink", "gaming",
+                 "screensaver", "couchmode", "bigpicture", "desktop",
+                 "steamlink", "gaming",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player")}
         return
@@ -1581,6 +1582,9 @@ def set_caps(mock):
         "power_schedule": safe(rtc_available),
         "screensaver": safe(screensaver_available),
         "couchmode": safe(couchmode_available),
+        # Degraded couch tier, EXCLUSIVE with couchmode (see
+        # bigpicture_available): a box never advertises both.
+        "bigpicture": safe(bigpicture_available),
         "session_default": safe(session_default_available),
         "desktop": safe(desktop_available),
         "steamlink": safe(steamlink_available),
@@ -3436,6 +3440,129 @@ def real_action(action_id):
 _INTERNAL_OUTPUT_PREFIXES = ("eDP", "LVDS", "DSI")
 # The session tools Couch Mode drives; all must be present to offer it.
 _COUCHMODE_TOOLS = ("gamescope", "steamos-session-select", "kscreen-doctor", "wpctl")
+
+# --------------------------------------------------------------------------
+# Couch Mode, degraded tier: Steam Big Picture on a box with no gamescope.
+#
+# A desktop-only machine (Nobara, a generic KDE box) has no session to switch
+# INTO, but it does have the thing people actually want on a TV: Big Picture.
+# So the couch button gets a second backend that opens BPM in the session that
+# is already running, instead of the feature being absent entirely.
+#
+# MEASURED on nobara-xps (Nobara 43 KDE, 2026-08-01), screen-captured each way:
+#   steam://open/bigpicture   with Steam running  -> BPM, FULLSCREEN
+#   steam://close/bigpicture                      -> back to the desktop
+#   `steam -gamepadui` with Steam DOWN            -> cold-starts into BPM, but
+#       ONLY when launched inside the user session (systemd-run --user worked;
+#       an ssh shell with hand-set DISPLAY/WAYLAND_DISPLAY did not). The agent
+#       IS in that session, which is why this is viable here and was not
+#       reproducible over ssh.
+#
+# WHAT COULD NOT BE MEASURED, and what it costs: there is NO reliable probe for
+# "is Big Picture on screen right now". `pgrep -f gamepadui` returns the same
+# count with BPM up and closed (steamwebhelper carries the flag either way),
+# and the cmdline test is equally blind once Steam was started with -gamepadui.
+# So this backend deliberately reports NO live session state — the app offers
+# both actions rather than rendering a toggle that would lie. Reporting
+# "desktop" while BPM is up is exactly the dead-session card that KI-047 was.
+_BIGPICTURE_OPEN_URL = "steam://open/bigpicture"
+_BIGPICTURE_CLOSE_URL = "steam://close/bigpicture"
+
+
+def bigpicture_available():
+    """True when the Big Picture tier applies: Steam is installed, and this box
+    canNOT do the real gamescope switch.
+
+    Deliberately EXCLUSIVE with couchmode_available(): a Deck/Bazzite box gets
+    the full session handoff and must never be offered the lesser one, so the
+    two capabilities can never both be true and the app never has to choose."""
+    if couchmode_available():
+        return False
+    if _steam_root() is None:
+        return False
+    return shutil.which("steam") is not None
+
+
+def _bigpicture_fire(url):
+    """Hand a steam:// URL to the client. argv list, fixed URL from the two
+    constants above — the caller passes no part of it and the client never sees
+    anything a phone typed."""
+    env = dict(os.environ)
+    env.setdefault("XDG_RUNTIME_DIR", "/run/user/%d" % os.getuid())
+    try:
+        p = subprocess.run(["steam", url], capture_output=True, timeout=20,
+                           env=env)
+        return p.returncode == 0
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _bigpicture_cold_start():
+    """Start Steam straight into Big Picture when it is not running at all.
+
+    `steam -gamepadui` needs the real user session — measured: it works from a
+    unit inside the session and dies from an ssh shell even with DISPLAY and
+    WAYLAND_DISPLAY set by hand. The agent already runs in that session
+    (User=<desktop user>, XDG_RUNTIME_DIR set by the unit), so spawning it here
+    is the supported case rather than the one that failed."""
+    env = dict(os.environ)
+    env.setdefault("XDG_RUNTIME_DIR", "/run/user/%d" % os.getuid())
+    try:
+        subprocess.Popen(["steam", "-gamepadui"], env=env,
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                         start_new_session=True)
+        return True
+    except (OSError, subprocess.SubprocessError):
+        return False
+
+
+def _steam_client_running():
+    """Is the Steam CLIENT up? (Not "is BPM showing" — that is unprobeable.)"""
+    try:
+        return subprocess.run(["pgrep", "-x", "steam"],
+                              capture_output=True, timeout=3).returncode == 0
+    except Exception:
+        return False
+
+
+def bigpicture_open():
+    """Put Big Picture on screen. Cold-starts Steam into it when the client is
+    down, otherwise asks the running client. Returns an ActionResult shape."""
+    if not bigpicture_available():
+        return {"ok": False, "exit_code": 1, "stdout": "",
+                "stderr": "Big Picture is not available on this box",
+                "duration_ms": 0}
+    start = time.monotonic()
+    if _steam_client_running():
+        ok = _bigpicture_fire(_BIGPICTURE_OPEN_URL)
+        how = "deep link"
+    else:
+        ok = _bigpicture_cold_start()
+        how = "cold start"
+    return {"ok": ok, "exit_code": 0 if ok else 1,
+            "stdout": how if ok else "",
+            "stderr": "" if ok else "could not launch Big Picture (%s)" % how,
+            "duration_ms": int((time.monotonic() - start) * 1000)}
+
+
+def bigpicture_close():
+    """Leave Big Picture, back to the desktop. Never quits Steam itself —
+    measured: the close URL returns to the desktop with the client still up,
+    which is what a user expects from 'exit couch mode'."""
+    if not bigpicture_available():
+        return {"ok": False, "exit_code": 1, "stdout": "",
+                "stderr": "Big Picture is not available on this box",
+                "duration_ms": 0}
+    start = time.monotonic()
+    if not _steam_client_running():
+        # Nothing to leave. Success: the box is already at the desktop, and an
+        # error here would make the app show a failure for a no-op.
+        return {"ok": True, "exit_code": 0, "stdout": "steam not running",
+                "stderr": "", "duration_ms": 0}
+    ok = _bigpicture_fire(_BIGPICTURE_CLOSE_URL)
+    return {"ok": ok, "exit_code": 0 if ok else 1, "stdout": "",
+            "stderr": "" if ok else "could not close Big Picture",
+            "duration_ms": int((time.monotonic() - start) * 1000)}
 
 
 def _couchmode_platform_ok():
@@ -16987,6 +17114,37 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(200, screensaver_stop(), started)
                 else:
                     self._send(400, {"error": "op must be start|stop"}, started)
+                return
+
+            # POST /api/big-picture: {"op":"open"|"close"} — the DEGRADED couch
+            # tier for a box with no gamescope session (see bigpicture_available).
+            # Its own route rather than a mode inside /api/couch-mode: that
+            # endpoint runs the staged TV ceremony and returns a JOB, while this
+            # is one synchronous action with no stages. Folding them would make
+            # one response shape mean two different things.
+            if path == "/api/big-picture":
+                if not (self.mock or bigpicture_available()):
+                    self._send(404, {"error": "big picture unavailable"}, started)
+                    return
+                # Parse OUR OWN body: each POST route does, and the first
+                # version of this route read a `req` that is defined further
+                # down inside the couch-mode block — a NameError that surfaced
+                # as a 500 on hardware, not as anything a unit test would see.
+                try:
+                    bp_req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(bp_req, dict):
+                        raise ValueError
+                except (ValueError, UnicodeDecodeError):
+                    self._send(400, {"error": "json body required"}, started)
+                    return
+                op = bp_req.get("op")
+                # Looked up against a frozen pair, never interpolated.
+                if op == "open":
+                    self._send(200, bigpicture_open(), started)
+                elif op == "close":
+                    self._send(200, bigpicture_close(), started)
+                else:
+                    self._send(400, {"error": "op must be open|close"}, started)
                 return
 
             # POST /api/couch-mode: {"output":"DP-2","hdr":false} — fling the box

--- a/app/components/RemotePowerBar.tsx
+++ b/app/components/RemotePowerBar.tsx
@@ -574,10 +574,19 @@ export function RemotePowerBar({ compact = false }: { compact?: boolean }) {
   const canWake = !reachable && !!settings.mac && (wolAvailable || boxes.length > 1);
   const hasSaver = reachable && saver?.available === true;
   const hasCouch = reachable && displays?.available === true;
+  // Couch Mode's DEGRADED tier: a box with Steam but no gamescope session gets
+  // a Big Picture button instead of the session-switch sheet. The agent makes
+  // the two caps mutually exclusive, so this can never race hasCouch — but the
+  // && !hasCouch is kept anyway: if a future agent ever set both, showing two
+  // couch buttons is a worse failure than showing the better one.
+  const hasBigPicture =
+    reachable && settings.caps?.bigpicture === true && !hasCouch;
+  const [bpBusy, setBpBusy] = React.useState(false);
 
   // Nothing to control on this box right now. (Couch Mode counts: it renders
   // its own header button, so the bar must not bail when it's the only thing.)
   if (
+    !hasBigPicture &&
     !canSuspend &&
     !canWake &&
     !hasVolume &&
@@ -603,6 +612,49 @@ export function RemotePowerBar({ compact = false }: { compact?: boolean }) {
 
   return (
     <>
+      {/* Big Picture — the degraded couch tier on a box with no gamescope.
+          Deliberately NOT a toggle: the agent measured that "is Big Picture on
+          screen" cannot be probed (steamwebhelper carries the -gamepadui flag
+          either way), so a two-state control would have to guess. One tap
+          opens it; long-press leaves it. Labelled "Big Picture", never "Game
+          Mode" — it is a different thing and saying otherwise would be the
+          same dead-session lie KI-047 was. */}
+      {hasBigPicture && (
+        <Pressable
+          onPress={async () => {
+            if (bpBusy) return;
+            hapticLight();
+            setBpBusy(true);
+            try {
+              await api.bigPicture(settings, 'open');
+            } catch {
+              // Surfaced by the box going quiet, not by a toast: the switch
+              // takes the screen over and a toast would land behind it.
+            } finally {
+              setBpBusy(false);
+            }
+          }}
+          onLongPress={async () => {
+            if (bpBusy) return;
+            hapticLight();
+            setBpBusy(true);
+            try {
+              await api.bigPicture(settings, 'close');
+            } catch {
+              /* same */
+            } finally {
+              setBpBusy(false);
+            }
+          }}
+          delayLongPress={600}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Big Picture (long-press to exit)"
+          style={styles.couchBtn}>
+          <Ionicons name="tv-outline" size={16} color={t.text} />
+          {!compact && <Text style={styles.couchLabel}>Big Picture</Text>}
+        </Pressable>
+      )}
       {/* Couch Mode: fling this desktop box to the TV in Game Mode (or come
           back). Fills the header's empty middle; only shows on capable boxes. */}
       {hasCouch && (

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -103,6 +103,13 @@ export type BoxCaps = {
    */
   couchmode?: boolean;
   /**
+   * Couch Mode's DEGRADED tier (agent >= 2.9.70): this box has Steam but no
+   * gamescope session, so the couch button opens Big Picture in the running
+   * desktop instead of switching sessions. EXCLUSIVE with `couchmode` — the
+   * agent never sets both, so the UI never has to choose.
+   */
+  bigpicture?: boolean;
+  /**
    * Desktop nav: a SteamOS/Bazzite box currently in the Plasma DESKTOP session.
    * Gates the RemoteView desktop cluster (Start menu, pointer/trackpad, overview)
    * — session-aware, so it flips off once the box is in Game Mode. Optional:
@@ -1086,6 +1093,7 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.power_schedule === b.power_schedule &&
     a.screensaver === b.screensaver &&
     a.couchmode === b.couchmode &&
+    a.bigpicture === b.bigpicture &&
     a.desktop === b.desktop &&
     a.steamlink === b.steamlink &&
     a.gaming === b.gaming &&
@@ -2285,6 +2293,24 @@ export const api = {
   /** Couch Mode ceremony status. Probe-and-appear: null on 404 (older agent, or
       the box can't do the handoff) so the sheet degrades to the synchronous
       path and never polls a route that isn't there. */
+  /**
+   * Big Picture — Couch Mode's degraded tier (agent >= 2.9.70), for a box with
+   * Steam but no gamescope session. Its own endpoint rather than a couch-mode
+   * option because that one returns a staged JOB and this is one synchronous
+   * action; folding them would make one shape mean two things.
+   *
+   * NOTE there is deliberately no "is Big Picture showing" read: the agent
+   * measured that unprobeable (steamwebhelper carries the -gamepadui flag
+   * whether BPM is up or closed), so the UI offers both actions rather than
+   * rendering a toggle that would lie about the box's state.
+   */
+  bigPicture(settings: ConnSettings, op: 'open' | 'close'): Promise<ActionResult> {
+    return request(settings, '/api/big-picture', {
+      method: 'POST',
+      body: JSON.stringify({ op }),
+    });
+  },
+
   couchModeStatus(settings: ConnSettings): Promise<CeremonyStatus | null> {
     return probeOrNull(
       request<CeremonyStatus>(settings, '/api/couch-mode/status'));

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -226,6 +226,11 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // they never survived a persist/reload and the app re-probed every launch.
   // Optional like screensaver: absent stays undefined = unknown, never false.
   const couchmode = bool('couchmode');
+  // bigpicture arrived with agent 2.9.70 (the degraded couch tier) — same
+  // optional-cap drop trap as every key around it: omit it here (or from
+  // capsEqual) and the cap never persists, so the Watch/couch control
+  // re-probes on every launch.
+  const bigpicture = bool('bigpicture');
   const desktop = bool('desktop');
   // steamlink arrived with agent 2.9.23 and had the SAME drop bug — add it here
   // (and to capsEqual) or the "Stream from PC" cap never persists. Optional:
@@ -267,7 +272,8 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   const player = bool('player');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
-    screensaver, couchmode, desktop, steamlink, gaming, streamhost, steammenus,
+    screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
+    steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
   };
 }

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -177,6 +177,7 @@
       "linux"
     ],
     "keys": [
+      "bigpicture",
       "boxbattery",
       "display_info",
       "file_upload",

--- a/tests/test_bigpicture.py
+++ b/tests/test_bigpicture.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Couch Mode's degraded tier: Steam Big Picture on a gamescope-less box.
+
+Run: python3 tests/test_bigpicture.py
+
+The behaviours worth pinning are the ones that would ship a lie:
+  * the cap is EXCLUSIVE with couchmode — a Deck must never be offered the
+    lesser tier, and the app must never have to choose between two trues;
+  * a non-allowlisted op runs NOTHING (asserted on a spawn counter);
+  * the two steam:// URLs are exactly the measured ones, in an argv LIST;
+  * close on a box with no Steam running is SUCCESS, not an error — it is a
+    no-op and an error would render a failure for "already where you asked".
+
+Both URLs were verified on real hardware (nobara-xps, Nobara 43 KDE,
+2026-08-01) with screen captures each way; these tests pin the plumbing that
+carries them, not the URLs' behaviour, which no unit test can check.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+SPAWNS = []
+POPENS = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class _R:
+    returncode = 0
+    stdout = b""
+    stderr = b""
+
+
+def fake_run(argv, **kw):
+    SPAWNS.append(list(argv))
+    return _R()
+
+
+def fake_popen(argv, **kw):
+    POPENS.append(list(argv))
+    return object()
+
+
+cs.subprocess.run = fake_run
+cs.subprocess.Popen = fake_popen
+
+print("the capability is EXCLUSIVE with couchmode")
+saved = {"couch": cs.couchmode_available, "root": cs._steam_root,
+         "which": cs.shutil.which}
+try:
+    # A real Game Mode box: full tier wins, degraded tier absent.
+    cs.couchmode_available = lambda: True
+    cs._steam_root = lambda: "/home/x/.steam/steam"
+    cs.shutil.which = lambda t: "/usr/bin/" + t
+    check("gamescope box does NOT offer big picture",
+          cs.bigpicture_available(), False)
+
+    # A desktop box with Steam: degraded tier appears.
+    cs.couchmode_available = lambda: False
+    check("desktop box WITH steam offers it", cs.bigpicture_available(), True)
+
+    # No Steam installed: nothing to open.
+    cs._steam_root = lambda: None
+    check("no steam root -> absent", cs.bigpicture_available(), False)
+
+    # Steam data but no binary (a leftover ~/.steam): still absent.
+    cs._steam_root = lambda: "/home/x/.steam/steam"
+    cs.shutil.which = lambda t: None
+    check("steam data but no binary -> absent", cs.bigpicture_available(), False)
+finally:
+    cs.couchmode_available = saved["couch"]
+    cs._steam_root = saved["root"]
+    cs.shutil.which = saved["which"]
+
+print()
+print("open/close fire exactly the measured URLs, as an argv list")
+saved_avail = cs.bigpicture_available
+saved_running = cs._steam_client_running
+try:
+    cs.bigpicture_available = lambda: True
+
+    # Steam already up -> deep link, no cold start.
+    cs._steam_client_running = lambda: True
+    SPAWNS.clear(); POPENS.clear()
+    r = cs.bigpicture_open()
+    check("open succeeds", r["ok"], True)
+    check("...via the deep link", SPAWNS, [["steam", "steam://open/bigpicture"]])
+    check("...and did NOT cold-start", POPENS, [])
+    check("...and says how", r["stdout"], "deep link")
+
+    SPAWNS.clear()
+    r = cs.bigpicture_close()
+    check("close fires the close URL",
+          SPAWNS, [["steam", "steam://close/bigpicture"]])
+    check("close succeeds", r["ok"], True)
+
+    # Steam down -> cold start, no deep link.
+    cs._steam_client_running = lambda: False
+    SPAWNS.clear(); POPENS.clear()
+    r = cs.bigpicture_open()
+    check("cold start when steam is down", POPENS, [["steam", "-gamepadui"]])
+    check("...and no deep link was sent", SPAWNS, [])
+    check("...and says how", r["stdout"], "cold start")
+
+    # Close with nothing running is a SUCCESSFUL no-op.
+    SPAWNS.clear(); POPENS.clear()
+    r = cs.bigpicture_close()
+    check("close with steam down is ok, not an error", r["ok"], True)
+    check("...and ran nothing", SPAWNS + POPENS, [])
+finally:
+    cs.bigpicture_available = saved_avail
+    cs._steam_client_running = saved_running
+
+print()
+print("an unavailable box refuses both ops and runs NOTHING")
+saved_avail = cs.bigpicture_available
+try:
+    cs.bigpicture_available = lambda: False
+    for fn in (cs.bigpicture_open, cs.bigpicture_close):
+        SPAWNS.clear(); POPENS.clear()
+        r = fn()
+        check("%s refuses" % fn.__name__, r["ok"], False)
+        check("...and nothing ran", SPAWNS + POPENS, [])
+finally:
+    cs.bigpicture_available = saved_avail
+
+print()
+print("the URLs are frozen constants, not built from anything")
+check("open url", cs._BIGPICTURE_OPEN_URL, "steam://open/bigpicture")
+check("close url", cs._BIGPICTURE_CLOSE_URL, "steam://close/bigpicture")
+
+print()
+print("the cap key exists at BOTH agent sites (CLAUDE.md §4)")
+src = open(os.path.join(ROOT, "agent", "couchsided.py")).read()
+check("in the mock tuple", '"bigpicture", "desktop"' in src, True)
+check("in the real CAPS dict",
+      '"bigpicture": safe(bigpicture_available)' in src, True)
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all big-picture tests passed")


### PR DESCRIPTION
A desktop-only box (Nobara, a generic KDE machine) has no gamescope session to
switch into — but it has the thing people actually want on a TV. Owner ask:
"if gamescope isn't installed could the couchmode button just launch Steam Big
Picture mode?"

## Measured before it was written, screen-captured each way

On nobara-xps (Nobara 43 KDE):

| | result |
|---|---|
| `steam://open/bigpicture`, client up | BPM, **fullscreen** |
| `steam://close/bigpicture` | back to the desktop, client still up |
| `steam -gamepadui`, client down | cold-starts into BPM — **only from inside the user session** (`systemd-run --user` worked; an ssh shell with hand-set DISPLAY/WAYLAND_DISPLAY did not). The agent runs in that session. |

## The finding that shaped the UI

**"Is Big Picture on screen" is not probeable.** `pgrep -f gamepadui` returns
the same count with BPM up and closed, and the cmdline test is equally blind
once Steam was started with the flag.

So this backend reports **no live session state**, and the app offers actions
instead of a toggle: tap opens, long-press exits, labelled "Big Picture" and
never "Game Mode". A toggle would have to guess, and guessing wrong is exactly
the dead-session card of KI-047.

## Design

- Cap is **EXCLUSIVE with couchmode** — a Deck/Bazzite box gets the real
  handoff and is never offered the lesser tier, so the app never chooses
  between two trues.
- Own endpoint, not a mode inside `/api/couch-mode`: that one returns a staged
  **job**, this is one synchronous action. Folding them would make one response
  shape mean two things.
- Allowlist: two frozen URL constants, argv lists, `op` looked up against a
  frozen pair. No client input reaches either call; no new privileges.
- `close` with Steam down is a **successful no-op**, not an error — the box is
  already where you asked.

## Verified live through the agent (not an ssh reconstruction)

Refusals, each running nothing: bad op → 400, missing op → 400, garbage body →
400 `json body required`, unauthenticated → 401.

Round trip: `{"op":"open"}` → `ok, "deep link", 78ms` → **screen capture shows
BPM fullscreen**; `{"op":"close"}` → `ok, 62ms` → **capture shows the desktop**.
Both directions, on hardware, through the shipped route.

Caps confirmed on that box: `bigpicture: true, couchmode: false`.

## Two things worth carrying forward

1. **SIX capability edit sites, not five.** CLAUDE.md §4 names the agent CAPS
   dict + mock tuple and the app's BoxCaps + normalizeCaps + capsEqual, but
   `protocol/protocol.json` carries a canonical declared-caps list and
   `test_protocol_parity.py` failed until `bigpicture` was declared there.
2. The first version of the route read a `req` defined inside the *couch-mode*
   block — a NameError that surfaced as a **500 on hardware**, invisible to
   unit tests. Each POST route parses its own body; it now does.

Agent battery green (incl. the new `test_bigpicture.py`), 157 app input tests,
typecheck clean. Nobara box restored to the signed 2.9.69.

**Not verified:** the app-side control on a device — it ships in the next app
build; the agent half is what this PR proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)