### PR TITLE
chore(ci): bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
   compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       # py_compile is a pure-syntax check and is cross-platform: compiling the
@@ -485,7 +485,7 @@ jobs:
       - name: Unit tests (Windows game launchers)
         run: python3 tests/test_win_launchers.py
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: npm
@@ -522,8 +522,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       # Boot the agent headless with --mock (never touches uinput/hardware/CEC),
@@ -613,8 +613,8 @@ jobs:
   app-input:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
       # --test-timeout, NOT --test-force-exit. Force-exit was here because a


### PR DESCRIPTION
Every CI job has been printing a Node 20 deprecation warning. The action pins were 2–3 majors behind:

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-python` | v5 | v7 |
| `actions/setup-node` | v4 | v7 |

**What does not change:** `python-version: "3.11"` and `node-version: "22"` are untouched, so the toolchains the tests actually run against are identical. Only the action runtimes move off Node 20.

**Verified how:** nothing here can be verified locally — these only exist on the runner. That is the whole point of the PR: it is not merged unless every job goes green, and a major bump is exactly the change that deserves that gate rather than a local claim.

**Not verified:** whether any v5/v6/v7 behavior change affects caching or checkout depth in a way CI would not surface. If a job goes red, the fix is to step the offending action back one major, not to pin the runner to Node 20.