### PR TITLE
fix(mac): the startup caps line printed nothing when nothing was available

### DIFF
--- a/agent/mac/couchsided-mac.py
+++ b/agent/mac/couchsided-mac.py
@@ -190,9 +190,14 @@ _CAFFEINATE_LOCK = threading.Lock()
 def _pmset_schedule_ok():
     """Can we ACTUALLY schedule a wake — i.e. do we have root?
 
-    Asks pmset to list the schedule, which is readable, then checks euid: the
-    write path is what needs root and probing it for real would leave a
-    scheduled wake behind. Degrades closed.
+    Two cheap facts, no subprocess: pmset must exist, and we must be euid 0.
+
+    It does NOT run pmset. `pmset -g sched` would only prove the schedule is
+    READABLE, which it is for everyone, so it cannot answer this question; and
+    probing the write path for real would leave a scheduled wake on the user's
+    machine. Both halves must be true or this returns False, so an
+    unprivileged agent reports the capability as absent rather than offering a
+    button that fails at the moment it is pressed. Degrades closed.
     """
     if not os.path.isfile(PMSET):
         return False
@@ -253,10 +258,23 @@ def keep_awake_set(on):
 # Media. Per-app AppleScript, because macOS has no MPRIS and MediaRemote is a
 # private framework a stdlib agent cannot link.
 #
-# The payload matches the Linux agent's /api/media shape exactly
+# The payload is the Linux agent's /api/media shape MINUS three fields
 # ({"available":true,"players":[...]}, each player with id/identity/status/
-# title/artist/album/position_ms/length_ms/can_*), so the app's Now Playing
-# card needs no macOS branch.
+# title/artist/album/position_ms/length_ms/can_*). The app's Now Playing card
+# needs no macOS branch, but the shape is not identical and the next person
+# should not be told it is:
+#
+#   rate     not read. AppleScript exposes no playback rate we have measured,
+#            and emitting a hardcoded 1.0 would be inventing a number.
+#   art      no art route on this train, so there are no bytes to advertise.
+#   art_key  the cache-buster for that fetch; meaningless without it.
+#
+# app/lib/api.ts declares all three NON-optional on MediaPlayer, so this is a
+# real divergence even though nothing breaks today (NowPlayingCard guards each
+# one before use). Adding them is legal -- response shapes here are append-only
+# -- but it is a deliberate change to a live payload, and the macOS agent is
+# absent from test_protocol_parity.py's AGENTS map, so nothing would catch a
+# mistake. Do it as its own commit with the parity wiring, not as a drive-by.
 # --------------------------------------------------------------------------
 
 OSASCRIPT = "/usr/bin/osascript"
@@ -715,7 +733,14 @@ def main(argv=None):
     srv.daemon_threads = True
     print("couchside-mac %s listening on %s:%d%s"
           % (VERSION, a.host, a.port, " (mock)" if a.mock else ""), flush=True)
-    print("caps: %s" % ",".join(sorted(k for k, v in CAPS.items() if v)) or "(none)",
+    # Parenthesise the join: `%` binds tighter than `or`, so without them this
+    # reads as ("caps: %s" % joined) or "(none)" -- the left side is always a
+    # non-empty string, so the fallback is unreachable and an all-false box
+    # prints a bare "caps: ". All-false is the DEFAULT state here (gamepad, tv,
+    # screensaver, couchmode and desktop are hardcoded False and _tcc_screen_ok()
+    # starts False), so the operator could not tell "nothing available" from
+    # "failed to compute". Wording matches the Linux agent verbatim: "none".
+    print("caps: %s" % (",".join(sorted(k for k, v in CAPS.items() if v)) or "none"),
           flush=True)
     try:
         srv.serve_forever()

--- a/tests/test_mac_agent.py
+++ b/tests/test_mac_agent.py
@@ -258,6 +258,53 @@ check("_app_running is deterministic across repeats",
       len({M._app_running("Finder") for _ in range(5)}), 1)
 
 print()
+print("the startup caps line says 'none' rather than nothing")
+# `%` binds tighter than `or`, so
+#     "caps: %s" % joined or "none"
+# is ("caps: %s" % joined) or "none" -- always truthy on the left, so the
+# fallback is unreachable and an all-false box printed a bare "caps: ". That is
+# the DEFAULT state on macOS (gamepad/tv/screensaver/couchmode/desktop are
+# hardcoded False), so the operator could not tell "nothing available" from
+# "failed to compute". Assert the behaviour, not just the source text.
+# Asserted STRUCTURALLY rather than by matching text: the defect is precedence,
+# so the question is where the `or` sits in the tree, not how the line is
+# spelled. A string match here also has to guess ast.unparse's quoting, which
+# is how the first version of this check failed.
+#
+#   fixed   BinOp(Mod, left="caps: %s", right=BoolOp(Or, ...))   <- or INSIDE %
+#   broken  BoolOp(Or, values=[BinOp(Mod, ...), "(none)"])       <- or OUTSIDE
+_caps_arg = None
+for _node in _ast.walk(_ast.parse(open(
+        os.path.join(ROOT, "agent", "mac", "couchsided-mac.py")).read())):
+    if (isinstance(_node, _ast.Call)
+            and isinstance(_node.func, _ast.Name) and _node.func.id == "print"
+            and _node.args
+            and "caps: %s" in _ast.dump(_node.args[0])):
+        _caps_arg = _node.args[0]
+check("the caps line was found at all", _caps_arg is not None, True)
+check("the format is the OUTER operation (or is inside it)",
+      isinstance(_caps_arg, _ast.BinOp) and isinstance(_caps_arg.op, _ast.Mod), True)
+check("the fallback is reachable (or is the right operand of %)",
+      isinstance(getattr(_caps_arg, "right", None), _ast.BoolOp), True)
+
+
+def _caps_line(caps):
+    """Reproduce the shipped expression against a given CAPS dict."""
+    return "caps: %s" % (",".join(sorted(k for k, v in caps.items() if v)) or "none")
+
+
+check("all-false renders a word, not an empty tail",
+      _caps_line({"gamepad": False, "tv": False}), "caps: none")
+# The control: an input whose answer is already known, and which the bug did
+# NOT affect. If this ever differs, the fix changed more than the broken case.
+check("some-true is unchanged by the fix",
+      _caps_line({"media": True, "power": True, "tv": False}), "caps: media,power")
+# Wording matches the Linux agent verbatim -- two agents, one vocabulary.
+with open(os.path.join(ROOT, "agent", "couchsided.py")) as f:
+    linux_src = f.read()
+check("Linux says 'none' too (not '(none)')", 'or "none")' in linux_src, True)
+
+print()
 if FAILURES:
     print("FAILED: %s" % ", ".join(FAILURES))
     sys.exit(1)


### PR DESCRIPTION
Three findings in `agent/mac/couchsided-mac.py`, from a repo sweep.

### 1. Precedence bug — a real, user-visible wrong output

```python
"caps: %s" % ",".join(...) or "none"
```

`%` binds tighter than `or`, so this is `("caps: %s" % joined) or "none"`. The left operand is always a non-empty string, so **the fallback was unreachable** and a box with no capabilities printed a bare `caps: `.

That is the *default* state on macOS — `gamepad`, `tv`, `screensaver`, `couchmode`, `desktop` are hardcoded `False` and `_tcc_screen_ok()` starts `False` — so an operator could not tell "nothing available" from "the agent failed to compute this". Wording now matches `agent/couchsided.py` verbatim: `none`, not `(none)`.

### 2. `_pmset_schedule_ok` docstring described a probe that does not happen

It claimed to ask pmset to list the schedule. The body runs no subprocess: pmset must exist, and euid must be 0. Reading the schedule would prove nothing (world-readable), and probing the write path for real would leave a scheduled wake on the user's machine. **Logic unchanged** — only the description now matches it.

### 3. "matches the Linux `/api/media` shape exactly" was false

`rate`, `art`, and `art_key` are absent, and `app/lib/api.ts` declares all three **non-optional** on `MediaPlayer`. Nothing breaks today (`NowPlayingCard` guards each), but the comment told the next person not to check. It now names the three and says why adding them belongs in its own commit: the macOS agent is absent from `test_protocol_parity.py`'s `AGENTS` map, so nothing would catch a mistake in a live payload.

## Verified how

- Reproduced the caps bug and demonstrated the fix against both an all-false and a some-true CAPS dict. **The some-true case is byte-identical before and after** — that control is what shows the change touches only the broken path.
- The new guard is **structural**, not textual: it asserts on the AST that the `or` is the right operand of the `%`. The defect is precedence, and a text match would also have to guess `ast.unparse`'s quoting — which is exactly how my first version of the check failed.
- The guard was then observed to **fail** on the reintroduced bug and pass again after restoring the fix. Both states.

## Not verified

The banner change is only observable when launching the agent by hand on a Mac with all caps false; I asserted the rendered strings rather than re-launching the agent to read its stdout.