### PR TITLE
ci: run the eight test suites that were never wired in, and guard the class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,6 +485,79 @@ jobs:
       - name: Unit tests (Windows game launchers)
         run: python3 tests/test_win_launchers.py
 
+      # ---------------------------------------------------------------------
+      # The eight suites below were written, committed, and then never wired
+      # into CI — so they have never once gated a push. Found 2026-08-01 by
+      # diffing tests/test_*.py against this file. Three of them are the
+      # security-shaped suites CLAUDE.md §6 requires for a route that takes
+      # client input, which means the guard existed and was not guarding.
+      # If you add a tests/test_*.py, add its step here in the same commit.
+      # ---------------------------------------------------------------------
+
+      # POST /api/upload — the §6 checklist for a route taking a client-supplied
+      # name: happy path, auth failure, and traversal/subdir/empty rejection.
+      # Runs against a REAL loopback server because the route streams the body
+      # straight to disk ahead of the generic in-memory cap; a faked rfile would
+      # prove nothing about the containment path that actually ships.
+      - name: Unit tests (upload auth + path containment)
+        run: python3 tests/test_upload.py
+
+      # steam_goto() — `steam://` can install games and run programs, so the
+      # destination is looked up in a frozen dict and the URL chosen in the
+      # agent, never supplied by the caller. The refusal cases are the point of
+      # the file.
+      - name: Unit tests (steam goto is allowlisted)
+        run: python3 tests/test_steam_goto.py
+
+      # stop_running_game() — the security shape IS the feature: it takes NO
+      # argument, so a client that cannot name a process cannot be steered into
+      # killing one. The first assertion is the signature itself, because the
+      # refactor that "helpfully" adds a pid is what turns a close-my-game
+      # button into a remote kill-anything primitive, and it looks like a
+      # convenience at review time.
+      - name: Unit tests (game stop takes no client argument)
+        run: python3 tests/test_game_stop.py
+
+      # Big Picture — Couch Mode's degraded tier. Pins that the cap is EXCLUSIVE
+      # with couchmode (a Deck must never be offered the lesser tier), that a
+      # non-allowlisted op runs nothing (asserted on a spawn counter), and that
+      # closing with no Steam running is SUCCESS, not an error.
+      - name: Unit tests (big picture tier)
+        run: python3 tests/test_bigpicture.py
+
+      # The box's OWN battery. Fixtures verbatim from a Legion Go S: BAT0's
+      # uevent repeats POWER_SUPPLY_TYPE, so a one-occurrence-per-key parser
+      # passes by luck rather than design. Both ENERGY- and CHARGE-based gauges
+      # are exercised.
+      - name: Unit tests (box battery)
+        run: python3 tests/test_box_battery.py
+
+      # PSI memory pressure. A used-percentage says what is spoken for, not what
+      # is hurting — a handheld reads 26% while a game stutters. Fixtures only:
+      # inducing real memory stall on a live box risks OOM-killing Steam.
+      - name: Unit tests (memory pressure parsing)
+        run: python3 tests/test_mem_pressure.py
+
+      # Steam cover art. The resolver looked only for library_600x900.jpg and
+      # left 30 of 80 installed games showing a blank text card while the real
+      # capsule sat one directory deeper under a content-hash subdirectory.
+      - name: Unit tests (steam cover art)
+        run: python3 tests/test_steam_cover_art.py
+
+      # _unreadable_reason() — why a controller cannot be read. The app used to
+      # tell every affected user to re-run install.sh, which on a Legion Go S
+      # cannot work: a POSIX ACL grants the user, and mode 000 collapses the
+      # mask that would make the grant effective. Sending someone to do
+      # something that cannot work is worse than saying nothing.
+      - name: Unit tests (controller unreadable reason)
+        run: python3 tests/test_guide_unreadable_reason.py
+
+      # The guard for the class of bug above: a suite in tests/ that no workflow
+      # runs is now itself a CI failure, in both directions (orphaned file, and
+      # a step pointing at a file that no longer exists).
+      - name: Unit tests (every suite in tests/ actually runs in CI)
+        run: python3 tests/test_ci_wiring.py
+
       - uses: actions/setup-node@v7
         with:
           node-version: "22"

--- a/tests/test_ci_wiring.py
+++ b/tests/test_ci_wiring.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Every test file in tests/ actually RUNS in CI.
+
+Run: python3 tests/test_ci_wiring.py
+
+WHY THIS EXISTS: on 2026-08-01, eight suites in this directory were found to
+have never once gated a push. They were written, reviewed, committed — and the
+matching step in .github/workflows/ci.yml was never added, so they sat green on
+somebody's laptop and red nowhere.
+
+    test_upload.py        auth + traversal containment on POST /api/upload
+    test_steam_goto.py    the frozen steam:// destination table
+    test_game_stop.py     the no-argument signature that keeps stop-my-game
+                          from becoming remote kill-anything
+    test_bigpicture.py    couchmode exclusivity + the spawn-counter refusal
+    test_box_battery.py, test_mem_pressure.py, test_steam_cover_art.py,
+    test_guide_unreadable_reason.py
+
+Three of those are the security-shaped suites CLAUDE.md §6 requires for a route
+that takes client input. The guard existed. It was not guarding. That is worse
+than no guard, because the checklist item was ticked.
+
+This is the cheapest possible fix for the whole class: adding a test file
+without wiring it is now itself a failing test. It is deliberately dumb — a
+substring search for the filename in the workflow — because anything cleverer
+(parsing the YAML, resolving shell) has its own way of being wrong, and the
+failure mode of dumb-and-textual is a false alarm, not a false pass.
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TESTS = os.path.join(ROOT, "tests")
+WORKFLOWS = os.path.join(ROOT, ".github", "workflows")
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# Read every workflow, not just ci.yml: a suite wired into any of them runs.
+blob = ""
+for fn in sorted(os.listdir(WORKFLOWS)):
+    if fn.endswith((".yml", ".yaml")):
+        with open(os.path.join(WORKFLOWS, fn)) as f:
+            blob += f.read()
+
+suites = sorted(fn for fn in os.listdir(TESTS)
+                if re.match(r"^test_.*\.(py|sh)$", fn))
+
+print("every suite in tests/ is referenced by a workflow")
+print("  (%d suites found)" % len(suites))
+
+orphans = [fn for fn in suites if fn not in blob]
+for fn in orphans:
+    print("  FAIL  %s is never run by any workflow" % fn)
+check("no orphaned suites", orphans, [])
+
+# The reverse direction, which is the half that actually bites: a step that
+# names a file that no longer exists would go green forever on a nonexistent
+# path only if the runner ignored the error — it does not, `python3 missing.py`
+# exits 2 — but a RENAMED suite leaves a stale step whose failure reads as a
+# broken test rather than a broken reference. Catch it here where the message
+# is unambiguous.
+referenced = set(re.findall(r"tests/(test_[A-Za-z0-9_]+\.(?:py|sh))", blob))
+missing = sorted(f for f in referenced if not os.path.exists(os.path.join(TESTS, f)))
+for fn in missing:
+    print("  FAIL  a workflow runs tests/%s, which does not exist" % fn)
+check("no workflow step points at a deleted suite", missing, [])
+
+# This file only means something if it is itself wired in. A guard that does
+# not run is exactly the bug it was written for.
+check("this guard itself runs in CI", "test_ci_wiring.py" in blob, True)
+
+# An unquoted ": " inside a step name is a YAML mapping, not text. Writing
+#     - name: Unit tests (upload: auth + path containment)
+# makes the whole workflow unparseable, and the failure mode is the worst one
+# available: GitHub cannot start the run at all, so nothing goes red — the
+# checks simply do not appear. Hit while writing this very commit.
+#
+# Checked textually rather than by importing yaml, because the tests here are
+# stdlib-only (CLAUDE.md §5) and because the rule is exact: a colon-space in an
+# unquoted scalar is always this bug.
+print()
+print("no step name contains an unquoted ': ' (it would break the whole file)")
+bad_names = []
+for fn in sorted(os.listdir(WORKFLOWS)):
+    if not fn.endswith((".yml", ".yaml")):
+        continue
+    with open(os.path.join(WORKFLOWS, fn)) as f:
+        for i, line in enumerate(f, 1):
+            m = re.match(r"\s*-?\s*name:\s+(.*?)\s*$", line)
+            if not m:
+                continue
+            val = m.group(1)
+            if val[:1] in ("'", '"'):      # quoted is fine, that is the escape
+                continue
+            if ": " in val:
+                bad_names.append("%s:%d  %s" % (fn, i, val))
+for b in bad_names:
+    print("  FAIL  %s" % b)
+check("no unquoted colon-space in a step name", bad_names, [])
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    print()
+    print("Fix: add a step to .github/workflows/ci.yml running the suite, with a")
+    print("comment saying WHY the suite exists — matching the steps around it.")
+    sys.exit(1)
+print("all CI wiring tests passed")


### PR DESCRIPTION
## The finding

Diffing `tests/test_*.py` against `.github/workflows/ci.yml` turned up **eight suites that have never once gated a push**. They were written, reviewed, and committed — the CI step was never added.

| suite | what it guards |
|---|---|
| `test_upload.py` | auth + traversal containment on `POST /api/upload` |
| `test_steam_goto.py` | the frozen `steam://` destination table |
| `test_game_stop.py` | the no-argument signature that keeps stop-my-game from becoming remote kill-anything |
| `test_bigpicture.py` | couchmode exclusivity + the spawn-counter refusal |
| `test_box_battery.py` | verbatim Legion Go S uevent fixtures (duplicate `POWER_SUPPLY_TYPE`) |
| `test_mem_pressure.py` | PSI parsing |
| `test_steam_cover_art.py` | the content-hash capsule path |
| `test_guide_unreadable_reason.py` | the ACL-mask diagnosis |

The first three are the security-shaped suites CLAUDE.md §6 **requires** for a route that takes client input. The guard existed and was not guarding — worse than no guard, because the checklist item read as ticked.

## The other half

Wiring them doesn't stop it recurring, so `tests/test_ci_wiring.py` now fails if:
- any suite in `tests/` is referenced by no workflow,
- a workflow step points at a suite that no longer exists,
- **it is not itself wired in** (a guard that doesn't run is the bug it was written for),
- a step `name:` contains an unquoted `": "`.

That last one was learned in this commit. Writing `- name: Unit tests (upload: auth + path containment)` made the **entire workflow unparseable** — and that failure mode is the worst available: GitHub cannot start the run, so nothing goes red, the checks simply never appear. Caught by validating the YAML before pushing.

The guard is a textual search, not a YAML parse — the tests here are stdlib-only (CLAUDE.md §5), and the failure mode of dumb-and-textual is a false alarm rather than a false pass.

## Verified how

- All eight suites pass locally.
- The guard was observed to **fail** on a planted orphan file and on a planted dangling reference, and to pass again after each was removed — both states, not just the green one.
- The colon rule was checked against a truth table including the real broken string plus legal controls (quoted colon, the fixed name).
- Both workflow files parse.

## Not verified

Local runs are **macOS**. This repo has been bitten by macOS-green ≠ CI-green before (a `/proc` parser passed locally and failed on ubuntu). **The CI run on this PR is the evidence, not my local exit codes** — if one of the eight goes red here, that is a genuine finding this PR surfaced rather than caused, and it gets fixed before merge.