### PR TITLE
feat(app): Scan for TVs — /24 sweep discovery for remote-only mode (Roku)

### DIFF
--- a/app/components/DirectTvSetup.tsx
+++ b/app/components/DirectTvSetup.tsx
@@ -14,15 +14,30 @@
  * no explanation is the worst version of this screen.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useCallback, useState } from 'react';
-import { Pressable, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 
 import { hapticSelection } from '@/lib/haptics';
 import { setPref, usePref } from '@/lib/prefs';
 import { useBoxes } from '@/lib/SettingsContext';
 import { isValidTvHost } from '@/lib/tvdirect/model';
 import { rokuIdentify } from '@/lib/tvdirect/roku';
-import { addTv, removeTv, selectTv, useTvs } from '@/lib/tvdirect/store';
+import {
+  addTv,
+  removeTv,
+  scanForTvs,
+  selectTv,
+  useTvs,
+  type FoundTv,
+} from '@/lib/tvdirect/store';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type AddState =
@@ -39,6 +54,48 @@ export function DirectTvSetup() {
   const { boxes } = useBoxes();
   const [host, setHost] = useState('');
   const [state, setState] = useState<AddState>({ kind: 'idle' });
+  // LAN sweep: found TVs stream in via onFound while workers drain. 'done'
+  // distinguishes "haven't scanned" from "scanned and the LAN is empty".
+  const [scanning, setScanning] = useState(false);
+  const [scanDone, setScanDone] = useState(false);
+  const [foundTvs, setFoundTvs] = useState<FoundTv[]>([]);
+  const scanAbort = useRef<{ aborted: boolean }>({ aborted: false });
+  useEffect(
+    () => () => {
+      scanAbort.current.aborted = true; // unmount mid-sweep: stop the workers
+    },
+    [],
+  );
+
+  const scan = useCallback(async () => {
+    hapticSelection();
+    scanAbort.current = { aborted: false };
+    setScanning(true);
+    setScanDone(false);
+    setFoundTvs([]);
+    await scanForTvs((tv) => {
+      // Dedupe on host: a TV that answers twice (Wi-Fi hiccup retry) is one row.
+      setFoundTvs((prev) => (prev.some((p) => p.host === tv.host) ? prev : [...prev, tv]));
+    }, scanAbort.current);
+    if (!scanAbort.current.aborted) {
+      setScanning(false);
+      setScanDone(true);
+    }
+  }, []);
+
+  const addFound = useCallback(
+    async (tv: FoundTv) => {
+      hapticSelection();
+      // Already identified by the sweep itself — adding is just storing.
+      const stored = await addTv({ name: tv.name, brand: tv.brand, host: tv.host });
+      if (stored) {
+        setFoundTvs((prev) => prev.filter((p) => p.host !== tv.host));
+        setState({ kind: 'added', name: stored.name });
+        if (boxes.length === 0 && !remoteOnly) await setPref('remoteOnlyMode', true);
+      }
+    },
+    [boxes.length, remoteOnly],
+  );
 
   const hostOk = isValidTvHost(host.trim());
 
@@ -130,6 +187,48 @@ export function DirectTvSetup() {
         </View>
       )}
 
+      {/* LAN sweep — the no-typing path. Same /24 HTTP sweep the box scanner
+          uses (iOS blocks UDP, so SSDP was never an option). Every row here
+          already answered device-info AS a Roku; ADD just stores it. */}
+      <Pressable
+        onPress={() => void scan()}
+        disabled={scanning}
+        style={({ pressed }) => [styles.scanBtn, (pressed || scanning) && styles.pressed]}>
+        {scanning ? (
+          <ActivityIndicator size="small" color={t.blue} />
+        ) : (
+          <Ionicons name="wifi" size={16} color={t.blue} />
+        )}
+        <Text style={styles.scanBtnText}>
+          {scanning ? 'SCANNING YOUR WI-FI…' : 'SCAN FOR ROKU TVS'}
+        </Text>
+      </Pressable>
+      {foundTvs.map((tv) => (
+        <View key={tv.host} style={styles.tvRow}>
+          <View style={styles.tvMain}>
+            <Ionicons name="tv-outline" size={16} color={t.blue} />
+            <View style={styles.tvBody}>
+              <Text style={styles.tvName} numberOfLines={1}>
+                {tv.name}
+              </Text>
+              <Text style={styles.tvHost} numberOfLines={1}>
+                {tv.model ? `${tv.model} · ` : ''}
+                {tv.host}
+              </Text>
+            </View>
+          </View>
+          <Pressable onPress={() => void addFound(tv)} hitSlop={8} style={styles.removeBtn}>
+            <Text style={[styles.removeText, { color: t.blue }]}>ADD</Text>
+          </Pressable>
+        </View>
+      ))}
+      {scanDone && foundTvs.length === 0 && (
+        <Text style={styles.help}>
+          No Roku answered on this network. TV on the same Wi-Fi as the phone? You can still add
+          it by IP below.
+        </Text>
+      )}
+
       <Text style={styles.fieldLabel}>ROKU TV — IP ADDRESS</Text>
       <TextInput
         style={styles.input}
@@ -200,6 +299,24 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   toggleLabel: { color: t.text, fontSize: 14, fontWeight: '700' },
   toggleSub: { color: t.textDim, fontSize: 12, lineHeight: 17 },
   list: { gap: 6 },
+  scanBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    borderRadius: 10,
+    paddingVertical: 12,
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  scanBtnText: {
+    color: t.blue,
+    fontSize: 12,
+    fontWeight: '800',
+    letterSpacing: 1,
+    fontFamily: mono,
+  },
   tvRow: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/lib/__tests__/tvdirect.test.ts
+++ b/app/lib/__tests__/tvdirect.test.ts
@@ -43,6 +43,7 @@ import {
   rokuOp,
   rokuText,
 } from '../tvdirect/roku.ts';
+import { sweepCandidates, sweepForRokus } from '../tvdirect/scan.ts';
 
 // ---------------------------------------------------------------- key tables
 
@@ -318,4 +319,62 @@ test('identify accepts a Roku and refuses anything else', async () => {
   } finally {
     await missing.close();
   }
+});
+
+// ---------------------------------------------------------------- the sweep
+
+test('sweep candidates cover the /24, excluding the phone and network/broadcast', () => {
+  const ips = sweepCandidates('10.1.1.60');
+  assert.equal(ips.length, 253); // 254 hosts minus the phone itself
+  assert.ok(!ips.includes('10.1.1.60'), 'never probes the phone');
+  assert.ok(!ips.includes('10.1.1.0') && !ips.includes('10.1.1.255'));
+  assert.ok(ips.every((ip) => ip.startsWith('10.1.1.')));
+  assert.ok(ips.includes('10.1.1.1') && ips.includes('10.1.1.254'));
+});
+
+test('no usable LAN address means NO sweep — same gate as TV hosts', () => {
+  // A phone on cellular/VPN must not spray 254 requests at a public /24.
+  assert.deepEqual(sweepCandidates(undefined), []);
+  assert.deepEqual(sweepCandidates('8.8.8.8'), []);
+  assert.deepEqual(sweepCandidates('010.1.1.5'), []); // KI-033 octal form
+  // CONTROL: a real LAN address does sweep (not passing by refusing all).
+  assert.ok(sweepCandidates('192.168.1.7').length === 253);
+});
+
+test('the sweep returns exactly the hosts that identified as Rokus', async () => {
+  const probed: string[] = [];
+  const found = await sweepForRokus(['10.0.0.1', '10.0.0.2', '10.0.0.3', '10.0.0.4'], {
+    identify: async (h) => {
+      probed.push(h);
+      // .2 is a Roku; .3 answers as something-else (identify returns null);
+      // .1/.4 are dead (null). Only .2 may appear.
+      return h === '10.0.0.2' ? { name: 'Bedroom Roku', model: 'Roku TV' } : null;
+    },
+  });
+  assert.deepEqual(found, [
+    { brand: 'roku', host: '10.0.0.2', name: 'Bedroom Roku', model: 'Roku TV' },
+  ]);
+  assert.equal(probed.length, 4, 'every candidate was probed');
+});
+
+test('onFound streams results and abort stops the workers', async () => {
+  const streamed: string[] = [];
+  const found = await sweepForRokus(['a', 'b'], {
+    identify: async () => ({ name: 'TV', model: 'M' }),
+    onFound: (tv) => streamed.push(tv.host),
+  });
+  assert.equal(found.length, 2);
+  assert.deepEqual(streamed.sort(), ['a', 'b']); // reported as they landed
+  // Aborted before start: no probes at all (the empty-result CONTROL for the
+  // signal path — a sweep that ignores its signal would still probe).
+  let probes = 0;
+  const aborted = await sweepForRokus(['a', 'b', 'c'], {
+    signal: { aborted: true },
+    identify: async () => {
+      probes++;
+      return { name: 'TV', model: 'M' };
+    },
+  });
+  assert.deepEqual(aborted, []);
+  assert.equal(probes, 0);
 });

--- a/app/lib/tvdirect/roku.ts
+++ b/app/lib/tvdirect/roku.ts
@@ -84,9 +84,10 @@ async function ecp(
   host: string,
   path: string,
   method: 'GET' | 'POST',
+  timeoutMs: number = TIMEOUT_MS,
 ): Promise<{ ok: boolean; status: number; body: string; error?: string }> {
   const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), TIMEOUT_MS);
+  const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
     const res = await fetch(`${base(host)}${path}`, {
       method,
@@ -168,8 +169,14 @@ export type RokuInfo = {
  * dependency. A missing field falls back rather than failing the identify —
  * being a Roku is what this proves; the name is cosmetic.
  */
-export async function rokuIdentify(host: string): Promise<RokuInfo | null> {
-  const r = await ecp(host, '/query/device-info', 'GET');
+export async function rokuIdentify(
+  host: string,
+  // Overridable for the LAN sweep: 4s x 254 dead hosts is a minute of nothing,
+  // while a live Roku answers in milliseconds. The ADD-by-IP flow keeps the
+  // patient default (a TV waking its network stack deserves the wait).
+  timeoutMs: number = TIMEOUT_MS,
+): Promise<RokuInfo | null> {
+  const r = await ecp(host, '/query/device-info', 'GET', timeoutMs);
   if (!r.ok || !r.body) return null;
   const tag = (name: string): string => {
     const m = new RegExp(`<${name}>([^<]*)</${name}>`).exec(r.body);

--- a/app/lib/tvdirect/scan.ts
+++ b/app/lib/tvdirect/scan.ts
@@ -1,0 +1,93 @@
+/**
+ * LAN sweep for TVs the app can drive DIRECTLY (remote-only mode). ZERO
+ * runtime imports beyond sibling tvdirect modules and lanIp — bare-Node
+ * testable like the rest of this directory.
+ *
+ * Same shape as lib/boxDiscovery.ts's httpSweep, for the same reason: iOS
+ * blocks app UDP, so SSDP/mDNS — how Roku is "supposed" to be discovered — is
+ * not available to this app, while a /24 HTTP sweep works on both platforms.
+ * Each candidate gets the same GET /query/device-info the ADD-by-IP flow uses,
+ * so a host only ever appears in results by proving it is a Roku.
+ *
+ * Only Roku today, matching DIRECT_BRANDS: discovery for a brand the app
+ * cannot drive would surface TVs whose ADD button leads nowhere. When the
+ * TLS-socket work lands for LG/Samsung/Google TV (see
+ * docs/memory/project_remote-only-mode.md Phase 2+), their probes join this
+ * sweep rather than growing a second one.
+ */
+
+import { isValidLanIp } from '../lanIp.ts';
+import { rokuIdentify, type RokuInfo } from './roku.ts';
+import type { DirectBrand } from './model.ts';
+
+/** A TV that answered the sweep. `host` has already proven itself. */
+export type FoundTv = {
+  brand: DirectBrand;
+  host: string;
+  name: string;
+  model: string;
+};
+
+/** Per-host probe timeout during a sweep. A live Roku answers device-info in
+ *  milliseconds; 900ms tolerates a congested Wi-Fi hop without letting 254
+ *  dead hosts stretch the sweep past a few seconds at CONC workers. */
+const SWEEP_TIMEOUT_MS = 900;
+/** Concurrent probes. Matches boxDiscovery's order of magnitude — small enough
+ *  not to trip AP client limits, large enough that 254/48 x 0.9s ≈ 5s worst case. */
+const SWEEP_CONC = 48;
+
+/**
+ * The /24 around the phone's own address, phone excluded, .0/.255 excluded.
+ * Empty when the address is missing or not a LAN IP: sweeping a public /24
+ * from a phone on cellular would be 254 requests at strangers — the same gate
+ * (isValidLanIp, KI-033-hardened) that decides what a TV host may be decides
+ * what a sweep may cover.
+ */
+export function sweepCandidates(myIp: string | undefined): string[] {
+  if (!myIp || !isValidLanIp(myIp)) return [];
+  const base = myIp.slice(0, myIp.lastIndexOf('.') + 1);
+  const ips: string[] = [];
+  for (let h = 1; h <= 254; h++) {
+    const ip = base + h;
+    if (ip !== myIp) ips.push(ip);
+  }
+  return ips;
+}
+
+export type SweepOpts = {
+  /** Fires the instant a TV answers, so the UI lists it while the sweep is
+   *  still draining — a found TV withheld for seconds reads as a slow app. */
+  onFound?: (tv: FoundTv) => void;
+  /** Cooperative cancel: workers exit within one per-host timeout. */
+  signal?: { aborted: boolean };
+  /** Injectable for tests; production uses rokuIdentify at the sweep timeout. */
+  identify?: (host: string) => Promise<RokuInfo | null>;
+  conc?: number;
+};
+
+/**
+ * Probe `ips` for Rokus, `conc` at a time. Never throws; a host that fails,
+ * times out, or answers as something-else-on-8060 is simply not in the result
+ * (rokuIdentify already refuses impostors).
+ */
+export async function sweepForRokus(ips: string[], opts: SweepOpts = {}): Promise<FoundTv[]> {
+  const identify = opts.identify ?? ((h: string) => rokuIdentify(h, SWEEP_TIMEOUT_MS));
+  const found: FoundTv[] = [];
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      if (opts.signal?.aborted) return;
+      const i = next++;
+      if (i >= ips.length) return;
+      const info = await identify(ips[i]);
+      if (info && !opts.signal?.aborted) {
+        const tv: FoundTv = { brand: 'roku', host: ips[i], name: info.name, model: info.model };
+        found.push(tv);
+        opts.onFound?.(tv);
+      }
+    }
+  };
+  const conc = Math.min(opts.conc ?? SWEEP_CONC, Math.max(ips.length, 1));
+  await Promise.all(Array.from({ length: conc }, worker));
+  return found;
+}

--- a/app/lib/tvdirect/store.ts
+++ b/app/lib/tvdirect/store.ts
@@ -11,6 +11,7 @@
  * All validation lives in ./model.ts, which is import-free and tested; this
  * file is only plumbing.
  */
+import * as Network from 'expo-network';
 import * as SecureStore from 'expo-secure-store';
 import { useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
@@ -24,6 +25,29 @@ import {
   nextTvId,
   normalizeTvState,
 } from './model.ts';
+import { sweepCandidates, sweepForRokus, type FoundTv } from './scan.ts';
+
+export type { FoundTv } from './scan.ts';
+
+/**
+ * Sweep the phone's /24 for TVs the app can drive directly. Resolves [] (never
+ * throws) when the phone has no usable LAN address — cellular, VPN'd, or the
+ * web harness — and the card renders that as "couldn't scan", not as a crash.
+ * expo-network is read HERE rather than in scan.ts so the sweep logic itself
+ * stays import-free for the bare-Node tests.
+ */
+export async function scanForTvs(
+  onFound?: (tv: FoundTv) => void,
+  signal?: { aborted: boolean },
+): Promise<FoundTv[]> {
+  let ip: string | undefined;
+  try {
+    ip = (await Network.getIpAddressAsync()) ?? undefined;
+  } catch {
+    ip = undefined;
+  }
+  return sweepForRokus(sweepCandidates(ip), { onFound, signal });
+}
 
 const KEY = 'couchside.tvs.v1';
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,6 +34,20 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **NOT verified:** no real Roku is owned, so no store copy may claim Roku support yet;
   the paywall's expired state, the iOS Local Network prompt and row overflow all need a
   device.
+- **SCAN FOR TVS added 2026-08-04 (late)** on `feat/tv-scan-direct`: a /24 HTTP sweep of
+  `GET :8060/query/device-info` (the boxDiscovery pattern — iOS blocks UDP, so SSDP/mDNS
+  were never options), 48 workers x 900ms, candidates gated by the same KI-033-hardened
+  LAN-IP rule as TV hosts (cellular/VPN = no sweep at all). Found TVs stream into the
+  Setup card and ADD stores them pre-identified. Unit-tested (candidates both directions,
+  identified-only results, abort stops workers); harness-pressed (scanning → honest empty
+  state). A real FIND needs Roku hardware.
+- **Owner asked 2026-08-04 for LG + Google TV app-direct too — DECLINED FOR NOW, not
+  forgotten:** both sit behind the measured TLS wall (LG wss:3001 self-signed — RN
+  WebSocket cannot skip validation, react-native-tcp-socket pins only; Google TV adds
+  mTLS + protobuf and the app cannot mint a cert). The next concrete step is the Phase 2
+  SPIKE from the spec: a dev build carrying react-native-tcp-socket on a real phone
+  against the owned LG (home LAN), proving pinned-TLS SSAP end to end before any UI or
+  claim. Both brands meanwhile work agent-mediated, and the setup card says so.
 
 ### First-run mode chooser — "gaming box" vs "remote only"
 - **priority:** P2 · **risk:** low (app only, one new route + one pref) · **affects:** app ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -45,8 +45,10 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   spike against the bedroom Hisense (10.1.1.98) minted a client cert in **pure JS**
   (node-forge, RSA-2048 in 0.2s — the headline blocker, since the agent shells to
   `openssl`), ported the `_atv_*` protobuf codec, PAIRED, **reconnected silently** on the
-  persisted cert, and injected keys the owner watched land: POWER toggled the TV, VOLUME_UP
-  took it to 30. So "the app cannot speak this protocol" is now false.
+  persisted cert, and injected keys the owner watched land across three classes: POWER
+  toggled the TV, VOLUME_UP took it to 30, and HOME/DOWN/RIGHT/UP moved the on-screen
+  selection. So "the app cannot speak this protocol" is now false, and **no part of the
+  protocol layer remains unproven**.
 - **The remaining blocker is narrower and unchanged in kind: react-native-tcp-socket TLS on
   a device.** Node needed `rejectUnauthorized:false` for the TV's self-signed leaf; that lib
   exposes only `ca` pinning — the TV's cert IS fetchable out-of-band first, so TOFU pinning
@@ -56,10 +58,13 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   testable against the real TV and only the RN adapter is device-gated. Adding the native
   dependency touches the shared build pipeline — the "shared-infra blast radius" the
   freemium analysis named as the top risk to the core — so it wants a device to hand.
-- **NOT verified even now:** nav keys (HOME/DOWN/RIGHT) were never visually confirmed (the
-  one test was inconclusive — TV asleep or on another input); node-forge keygen time on a
-  phone; anything LG (webOS is JSON-over-WSS with no client cert — easier, same pinning
-  question). Both brands work agent-mediated today and the setup card says so.
+- **NOT verified even now:** node-forge keygen time on a PHONE (0.2s on this Mac says
+  nothing about a mid-range Android); anything LG (webOS is JSON-over-WSS with no client
+  cert — easier, same pinning question); and the RN socket itself. Both brands work
+  agent-mediated today and the setup card says so.
+- **Observation lesson worth keeping:** the first nav test read as a failure and was merely
+  unwatched. Key inject is fire-and-forget, so the human IS the instrument — give them a
+  countdown lead-in and space the keys, or the run produces no evidence in either direction.
 
 ### First-run mode chooser — "gaming box" vs "remote only"
 - **priority:** P2 · **risk:** low (app only, one new route + one pref) · **affects:** app ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -41,13 +41,25 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   Setup card and ADD stores them pre-identified. Unit-tested (candidates both directions,
   identified-only results, abort stops workers); harness-pressed (scanning → honest empty
   state). A real FIND needs Roku hardware.
-- **Owner asked 2026-08-04 for LG + Google TV app-direct too — DECLINED FOR NOW, not
-  forgotten:** both sit behind the measured TLS wall (LG wss:3001 self-signed — RN
-  WebSocket cannot skip validation, react-native-tcp-socket pins only; Google TV adds
-  mTLS + protobuf and the app cannot mint a cert). The next concrete step is the Phase 2
-  SPIKE from the spec: a dev build carrying react-native-tcp-socket on a real phone
-  against the owned LG (home LAN), proving pinned-TLS SSAP end to end before any UI or
-  claim. Both brands meanwhile work agent-mediated, and the setup card says so.
+- **Google TV app-direct: the protocol half is PROVEN (2026-08-05, real hardware).** A JS
+  spike against the bedroom Hisense (10.1.1.98) minted a client cert in **pure JS**
+  (node-forge, RSA-2048 in 0.2s — the headline blocker, since the agent shells to
+  `openssl`), ported the `_atv_*` protobuf codec, PAIRED, **reconnected silently** on the
+  persisted cert, and injected keys the owner watched land: POWER toggled the TV, VOLUME_UP
+  took it to 30. So "the app cannot speak this protocol" is now false.
+- **The remaining blocker is narrower and unchanged in kind: react-native-tcp-socket TLS on
+  a device.** Node needed `rejectUnauthorized:false` for the TV's self-signed leaf; that lib
+  exposes only `ca` pinning — the TV's cert IS fetchable out-of-band first, so TOFU pinning
+  is plausible but UNPROVEN, as are client key/cert options on iOS.
+- **Shape for the build when it happens:** the proven codec/crypto goes in
+  `lib/tvdirect/androidtv.ts` behind an INJECTED socket interface, so it stays bare-Node
+  testable against the real TV and only the RN adapter is device-gated. Adding the native
+  dependency touches the shared build pipeline — the "shared-infra blast radius" the
+  freemium analysis named as the top risk to the core — so it wants a device to hand.
+- **NOT verified even now:** nav keys (HOME/DOWN/RIGHT) were never visually confirmed (the
+  one test was inconclusive — TV asleep or on another input); node-forge keygen time on a
+  phone; anything LG (webOS is JSON-over-WSS with no client cert — easier, same pinning
+  question). Both brands work agent-mediated today and the setup card says so.
 
 ### First-run mode chooser — "gaming box" vs "remote only"
 - **priority:** P2 · **risk:** low (app only, one new route + one pref) · **affects:** app ·


### PR DESCRIPTION
Adds a **SCAN FOR ROKU TVS** button to the TV REMOTE (NO BOX) card, so a TV-only user never has to dig an IP out of their TV's settings menu. Follow-on to #350.

## Mechanism

Same discovery shape as the box scanner, for the same reason: **iOS blocks app UDP**, so SSDP/mDNS — how Roku is "supposed" to be discovered — were never available to this app. Instead: a /24 HTTP sweep of `GET :8060/query/device-info`, 48 workers × 900 ms per host (a live Roku answers in milliseconds). Found TVs stream into the card as they answer; **ADD** stores them pre-identified. `rokuIdentify` gains a `timeoutMs` param — the sweep probes at 900 ms while ADD-by-IP keeps the patient 4 s for a TV waking its network stack.

## Safety shape

- Candidates derive **only from the phone's own /24**, and the phone's address must pass the KI-033-hardened LAN gate first — cellular/VPN means **no sweep at all**, never a sweep of somewhere else.
- A host appears in results only by answering device-info **as a Roku** (impostors on :8060 are refused), and ADD goes through the same normalizer as the manual path and the persisted blob.
- `scan.ts` is import-free (bare-Node testable); the `expo-network` read lives in `store.ts`.

## Verification

- **4 new unit tests** (tvdirect file now 17; suite 174/174; `tsc` clean): candidate generation both directions with a control (`10.1.1.60` → 253 hosts excluding itself and .0/.255; `undefined`/public/octal → zero), identified-only results (4 probed, 1 returned), `onFound` streaming, abort probes nothing.
- **Harness, pressed:** SCAN → SCANNING spinner → completion → the honest "No Roku answered on this network" empty state; button restored; no console errors.

## NOT verified

- **A real find, end to end** — no Roku hardware is owned, and the web harness is additionally CORS-blind to direct-device traffic (recorded in CONVENTIONS). The find path is carried by the injectable-identify unit tests until a real set is on a LAN. Same claim-lockstep rule as the remote itself.
- Device-only: the iOS Local Network prompt firing on the sweep's first probe.

## Also in this PR (ROADMAP)

The owner's ask for **LG + Google TV app-direct is recorded as declined-for-now**: both sit behind the measured TLS wall (RN WebSocket can't skip validation; `react-native-tcp-socket` pins only; Google TV adds mTLS+protobuf the app can't mint certs for). ROADMAP names the Phase 2 spike — a dev build with the TLS socket lib on a real phone against the owned LG — as the next concrete step. Both brands work agent-mediated today, and the setup card says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
