### PR TITLE
feat(app): remote-only mode — Couchside as just a TV remote, no box (Roku direct)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.35",
+    "version": "2.9.36",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "114",
+      "buildNumber": "116",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -21,6 +21,11 @@ export default function TabLayout() {
   const t = useTheme();
   const { boxes, activeBox, ready } = useBoxes();
   const landingTab = usePref('landingTab');
+  // REMOTE-ONLY MODE: the app is just a smart-TV remote, no box anywhere. Every
+  // box tab is hidden and the Remote tab (which talks to the TV directly, see
+  // lib/tvdirect/) takes over. A pref rather than derived state, so a box owner
+  // can flip to it while the box is off and flip back without the box answering.
+  const remoteOnly = usePref('remoteOnlyMode');
   const segments = useSegments();
   // Always-mounted caps safety net: heals a stale persisted caps snapshot
   // (e.g. couchmode:false cached before the box became capable) no matter
@@ -31,12 +36,13 @@ export default function TabLayout() {
   // in /api/status caps, so its gaming tabs are hidden. Undefined caps (unknown,
   // or agent < 2.8.2) leaves both visible — never hide a tab on a guess.
   const caps = activeBox?.caps;
-  const hidePad = caps?.gamepad === false;
+  const hidePad = caps?.gamepad === false || remoteOnly;
   // `launchers` (Windows agent >= 0.4.0-win) means "any launcher present"
   // (Steam/Epic/GOG/custom), so an Epic/GOG/Game Pass box shows the Launch tab
   // even without Steam. Older agents (and every Linux agent) don't send it, so
   // fall back to the `steam` cap — never hide the tab on a guess.
   const hideLaunch =
+    remoteOnly ||
     caps?.launchers === false ||
     (caps?.launchers === undefined && caps?.steam === false);
 
@@ -55,6 +61,14 @@ export default function TabLayout() {
   useEffect(() => {
     if (!ready || redirected.current) return;
     redirected.current = true;
+    // In remote-only mode the landing tab is the Remote, always: the box tabs
+    // it could otherwise name are hidden, and Console with no box is an empty
+    // dashboard. Setup is still where someone with no TV yet has to go, but
+    // the Remote screen says so itself rather than skipping past its own tab.
+    if (remoteOnly) {
+      router.replace('/(tabs)/remote');
+      return;
+    }
     if (boxes.length === 0) {
       router.replace('/(tabs)/setup');
       return;
@@ -64,7 +78,7 @@ export default function TabLayout() {
     if (landingTab !== 'index') {
       router.replace(`/(tabs)/${landingTab}`);
     }
-  }, [ready, boxes.length, landingTab]);
+  }, [ready, boxes.length, landingTab, remoteOnly]);
 
   // Bounce off a tab hidden for the active box — landing on the Pad initial
   // route for a server box, or switching from an HTPC to a server box while the
@@ -72,10 +86,24 @@ export default function TabLayout() {
   useEffect(() => {
     if (!ready) return;
     const leaf = segments[segments.length - 1];
+    // Remote-only hides every box tab INCLUDING Console, so the bounce target
+    // is the Remote, not the tabs index. This is also what carries a runtime
+    // flip of the toggle: the landing redirect above is one-shot, so without
+    // this, switching modes from Setup would leave you on a tab that no longer
+    // has a tab-bar entry. Setup stays reachable in both modes — it is where
+    // the toggle lives, and a mode you cannot leave is a trap.
+    if (remoteOnly) {
+      if (leaf !== 'remote' && leaf !== 'setup') router.replace('/(tabs)/remote');
+      return;
+    }
+    if (leaf === 'remote') {
+      router.replace('/(tabs)');
+      return;
+    }
     if ((hidePad && leaf === 'pad') || (hideLaunch && leaf === 'launch')) {
       router.replace('/(tabs)');
     }
-  }, [ready, hidePad, hideLaunch, segments]);
+  }, [ready, hidePad, hideLaunch, remoteOnly, segments]);
 
   return (
     <Tabs
@@ -95,6 +123,21 @@ export default function TabLayout() {
         options={{
           title: 'Console',
           tabBarIcon: ({ color }) => <Ionicons name="pulse" size={24} color={color} />,
+          // A box dashboard with no box is an empty screen, so Console goes too
+          // in remote-only mode — the only tab left is the Remote (plus Setup).
+          href: remoteOnly ? null : undefined,
+        }}
+      />
+      {/* The TV remote. Present only in remote-only mode: a box owner already
+          has a richer remote inside the Pad tab (it reaches CEC, RS-232 and the
+          box's own volume through the agent), and two remotes in one tab bar
+          would be a question the user has to answer on every press. */}
+      <Tabs.Screen
+        name="remote"
+        options={{
+          title: 'Remote',
+          tabBarIcon: ({ color }) => <Ionicons name="tv" size={24} color={color} />,
+          href: remoteOnly ? undefined : null,
         }}
       />
       <Tabs.Screen
@@ -103,7 +146,7 @@ export default function TabLayout() {
           title: 'Fleet',
           tabBarIcon: ({ color }) => <Ionicons name="server" size={24} color={color} />,
           // Only useful with several boxes; single-box users keep a clean bar.
-          href: boxes.length >= 2 ? undefined : null,
+          href: !remoteOnly && boxes.length >= 2 ? undefined : null,
         }}
       />
       <Tabs.Screen
@@ -111,6 +154,7 @@ export default function TabLayout() {
         options={{
           title: 'Actions',
           tabBarIcon: ({ color }) => <Ionicons name="flash" size={24} color={color} />,
+          href: remoteOnly ? null : undefined,
         }}
       />
       <Tabs.Screen

--- a/app/app/(tabs)/remote.tsx
+++ b/app/app/(tabs)/remote.tsx
@@ -1,0 +1,202 @@
+/**
+ * The Remote tab — REMOTE-ONLY MODE.
+ *
+ * Visible only while the remoteOnlyMode pref is on (app/(tabs)/_layout.tsx),
+ * which is the mode for someone who has a smart TV and no Couchside box. It
+ * deliberately does NOT use TabScreen: that frame carries the BoxSwitcher and
+ * RemotePowerBar, which are box furniture ("No box, tap to add", box suspend,
+ * box volume) and would be noise-at-best on a screen where no box exists. This
+ * screen's header is the TV picker instead.
+ *
+ * Gated like every other feature tab: remote-only mode is an architecture
+ * change, not a pricing change. Whether this tier ever becomes free is a
+ * separate, later decision (docs/memory/project_remote-only-mode.md §3).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { useState } from 'react';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { DirectRemoteView } from '@/components/DirectRemoteView';
+import { Gated } from '@/components/Gated';
+import { useLockOrientation } from '@/hooks/useLockOrientation';
+import { hapticSelection } from '@/lib/haptics';
+import { DirectTv } from '@/lib/tvdirect/model';
+import { selectTv, useTvs } from '@/lib/tvdirect/store';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export default function RemoteTab() {
+  useLockOrientation('portrait');
+  return (
+    <Gated>
+      <RemoteScreen />
+    </Gated>
+  );
+}
+
+function RemoteScreen() {
+  const styles = useThemedStyles(makeStyles);
+  const insets = useSafeAreaInsets();
+  const { tvs, active, ready } = useTvs();
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top + 6 }]}>
+      <TvPicker tvs={tvs} active={active} />
+      <View style={styles.body}>
+        {/* `ready` distinguishes "no TVs" from "the store has not loaded yet".
+            Without it the empty state flashes on every cold start and reads as
+            "your TV is gone". */}
+        {!ready ? null : active ? <DirectRemoteView tv={active} /> : <NoTv />}
+      </View>
+    </View>
+  );
+}
+
+/** Header pill: which TV this remote is pointed at, and a sheet to change it. */
+function TvPicker({ tvs, active }: { tvs: DirectTv[]; active: DirectTv | null }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Pressable
+        onPress={() => {
+          hapticSelection();
+          setOpen(true);
+        }}
+        style={({ pressed }) => [styles.pill, pressed && styles.pressed]}>
+        <Ionicons name="tv-outline" size={16} color={t.blue} />
+        <Text style={styles.pillText} numberOfLines={1}>
+          {active?.name ?? 'No TV, tap to add'}
+        </Text>
+        <Ionicons name="chevron-down" size={14} color={t.textDim} />
+      </Pressable>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        <Pressable style={styles.backdrop} onPress={() => setOpen(false)}>
+          <Pressable style={styles.sheet} onPress={() => {}}>
+            <Text style={styles.sheetTitle}>YOUR TVs</Text>
+            {tvs.length === 0 ? (
+              <Text style={styles.sheetEmpty}>No TVs yet.</Text>
+            ) : (
+              tvs.map((tv) => (
+                <Pressable
+                  key={tv.id}
+                  onPress={() => {
+                    hapticSelection();
+                    void selectTv(tv.id);
+                    setOpen(false);
+                  }}
+                  style={({ pressed }) => [styles.row, pressed && styles.pressed]}>
+                  <Ionicons
+                    name={tv.id === active?.id ? 'radio-button-on' : 'radio-button-off'}
+                    size={16}
+                    color={tv.id === active?.id ? t.blue : t.textFaint}
+                  />
+                  <View style={styles.rowBody}>
+                    <Text style={styles.rowName} numberOfLines={1}>
+                      {tv.name}
+                    </Text>
+                    <Text style={styles.rowHost} numberOfLines={1}>
+                      {tv.brand} · {tv.host}
+                    </Text>
+                  </View>
+                </Pressable>
+              ))
+            )}
+            <Pressable
+              onPress={() => {
+                setOpen(false);
+                router.push('/(tabs)/setup');
+              }}
+              style={({ pressed }) => [styles.addRow, pressed && styles.pressed]}>
+              <Ionicons name="add" size={16} color={t.blue} />
+              <Text style={[styles.rowName, { color: t.blue }]}>Add a TV</Text>
+            </Pressable>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}
+
+function NoTv() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View style={styles.empty}>
+      <Ionicons name="tv-outline" size={40} color={t.textFaint} />
+      <Text style={styles.emptyTitle}>No TV set up yet</Text>
+      <Text style={styles.emptyBody}>
+        Add your TV in Setup and this becomes its remote. The phone talks to the TV directly
+        over your Wi-Fi — nothing else has to be running.
+      </Text>
+      <Pressable
+        onPress={() => router.push('/(tabs)/setup')}
+        style={({ pressed }) => [styles.emptyBtn, pressed && styles.pressed]}>
+        <Text style={styles.emptyBtnText}>OPEN SETUP</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  root: { flex: 1, backgroundColor: t.bg, paddingHorizontal: 14 },
+  body: { flex: 1, paddingTop: 10 },
+  pressed: { opacity: 0.6 },
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    alignSelf: 'center',
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 999,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  pillText: { color: t.text, fontSize: 13, fontWeight: '700', maxWidth: 200 },
+  backdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'center', padding: 24 },
+  sheet: {
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 16,
+    gap: 10,
+  },
+  sheetTitle: {
+    color: t.textDim,
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 1.5,
+    fontFamily: mono,
+  },
+  sheetEmpty: { color: t.textDim, fontSize: 13 },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 10, paddingVertical: 8 },
+  rowBody: { flex: 1 },
+  rowName: { color: t.text, fontSize: 14, fontWeight: '700' },
+  rowHost: { color: t.textDim, fontSize: 11, fontFamily: mono },
+  addRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingTop: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: t.cardBorder,
+  },
+  empty: { flex: 1, alignItems: 'center', justifyContent: 'center', gap: 12, paddingHorizontal: 20 },
+  emptyTitle: { color: t.text, fontSize: 17, fontWeight: '700' },
+  emptyBody: { color: t.textDim, fontSize: 13, lineHeight: 19, textAlign: 'center' },
+  emptyBtn: {
+    marginTop: 6,
+    paddingHorizontal: 18,
+    paddingVertical: 11,
+    borderRadius: 10,
+    backgroundColor: t.blue,
+  },
+  emptyBtnText: { color: t.bg, fontSize: 12, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+});

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -26,6 +26,7 @@ import { Gated } from '@/components/Gated';
 import { LogsPanel } from '@/components/LogsPanel';
 import { QrView } from '@/components/QrView';
 import { BoxScanPair } from '@/components/BoxScanPair';
+import { DirectTvSetup } from '@/components/DirectTvSetup';
 import { BoxScanQr } from '@/components/BoxScanQr';
 import { SetupProgress, SETUP_GUIDE_URL } from '@/components/SetupProgress';
 import { buildPairLink } from '@/lib/pairLink';
@@ -1123,6 +1124,14 @@ function SetupBody() {
             );
           })
         )}
+
+        {/* ---- TV remote without a box ---- */}
+        {/* Above the box-pairing section on purpose: someone who has no gaming
+            machine has nothing to pair, and the fleet empty state above already
+            spends its whole card telling them to install the service. This is
+            the answer to "I only have a TV". */}
+        <Text style={[styles.sectionLabel, { marginTop: 18 }]}>NO GAMING BOX?</Text>
+        <DirectTvSetup />
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>

--- a/app/components/DirectRemoteView.tsx
+++ b/app/components/DirectRemoteView.tsx
@@ -1,0 +1,273 @@
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useCallback, useState } from 'react';
+import { Alert, Modal, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+
+import { hapticLight } from '@/lib/haptics';
+import { DirectTv } from '@/lib/tvdirect/model';
+import { RokuKey, RokuOp, rokuKey, rokuOp, rokuText } from '@/lib/tvdirect/roku';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+import { CornerBtn, Dpad, MidBtn, Rocker } from './RemoteView';
+
+/** Shown once per app session: a Roku that 403s control needs its "Control by
+ *  mobile apps" network access made permissive. Same rule and copy as
+ *  RemoteView's agent-mediated path — the two can never be on screen together
+ *  (one needs a box, the other needs remote-only mode), so a shared counter
+ *  would be indistinguishable from this and buy nothing. */
+let rokuHintShown = false;
+
+/**
+ * The remote for REMOTE-ONLY mode: this phone driving a smart TV directly, with
+ * no Couchside box anywhere.
+ *
+ * It renders the SAME controls as RemoteView (Dpad/CornerBtn/Rocker/MidBtn are
+ * imported from it) so the two modes do not drift into two remotes. What
+ * differs is everything behind the press: RemoteView routes to a box's agent
+ * over HTTP + a gamepad WebSocket, this sends ECP straight to the TV.
+ *
+ * There is no BOX/TV target toggle here (there is no box), no Steam or QAM
+ * button, and no joystick — Roku has no pointer, so the OK disc is a plain OK
+ * exactly as it is when RemoteView's target is a serial TV.
+ */
+export function DirectRemoteView({ tv }: { tv: DirectTv }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [circleSize, setCircleSize] = useState(200);
+  const [muted, setMuted] = useState(false);
+  const [textOpen, setTextOpen] = useState(false);
+  const [textVal, setTextVal] = useState('');
+
+  const onCircleLayout = useCallback(
+    (e: { nativeEvent: { layout: { width: number; height: number } } }) => {
+      const { width, height } = e.nativeEvent.layout;
+      const s = Math.max(132, Math.min(240, Math.floor(Math.min(width, height)) - 4));
+      setCircleSize((prev) => (Math.abs(prev - s) > 1 ? s : prev));
+    },
+    [],
+  );
+
+  // Every send goes through here so the 403 explanation exists in exactly one
+  // place. Results are never thrown — the transport degrades closed by design.
+  const report = useCallback((r: { ok: boolean; hint?: string }) => {
+    if (!r.ok && r.hint === 'roku_control_disabled' && !rokuHintShown) {
+      rokuHintShown = true;
+      Alert.alert(
+        'Roku is refusing control',
+        'This Roku is set to block control from apps. On the Roku, open Settings → System → Advanced system settings → Control by mobile apps → Network access and choose Permissive.',
+      );
+    }
+  }, []);
+
+  const key = useCallback(
+    (k: RokuKey) => {
+      hapticLight();
+      void rokuKey(tv.host, k).then(report);
+    },
+    [tv.host, report],
+  );
+
+  const op = useCallback(
+    (o: RokuOp) => {
+      hapticLight();
+      void rokuOp(tv.host, o).then(report);
+    },
+    [tv.host, report],
+  );
+
+  const sendText = useCallback(() => {
+    const s = textVal;
+    setTextOpen(false);
+    setTextVal('');
+    if (s) void rokuText(tv.host, s).then(report);
+  }, [textVal, tv.host, report]);
+
+  return (
+    <View style={styles.root}>
+      {/* Power + keyboard row. Roku answers ECP in standby, so power ON is a
+          real keypress here rather than the Wake-on-LAN dance the box path
+          needs for webOS/Samsung. */}
+      <View style={styles.topRow}>
+        <Pressable
+          onPress={() => op('power_off')}
+          style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+          <Ionicons name="power" size={20} color={t.red} />
+          <Text style={[styles.pwrText, { color: t.red }]}>OFF</Text>
+        </Pressable>
+        <Pressable
+          onPress={() => op('power_on')}
+          style={({ pressed }) => [styles.pwr, pressed && styles.pressed]}>
+          <Ionicons name="power" size={20} color={t.green} />
+          <Text style={[styles.pwrText, { color: t.green }]}>ON</Text>
+        </Pressable>
+        <View style={styles.spacer} />
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            setTextOpen(true);
+          }}
+          style={({ pressed }) => [styles.iconBtn, pressed && styles.pressed]}>
+          <Ionicons name="keypad" size={20} color={t.blue} />
+        </Pressable>
+      </View>
+
+      <View style={styles.navBlock}>
+        <View style={styles.cornerRow}>
+          <CornerBtn icon="menu" label="OPTIONS" onPress={() => key('menu')} />
+          <CornerBtn icon="home-outline" label="HOME" onPress={() => key('home')} />
+        </View>
+
+        <View style={styles.circleArea} onLayout={onCircleLayout}>
+          <Dpad
+            size={circleSize}
+            onUp={() => key('up')}
+            onDown={() => key('down')}
+            onLeft={() => key('left')}
+            onRight={() => key('right')}
+            onOk={() => key('ok')}
+            // No pointer on a Roku: the hold-to-point joystick would arm a
+            // gesture that can send nothing. Same choice RemoteView makes when
+            // its target is a serial TV.
+            joyEnabled={false}
+            onJoyMove={() => {}}
+            onJoyActive={() => {}}
+          />
+        </View>
+
+        <View style={styles.cornerRow}>
+          <CornerBtn icon="arrow-undo" label="BACK" onPress={() => key('back')} />
+          <CornerBtn icon="information-circle-outline" label="INFO" onPress={() => key('info')} />
+        </View>
+      </View>
+
+      {/* Transport row. Roku has ONE key for play/pause/stop (Play toggles), so
+          there is one button rather than three that would all do the same thing. */}
+      <View style={styles.mediaRow}>
+        <MidBtn icon="play-back" label="REW" color={t.text} onPress={() => key('rewind')} />
+        <MidBtn icon="play" label="PLAY/PAUSE" color={t.text} onPress={() => key('play')} />
+        <MidBtn icon="play-forward" label="FF" color={t.text} onPress={() => key('fast_forward')} />
+      </View>
+
+      <View style={styles.rockerRow}>
+        <Rocker
+          label="VOL"
+          onPlus={() => op('volume_up')}
+          onMinus={() => op('volume_down')}
+        />
+        <View style={styles.midStack}>
+          <MidBtn
+            icon={muted ? 'volume-mute' : 'volume-high'}
+            label="MUTE"
+            color={muted ? t.red : t.text}
+            onPress={() => {
+              setMuted((m) => !m);
+              op('mute');
+            }}
+          />
+        </View>
+        {/* Balances the row against the VOL rocker: Roku exposes no brightness
+            keys, and a dead rocker would be worse than an empty slot. */}
+        <View style={styles.rockerGhost} />
+      </View>
+
+      <Modal visible={textOpen} transparent animationType="fade" onRequestClose={() => setTextOpen(false)}>
+        <Pressable style={styles.textBackdrop} onPress={() => setTextOpen(false)}>
+          <Pressable style={styles.textSheet} onPress={() => {}}>
+            <Text style={styles.textTitle}>Send text to {tv.name}</Text>
+            <Text style={styles.textHint}>
+              Open a search or text box on the TV first — the letters are typed one at a time
+              wherever its cursor already is.
+            </Text>
+            <TextInput
+              value={textVal}
+              onChangeText={setTextVal}
+              placeholder="Type here…"
+              placeholderTextColor={t.textFaint}
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect={false}
+              returnKeyType="send"
+              onSubmitEditing={sendText}
+              style={styles.textInput}
+            />
+            <View style={styles.textBtnRow}>
+              <Pressable onPress={() => setTextOpen(false)} style={styles.textBtn}>
+                <Text style={styles.textBtnCancel}>CANCEL</Text>
+              </Pressable>
+              <Pressable onPress={sendText} style={[styles.textBtn, styles.textBtnSendBg]}>
+                <Text style={styles.textBtnSend}>SEND</Text>
+              </Pressable>
+            </View>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  root: { flex: 1, gap: 10, paddingBottom: 6 },
+  pressed: { opacity: 0.6 },
+  topRow: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+  spacer: { flex: 1 },
+  pwr: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    height: 40,
+    paddingHorizontal: 14,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  pwrText: { fontSize: 11, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+  iconBtn: {
+    width: 44,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: t.card,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  navBlock: { flex: 1, gap: 6, minHeight: 190 },
+  circleArea: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  cornerRow: { flexDirection: 'row', justifyContent: 'space-between', paddingHorizontal: 8 },
+  mediaRow: { flexDirection: 'row', justifyContent: 'center', gap: 8 },
+  rockerRow: { flexDirection: 'row', justifyContent: 'center', gap: 12 },
+  rockerGhost: { width: 84 },
+  midStack: { justifyContent: 'center' },
+  textBackdrop: { flex: 1, backgroundColor: '#000a', justifyContent: 'center', padding: 24 },
+  textSheet: {
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 14,
+    padding: 16,
+    gap: 12,
+  },
+  textTitle: { color: t.text, fontSize: 15, fontWeight: '700' },
+  textHint: { color: t.textDim, fontSize: 12, lineHeight: 17 },
+  textInput: {
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: t.text,
+    fontSize: 16,
+  },
+  textBtnRow: { flexDirection: 'row', gap: 10 },
+  textBtn: {
+    flex: 1,
+    borderRadius: 10,
+    paddingVertical: 11,
+    alignItems: 'center',
+    backgroundColor: t.inset,
+  },
+  textBtnSendBg: { backgroundColor: t.blue },
+  textBtnCancel: { color: t.textDim, fontWeight: '700', fontSize: 13 },
+  textBtnSend: { color: t.bg, fontWeight: '800', fontSize: 13 },
+});

--- a/app/components/DirectTvSetup.tsx
+++ b/app/components/DirectTvSetup.tsx
@@ -1,0 +1,255 @@
+/**
+ * Setup card for REMOTE-ONLY MODE: the toggle, plus adding a TV the phone
+ * drives directly (no Couchside box, no agent).
+ *
+ * Distinct from components/SmartTvSetup.tsx, which pairs a TV to a BOX — that
+ * one posts to the agent's /api/tv/* routes and the credentials live on the
+ * box. This one has no box to post to, so the TV list lives on the phone
+ * (lib/tvdirect/store.ts) and the commands go straight out over the LAN.
+ *
+ * Only Roku is offered today, and that is a capability statement rather than a
+ * shortlist: Roku's ECP is plain unauthenticated HTTP, while LG/Samsung/Google
+ * TV need a raw TLS socket the app does not have yet. The other brands are
+ * NAMED here with what they currently need, because "my TV isn't listed" with
+ * no explanation is the worst version of this screen.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useCallback, useState } from 'react';
+import { Pressable, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
+
+import { hapticSelection } from '@/lib/haptics';
+import { setPref, usePref } from '@/lib/prefs';
+import { useBoxes } from '@/lib/SettingsContext';
+import { isValidTvHost } from '@/lib/tvdirect/model';
+import { rokuIdentify } from '@/lib/tvdirect/roku';
+import { addTv, removeTv, selectTv, useTvs } from '@/lib/tvdirect/store';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+type AddState =
+  | { kind: 'idle' }
+  | { kind: 'testing' }
+  | { kind: 'failed'; msg: string }
+  | { kind: 'added'; name: string };
+
+export function DirectTvSetup() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const remoteOnly = usePref('remoteOnlyMode');
+  const { tvs, activeTvId } = useTvs();
+  const { boxes } = useBoxes();
+  const [host, setHost] = useState('');
+  const [state, setState] = useState<AddState>({ kind: 'idle' });
+
+  const hostOk = isValidTvHost(host.trim());
+
+  const add = useCallback(async () => {
+    const ip = host.trim();
+    if (!isValidTvHost(ip)) {
+      setState({ kind: 'failed', msg: 'Enter the TV’s IP address on your network.' });
+      return;
+    }
+    setState({ kind: 'testing' });
+    // IDENTIFY BEFORE ADDING. A TV that never answers would otherwise sit in the
+    // list looking configured while every press vanished — the repo's
+    // dead-button-costs-more-than-a-missing-one rule.
+    const info = await rokuIdentify(ip);
+    if (!info) {
+      setState({
+        kind: 'failed',
+        msg: 'No Roku answered at that address. Check the IP in the TV’s Settings → Network → About, and that the phone is on the same Wi-Fi.',
+      });
+      return;
+    }
+    const stored = await addTv({ name: info.name, brand: 'roku', host: ip });
+    if (!stored) {
+      setState({ kind: 'failed', msg: 'That address could not be stored.' });
+      return;
+    }
+    setHost('');
+    setState({ kind: 'added', name: stored.name });
+    // Someone with no box who just added a TV has told us which app they want.
+    // Only auto-enable when the fleet is EMPTY: flipping a box owner into
+    // remote-only would hide the tabs they came for.
+    if (boxes.length === 0 && !remoteOnly) await setPref('remoteOnlyMode', true);
+  }, [host, boxes.length, remoteOnly]);
+
+  return (
+    <View style={styles.card}>
+      <View style={styles.header}>
+        <Ionicons name="tv-outline" size={16} color={t.blue} />
+        <Text style={styles.headerText}>TV REMOTE (NO BOX)</Text>
+      </View>
+
+      <View style={styles.toggleRow}>
+        <View style={styles.toggleBody}>
+          <Text style={styles.toggleLabel}>Remote-only mode</Text>
+          <Text style={styles.toggleSub}>
+            Turns Couchside into just a TV remote: the box tabs are hidden and the phone talks
+            to your TV directly. Turn it off any time to get them back.
+          </Text>
+        </View>
+        <Switch
+          value={remoteOnly}
+          onValueChange={(v) => {
+            hapticSelection();
+            void setPref('remoteOnlyMode', v);
+          }}
+          trackColor={{ true: t.blue, false: t.inset }}
+        />
+      </View>
+
+      {tvs.length > 0 && (
+        <View style={styles.list}>
+          {tvs.map((tv) => (
+            <View key={tv.id} style={styles.tvRow}>
+              <Pressable
+                onPress={() => {
+                  hapticSelection();
+                  void selectTv(tv.id);
+                }}
+                style={styles.tvMain}>
+                <Ionicons
+                  name={tv.id === activeTvId ? 'radio-button-on' : 'radio-button-off'}
+                  size={16}
+                  color={tv.id === activeTvId ? t.blue : t.textFaint}
+                />
+                <View style={styles.tvBody}>
+                  <Text style={styles.tvName} numberOfLines={1}>
+                    {tv.name}
+                  </Text>
+                  <Text style={styles.tvHost} numberOfLines={1}>
+                    {tv.brand} · {tv.host}
+                  </Text>
+                </View>
+              </Pressable>
+              <Pressable onPress={() => void removeTv(tv.id)} hitSlop={8} style={styles.removeBtn}>
+                <Text style={[styles.removeText, { color: t.red }]}>REMOVE</Text>
+              </Pressable>
+            </View>
+          ))}
+        </View>
+      )}
+
+      <Text style={styles.fieldLabel}>ROKU TV — IP ADDRESS</Text>
+      <TextInput
+        style={styles.input}
+        value={host}
+        onChangeText={(v) => {
+          setHost(v);
+          if (state.kind !== 'idle') setState({ kind: 'idle' });
+        }}
+        placeholder="192.168.1.24"
+        placeholderTextColor={t.textFaint}
+        autoCapitalize="none"
+        autoCorrect={false}
+        keyboardType="numbers-and-punctuation"
+      />
+      <Text style={styles.help}>
+        On the TV: Settings → Network → About. Roku only for now — see below.
+      </Text>
+
+      <Pressable
+        onPress={() => void add()}
+        disabled={!hostOk || state.kind === 'testing'}
+        style={({ pressed }) => [
+          styles.addBtn,
+          (!hostOk || state.kind === 'testing' || pressed) && styles.pressed,
+        ]}>
+        <Text style={styles.addBtnText}>
+          {state.kind === 'testing' ? 'CHECKING…' : 'ADD TV'}
+        </Text>
+      </Pressable>
+
+      {state.kind === 'failed' && <Text style={styles.err}>{state.msg}</Text>}
+      {state.kind === 'added' && (
+        <Text style={styles.ok}>Added {state.name}. It’s on the Remote tab.</Text>
+      )}
+
+      {/* Honest ceiling. These brands work TODAY through a box (Setup → your
+          box → Smart TV), and need app-side TLS sockets to work without one. */}
+      <Text style={styles.note}>
+        LG, Samsung, Google TV and Hisense need a Couchside box to control for now — the app
+        can’t yet make the encrypted connection those TVs require on its own. With a box, all
+        of them work: open the box above and use its Smart TV section.
+      </Text>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  card: {
+    backgroundColor: t.card,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 12,
+    padding: 14,
+    gap: 10,
+    marginBottom: 12,
+  },
+  pressed: { opacity: 0.6 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  headerText: {
+    color: t.textDim,
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 1.5,
+    fontFamily: mono,
+  },
+  toggleRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  toggleBody: { flex: 1, gap: 3 },
+  toggleLabel: { color: t.text, fontSize: 14, fontWeight: '700' },
+  toggleSub: { color: t.textDim, fontSize: 12, lineHeight: 17 },
+  list: { gap: 6 },
+  tvRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: t.inset,
+    borderRadius: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+  },
+  tvMain: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 10 },
+  tvBody: { flex: 1 },
+  tvName: { color: t.text, fontSize: 13, fontWeight: '700' },
+  tvHost: { color: t.textDim, fontSize: 11, fontFamily: mono },
+  removeBtn: { paddingHorizontal: 6, paddingVertical: 4 },
+  removeText: { fontSize: 11, fontWeight: '800', letterSpacing: 0.5, fontFamily: mono },
+  fieldLabel: {
+    color: t.textDim,
+    fontSize: 10,
+    fontWeight: '800',
+    letterSpacing: 1.2,
+    fontFamily: mono,
+    marginTop: 2,
+  },
+  input: {
+    backgroundColor: t.inset,
+    borderColor: t.cardBorder,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    color: t.text,
+    fontSize: 15,
+    fontFamily: mono,
+  },
+  help: { color: t.textFaint, fontSize: 11, lineHeight: 16 },
+  addBtn: {
+    borderRadius: 10,
+    paddingVertical: 12,
+    alignItems: 'center',
+    backgroundColor: t.blue,
+  },
+  addBtnText: { color: t.bg, fontSize: 12, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+  err: { color: t.red, fontSize: 12, lineHeight: 17 },
+  ok: { color: t.green, fontSize: 12, lineHeight: 17 },
+  note: {
+    color: t.textFaint,
+    fontSize: 11,
+    lineHeight: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: t.cardBorder,
+    paddingTop: 10,
+  },
+});

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -569,7 +569,10 @@ export function RemoteView({
 
 // ---- pieces ----------------------------------------------------------------
 
-function CornerBtn({
+/* CornerBtn / Dpad / Rocker / MidBtn are EXPORTED so the remote-only mode's
+   DirectRemoteView renders the identical controls rather than a lookalike copy
+   (components/DirectRemoteView.tsx). Export-only: the box path is unchanged. */
+export function CornerBtn({
   icon,
   label,
   onPress,
@@ -614,7 +617,7 @@ const JOY_TAP_MS = 350;
  * cursor VELOCITY (deadzone + expo curve, like a laptop pointing stick). A
  * quick tap is still OK. No mode switch needed for casual pointing.
  */
-function Dpad({
+export function Dpad({
   size,
   onUp,
   onDown,
@@ -821,7 +824,7 @@ function DeskBtn({
   );
 }
 
-function Rocker({
+export function Rocker({
   label,
   onPlus,
   onMinus,
@@ -845,7 +848,7 @@ function Rocker({
   );
 }
 
-function MidBtn({
+export function MidBtn({
   icon,
   label,
   color,

--- a/app/lib/__tests__/tvdirect.test.ts
+++ b/app/lib/__tests__/tvdirect.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Remote-only mode's direct-to-TV path — lib/tvdirect/{model,roku}.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * WHY THIS FILE EXISTS. In remote-only mode there is no agent between the phone
+ * and the TV, so two things that were previously the box's problem become the
+ * app's:
+ *
+ *  1. THE KEY TABLES ARE NOW DUPLICATED. lib/tvdirect/roku.ts carries a copy of
+ *     the agent's _ROKU_KEYS / _ROKU_OP_KEY (agent/couchsided.py:8752, :8759)
+ *     because there is no agent to ask. A copy drifts silently, so the tables
+ *     are pinned here against the values read out of the agent — if someone
+ *     "fixes" the pause->Play collision on one side only, this fails.
+ *  2. THE HOST IS NOW A COMMAND DESTINATION CHOSEN IN THE APP. The agent used
+ *     to be the only thing that opened sockets. isValidTvHost is the gate, and
+ *     it is tested in both directions (a private IP accepted, a public one and
+ *     the KI-033 octal form refused) rather than as an all-rejects list.
+ *
+ * The Roku client is driven against a REAL loopback HTTP server that records
+ * what it received, so "the key was sent" and "the right path was requested"
+ * are separate observations, and a 403 branch is proven to produce the hint
+ * rather than a generic failure.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+import {
+  DIRECT_BRANDS,
+  isValidTvHost,
+  nextTvId,
+  normalizeTv,
+  normalizeTvState,
+} from '../tvdirect/model.ts';
+import {
+  ROKU_KEYS,
+  ROKU_OP_KEY,
+  ROKU_PORT,
+  rokuIdentify,
+  rokuKey,
+  rokuOp,
+  rokuText,
+} from '../tvdirect/roku.ts';
+
+// ---------------------------------------------------------------- key tables
+
+test('the Roku key table matches the agent VERBATIM (drift guard)', () => {
+  // Copied from agent/couchsided.py:8759 _ROKU_KEYS. The collisions are real
+  // and deliberate: Roku's Play toggles (no distinct pause/stop) and it has no
+  // menu key (Info is the "*" options key).
+  assert.deepEqual(ROKU_KEYS, {
+    up: 'Up',
+    down: 'Down',
+    left: 'Left',
+    right: 'Right',
+    ok: 'Select',
+    menu: 'Info',
+    home: 'Home',
+    back: 'Back',
+    exit: 'Home',
+    info: 'Info',
+    play: 'Play',
+    pause: 'Play',
+    stop: 'Play',
+    rewind: 'Rev',
+    fast_forward: 'Fwd',
+  });
+});
+
+test('the Roku op table matches the agent VERBATIM (drift guard)', () => {
+  // agent/couchsided.py:8752 _ROKU_OP_KEY. power_on is an ECP keypress, NOT
+  // Wake-on-LAN: a Roku stays reachable in standby. If this ever becomes a WoL
+  // packet the app has no relay box to send it through on iOS.
+  assert.deepEqual(ROKU_OP_KEY, {
+    power_off: 'PowerOff',
+    power_on: 'PowerOn',
+    volume_up: 'VolumeUp',
+    volume_down: 'VolumeDown',
+    mute: 'VolumeMute',
+  });
+  assert.equal(ROKU_PORT, 8060);
+});
+
+// ------------------------------------------------------------------ the gate
+
+test('a TV host must be a LAN IP literal — both directions', () => {
+  // Accepted: real private addresses (the control that stops this passing by
+  // rejecting everything).
+  assert.equal(isValidTvHost('192.168.1.24'), true);
+  assert.equal(isValidTvHost('10.1.1.60'), true);
+  // Refused: public, the KI-033 octal smuggle (010.1.1.5 resolves to 8.1.1.5),
+  // hostnames (what a name resolves to is up to whoever answers DNS), and junk.
+  assert.equal(isValidTvHost('8.8.8.8'), false);
+  assert.equal(isValidTvHost('010.1.1.5'), false);
+  assert.equal(isValidTvHost('roku.local'), false);
+  assert.equal(isValidTvHost('my-tv'), false);
+  assert.equal(isValidTvHost(''), false);
+  assert.equal(isValidTvHost(undefined), false);
+});
+
+test('only implemented brands are offered', () => {
+  // If a brand is added to DIRECT_BRANDS without a transport, the setup card
+  // will offer a TV it cannot drive. Change this list only alongside a client.
+  assert.deepEqual([...DIRECT_BRANDS], ['roku']);
+});
+
+// ------------------------------------------------------------ the TV store's
+// validation (pure half; the persistence half needs SecureStore and is not
+// loadable here — noted in the PR body rather than faked)
+
+test('an entry with an unusable host is DROPPED, not repaired', () => {
+  assert.equal(normalizeTv({ id: 'tv-0', brand: 'roku', host: '8.8.8.8' }), null);
+  assert.equal(normalizeTv({ id: 'tv-0', brand: 'lg', host: '10.0.0.5' }), null);
+  assert.equal(normalizeTv({ id: '', brand: 'roku', host: '10.0.0.5' }), null);
+  // CONTROL: the same shape with a good host survives, so this is not passing
+  // by dropping everything.
+  assert.deepEqual(normalizeTv({ id: 'tv-0', brand: 'roku', host: '10.0.0.5' }), {
+    id: 'tv-0',
+    name: '10.0.0.5', // no name given -> host, never blank
+    brand: 'roku',
+    host: '10.0.0.5',
+  });
+});
+
+test('a blob keeps only trustworthy entries and never leaves a dangling active id', () => {
+  const state = normalizeTvState({
+    tvs: [
+      { id: 'tv-0', name: 'Living room', brand: 'roku', host: '10.0.0.5' },
+      { id: 'tv-1', name: 'Evil', brand: 'roku', host: '203.0.113.9' }, // public: dropped
+      { id: 'tv-2', name: 'Dupe', brand: 'roku', host: '10.0.0.5' }, // same TV: dropped
+    ],
+    activeTvId: 'tv-1', // points at the dropped one
+  });
+  assert.equal(state.tvs.length, 1);
+  assert.equal(state.tvs[0].id, 'tv-0');
+  // Falls back to the surviving TV rather than null — a remote with TVs and
+  // none selected is a dead end.
+  assert.equal(state.activeTvId, 'tv-0');
+  // Garbage in, empty out; never a throw.
+  assert.deepEqual(normalizeTvState(null), { tvs: [], activeTvId: null });
+  assert.deepEqual(normalizeTvState('nope'), { tvs: [], activeTvId: null });
+});
+
+test('ids do not collide with persisted ones', () => {
+  assert.equal(nextTvId([]), 'tv-0');
+  assert.equal(nextTvId([{ id: 'tv-0', name: 'a', brand: 'roku', host: '10.0.0.5' }]), 'tv-1');
+  // A gap must not produce a reused id.
+  assert.equal(nextTvId([{ id: 'tv-4', name: 'a', brand: 'roku', host: '10.0.0.5' }]), 'tv-5');
+});
+
+// ------------------------------------------------------- the client, against
+// a real server (the port is not 8060, so these drive an explicit host:port —
+// see the note on rokuAt below)
+
+type Hit = { method: string; url: string };
+
+/** Start a stub ECP server. `status` decides what every keypress answers. */
+async function stubRoku(opts: { status?: number; deviceInfo?: string | null } = {}) {
+  const hits: Hit[] = [];
+  const server = http.createServer((req, res) => {
+    hits.push({ method: req.method ?? '', url: req.url ?? '' });
+    if (req.url === '/query/device-info') {
+      if (opts.deviceInfo === null) {
+        res.writeHead(404).end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/xml' });
+      res.end(
+        opts.deviceInfo ??
+          '<device-info><udn>abc-123</udn><model-name>Roku TV</model-name><user-device-name>Living Room TV</user-device-name></device-info>',
+      );
+      return;
+    }
+    res.writeHead(opts.status ?? 200).end();
+  });
+  await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    hits,
+    /** Host string the client will use — see rokuAt. */
+    host: `127.0.0.1:${port}`,
+    close: () => new Promise<void>((r) => server.close(() => r())),
+  };
+}
+
+/**
+ * The client builds `http://<host>:8060`; the stub is on an ephemeral port. So
+ * these tests pass "127.0.0.1:PORT" as the host, which produces a URL with a
+ * trailing ":8060" — Node's fetch rejects that, which is exactly what we do NOT
+ * want to test. Instead the host carries the port and the client's own port is
+ * neutralised by pointing at a path-preserving proxy... which would be more
+ * machinery than the thing under test.
+ *
+ * Simplest honest approach: temporarily bind the stub's behaviour behind a
+ * fetch shim that rewrites ONLY the port, so every other part of the request
+ * (method, path, empty body, abort) is the real client's work.
+ */
+function withPortRewrite<T>(realHostPort: string, fn: () => Promise<T>): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request, init?: RequestInit) => {
+    const url = new URL(String(input));
+    assert.equal(url.port, String(ROKU_PORT), 'client must target the ECP port');
+    const [h, p] = realHostPort.split(':');
+    url.hostname = h;
+    url.port = p;
+    return original(url.toString(), init);
+  }) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+test('a key press becomes exactly one ECP POST at the mapped path', async () => {
+  const s = await stubRoku();
+  try {
+    const r = await withPortRewrite(s.host, () => rokuKey('10.0.0.5', 'ok'));
+    assert.equal(r.ok, true);
+    assert.deepEqual(s.hits, [{ method: 'POST', url: '/keypress/Select' }]);
+  } finally {
+    await s.close();
+  }
+});
+
+test('an op press uses the op table, not the key table', async () => {
+  const s = await stubRoku();
+  try {
+    const r = await withPortRewrite(s.host, () => rokuOp('10.0.0.5', 'power_on'));
+    assert.equal(r.ok, true);
+    assert.deepEqual(s.hits, [{ method: 'POST', url: '/keypress/PowerOn' }]);
+  } finally {
+    await s.close();
+  }
+});
+
+test('403 produces the actionable hint, other failures do not', async () => {
+  const denied = await stubRoku({ status: 403 });
+  try {
+    const r = await withPortRewrite(denied.host, () => rokuKey('10.0.0.5', 'home'));
+    assert.equal(r.ok, false);
+    assert.equal(r.hint, 'roku_control_disabled');
+  } finally {
+    await denied.close();
+  }
+  // CONTROL, the other direction: a 500 is a failure with NO hint, so the
+  // "Control by mobile apps" alert cannot fire for an unrelated fault.
+  const broken = await stubRoku({ status: 500 });
+  try {
+    const r = await withPortRewrite(broken.host, () => rokuKey('10.0.0.5', 'home'));
+    assert.equal(r.ok, false);
+    assert.equal(r.hint, undefined);
+  } finally {
+    await broken.close();
+  }
+});
+
+test('an unreachable TV fails closed instead of throwing into a press handler', async () => {
+  // Nothing is listening: the press must resolve to a failed result. A rejected
+  // promise here would be an unhandled rejection on every tap.
+  const r = await rokuKey('10.255.255.1', 'up');
+  assert.equal(r.ok, false);
+  assert.equal(typeof r.error, 'string');
+});
+
+test('text is sent one percent-encoded character at a time and stops at the first failure', async () => {
+  const s = await stubRoku();
+  try {
+    const r = await withPortRewrite(s.host, () => rokuText('10.0.0.5', 'a b&c'));
+    assert.equal(r.ok, true);
+    assert.deepEqual(
+      s.hits.map((h) => h.url),
+      ['/keypress/Lit_a', '/keypress/Lit_%20', '/keypress/Lit_b', '/keypress/Lit_%26', '/keypress/Lit_c'],
+    );
+    // Nothing in the text can escape its path segment: a '/' or '?' would
+    // otherwise re-target the request.
+    s.hits.length = 0;
+    await withPortRewrite(s.host, () => rokuText('10.0.0.5', '/?'));
+    assert.deepEqual(
+      s.hits.map((h) => h.url),
+      ['/keypress/Lit_%2F', '/keypress/Lit_%3F'],
+    );
+  } finally {
+    await s.close();
+  }
+  // A refusing TV stops the string rather than typing half of it blindly.
+  const denied = await stubRoku({ status: 403 });
+  try {
+    const r = await withPortRewrite(denied.host, () => rokuText('10.0.0.5', 'abc'));
+    assert.equal(r.ok, false);
+    assert.equal(denied.hits.length, 1, 'stopped after the first refusal');
+  } finally {
+    await denied.close();
+  }
+});
+
+test('identify accepts a Roku and refuses anything else', async () => {
+  const s = await stubRoku();
+  try {
+    const info = await withPortRewrite(s.host, () => rokuIdentify('10.0.0.5'));
+    assert.equal(info?.name, 'Living Room TV');
+    assert.equal(info?.model, 'Roku TV');
+  } finally {
+    await s.close();
+  }
+  // Something else answering on 8060 with a 200 but no Roku fields is NOT a
+  // Roku — otherwise the setup card would add a device that never responds.
+  const impostor = await stubRoku({ deviceInfo: '<html>hello</html>' });
+  try {
+    assert.equal(await withPortRewrite(impostor.host, () => rokuIdentify('10.0.0.5')), null);
+  } finally {
+    await impostor.close();
+  }
+  // And a 404 is not a Roku either.
+  const missing = await stubRoku({ deviceInfo: null });
+  try {
+    assert.equal(await withPortRewrite(missing.host, () => rokuIdentify('10.0.0.5')), null);
+  } finally {
+    await missing.close();
+  }
+});

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -30,6 +30,20 @@ export type LandingTab = (typeof LANDING_TABS)[number];
 export type Prefs = {
   /** Ask before suspending the box (the Suspend button in the header). */
   confirmSuspend: boolean;
+  /** REMOTE-ONLY MODE: the app is just a smart-TV remote, no Couchside box.
+   *
+   *  For someone with a smart TV and no gaming machine. On, the box tabs
+   *  (Console/Pad/Launch/Actions/Fleet) are hidden and a single Remote tab
+   *  drives a TV the phone talks to DIRECTLY over the LAN — no agent involved,
+   *  see lib/tvdirect/. Off is the shipped behaviour and stays the default;
+   *  this is opt-in, and Setup turns it on by itself only when a TV is added
+   *  while the box fleet is empty (a user with no box who just paired a TV is
+   *  telling us which mode they want).
+   *
+   *  Deliberately a pref and not derived state: someone who owns both a box and
+   *  a TV can flip to the plain remote when the box is off, and flipping it back
+   *  must not depend on the box answering. */
+  remoteOnlyMode: boolean;
   /** Which tab the app opens on.
    *
    *  Defaults to 'index' (Console) because that is what the app has ALWAYS
@@ -214,6 +228,7 @@ export type Prefs = {
 
 export const DEFAULTS: Prefs = {
   confirmSuspend: true,
+  remoteOnlyMode: false,
   landingTab: 'index',
   autoKeyboard: true,
   keyboardMode: false,
@@ -327,6 +342,7 @@ function normalize(raw: unknown): Prefs {
     appUpdateReminder,
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
+    remoteOnlyMode: bool(o.remoteOnlyMode, DEFAULTS.remoteOnlyMode),
     landingTab,
     autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),
     keyboardMode: bool(o.keyboardMode, DEFAULTS.keyboardMode),

--- a/app/lib/tvdirect/model.ts
+++ b/app/lib/tvdirect/model.ts
@@ -1,0 +1,117 @@
+/**
+ * The app-side TV device model for REMOTE-ONLY mode. ZERO runtime imports.
+ *
+ * Remote-only mode is the app driving a smart TV directly over the LAN with no
+ * Couchside box in the picture. That inverts the model the rest of the app is
+ * built on: every TV control today is agent-mediated, and every TV credential
+ * lives in the BOX's /etc/couchside/config.json. With no box there is no agent
+ * and no config file, so the phone has to own the device record itself.
+ *
+ * WHY A TV IS NOT A `Box`. Reusing lib/settings.ts's Box would be one field
+ * cheaper and wrong: every Box consumer polls /api/status, opens /ws/gamepad,
+ * syncs caps and expects a bearer token. A TV answers none of that, so a TV
+ * masquerading as a Box would produce a fleet entry that is permanently
+ * "unreachable" while working fine. Separate store, separate type.
+ *
+ * Import-free for the same reason lib/lanIp.ts is: this file holds the
+ * validation that decides what the app will send commands to, and the bare-Node
+ * test runner cannot load anything that imports react-native.
+ */
+
+import { isValidLanIp } from '../lanIp.ts';
+
+/** Brands the app can drive DIRECTLY (no box). Distinct from the agent's larger
+ *  backend list — webos/samsung/androidtv/vidaa all need raw TLS sockets the app
+ *  does not have yet, so they are absent here rather than listed-and-broken. */
+export const DIRECT_BRANDS = ['roku'] as const;
+export type DirectBrand = (typeof DIRECT_BRANDS)[number];
+
+export type DirectTv = {
+  /** Stable id within the list ('tv-N'). */
+  id: string;
+  /** User-facing name, defaulted from the TV's own device-info. */
+  name: string;
+  brand: DirectBrand;
+  /** LAN IPv4 literal. Names are refused — see isValidLanIp. */
+  host: string;
+};
+
+export type DirectTvState = {
+  tvs: DirectTv[];
+  activeTvId: string | null;
+};
+
+export const EMPTY_TV_STATE: DirectTvState = { tvs: [], activeTvId: null };
+
+/**
+ * Accept a host for a direct TV connection.
+ *
+ * IP literals in LAN space only, reusing the KI-033-hardened gate rather than
+ * writing a second address rule. Hostnames are refused deliberately: what a name
+ * resolves to is decided by whoever answers DNS, and the whole promise of this
+ * mode is that the phone only ever talks to something on the local network.
+ * A user with a TV on a name can type its IP; a TV that only has a name is a
+ * case we have not proven, and refusing is the closed direction.
+ */
+export function isValidTvHost(v: unknown): v is string {
+  return typeof v === 'string' && isValidLanIp(v);
+}
+
+function isBrand(v: unknown): v is DirectBrand {
+  return typeof v === 'string' && (DIRECT_BRANDS as readonly string[]).includes(v);
+}
+
+/**
+ * Coerce one persisted entry, or null if it cannot be trusted.
+ *
+ * Drops rather than repairs: an entry with a bad host is a command destination
+ * we cannot vouch for, and the repo rule is reject-don't-sanitise. A missing
+ * name is cosmetic, so that one is defaulted.
+ */
+export function normalizeTv(raw: unknown): DirectTv | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.id !== 'string' || o.id.length === 0) return null;
+  if (!isBrand(o.brand)) return null;
+  if (!isValidTvHost(o.host)) return null;
+  const name =
+    typeof o.name === 'string' && o.name.trim().length > 0 ? o.name.trim() : o.host;
+  return { id: o.id, name, brand: o.brand, host: o.host };
+}
+
+/** Coerce a whole persisted blob. Never throws; an unusable blob yields empty. */
+export function normalizeTvState(raw: unknown): DirectTvState {
+  if (!raw || typeof raw !== 'object') return EMPTY_TV_STATE;
+  const o = raw as Record<string, unknown>;
+  const list = Array.isArray(o.tvs) ? o.tvs : [];
+  const tvs: DirectTv[] = [];
+  for (const entry of list) {
+    const tv = normalizeTv(entry);
+    // Dedupe on brand+host: the same TV added twice is one device, and two
+    // entries would make the active-id pointer ambiguous.
+    if (tv && !tvs.some((t) => t.brand === tv.brand && t.host === tv.host)) tvs.push(tv);
+  }
+  const wanted = typeof o.activeTvId === 'string' ? o.activeTvId : null;
+  // A dangling active id falls back to the first TV rather than to null: the
+  // remote screen with a list of TVs and none selected is a dead end.
+  const activeTvId = tvs.some((t) => t.id === wanted) ? wanted : (tvs[0]?.id ?? null);
+  return { tvs, activeTvId };
+}
+
+/** Next free id for a list. Counter-free so it is a pure function of the list. */
+export function nextTvId(tvs: DirectTv[]): string {
+  let n = 0;
+  for (const t of tvs) {
+    const m = /^tv-(\d+)$/.exec(t.id);
+    if (m) {
+      const v = Number(m[1]);
+      if (Number.isFinite(v) && v >= n) n = v + 1;
+    }
+  }
+  return `tv-${n}`;
+}
+
+/** The active TV, or null. */
+export function activeTv(state: DirectTvState): DirectTv | null {
+  return state.tvs.find((t) => t.id === state.activeTvId) ?? null;
+}

--- a/app/lib/tvdirect/roku.ts
+++ b/app/lib/tvdirect/roku.ts
@@ -1,0 +1,184 @@
+/**
+ * Roku ECP client, spoken by the PHONE directly. ZERO runtime imports.
+ *
+ * Roku is the one brand the app can drive with no native module and no box:
+ * ECP is plain unauthenticated HTTP on port 8060, there is no pairing, and a
+ * Roku stays reachable in standby (so power-on is a keypress, not Wake-on-LAN).
+ * Every other brand needs a raw TLS socket the app does not have — see
+ * docs/memory/project_remote-only-mode.md for that ladder.
+ *
+ * THE TABLES BELOW ARE COPIED VERBATIM from the agent's Roku backend
+ * (agent/couchsided.py: _ROKU_OP_KEY :8752, _ROKU_KEYS :8759). They are
+ * duplicated rather than derived because there is no agent in this mode to ask
+ * — which makes them a divergence risk, so lib/__tests__/tvdirect.test.ts pins
+ * both tables and CI fails if one drifts.
+ *
+ * Import-free so the bare-Node runner can exercise it against a stub server:
+ * global fetch/AbortController exist in both RN 0.86 and Node 22.
+ */
+
+/** Roku's External Control Protocol port. Not configurable — it is fixed by Roku. */
+export const ROKU_PORT = 8060;
+
+/** Request timeout. Matches the agent's 4s (couchsided.py:8778-8796): long
+ *  enough for a TV waking its network stack, short enough that a dead host does
+ *  not freeze a held D-pad. */
+const TIMEOUT_MS = 4000;
+
+/** Unified TV ops -> ECP keys. VERBATIM from _ROKU_OP_KEY (couchsided.py:8752). */
+export const ROKU_OP_KEY = {
+  power_off: 'PowerOff',
+  power_on: 'PowerOn',
+  volume_up: 'VolumeUp',
+  volume_down: 'VolumeDown',
+  mute: 'VolumeMute',
+} as const;
+export type RokuOp = keyof typeof ROKU_OP_KEY;
+
+/**
+ * Remote keys -> ECP keys. VERBATIM from _ROKU_KEYS (couchsided.py:8759).
+ *
+ * The agent's own comment explains the collisions, and they are kept rather
+ * than "fixed": Roku has no distinct pause/stop (Play toggles) and no menu key
+ * (Info is the "*" options key). Inventing separate keys here would send
+ * something the TV does not implement.
+ */
+export const ROKU_KEYS = {
+  up: 'Up',
+  down: 'Down',
+  left: 'Left',
+  right: 'Right',
+  ok: 'Select',
+  menu: 'Info',
+  home: 'Home',
+  back: 'Back',
+  exit: 'Home',
+  info: 'Info',
+  play: 'Play',
+  pause: 'Play',
+  stop: 'Play',
+  rewind: 'Rev',
+  fast_forward: 'Fwd',
+} as const;
+export type RokuKey = keyof typeof ROKU_KEYS;
+
+export type RokuResult = {
+  ok: boolean;
+  /** Set when a reachable Roku REFUSED control (HTTP 403), so the UI can explain
+   *  the "Control by mobile apps" setting instead of showing a silent failure.
+   *  Same hint string the agent returns, so both remote surfaces share copy. */
+  hint?: 'roku_control_disabled';
+  /** Present on failure, for logs — never rendered raw. */
+  error?: string;
+};
+
+function base(host: string): string {
+  return `http://${host}:${ROKU_PORT}`;
+}
+
+/**
+ * One ECP request. Never throws: a dead TV must return a failed result, not
+ * reject a promise into a press handler (the repo's degrade-closed rule).
+ */
+async function ecp(
+  host: string,
+  path: string,
+  method: 'GET' | 'POST',
+): Promise<{ ok: boolean; status: number; body: string; error?: string }> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${base(host)}${path}`, {
+      method,
+      // ECP wants a POST with an EMPTY body; some stacks omit Content-Length
+      // without an explicit body and Roku then waits. Matches the agent's
+      // data=b"" (couchsided.py:8778-8796).
+      body: method === 'POST' ? '' : undefined,
+      signal: ctrl.signal,
+    });
+    const body = res.ok ? await res.text() : '';
+    return { ok: res.ok, status: res.status, body };
+  } catch (e) {
+    return { ok: false, status: 0, body: '', error: String(e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function result(r: { ok: boolean; status: number; error?: string }): RokuResult {
+  if (r.ok) return { ok: true };
+  // 403 = the TV is up and deliberately refusing app control. Distinct from
+  // unreachable, and the only failure with an action the user can take.
+  if (r.status === 403) return { ok: false, hint: 'roku_control_disabled' };
+  return { ok: false, error: r.error ?? `HTTP ${r.status}` };
+}
+
+/** Send a remote key. An id outside ROKU_KEYS is refused locally — the same
+ *  lookup-never-interpolate rule the agent applies to /api/tv/key/<k>. */
+export async function rokuKey(host: string, key: RokuKey): Promise<RokuResult> {
+  const ecpKey = ROKU_KEYS[key];
+  if (!ecpKey) return { ok: false, error: 'unknown key' };
+  return result(await ecp(host, `/keypress/${ecpKey}`, 'POST'));
+}
+
+/** Send a unified TV op (power/volume/mute). */
+export async function rokuOp(host: string, op: RokuOp): Promise<RokuResult> {
+  const ecpKey = ROKU_OP_KEY[op];
+  if (!ecpKey) return { ok: false, error: 'unknown op' };
+  return result(await ecp(host, `/keypress/${ecpKey}`, 'POST'));
+}
+
+/**
+ * Type a string on the TV, one Lit_ keypress per character (the only text
+ * mechanism ECP has). Aborts on the first failure like the agent does — half a
+ * search query landing is worse than none, because the user cannot see which
+ * half made it.
+ *
+ * Characters are percent-encoded whole, including '/' and '?', so nothing in
+ * the text can alter the request path. encodeURIComponent leaves !'()*~ alone,
+ * which are literal-safe in a path segment, and Roku accepts them raw.
+ */
+export async function rokuText(host: string, text: string): Promise<RokuResult> {
+  for (const ch of Array.from(text)) {
+    const r = await rokuKey0(host, `Lit_${encodeURIComponent(ch)}`);
+    if (!r.ok) return r;
+  }
+  return { ok: true };
+}
+
+/** Internal: send an already-resolved ECP key name. Not exported — callers go
+ *  through the tables so a client-chosen string can never become a key. */
+async function rokuKey0(host: string, ecpKey: string): Promise<RokuResult> {
+  return result(await ecp(host, `/keypress/${ecpKey}`, 'POST'));
+}
+
+export type RokuInfo = {
+  /** The TV's own friendly name, for the device list. */
+  name: string;
+  model: string;
+};
+
+/**
+ * Identify a host as a Roku, for the ADD flow. Returns null when it is not one
+ * — the caller shows "no Roku answered" rather than adding a device that will
+ * never respond. Same probe the agent uses to register (GET /query/device-info).
+ *
+ * XML is matched with a tag regex rather than parsed: RN has no DOMParser, the
+ * two fields wanted are flat text nodes, and a real parser for this would be a
+ * dependency. A missing field falls back rather than failing the identify —
+ * being a Roku is what this proves; the name is cosmetic.
+ */
+export async function rokuIdentify(host: string): Promise<RokuInfo | null> {
+  const r = await ecp(host, '/query/device-info', 'GET');
+  if (!r.ok || !r.body) return null;
+  const tag = (name: string): string => {
+    const m = new RegExp(`<${name}>([^<]*)</${name}>`).exec(r.body);
+    return m ? m[1].trim() : '';
+  };
+  const model = tag('model-name') || tag('model-number');
+  // A response that carries neither a Roku udn nor a model is not a Roku that
+  // answered — it is something else on :8060. Refuse it.
+  if (!model && !tag('udn')) return null;
+  const name = tag('user-device-name') || tag('friendly-device-name') || model || host;
+  return { name, model };
+}

--- a/app/lib/tvdirect/store.ts
+++ b/app/lib/tvdirect/store.ts
@@ -1,0 +1,158 @@
+/**
+ * Persistence + external store for directly-driven TVs (remote-only mode).
+ *
+ * Same shape as lib/prefs.ts — a module-scope value, a listener set, and a
+ * useSyncExternalStore hook — rather than a React context, because the remote
+ * screen, the Setup card and the tab layout all need it and none of them owns
+ * the others. Storage is SecureStore on native / localStorage on web, matching
+ * lib/settings.ts (a TV host is not a secret, but using one storage wrapper
+ * means one set of failure modes).
+ *
+ * All validation lives in ./model.ts, which is import-free and tested; this
+ * file is only plumbing.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import {
+  DirectBrand,
+  DirectTv,
+  DirectTvState,
+  EMPTY_TV_STATE,
+  activeTv,
+  nextTvId,
+  normalizeTvState,
+} from './model.ts';
+
+const KEY = 'couchside.tvs.v1';
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(key, value);
+      }
+    } catch {
+      // storage unavailable (private mode): TVs live in memory this session
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+let state: DirectTvState = EMPTY_TV_STATE;
+let ready = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+async function persist(): Promise<void> {
+  await storageSet(KEY, JSON.stringify(state));
+}
+
+let loadStarted = false;
+/** Load persisted TVs once. Safe to call repeatedly; never throws. */
+export async function loadTvs(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  const raw = await storageGet(KEY);
+  if (raw != null) {
+    try {
+      state = normalizeTvState(JSON.parse(raw));
+    } catch {
+      // malformed blob: stay empty rather than guessing
+    }
+  }
+  ready = true;
+  emit();
+}
+// Kicked off at import, like prefs, so the first render has real data.
+void loadTvs();
+
+export function getTvState(): DirectTvState {
+  return state;
+}
+
+/** Add a TV and make it active. Returns the stored record, or null if the host
+ *  was refused (see model.isValidTvHost — LAN IP literals only). */
+export async function addTv(input: {
+  name: string;
+  brand: DirectBrand;
+  host: string;
+}): Promise<DirectTv | null> {
+  const existing = state.tvs.find((t) => t.brand === input.brand && t.host === input.host);
+  if (existing) {
+    // Re-adding a known TV selects it rather than duplicating it.
+    state = { ...state, activeTvId: existing.id };
+    emit();
+    await persist();
+    return existing;
+  }
+  const candidate = {
+    id: nextTvId(state.tvs),
+    name: input.name,
+    brand: input.brand,
+    host: input.host,
+  };
+  // Validate through the same normalizer the persisted blob goes through, so an
+  // entry can never enter the store by a path the load path would reject.
+  const next = normalizeTvState({ tvs: [...state.tvs, candidate], activeTvId: candidate.id });
+  const stored = next.tvs.find((t) => t.id === candidate.id) ?? null;
+  if (!stored) return null;
+  state = next;
+  emit();
+  await persist();
+  return stored;
+}
+
+export async function removeTv(id: string): Promise<void> {
+  const tvs = state.tvs.filter((t) => t.id !== id);
+  state = normalizeTvState({ tvs, activeTvId: state.activeTvId });
+  emit();
+  await persist();
+}
+
+export async function selectTv(id: string): Promise<void> {
+  if (!state.tvs.some((t) => t.id === id)) return;
+  state = { ...state, activeTvId: id };
+  emit();
+  await persist();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** Live TV list + active id + whether the load has finished. */
+export function useTvs(): DirectTvState & { ready: boolean; active: DirectTv | null } {
+  const s = useSyncExternalStore(
+    subscribe,
+    () => state,
+    () => state,
+  );
+  const r = useSyncExternalStore(
+    subscribe,
+    () => ready,
+    () => ready,
+  );
+  return { ...s, ready: r, active: activeTv(s) };
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,18 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   the paywall's expired state, the iOS Local Network prompt and row overflow all need a
   device.
 
+### First-run mode chooser — "gaming box" vs "remote only"
+- **priority:** P2 · **risk:** low (app only, one new route + one pref) · **affects:** app ·
+  **depends_on:** remote-only mode (this branch)
+- **Full spec: `docs/memory/project_first-run-mode-chooser.md`.** Owner ask 2026-08-04: "a
+  first time download tutorial that allows the user to select gaming mode or remote only
+  mode."
+- One full-screen chooser on a truly FRESH install (no boxes, no TVs, pref unset): a gaming
+  card into the existing Setup funnel, a smart-TV card that flips `remoteOnlyMode` and lands
+  on the TV card, and a "decide later" skip. Upgrading users must never see it — the
+  empty-state guards carry that, not the pref alone.
+- NOT in iOS build 115 (spec was written while that build compiled).
+
 ### Trackpad WS liveness on iOS: the couch-switch half (#245)
 `priority: P1` · `risk: med (input path)` · `affects: app/lib/gamepad.ts` · `depends_on: —`
 - **Idle churn: DONE, shipped** in agent 2.9.53 (box-driven WS PING; the phone's OS

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,32 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Remote-only mode — Couchside as just a TV remote, no box
+- **priority:** P2 · **risk:** medium (new app-side transport; shared tab/entitlement
+  plumbing) · **affects:** app only · **depends_on:** nothing for Phase 1; Phase 2 depends
+  on a self-signed-TLS spike
+- **Full spec: `docs/memory/project_remote-only-mode.md`.** Read it first — the transport
+  ladder, the phase plan and the verification ledger are all there.
+- **Owner ask 2026-08-04:** a mode for people with a smart TV and no gaming computer —
+  "a way to toggle remote only mode so its just a tv remote app." This is the AGENTLESS
+  half of the 2026-07-17 freemium decision; the FREE half stays deferred and separate.
+- **PHASE 1 BUILT 2026-08-04** (uncommitted, `claude/remote-only-smart-tv-ecb9b3`): the
+  toggle, an app-side TV store, a direct Roku ECP client, a Remote tab, and the Setup card.
+  Harness-verified by PRESSING every control against a stub Roku and reading the wire —
+  18 presses, exactly the right ECP keys, both toggle directions, and a public IP refused
+  with nothing sent. 13 new tests (mutation-checked), 170/170 suite, tsc clean.
+- **The structural finding that shapes everything:** all TV control today is
+  agent-mediated and every TV credential lives on the BOX, so a box-less path is net-new
+  code, not a re-mount of `SmartTvSetup`.
+- **Roku is the only brand app-direct today, and that is a capability statement:** its ECP
+  is plain unauthenticated HTTP. LG/Samsung/Google TV/VIDAA need raw TLS with self-signed
+  certs, which RN's WebSocket cannot do at all and `react-native-tcp-socket` can only do by
+  PINNING a cert it has no way to obtain first. Phase 2 starts with that spike, on the
+  owned LG and Samsung sets — no UI work until it resolves.
+- **NOT verified:** no real Roku is owned, so no store copy may claim Roku support yet;
+  the paywall's expired state, the iOS Local Network prompt and row overflow all need a
+  device.
+
 ### Trackpad WS liveness on iOS: the couch-switch half (#245)
 `priority: P1` · `risk: med (input path)` · `affects: app/lib/gamepad.ts` · `depends_on: —`
 - **Idle churn: DONE, shipped** in agent 2.9.53 (box-driven WS PING; the phone's OS

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -472,3 +472,33 @@ path that only exists on Linux goes in `linuxOnlyCapabilities`.
 
 Observed adding `boxbattery` (agent 2.9.40): the parity test caught the wiring half-done after
 the two agent sites were written and before any app site was.
+
+## App-side direct-device transports (`app/lib/tvdirect/`) — added for remote-only mode
+
+Remote-only mode (the app as a plain TV remote, no box) is the first place the APP opens a
+connection to something that is not a Couchside agent. Two rules carry over from the agent
+and one is new:
+
+1. **Command ids are LOOKED UP in a frozen table, never interpolated.** `roku.ts` exports
+   `rokuKey`/`rokuOp`, which index `ROKU_KEYS` / `ROKU_OP_KEY`; the helper that takes an
+   already-resolved ECP key is deliberately NOT exported. Same rule as the agent's
+   `/api/tv/key/<k>`, for the same reason.
+2. **The destination host goes through `isValidTvHost`** (LAN IP literals only, via the
+   KI-033-hardened `lib/lanIp.ts`). Hostnames are refused: what a name resolves to is up
+   to whoever answers DNS.
+3. **A duplicated table gets a drift guard.** `roku.ts` copies the agent's key tables
+   because in this mode there is no agent to ask. `lib/__tests__/tvdirect.test.ts` pins
+   both tables verbatim, so "fixing" the Roku pause→Play collision on one side fails CI.
+
+Transport modules stay **import-free** so the bare-Node runner can drive them against a
+real stub server (`lib/__tests__/*.test.ts` is already a CI glob — a new file there runs
+with no ci.yml edit).
+
+### The harness cannot judge a direct-to-device call
+
+**MEASURED 2026-08-04.** Adding a stub Roku in the web harness reported "No Roku answered"
+while the stub's own log showed the request had ARRIVED. Cause: browser CORS. React
+Native's `fetch` does not enforce CORS; the harness's browser does. So a direct-device call
+failing on web is not evidence of a bug, and the fix is a CORS header on the STUB — never
+CORS handling in the app. Everything else about such a call (which path, how many requests,
+what encoding) IS observable in the harness by reading the stub's log rather than the screen.

--- a/docs/memory/project_first-run-mode-chooser.md
+++ b/docs/memory/project_first-run-mode-chooser.md
@@ -1,0 +1,70 @@
+# First-run mode chooser — "gaming box" vs "remote only" (owner ask 2026-08-04)
+
+> Owner: "we need to build a first time download tutorial that allows the user to select
+> gaming mode or remote only mode."
+
+## 1. What it is
+
+One full-screen chooser, shown ONCE on a truly fresh install, before the tabs render
+anything. Two big cards:
+
+- **"I have a gaming machine"** — Steam Deck / Bazzite box / gaming PC. Continues into the
+  EXISTING funnel unchanged: Setup, the SetupProgress sweep, PIN pairing. Sets nothing.
+- **"I just have a smart TV"** — sets `remoteOnlyMode: true` and lands on Setup with the
+  TV card (`DirectTvSetup`) as the job to do. The Remote tab takes over from there.
+
+Below both: a small "decide later" escape that just goes to Setup — a chooser you cannot
+skip is a wall, and the measured funnel problem (launch baseline: ~20 installs, ~0 paired)
+is people bouncing, not people choosing wrong.
+
+## 2. Why a chooser at all
+
+The zero-box Setup screen today opens with "Couchside needs a small service running on the
+box you want to control" — which is a dead end for the no-box user the remote-only mode was
+built for. They currently have to scroll past an installer tutorial that does not apply to
+them to find the "NO GAMING BOX?" card. The chooser routes each audience to its own first
+step instead of making one audience read the other's instructions.
+
+## 3. Mechanics (decided by reading the code, not preference)
+
+- **Where it mounts:** a `Stack.Screen` route (`app/onboarding.tsx`) beside `(tabs)` in the
+  root layout — NOT inside the tab navigator, so the tab bar does not render behind it and
+  the tab layout's own redirects cannot race it.
+- **What triggers it:** the one-shot redirect in `app/(tabs)/_layout.tsx` (the same effect
+  that today routes an empty fleet to Setup) gains one earlier branch:
+  `!onboardingDone && boxes.length === 0 && tvs.length === 0` → `/onboarding`.
+- **Why the empty-state guards:** an UPGRADING user must never see it. Anyone with a box or
+  a TV already answered the question by having one; the pref alone can't carry this because
+  it defaults false for every existing install.
+- **The flag:** `onboardingDone: boolean` pref (prefs.ts, three edit sites), set true on ANY
+  exit from the chooser — either card, the skip link, and the hardware back button on
+  Android (a re-shown chooser after a deliberate back-out is a nag).
+- **Remote-only card exit:** `setPref('remoteOnlyMode', true)` then `router.replace` to
+  Setup. It must NOT go to the Remote tab: the empty-remote state points at Setup anyway,
+  so going there directly saves a bounce. The gaming card exits to Setup with the mode off.
+  BOTH exits confirm the pref write completed before navigating — the tab layout reads
+  `remoteOnlyMode` to decide which tabs exist, and navigating before the write lands would
+  flash the wrong tab bar.
+
+## 4. Copy rules
+
+- The remote-only card names what works TODAY ("Roku TVs now; LG, Samsung, Google TV need a
+  Couchside box") — same honesty rule as DirectTvSetup, and the same claim-lockstep caveat:
+  no real Roku has been driven yet, so in-app copy stays capability-shaped and store copy
+  stays silent about Roku entirely until hardware verification.
+- The gaming card does not say "recommended". The chooser exists precisely because neither
+  audience is the default.
+
+## 5. Verification plan
+
+- Harness: fresh localStorage → chooser appears; each card pressed → correct landing +
+  correct pref state (read the blob, not the screen); reload → chooser does NOT reappear
+  (both because the pref is set and — separately — because a box/TV exists; test each guard
+  alone). Existing-user simulation: seed a box, clear the pref → chooser must NOT appear.
+- Device-only: Android hardware back from the chooser; safe-area at the top card.
+
+## 6. Status
+
+- 2026-08-04: spec written mid-build (iOS 115 compiling — app source frozen until it
+  finishes, so the chooser is NOT in build 115). Implementation next session or after the
+  115 submit completes.

--- a/docs/memory/project_remote-only-mode.md
+++ b/docs/memory/project_remote-only-mode.md
@@ -1,0 +1,148 @@
+# Remote-only mode — Couchside as just a TV remote (no box)
+
+**Owner ask (2026-08-04):** "add a remote only feature for users that dont have a gaming
+computer they can setup their smart tv only … basically a way to toggle remote only mode so
+its just a tv remote app."
+
+**Prior decision this builds on (2026-07-17, confirmed):** build the AGENTLESS architecture
+(app → TV directly), ship it FIRST behind the CURRENT paywall (7-day trial + one-time
+unlock, unchanged), and defer the "free tier" flip to a later, separate, reversible
+decision. "Agentless" and "free" are independent axes; this project is the agentless axis
+only. See the freemium-split analysis in the maintainer's session memory.
+
+---
+
+## 1. Why this is net-new architecture, not a re-mount
+
+Today **all TV control is agent-mediated**: the app's eleven `api.ts` `tv*` calls go to the
+box's agent, and every credential (webOS client_key, Samsung token, Roku host) persists in
+`/etc/couchside/config.json` **on the box** (`SmartTvSetup.tsx:86-91` states the model).
+`SmartTvSetup` is only mountable inside a paired box's edit panel. A user with no box has
+no agent, no config store, no `api.tv` — so remote-only mode needs:
+
+- an app-side **TV device store** (a TV cannot be a `Box`: `normalizeBox` drops hostless
+  entries, and every Box consumer polls `/api/status`, opens `/ws/gamepad`, syncs caps —
+  pointing all of that at a TV's IP would be a bug farm);
+- an app-side **direct transport** per brand;
+- a **mode shell**: the toggle, the tab set, the TV-only setup path.
+
+## 2. Transport feasibility ladder (recon 2026-08-04, sourced)
+
+| Brand | Transport | App-direct feasibility |
+|---|---|---|
+| **Roku** | plain HTTP ECP :8060, no auth, no pairing, reachable in standby | **TRIVIAL — plain `fetch`, zero native modules. Phase 1.** |
+| LG webOS | SSAP JSON over **wss:3001, self-signed cert** | Needs `react-native-tcp-socket` (v6.4.2, maintained). **No `rejectUnauthorized:false` exists** — self-signed certs are accepted only by PINNING via `ca`. TOFU bootstrap problem: the peer cert is only readable AFTER a trusted handshake (`getPeerCertificate()`), so obtaining the cert to pin needs an out-of-band step. **Spike required before promising.** |
+| Samsung Tizen | wss:8002 `samsung.remote.control`, token on first Allow | Same TLS wall as webOS. Older sets accept plaintext ws:8001 (token support there unverified). Pre-2016 sets unsupported regardless (KI-007). |
+| Google TV / Android TV | protobuf over TLS **with client cert (mTLS)**, 6-digit PIN pairing | Hardest. `react-native-tcp-socket` DOES support client certs (key/cert PEM); prior art: `vricosti/react-native-androidtv-remote` (on that stack, low-maintenance), `kud/androidtv-remote` (Node, protocol reference). Own protobuf codec needed (the agent's `_atv_*` hand-rolled codec is the porting source). |
+| VIDAA (Hisense) | MQTT 3.1.1 over TLS :36669, default broker creds | Same raw-TLS need; agent's hand-rolled MQTT is the porting source. Newer sets need a 4-digit authorize we never built. |
+
+RN's built-in WebSocket **cannot** skip TLS validation on either platform (options accept
+only `headers`; facebook/react-native #30341 closed stale) — so LG/Samsung can never ride
+the stock WS client against wss with a self-signed cert.
+
+**Native-module cost:** the app is CNG/prebuild (no committed ios/android dirs) and already
+ships native modules incl. `react-native-udp` — adding `react-native-tcp-socket` is the
+same class of change (autolinks, no config plugin, NOT runnable in Expo Go; metro
+`assetExts` += pem/p12 only if certs ship as assets). `expo-dev-client` is NOT currently
+installed; on-device iteration for Phase 2 needs it (or TestFlight builds).
+
+## 3. Phases
+
+### Phase 1 — mode shell + Roku direct (NO native work) ← built first
+- `app/lib/tvdirect/model.ts` — `DirectTv {id,name,brand,host}`, normalize (LAN-IP-only
+  hosts via `lanIp.ts` — the KI-033 corpus applies), `couchside.tvs.v1` store shape.
+- `app/lib/tvdirect/roku.ts` — ECP client mirroring the agent tables VERBATIM
+  (`_ROKU_KEYS` `couchsided.py:8759`, `_ROKU_OP_KEY` `:8752`): `POST /keypress/<Key>`
+  empty body, 4s timeout, 403 → `roku_control_disabled` hint (same copy as
+  `RemoteView.tsx:213`), per-char `Lit_<pct>` text, `GET /query/device-info` identify.
+  Import-free → bare-Node testable (CI `app-input` glob).
+- `app/lib/tvdirect/store.ts` — persisted TV list + active id, prefs.ts external-store
+  pattern.
+- `remoteOnlyMode` pref (prefs.ts, 3 edits) — the toggle.
+- New `remote` tab (`app/app/(tabs)/remote.tsx`), visible only in remote-only mode;
+  box tabs `href: null` in that mode; cold-start redirect → remote (or setup when no TV).
+  Content wrapped in `<Gated>` — the 2026-07-17 "current paywall first" decision.
+- `DirectRemoteView` composing the pieces EXPORTED from `RemoteView.tsx` (Dpad, Rocker,
+  CornerBtn, MidBtn — export-only change, box path untouched).
+- `DirectTvSetup` card in Setup: brand (Roku now; others listed as needs-a-box), IP,
+  TEST (identify) → ADD; TV list; the mode switch. Auto-enables remote-only mode when a
+  TV is added to an empty fleet.
+- **Honesty constraint:** no Roku hardware is owned. Verified against a stub ECP server
+  (same method as the agent's Roku backend) + the harness pressing every control. Store
+  copy must not claim Roku until a real set confirms — same lockstep rule as the agent
+  backends (marketing-expansion memory).
+
+### Phase 2 — LG webOS + Samsung direct (the native step)
+- Add `react-native-tcp-socket`; hand-rolled WS client over its TLS socket (the agent's
+  `_WebOSWS` is the porting source; same SSAP register manifest byte-verbatim).
+- **THE blocker to spike first: self-signed acceptance.** Options, in test order:
+  (a) pin a leaf self-signed cert via `ca` — UNVERIFIED that iOS accepts a leaf (issue
+  #190 history suggests platform quirks); (b) TOFU via a first plain-TCP fetch of the cert
+  — needs a handshake path that yields the cert without trust (may not exist in the lib);
+  (c) upstream PR/patch-package for an insecure-accept option; (d) Samsung-only fallback
+  ws:8001 plaintext where it still works. Spike on the OWNED LG (home) + Samsung before
+  committing to copy or store claims.
+- WoL power-on from the phone: `wol.ts` already broadcasts magic packets via
+  react-native-udp — **Android only; iOS blocks app UDP**, and there is no relay box in
+  remote-only mode. So on iOS, webOS/Samsung power-ON stays honest-absent (button hidden,
+  copy says why). Roku is unaffected (ECP PowerOn, reachable in standby).
+- Pairing UX ports from `SmartTvSetup` (Allow-prompt / client_key, token persist —
+  app-side SecureStore instead of agent config.json).
+
+### Phase 3 — Google TV direct
+- mTLS + protobuf port (`_atv_*` codec → TS), cert generation problem: the agent shells
+  out to `openssl` — the app cannot; needs either the lib's KeyStore path or a bundled
+  pure-JS keypair+self-sign (spike; `react-native-modpow` prior art for the pairing hash).
+- KI-031 applies: no `source` key claim on Google TV.
+
+### Phase 4 — discovery + polish
+- SSDP (`roku:ecp`, webOS) needs UDP multicast: react-native-udp may serve on Android;
+  **iOS blocks UDP and raw-multicast needs a restricted Apple entitlement** — mDNS via an
+  NSNetServiceBrowser-backed module (react-native-zeroconf class) + `NSBonjourServices`
+  additions is the iOS path. Until then: manual IP (works today, matches the agent-side
+  "Add by IP" precedent).
+- Hardware volume buttons → TV volume in remote-only mode (react-native-volume-manager is
+  already a dep; the Pad tab has the pattern).
+- The free-tier flip (entitlement re-gate + two-tier marketing) — SEPARATE decision,
+  deliberately not here.
+
+## 4. Interactions and traps
+- **Paywall:** remote tab is `<Gated>` like every feature tab (trial → unlock). Flip-free
+  later is a one-gate change by design.
+- **Marketing lockstep:** "no box needed" / "universal remote" copy ONLY once a brand is
+  live-verified app-direct. Currently that would be NOTHING (Roku is stub-verified).
+- **iOS Local Network prompt:** first direct fetch to the TV triggers it;
+  `NSLocalNetworkUsageDescription` already declared, wording currently box-specific —
+  revisit when store copy changes.
+- **Both-modes users:** a box owner can add TVs too, but in v1 the remote tab only shows
+  in remote-only mode (box owners already have RemoteView via the agent, which is richer —
+  CEC/RS-232/soft volume). Hybrid (app-direct fallback when the box is asleep) is Phase 4+.
+- **Existing RemoteView Roku hint** dedupe: both surfaces alert once per session
+  independently — acceptable, they cannot both be visible.
+
+## 5. Verification ledger (update as it happens)
+- 2026-08-04: recon (6-agent workflow) — transport tables read from agent source; TLS
+  library research web-sourced; nothing executed against hardware yet.
+- 2026-08-04: **Phase 1 BUILT and harness-verified by pressing every control** against a
+  stub Roku on loopback (`127.0.0.1:8060` — loopback is a valid LAN host, so the real
+  add-flow accepted it). Observed on the wire, not on screen: the ADD flow's
+  `GET /query/device-info` (the TV was stored under the name the stub advertised, so the
+  response was genuinely parsed), then 18 presses producing exactly
+  `Up, Down, Left, Right, Select, Info, Home, Back, Info, Rev, Play, Fwd, VolumeUp,
+  VolumeDown, VolumeMute, PowerOff, PowerOn` plus text as
+  `Lit_a, Lit_%20, Lit_b, Lit_%26, Lit_c` — one request per press, no duplicates.
+  BOTH directions of the toggle observed: on → tab bar collapses to Remote + Setup;
+  off → Console/Actions/Pad/Launch return. Persistence + the bounce guard proven by
+  loading `/pad` directly with the mode on and landing on the Remote. Empty state (no TV)
+  and the host gate both observed — typing `8.8.8.8` left ADD TV disabled, and pressing it
+  anyway sent NOTHING (stub hit count unchanged) and stored nothing.
+- **HARNESS TRAP, banked:** the first ADD attempt reported "No Roku answered" while the
+  stub's log showed the request had ARRIVED. Cause is browser CORS — RN's fetch has no CORS
+  enforcement, the web harness's does. The stub grew an `Access-Control-Allow-Origin`
+  header to get past it; **the app must never grow CORS handling for this**, and a web-only
+  failure of a direct-TV call is not evidence of a product bug.
+- **NOT verified, owed before any public claim:** a REAL Roku (none owned) — hint 403 path,
+  standby PowerOn, and whether a real set's `device-info` matches the stub's field names;
+  anything native (the paywall gate — `expo-iap` is a no-op on web so the expired state
+  could not be observed; the iOS Local Network prompt on first direct fetch; row overflow
+  on a device); and every non-Roku brand, which is Phase 2+.


### PR DESCRIPTION
A toggle in Setup turns the app into a plain smart-TV remote, for people who have a TV and no gaming computer. With it on, every box tab is hidden (Console included) and a **Remote** tab drives the TV **directly** over the LAN — no agent, no box, nothing else running. Setup stays reachable in both modes, because a mode you cannot leave is a trap.

This is the **agentless** half of the 2026-07-17 freemium decision. The **free** half is deliberately not here: the mode ships behind the unchanged paywall, so entitlement rework, the fail-open/closed split and two-tier marketing stay out of this change. Flipping the tier free later is a one-gate decision.

Full spec: `docs/memory/project_remote-only-mode.md`.

## Why this is net-new code, not a re-mount

All TV control today is agent-mediated: the app's eleven `api.ts` `tv*` calls go to the box, every TV credential persists in the **box's** `/etc/couchside/config.json`, and `SmartTvSetup` only mounts inside a paired box's edit panel. No box means no agent and no TV path at all. So this adds an app-side device store, an app-side transport, and the mode shell.

**A TV is not a `Box`.** Reusing the fleet record would be one field cheaper and wrong: every Box consumer polls `/api/status`, opens `/ws/gamepad` and syncs caps. A TV answers none of that, so it would read permanently unreachable while working fine. Separate store (`couchside.tvs.v1`), separate type.

## Why only Roku — a capability statement, not a shortlist

Roku's ECP is plain unauthenticated HTTP on :8060 with no pairing, and it stays reachable in standby (so power-on is a keypress, not Wake-on-LAN). Every other brand needs a raw TLS socket to a **self-signed** cert. Measured 2026-08-04:

- RN's built-in WebSocket **cannot** skip TLS validation on either platform (facebook/react-native#30341, closed stale) — so LG `wss:3001` and Samsung `wss:8002` can never ride the stock client.
- `react-native-tcp-socket` (v6.4.2, maintained) has **no** `rejectUnauthorized:false`. Self-signed is accepted only by **pinning** via `ca`, and the peer cert is readable only after an already-trusted handshake.

That bootstrap problem is a spike, so it gates Phase 2 rather than delaying this. The setup card **names** LG/Samsung/Google TV/Hisense as needing a box — they all work that way today — instead of listing them broken.

## Allowlist discipline, app-side

- Command ids are **looked up** in frozen tables (`ROKU_KEYS` / `ROKU_OP_KEY`), never interpolated; the helper taking an already-resolved key is not exported.
- Free text is percent-encoded byte-wise, so `/` and `?` cannot escape the path segment (tested).
- The destination host must pass `isValidTvHost` — LAN IP literals only via the KI-033-hardened `lanIp.ts`; hostnames and the octal form are refused.
- `DIRECT_BRANDS` is pinned by a test, so a brand cannot be offered before it has a transport.
- `roku.ts` duplicates the agent's key tables (there is no agent here to ask), so the tests pin both **verbatim** and CI fails if one side drifts.

No new dependency, no agent change, no API shape change. `RemoteView`'s change is **export-only** (`CornerBtn`/`Dpad`/`Rocker`/`MidBtn`) so both modes render the same controls instead of growing two remotes; the box path is untouched.

## Verification

- **13 new tests, all mutation-checked** — breaking `ok: 'Select'` failed 2, deleting the 403-hint branch failed 1, deleting the host gate failed 2. 170/170 across the `app-input` suite (picked up by the existing `lib/__tests__/*.test.ts` glob, so no ci.yml edit). `tsc` clean.
- **Harness, pressing every control** against a stub Roku on loopback, reading the **wire** rather than the screen: 18 presses produced exactly `Up, Down, Left, Right, Select, Info, Home, Back, Info, Rev, Play, Fwd, VolumeUp, VolumeDown, VolumeMute, PowerOff, PowerOn` — one request each, no duplicates — and text sent `Lit_a, Lit_%20, Lit_b, Lit_%26, Lit_c`.
- **Both toggle directions observed**: on → tab bar collapses to Remote + Setup; off → Console/Actions/Pad/Launch return. Persistence and the bounce guard proven by loading `/pad` directly with the mode on and landing on the Remote.
- The add flow stored the TV under **the name the stub advertised**, so the `device-info` response was genuinely parsed rather than assumed.
- Typing `8.8.8.8` left ADD TV disabled, and pressing it anyway **sent nothing** (stub hit count unchanged) and stored nothing.

## NOT verified

- **No real Roku is owned.** Everything above is a stub, so no store or site copy may claim Roku support until a real set is driven — the same lockstep rule the agent's TV backends follow.
- Unobservable on web, owed on a device: the paywall's expired state (`expo-iap` is a no-op on web), the iOS Local Network prompt on the first direct fetch, and row overflow.
- `NSLocalNetworkUsageDescription` still describes connecting to a box; it should mention the TV before a store build.
- Every non-Roku brand, which is Phase 2+.

## Banked trap

The first add attempt reported "No Roku answered" while the stub's log showed the request had **arrived** — browser CORS, which RN's `fetch` does not enforce. The **stub** grew a CORS header; the app must never grow one for this. Recorded in CONVENTIONS.md, because a web-only failure of a direct-device call is not evidence of a product bug.

Also banked: `expo export` does **not** regenerate typed routes for a new screen — `npx expo customize tsconfig.json` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
