### PR TITLE
chore(release): 2.9.35 build 114 — the iOS build number and its release notes

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "113",
+      "buildNumber": "114",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,3 +1,5 @@
-Fixes a bug where the app could stop responding — trackpad and buttons frozen — within a minute of opening, then quietly restart itself. It was a purchase-verification loop, most likely on iOS beta versions, and it could also drain battery. Restoring purchases is more reliable now.
+Fixes the big one: switching your box between Game Mode and Desktop no longer freezes the app. The trackpad would stop moving the cursor while everything still looked connected, and the only way back was force-quitting or switching boxes. That's fixed — switch as often as you like.
 
-Also new: the Console shows every GPU in your box — dual-GPU machines show both cards, each with its own temperature, usage and memory.
+New: a Big Picture button for PCs that have Steam but no Game Mode session (Nobara, most desktop Linux). One tap opens Steam Big Picture on the TV; long-press the same button to come back to the desktop.
+
+Also: connection diagnostics are reachable in large-pad mode, and tap-to-retry does a deeper reset when a connection goes quiet.


### PR DESCRIPTION
Two files left uncommitted after the 2.9.35 cloud build and store submission.

- **`app/app.json`** — `ios.buildNumber` 113 → **114**. Written by EAS `autoIncrement` at build-kick, not by hand. 114 is what is on TestFlight and what is in App Store review.
- **`app/changelogs/whatsnew-en-US.txt`** — the 2.9.35 notes actually submitted to ASC (session-switch freeze fix, the Big Picture button, diagnostics reachable in large-pad mode). It still held **2.9.32's** copy, so the text that shipped existed only on one machine. `scripts/asc-submit.py` defaults to this path precisely so the notes live in git with the code.

## On the 500-char question

617 chars, which is fine — this is the **ASC** file. Google's 500-char cap applies to `app/changelogs/whatsnew-play-en-US.txt`, which is deliberately still on 2.9.32's text because **Play is still on versionCode 70** and Android 2.9.35 has not shipped. That file gets updated when it does.

## One footgun noticed, not changed here

`scripts/play-release-notes.py` **defaults** to `whatsnew-en-US.txt` rather than the play-specific file, so running it without `--notes` now hits the 500-char refusal. It fails closed — refuses rather than letting Google truncate — so it is a papercut, not a hazard. Worth a follow-up to point the default at the right file.

## Verified how

Char counts measured on both files; confirmed both submit scripts' `DEFAULT_NOTES`; confirmed `whatsnew-play-en-US.txt` is tracked and last touched in #317. No code paths changed.