### PR TITLE
docs: the capability checklist said FIVE edit sites; there are six

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ injected actions) with real snippets. New code matches those exactly.
 | New agent endpoint | Happy path + auth failure + unknown-input rejection |
 | Anything taking a client id | A test proving a non-allowlisted id is refused and nothing runs |
 | Gamepad / input path change | Device lifecycle test (create → hold → hand off → reap) |
-| New capability key | A test asserting all five edit sites are wired |
+| New capability key | A test asserting all six edit sites are wired (§4) |
 | Parsing `/proc` or sysfs | Fixtures copied VERBATIM from real hardware |
 | App UI change | Driven in the web harness — **press the control, don't just render it** |
 | Anything only observable on the TV | Screen-capture proof via `/api/screen/frame` |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -233,8 +233,8 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   table only; the URL, exe and argv come from the agent. This is the same rule as
   LAUNCHERS/ACTIONS and is the single thing most likely to be got wrong here.
 - Creating/removing tiles is state-changing, so it needs the bearer token, a capability
-  key (all five edit sites), and tests proving a non-allowlisted service_id registers
-  nothing.
+  key (all six edit sites — the sixth is `protocol/protocol.json`), and tests proving a
+  non-allowlisted service_id registers nothing.
 
 ### Two-way clipboard (box <-> phone)
 - **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none

--- a/docs/memory/ARCHITECTURE.md
+++ b/docs/memory/ARCHITECTURE.md
@@ -178,28 +178,47 @@ Two details worth knowing:
   `false` (cached before a box *became* capable) stuck forever for a user who lived on the Pad
   tab — observed in the field.
 
-### 3c. Adding a capability key — FIVE sites, all mandatory
+### 3c. Adding a capability key — SIX sites, all mandatory
 
 Miss any one and the cap silently never persists, so the app re-probes on every launch. This
-has been shipped-and-fixed five separate times (`screensaver`, `couchmode`/`desktop`,
-`steamlink`, `gaming`, `streamhost`, `steammenus` — the comments in `normalizeCaps` are a
-scar log).
+has been shipped-and-fixed repeatedly (`screensaver`, `couchmode`/`desktop`, `steamlink`,
+`gaming`, `streamhost`, `steammenus` — the comments in `normalizeCaps` are a scar log).
+
+**This section said FIVE until 2026-08-01**, omitting site 6 — the canonical list in
+`protocol/protocol.json`, which is the file CLAUDE.md calls THE authority and which
+`tests/test_protocol_parity.py` enforces. Adding `bigpicture` failed parity on exactly that
+sixth site, because the checklist that was supposed to prevent it did not mention it.
 
 | # | File | Site |
 |---|---|---|
-| 1 | `agent/couchsided.py:980-994` | the real `CAPS` dict — `"newcap": safe(newcap_available)` |
-| 2 | `agent/couchsided.py:975-978` | the **mock all-true tuple** — add the string or `--mock` lies |
-| 3 | `app/lib/api.ts:79-137` | the `BoxCaps` type — declare it **optional** (`newcap?: boolean`) |
-| 4 | `app/lib/settings.ts:200-241` | `normalizeCaps` — `const newcap = bool('newcap')` **and** put it in the returned object |
-| 5 | `app/lib/api.ts:715-733` | `capsEqual` — add `a.newcap === b.newcap` |
+| 1 | `agent/couchsided.py:1586` | the real `CAPS` dict — `"newcap": safe(newcap_available)` |
+| 2 | `agent/couchsided.py:1579` | the **mock all-true tuple** — add the string or `--mock` lies |
+| 3 | `app/lib/api.ts:80` | the `BoxCaps` type — declare it **optional** (`newcap?: boolean`) |
+| 4 | `app/lib/settings.ts:205` | `normalizeCaps` — `const newcap = bool('newcap')` **and** put it in the returned object |
+| 5 | `app/lib/api.ts:1084` | `capsEqual` — add `a.newcap === b.newcap` |
+| 6 | `protocol/protocol.json` | the canonical list: `capabilities.keys`, or `linuxOnlyCapabilities.keys` if the Windows/macOS agents will not have it |
+
+Line numbers are a starting point, not a promise — every one in this table had drifted by
+hundreds of lines before 2026-08-01 (site 1 read `:980`, actually `:1586`; site 5 read
+`:715`, actually `:1084`). Grep the symbol.
 
 Sites 4 and 5 are the trap. `normalizeCaps` hard-requires the six **original** keys as booleans
 (`gamepad, steam, media, tv, screen, power_schedule`) and drops the whole blob if any is
 missing — a partial payload is not half-trusted. Every key added *after* those six must be
 optional, so `undefined` stays "unknown, probe" and never degrades to `false`.
 
-Current keys: `gamepad`, `steam`, `media`, `tv`, `screen`, `power_schedule`, `screensaver`,
-`couchmode`, `desktop`, `steamlink`, `gaming`, `streamhost`, `steammenus`.
+Current keys, in the two groups `protocol/protocol.json` splits them into — the split IS the
+subtlety of site 6, so pick the right group when adding one:
+
+- `capabilities.keys` (**every** agent must declare these, including Windows and macOS):
+  `gamepad`, `steam`, `media`, `tv`, `screen`, `power_schedule`, `screensaver`, `couchmode`,
+  `desktop`.
+- `linuxOnlyCapabilities.keys` (the Linux agent only; parity does not demand them elsewhere):
+  `bigpicture`, `boxbattery`, `display_info`, `file_upload`, `gaming`, `player`,
+  `session_default`, `steamlink`, `steammenus`, `streamhost`.
+
+This list is generated from the file above rather than remembered; it omitted six keys until
+2026-08-01. If it disagrees with `protocol.json`, the JSON is right.
 
 Caps also gate whole tabs — `hidePad = caps?.gamepad === false`,
 `hideLaunch = caps?.steam === false` (`app/app/(tabs)/_layout.tsx:28-30`), which is how a

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -206,9 +206,14 @@ node --experimental-strip-types --test app/lib/__tests__/*.test.ts   # Node >= 2
 bundler-dependent test would have meant a whole toolchain; this needs none. If you make the
 tested module import a real dependency, this standalone path breaks — keep it import-free.
 
-CI is two jobs: `compile` (`py_compile` on all three entrypoints, then the unit tests) and `smoke`
-(boots the agent `--mock` on a spare port and proves auth: `/api/ping` 200, `/api/status` 401
-without a token, 200 with one) — `.github/workflows/ci.yml:103-186`.
+CI is three jobs — `compile` (`py_compile` on all three entrypoints, then every unit suite),
+`smoke` (boots the agent `--mock` on a spare port and proves auth: `/api/ping` 200,
+`/api/status` 401 without a token, 200 with one), and `app-input` (the standalone module
+above). This paragraph said "two jobs" until 2026-08-01 while naming `app-input` four lines
+earlier. Jobs begin at `.github/workflows/ci.yml:16`, `:594` and `:686`.
+
+Every suite in `tests/` must have a step, and `tests/test_ci_wiring.py` fails the build if one
+does not — eight suites had been committed and never run before that guard existed.
 
 ---
 

--- a/docs/memory/project_media-player.md
+++ b/docs/memory/project_media-player.md
@@ -363,8 +363,10 @@ file exfiltration. Therefore:
 
 ### Capability key
 
-`player`, wired at all five edit sites (agent CAPS dict + mock tuple; app BoxCaps +
-normalizeCaps + capsEqual), with a test asserting all five.
+`player`, wired at all six edit sites (agent CAPS dict + mock tuple; app BoxCaps +
+normalizeCaps + capsEqual; and `protocol/protocol.json`, where it sits in
+`linuxOnlyCapabilities.keys`). `tests/test_player_api.py` asserts the first five;
+`tests/test_protocol_parity.py` gates the sixth.
 
 ---
 
@@ -641,7 +643,7 @@ Asked directly by the owner, so it was measured rather than reasoned about:
 | Layer | Gate | How it is known |
 |---|---|---|
 | `player_available()` | tile file + service list + Widevine browser + steam + steamos-add-to-steam | test: cap is `false` when the tile is absent |
-| `caps.player` | that boolean on `/api/status` | test: all five edit sites |
+| `caps.player` | that boolean on `/api/status` | test: five edit sites here, sixth in parity |
 | `GET /api/player` | **404** | test: probe-and-appear |
 | Launch segment | `caps?.player === true && watchEnabled` | **harness, observed** |
 

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -20,9 +20,11 @@
     "not an omission, and asserting it stops a half-port from looking finished.",
     "",
     "CAPABILITIES are included because they are the highest-drift surface here: a",
-    "capability key needs FIVE edit sites (agent CAPS + mock; app BoxCaps,",
-    "normalizeCaps, capsEqual) and missing the app ones is SILENT -- the cap never",
-    "persists and the app re-probes forever.",
+    "capability key needs SIX edit sites (agent CAPS + mock; app BoxCaps,",
+    "normalizeCaps, capsEqual; and THIS FILE) and missing the app ones is SILENT",
+    "-- the cap never persists and the app re-probes forever. This said FIVE and",
+    "omitted itself until 2026-08-01, when adding `bigpicture` failed parity on",
+    "the very site the checklist did not mention.",
     "",
     "HTTP ENDPOINTS are deliberately NOT modelled. Route dispatch takes at least",
     "four forms in the agents (path ==, path in (...), prefix match, and a generic",
@@ -154,7 +156,7 @@
     ]
   },
   "capabilities": {
-    "_doc": "/api/status caps flags. Compared against the agents' REAL runtime CAPS dicts (set_caps is called and the dict read) and the app's BoxCaps / normalizeCaps / capsEqual -- all five edit sites.",
+    "_doc": "/api/status caps flags. Compared against the agents' REAL runtime CAPS dicts (set_caps is called and the dict read) and the app's BoxCaps / normalizeCaps / capsEqual -- five of the six edit sites. The sixth is this list itself, which is why adding a key here is part of the checklist and not a side effect of it.",
     "platforms": [
       "linux",
       "windows"

--- a/tests/test_player_api.py
+++ b/tests/test_player_api.py
@@ -17,9 +17,12 @@ the tile (`--print-url`), so these tests drive the real tile through the real
 route — which is the point of that design: one copy of the table, and the
 validator is the code that will actually run.
 
-The cap check covers all five edit sites (agent CAPS dict + mock tuple; app
-BoxCaps + normalizeCaps + capsEqual). Miss the app three and the cap never
-persists, so the tab re-probes forever — the specific bug CLAUDE.md §4 names.
+The cap check here covers five of the SIX edit sites (agent CAPS dict + mock
+tuple; app BoxCaps + normalizeCaps + capsEqual). Miss the app three and the cap
+never persists, so the tab re-probes forever — the specific bug CLAUDE.md §4
+names. The sixth site is the canonical list in protocol/protocol.json, which is
+enforced by tests/test_protocol_parity.py rather than here; `player` is in
+linuxOnlyCapabilities.keys, so that gate is live for this cap.
 
 Pure stdlib, no pytest.
 """
@@ -290,7 +293,8 @@ finally:
     srv.shutdown()
 
 # ---------------------------------------------------------------------------
-print("\nthe `player` cap is wired at all five edit sites")
+print("\nthe `player` cap is wired at five of the six edit sites "
+      "(protocol.json is site 6, gated by test_protocol_parity.py)")
 # ---------------------------------------------------------------------------
 cs.set_player(True)
 cs.set_caps(True)

--- a/tests/test_protocol_parity.py
+++ b/tests/test_protocol_parity.py
@@ -202,12 +202,18 @@ def test_app_matches_spec():
               % (ts, gname, sorted(want - got) or "none", sorted(got - want) or "none"))
 
 
-# ---- capabilities: the five-edit-site rule, checked ------------------------
+# ---- capabilities: the six-edit-site rule, checked -------------------------
 #
-# A capability key needs FIVE edits: the agent's CAPS dict + its mock tuple, and
-# the app's BoxCaps + normalizeCaps + capsEqual. Missing the app ones is SILENT
-# -- the cap never persists, so the app re-probes on every launch forever. That
-# is exactly how `steammenus` and the TV sections drifted.
+# A capability key needs SIX edits: the agent's CAPS dict + its mock tuple, the
+# app's BoxCaps + normalizeCaps + capsEqual, and the canonical list in
+# protocol/protocol.json. Missing the app ones is SILENT -- the cap never
+# persists, so the app re-probes on every launch forever. That is exactly how
+# `steammenus` and the TV sections drifted.
+#
+# This comment said FIVE and omitted protocol.json until 2026-08-01 -- in a file
+# whose entire job is to ENFORCE the sixth site. Adding `bigpicture` failed here
+# for exactly that reason: the checklist did not mention the site the test was
+# about to fail on.
 #
 # Read from the agents' REAL runtime dicts (set_caps is called and CAPS is read),
 # not from source text. An earlier regex pass over the same data produced two
@@ -218,7 +224,7 @@ def _agent_caps(mod):
 
     set_caps(mock) has two code paths: the mock branch builds CAPS from a fixed
     name tuple, the real branch from a dict of detector calls. Those are two of
-    the five edit sites, and a cap added to one but not the other is exactly the
+    the six edit sites, and a cap added to one but not the other is exactly the
     drift being hunted -- an earlier version of this test read only the mock
     path and did NOT catch a cap injected into the real dict. Union both, and
     _agent_caps_disagree() reports the pair falling out of step."""

--- a/tests/test_win_launchers.py
+++ b/tests/test_win_launchers.py
@@ -16,9 +16,17 @@ they run cross-platform (the agent module imports fine on macOS; winreg + the
 PowerShell bridge are guarded). Live GOG/Xbox enumeration is Windows-only and is
 verified on a real box separately; here we test their pure transforms + resolver.
 
-Also asserts the `launchers` capability is wired at all five edit sites
+Also asserts the `launchers` capability is wired at five of the SIX edit sites
 (CLAUDE.md §4): the two agent sites here, plus the three app sites by reading the
 app source — a missing app site is the classic silent "cap never persists" bug.
+
+The sixth site does not exist for this cap, and that is a real gap rather than an
+exemption: protocol/protocol.json models `capabilities.keys` (every agent must
+declare these) and `linuxOnlyCapabilities.keys`, with NO group for a
+Windows-only cap. `launchers` is therefore absent from the canonical list and
+test_protocol_parity.py does not gate it either way. Noted 2026-08-01; adding a
+windowsOnlyCapabilities group is a protocol change and belongs in its own PR,
+not smuggled in as a comment fix.
 
 Pure stdlib, no pytest — same style as the other agent tests.
 """
@@ -250,7 +258,8 @@ def test_auto_ids_not_creatable_or_deletable():
 
 
 def test_launchers_cap_five_sites():
-    print("`launchers` capability wired at all five edit sites (CLAUDE.md §4)")
+    print("`launchers` capability wired at five of six edit sites "
+          "(no protocol.json group exists for a Windows-only cap)")
     # Agent site 1: mock CAPS
     cw.set_caps(mock=True)
     check(cw.CAPS.get("launchers") is True, "agent mock CAPS carries launchers")


### PR DESCRIPTION
CLAUDE.md was corrected to **SIX** on 2026-08-01, after adding `bigpicture` failed parity on the sixth site. That correction never reached the other seven places that state the count — including two with real irony:

- **`protocol/protocol.json`**, which CLAUDE.md calls *THE authority*, and which **omitted itself** from the checklist.
- **`tests/test_protocol_parity.py`**, the file whose entire job is to enforce that sixth site.

Corrected across: `protocol/protocol.json` (header note + capabilities `_doc`), `docs/memory/ARCHITECTURE.md` §3c, `CLAUDE.md`'s §6 table row, ROADMAP's forward-looking tile entry, `project_media-player.md`, and the prose in `tests/test_player_api.py` and `tests/test_win_launchers.py`.

## Two things found while doing it

**§3c's line references had drifted by hundreds of lines.** Site 1 read `agent/couchsided.py:980` — actually `:1586`. Site 5 read `app/lib/api.ts:715` — actually `:1084`. Refreshed, with a note that line numbers are a starting point and the symbol is the real address.

**Its "Current keys" list was missing six keys** — `bigpicture`, `boxbattery`, `display_info`, `file_upload`, `player`, `session_default`. Regenerated by diffing against `protocol.json` rather than transcribing, and split into the two groups that file actually models, since choosing the right group *is* the subtlety of site 6.

## One genuine gap — recorded, not fixed here

**`launchers` is absent from `protocol/protocol.json` entirely.** The file models `capabilities.keys` (every agent must declare) and `linuxOnlyCapabilities.keys` — there is **no group for a Windows-only cap**. So `test_protocol_parity` gates `launchers` in neither direction, while `tests/test_win_launchers.py` claimed all sites were wired.

The test now says what is actually true. Adding a `windowsOnlyCapabilities` group is a protocol change and belongs in its own PR, not smuggled in as a comment fix.

## Also

`docs/memory/CONVENTIONS.md` said "CI is two jobs" while naming the third, `app-input`, **four lines earlier**. There are three.

## Verified how

- `protocol.json` still parses.
- `test_protocol_parity`, `test_player_api`, `test_win_launchers`, `test_ci_wiring` all pass.
- The key list was **diffed** against `protocol.json` programmatically, not transcribed by eye.
- A repo-wide re-sweep leaves no stale five-site claim — the two remaining hits are Nobara's "five editions" and a corrected line.

Historical records that say "SHIPPED at five edit sites" were **deliberately left alone**: they describe what was true when written, and rewriting them would falsify the log.