### PR TITLE
fix: copy and comments that told the reader something untrue

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4033,26 +4033,41 @@ def _installed_session_files():
 # The session-switch ACTIONS above are one-shot: they move you now and leave the
 # boot default alone (see SESSION_ACTIONS). This is the persistent counterpart.
 #
-# TWO BACKENDS, because the obvious one does not work everywhere:
+# FOUR BACKENDS, because the obvious one does not work everywhere:
 #
-#   steamosctl  — SteamOS's own utility. MEASURED on Bazzite 2026-07-27: the
-#                 binary ships, but the call fails with
-#                 "org.freedesktop.DBus.Error.UnknownInterface ...
-#                 SessionManagement1" AND STILL EXITS 0. So the probe reads the
-#                 OUTPUT, never the exit status — an exit-code probe would
-#                 report this backend working on every Bazzite box and then
-#                 silently do nothing.
+#   steamosctl   — SteamOS's own utility. MEASURED on Bazzite 2026-07-27: the
+#                  binary ships, but the call fails with
+#                  "org.freedesktop.DBus.Error.UnknownInterface ...
+#                  SessionManagement1" AND STILL EXITS 0. So the probe reads the
+#                  OUTPUT, never the exit status — an exit-code probe would
+#                  report this backend working on every Bazzite box and then
+#                  silently do nothing.
 #
-#   sddm        — the drop-in that actually decides it on Bazzite:
-#                 /etc/sddm.conf.d/steamos.conf carries
-#                 "[Autologin] Session=gamescope-session.desktop". We never edit
-#                 that file; we write our OWN later-sorting drop-in, so removing
-#                 ours restores the box's original behaviour exactly.
+#   sddm         — a conf-dir drop-in. On Bazzite /etc/sddm.conf.d/steamos.conf
+#                  carries "[Autologin] Session=gamescope-session.desktop". We
+#                  never edit that file; we write our OWN later-sorting drop-in,
+#                  so removing ours restores the box's original behaviour.
 #
-# Root-owned either way, so the sddm backend is gated on a real NOPASSWD grant
-# (last-match evaluated — see _sudo_nopasswd_allows for why exit codes lie
-# there too). No grant, no capability: the setting never appears rather than
-# appearing and failing.
+#   plasmalogin  — KDE's SDDM successor, shipping today on CachyOS deckify.
+#                  Identical config scheme, so it shares sddm's reader and
+#                  writer via _DM_CONF_DIRS — but it is a DIFFERENT conf dir and
+#                  a different unit to restart.
+#
+#   greetd       — gated on _greetd_session_ok(). Its own config format, so its
+#                  own setter dispatch.
+#
+# THE HEADER SAID "TWO" UNTIL 2026-08-01, and the missing pair is exactly the
+# bug this section shipped in 2.9.65: because sddm read as the only conf-dir
+# path, the availability probe treated an sddm sudoers grant — which install.sh
+# used to write unconditionally — as PROOF that sddm was the display manager. On
+# a plasmalogin box that advertised backend "sddm", showed the Boots-into card,
+# and wrote to a directory that did not exist. Detect the manager; never infer
+# it from a grant. (KDE is migrating, so Bazzite reaches plasmalogin too.)
+#
+# Root-owned either way, so the conf-dir backends are gated on a real NOPASSWD
+# grant for the DETECTED manager's path (last-match evaluated — see
+# _sudo_nopasswd_allows for why exit codes lie there too). No grant, no
+# capability: the setting never appears rather than appearing and failing.
 # ---------------------------------------------------------------------------
 
 # Closed set. A client selects one of these; it never reaches a command line.
@@ -15282,10 +15297,23 @@ def render_pin_page(pin):
         "fetch('/api/pair/status').then(function(r){return r.json()})"
         ".then(function(d){if(d&&d.active===false&&!done){done=true;"
         "document.body.innerHTML="
-        "'<div class=t>PAIRED</div><div class=s>Press B (Back) to close.</div>'"
+        "'<div class=t>PAIRED</div>"
+        "<div class=s>Press B (Back), or close this window.</div>'"
         # Steam's browser can't be closed programmatically (neither a page-side
         # window.close()/steam:// nav nor an agent steam:// CLI dismisses it), so
         # we land on a clean PAIRED screen and tell the user how to close it.
+        #
+        # BOTH contexts, because pair_show_on_box_url() branches: in gamescope it
+        # opens in Steam's browser (B = Back), but on ANY desktop session it goes
+        # through xdg-open into Firefox or Chrome, where there is no B button and
+        # "Press B (Back) to close." was simply nonsense — and it is the last
+        # sentence a brand-new user reads. That desktop path is what every
+        # CachyOS / Nobara / Pop!_OS box takes. The Windows agent already words
+        # it for a plain browser (agent/win/couchsided-win.py, render_pin_page).
+        #
+        # NO APOSTROPHES in this copy: it is a single-quoted JS string literal
+        # nested inside a double-quoted Python one, and an apostrophe would end
+        # the JS string and break the poll script that closes the page.
         "}}).catch(function(){})},3000)</script>"
         "</body></html>".replace("__PIN__", " ".join(pin)))
 

--- a/app/components/SetupProgress.tsx
+++ b/app/components/SetupProgress.tsx
@@ -74,9 +74,19 @@ import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
  */
 export const SETUP_GUIDE_URL = 'https://couchside.tv/#install';
 
-/** The four steps, in the order a new user actually performs them. */
+/** The four steps, in the order a new user actually performs them.
+ *
+ * Step 1 used to read "switch to Desktop Mode and open a terminal". That
+ * imperative presumes you are IN Game Mode, which is true on a Deck and false
+ * on every desktop Linux box — CachyOS, Nobara, Pop!_OS, plain systemd — all of
+ * which README.md sells to and which are already sitting at a desktop. It sent
+ * those users hunting for a toggle their machine does not have, on the first
+ * line of the first screen. ("Desktop Mode" itself is fine as a noun; the app
+ * uses it for any non-gamescope session in RemotePowerBar. It was the verb.)
+ *
+ * Text here is not load-bearing: stepMarks() keys off the array INDEX. */
 const STEPS = [
-  'On your PC, switch to Desktop Mode and open a terminal.',
+  'On your PC, open a terminal. (On a Steam Deck or in Game Mode, switch to Desktop Mode first.)',
   'Open couchside.tv and run the install command.',
   'Watch this screen — it updates by itself.',
   'A PIN appears on your TV. Type it here.',

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -165,9 +165,11 @@ export type BoxCaps = {
    * (drop dir not writable) hides the card.
    */
   file_upload?: boolean;
-  /** Box can set which session it BOOTS into (agent >= 2.9.58). Two backends:
-   *  SteamOS's steamosctl, or an sddm drop-in on Bazzite — absent when neither
-   *  is usable, so the setting never appears on a box that cannot honour it. */
+  /** Box can set which session it BOOTS into (agent >= 2.9.58). Four backends —
+   *  steamosctl, or a conf-dir drop-in for sddm or plasmalogin, or greetd; see
+   *  the `backend` union on SessionDefault below, which this comment used to
+   *  contradict. Absent when none is usable, so the setting never appears on a
+   *  box that cannot honour it. */
   session_default?: boolean;
   /**
    * Display + audio readout (agent >= 2.9.59): mode, panel identity, HDR/VRR,


### PR DESCRIPTION
Three wrong claims found by a repo sweep. **No behaviour changes** — one user-facing string, two comments.

### 1. The PAIRED screen told desktop users to press a gamepad button

`pair_show_on_box_url()` branches: under gamescope the PIN page opens in Steam's browser, but on **any** desktop session it goes through `xdg-open` into Firefox or Chrome. There is no B button there, and `Press B (Back) to close.` is the **last sentence a brand-new user reads at the end of pairing**. That desktop path is what every CachyOS / Nobara / Pop!_OS box takes — the distros the recent display-manager work targets.

Now: `Press B (Back), or close this window.` The Windows agent already words its equivalent for a plain browser.

> ⚠️ The copy is a single-quoted JS string literal nested inside a double-quoted Python one. **An apostrophe would terminate the JS string and break the poll script that closes the page.** Noted in a comment beside it so the next editor doesn't step on it.

### 2. `agent/couchsided.py` — "TWO BACKENDS", where the code has four

`steamosctl`, `sddm`, `plasmalogin` (shares sddm's reader/writer via `_DM_CONF_DIRS`, but a different conf dir and a different unit to restart), and `greetd`.

The undercount isn't cosmetic — **it is the exact assumption that shipped the 2.9.65 bug.** Because sddm read as the only conf-dir path, the availability probe treated an sddm sudoers grant (which install.sh wrote unconditionally) as *proof* that sddm was the display manager. On a plasmalogin box that advertised `backend: "sddm"`, showed the Boots-into card, and wrote to a directory that did not exist.

### 3. `app/lib/api.ts` contradicted itself

The `session_default` doc comment said "Two backends: steamosctl, or an sddm drop-in on Bazzite" — while the `backend` union **950 lines below in the same file** lists `'steamosctl' | 'sddm' | 'plasmalogin' | 'greetd'`.

## Verified how

- **Rendered the pairing page** and read the copy back out of the generated HTML — not grepped for. Checked the JS literal for balanced quotes: exactly two, the delimiters.
- **Exercised the onboarding string in the web harness at 375×812.** It wraps to three lines under the step marker; `bodyScrollWidth === innerWidth` (no horizontal overflow); the element is not clipped (`scrollHeight === clientHeight`); console clean. Screenshot taken.
- `test_pair_page`, `test_session_default`, `test_ci_wiring` pass; `py_compile` on the agent and `tsc --noEmit` on the app both clean.

## Not verified

The PAIRED copy was verified in the **rendered HTML**, not by completing a real pairing on a box and watching the page flip to it. The flip is driven by the existing `/api/pair/status` poll, which this change does not touch.