### PR TITLE
fix(app): stop rendering "0.0 / 0.0 GB" on Launch downloads (KI-056)

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -7202,8 +7202,22 @@ def mock_downloads():
         {"appid": 1091500, "name": "Cyberpunk 2077", "state": "downloading",
          "active": True, "bytes_total": total, "bytes_downloaded": done,
          "percent": _MOCK_DL_PCT},
+        # KI-056 shapes, all legitimately produced by Steam's own .acf fields
+        # (BytesToDownload=0 pre-manifest; tiny content-only patches). The app's
+        # presentation is what the harness asserts against these rows.
+        {"appid": 100001, "name": "TRON RUN/r", "state": "finalizing",
+         "active": True, "bytes_total": 30_000_000,
+         "bytes_downloaded": 30_000_000, "percent": 100},
+        {"appid": 100002, "name": "Path of Exile 2", "state": "downloading",
+         "active": True, "bytes_total": 0, "bytes_downloaded": 0, "percent": 0},
+        {"appid": 100003, "name": "Grim Dawn", "state": "downloading",
+         "active": True, "bytes_total": 31_000_000,
+         "bytes_downloaded": 28_000_000, "percent": 90},
         {"appid": 570, "name": "Dota 2", "state": "queued", "active": False,
          "bytes_total": 18_000_000_000, "bytes_downloaded": 0, "percent": 0},
+        {"appid": 100004, "name": "Small Patch DLC", "state": "queued",
+         "active": False, "bytes_total": 45_000_000, "bytes_downloaded": 0,
+         "percent": 0},
         {"appid": 1245620, "name": "Elden Ring", "state": "queued",
          "active": False, "bytes_total": 3_100_000_000, "bytes_downloaded": 0,
          "percent": 0},

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -183,6 +183,29 @@ function fmtGB(bytes: number): string {
   return (bytes / 1e9).toFixed(1);
 }
 
+/**
+ * Unit floor for switching a row from GB to MB. fmtGB's toFixed(1) rounds
+ * anything under ~50 MB to "0.0", so a tiny content patch sailed through the
+ * bytes_total > 0 gate below and printed "0.0 / 0.0 GB" — the row Steam was
+ * being honest about read as broken (KI-056, reported twice by the same
+ * tester). Under this floor sizes render as whole MB instead.
+ */
+const MB_FLOOR = 100e6;
+
+/** "1.2 / 42.0 GB" above the floor, "28 / 31 MB" under it. One unit per row,
+ *  chosen by the TOTAL, so the pair never mixes units mid-line. */
+function fmtPair(downloaded: number, total: number): string {
+  if (total < MB_FLOOR) {
+    return `${Math.round(downloaded / 1e6)} / ${Math.round(total / 1e6)} MB`;
+  }
+  return `${fmtGB(downloaded)} / ${fmtGB(total)} GB`;
+}
+
+/** Single-size variant for queued rows. */
+function fmtTotal(total: number): string {
+  return total < MB_FLOOR ? `${Math.round(total / 1e6)} MB` : `${fmtGB(total)} GB`;
+}
+
 function DownloadRow({ d }: { d: SteamDownload }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
@@ -204,10 +227,16 @@ function DownloadRow({ d }: { d: SteamDownload }) {
         <Text style={[styles.dlState, paused && { color: t.amber }]}>
           {d.state.toUpperCase()}
         </Text>
-        {d.bytes_total > 0 && (
-          <Text style={styles.dlBytes}>
-            {fmtGB(d.bytes_downloaded)} / {fmtGB(d.bytes_total)} GB
-          </Text>
+        {/* KI-056: FINALIZING gets no size line at all — 100% down, nothing
+            left to fetch, so any size it could show is either 0 or noise; the
+            state label carries the story. An active row Steam hasn't sized yet
+            (bytes_total 0: pre-manifest, content-only patch) says so instead
+            of printing the "0.0 / 0.0 GB" that read as broken. The totals are
+            Steam's own truth — never faked, only presented. */}
+        {d.state === 'finalizing' ? null : d.bytes_total > 0 ? (
+          <Text style={styles.dlBytes}>{fmtPair(d.bytes_downloaded, d.bytes_total)}</Text>
+        ) : (
+          <Text style={styles.dlBytes}>starting…</Text>
         )}
       </View>
     </View>
@@ -222,7 +251,7 @@ function QueuedRow({ d }: { d: SteamDownload }) {
       <Text style={styles.qName} numberOfLines={1}>
         {d.name}
       </Text>
-      {d.bytes_total > 0 && <Text style={styles.qSize}>{fmtGB(d.bytes_total)} GB</Text>}
+      {d.bytes_total > 0 && <Text style={styles.qSize}>{fmtTotal(d.bytes_total)}</Text>}
     </View>
   );
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -380,6 +380,28 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   resets produces a large negative delta — clamp at zero and show nothing rather than a
   nonsense spike.
 
+### ~~Downloads that show "0.0 / 0.0 GB · 0%" read as broken (Launch tab)~~ — FIXED (KI-056)
+- **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
+- **Entry recovered:** originally captured 2026-07-22 in commit 63b353b, which was STRANDED
+  on the never-merged branch `docs/roadmap-community-captures-0722b` — the roadmap entry
+  everyone remembered was not actually in the roadmap, which is half of how the fix
+  "everyone remembers shipping" never shipped (KI-056; likwidtek reported on 2.9.21, was
+  told 2.9.35 fixed it, re-reported on 2.9.35 with a screenshot).
+- **The agent was always truthful** — Steam's own `.acf` `BytesToDownload=0` is legitimate
+  for finalizing rows, content-only patches, and pre-manifest fetches. Two app-side causes:
+  the `bytes_total > 0` gate never helped because `fmtGB`'s `toFixed(1)` rounds anything
+  under ~50 MB to `"0.0"`, and finalizing/unsized rows printed a size line at all.
+- **FIXED app-side in launch.tsx:** FINALIZING rows drop the size line (the state label
+  carries it); active rows with `bytes_total === 0` say "starting…"; totals under 100 MB
+  render as whole MB ("28 / 31 MB") in DownloadRow AND QueuedRow. Percent untouched —
+  always exactly what the agent reports. Totals are never faked.
+- **Verified in the harness against extended mock rows** (mock_downloads gained the
+  finalizing / unsized / tiny-patch shapes): row-level text asserted — TRON `100% ·
+  FINALIZING` with NO size line, `starting…` on the unsized row, `28 / 31 MB`, queued
+  `45 MB` (queue expanded by pressing), and the multi-GB control row still `26.5 / 42.0 GB`;
+  the string `0.0 GB` renders nowhere. Screenshot taken. NOT verified: a live box with a
+  real tiny patch (none queued today) — the mock shapes mirror the tester's screenshot.
+
 ### Make Preferences findable (filter + collapse + re-split PAD LAYOUT)
 - **priority:** P2 · **risk:** low · **affects:** app only · **depends_on:** none
 - **FILTER SHIPPED in #224 (2026-07-22).** Find-as-you-type over label+sub, card chrome


### PR DESCRIPTION
Presentation-only fix for the downloads display-honesty bug likwidtek reported **twice** — on 2.9.21 (2026-07-22) and again on 2.9.35 (2026-08-04) after being told it was fixed. It never was: the prescribing roadmap entry was stranded on the never-merged branch `docs/roadmap-community-captures-0722b`, and no downloads commit exists between 2.9.31 and 2.9.35. The entry is folded into ROADMAP.md as fixed in this PR, so the record and the code finally agree.

**The agent is truthful and stays untouched** — Steam's own `.acf` `BytesToDownload=0` is legitimate for finalizing rows, content-only patches, and pre-manifest fetches. Totals are never faked; only presentation changes, all in `launch.tsx`:

- **FINALIZING rows drop the size line** — 100% down, nothing left to fetch; the state label carries it.
- **Unsized active rows say "starting…"** instead of a zero size.
- **Totals under 100 MB render as whole MB** ("28 / 31 MB") in `DownloadRow` AND `QueuedRow`. This is the missed half of the root cause: the `bytes_total > 0` gate existed all along, but `fmtGB`'s `toFixed(1)` rounds anything under ~50 MB to `"0.0"` — a tiny patch passed the gate and printed `0.0 / 0.0 GB`.
- **Percent untouched** — always exactly what the agent reports.

`mock_downloads()` (`--mock` only) gains the three KI-056 shapes plus a tiny queued row so the harness can render them on demand; the real downloads path is untouched, so no agent version bump.

## Verification

Web harness against the extended mock, **row-level text asserted, not renders**:

- TRON RUN/r: `100% · FINALIZING`, **no size line** following it.
- Path of Exile 2: `0% · DOWNLOADING · starting…`
- Grim Dawn: `90% · DOWNLOADING · 28 / 31 MB`
- Queue expanded **by pressing** the QUEUED header: `Small Patch DLC · 45 MB`, with `Dota 2 · 18.0 GB` unchanged beside it.
- Control: the active multi-GB row still reads `26.5 / 42.0 GB`.
- The strings `0.0 / 0.0 GB` and `0.0 GB` render **nowhere** on the tab (asserted over `body.innerText`).
- `tsc` clean · app-input suite 170/170 · `py_compile` clean.

## NOT verified

- A live box with a real tiny patch or finalizing row (none queued today). The mock shapes mirror the tester's screenshot values (TRON `100%/FINALIZING/0 bytes`, tiny-patch totals).
- On-device row overflow (web harness cannot see it) — the changed line is shorter than what it replaces, so risk is low.

App-only; rides the next app release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
