### PR TITLE
chore(agent): 2.9.70

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,18 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.70
+
+- **Big Picture on boxes that can't do Game Mode.** If your machine has Steam
+  but isn't a Steam Deck / Bazzite-style setup, the couch control now opens
+  **Steam Big Picture** on it instead of being missing entirely — tap to open,
+  long-press to come back to the desktop. Boxes that can do the real Game Mode
+  handoff are unaffected and keep it.
+- **The Console shows the right OS name on Nobara** (and any distro that bakes
+  its version into the name) — it was reading "Nobara Linux 43 … 43".
+- **Uninstalling now removes everything**, including the privileged helper
+  added in 2.9.69. Re-running the installer restores it.
+
 ## 2.9.69
 
 - **Groundwork release: a safer way for Couchside to do its privileged work.**

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.69"
+VERSION = "2.9.70"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 


### PR DESCRIPTION
Version bump + changelog for the release. Ships: the Big Picture couch tier (#332), the Nobara OS-name fix (#331), and the complete uninstall (#330) — the last of which only reaches boxes through a release, since install.sh is a signed asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)