### PR TITLE
chore(release): Android 2.9.35 (versionCode 73) live on Play production

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 71
+      "versionCode": 73
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,3 +1,5 @@
-Fixes a bug where the app could stop responding — trackpad and buttons frozen — within a minute of opening, then quietly restart itself. It was a purchase-verification loop, most likely on iOS beta versions, and it could also drain battery. Restoring purchases is more reliable now.
+New: a Big Picture button for PCs that have Steam but no Game Mode session (Nobara, most desktop Linux). One tap opens Steam Big Picture on the TV; tap again to come back to the desktop.
 
-Also new: the Console shows every GPU in your box — dual-GPU machines show both cards, each with its own temperature, usage and memory.
+The Console now shows which OS and version your box is running.
+
+Also: connection diagnostics are reachable in large-pad mode, tap-to-retry does a deeper reset when a connection goes quiet, and the app does less redundant work after a session switch.


### PR DESCRIPTION
Play was on **vc 70 / 2.9.32** while iOS had already gone `READY_FOR_SALE` at **2.9.35**. This brings Android to parity. Both stores are now on 2.9.35.

## `app/app.json` — versionCode 71 → 73

Written by EAS `autoIncrement`, not by hand, and it bumped **twice**: once for a build that failed before producing an artifact (`ANDROID_HOME` was unset on this machine), and again for the build that succeeded. **72 was never published and never will be.**

The shipped AAB's manifest reads 73 — verified by extracting `base/manifest/AndroidManifest.xml` and reading the version out of it, not by trusting the build log.

## `whatsnew-play-en-US.txt` — rewritten, not copied

Android's delta is **2.9.33 + 2.9.34 + 2.9.35** (Play skipped two versions).

The iOS copy leads with *"switching between Game Mode and Desktop no longer freezes the app"* — a bug that was measured **iOS-only** (KI-053/054; Android was clean on identical code with both caps writers present). Shipping that to Play would advertise a fix for a bug those users never had.

The Android notes lead with the Big Picture button and the Console OS line, and describe the caps-writer change honestly as *"does less redundant work after a session switch"*. 438 chars against Play's 500 cap.

## Verified how

- Play production reports `vc=73 / name=2.9.35 / status=completed` via the Android Publisher API — not from the CLI's "All done".
- Release notes are present **and were read back**: this is the post-commit verification added in #346, exercised for real for the first time — `verified: Play shows the 438-char notes we sent`.
- `couchside.tv/app-version.json` serves vc 73, fetched live from the site.
- `publish-app-version.py` reported a deploy failure during the release run, but the artifact was already correct and a clean re-run exits 0 — transient. Worth knowing it can cry wolf: re-running the script afterwards says *"already current — nothing to do"*, which would mask a **real** deploy failure. Checking the live URL is the only honest verification.

## Security note, unrelated to this diff

The first (failed) local build caused `eas-cli-local-build-plugin` to dump its entire job payload — **including the Android keystore and both passwords**, base64-encoded — into the build log. Those files have been shredded and verified gone by decoding, not string-matching. Subsequent builds pipe through a redaction filter before anything reaches disk. Exposure was local-only; whether to rotate the upload key is the maintainer's call.