### PR TITLE
feat(app): Android TV / Google TV protocol layer, hardware-proven (no UI yet)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,9 @@ docs/BUILD_LOG.md
 # untracked file at the root is exactly how an unrelated copy change got swept
 # into a feature commit once already.
 *-build-prompt.md
+
+# Live-hardware test identity (a real paired client cert + private key)
+app/lib/__tests__/.atv-identity.json
+app/lib/__tests__/.atv-code.txt
+app/build-*.ipa
+scratchpad-atv/

--- a/app/lib/__tests__/atv-live.mjs
+++ b/app/lib/__tests__/atv-live.mjs
@@ -1,0 +1,147 @@
+/**
+ * LIVE hardware check for the SHIPPING Android TV modules. Not part of CI —
+ * it needs a real Google TV on the LAN, so it is run by hand:
+ *
+ *   node --experimental-strip-types lib/__tests__/atv-live.mjs <tv-ip> [--pair]
+ *
+ * WHY THIS EXISTS. lib/tvdirect/androidtv.ts injects its socket and hashing
+ * precisely so the code that ships can be driven from Node against real
+ * hardware. Without this file the app-side port would be unproven until it was
+ * inside a TestFlight build, which is the slowest possible place to find a
+ * protobuf mistake. With it, only the thin RN socket adapter is device-gated.
+ *
+ * Proven with it on 2026-08-05 against the bedroom Hisense (10.1.1.98).
+ */
+import fs from 'node:fs';
+import tls from 'node:tls';
+import { createHash } from 'node:crypto';
+import forge from 'node-forge';
+
+import { frame, makeFramer } from '../tvdirect/atvproto.ts';
+import { AtvSession, pairStart } from '../tvdirect/androidtv.ts';
+
+const HOST = process.argv[2];
+const DO_PAIR = process.argv.includes('--pair');
+if (!HOST) {
+  console.error('usage: atv-live.mjs <tv-ip> [--pair]');
+  process.exit(2);
+}
+const ID_FILE = new URL('./.atv-identity.json', import.meta.url).pathname;
+const CODE_FILE = new URL('./.atv-code.txt', import.meta.url).pathname;
+const log = (...a) => console.log(new Date().toISOString().slice(11, 19), ...a);
+
+// ---- the two injected pieces, Node flavour -------------------------------
+
+const sha256 = async (bytes) => new Uint8Array(createHash('sha256').update(bytes).digest());
+
+const connect = (host, port, certPem, keyPem) =>
+  new Promise((resolve, reject) => {
+    const sock = tls.connect(
+      // The TV's cert is self-signed by the TV itself. Node opts out of
+      // verification with this flag; react-native-tcp-socket has no equivalent
+      // and must PIN the cert instead — the whole reason the socket is injected.
+      { host, port, cert: certPem, key: keyPem, rejectUnauthorized: false },
+      () => {
+        const framer = makeFramer();
+        const frames = [];
+        const waiters = [];
+        sock.on('data', (d) => {
+          for (const f of framer.push(new Uint8Array(d))) {
+            const w = waiters.shift();
+            if (w) w.resolve(f);
+            else frames.push(f);
+          }
+        });
+        const fail = (e) => { const w = waiters.shift(); if (w) w.reject(e); };
+        sock.on('error', fail);
+        sock.on('close', () => fail(new Error('socket closed')));
+        resolve({
+          write: (bytes) => sock.write(frame(bytes)),
+          recv: (timeoutMs = 20000) =>
+            frames.length
+              ? Promise.resolve(frames.shift())
+              : new Promise((res, rej) => {
+                  const t = setTimeout(() => rej(new Error('recv timeout')), timeoutMs);
+                  waiters.push({
+                    resolve: (f) => { clearTimeout(t); res(f); },
+                    reject: (e) => { clearTimeout(t); rej(e); },
+                  });
+                }),
+          close: () => sock.destroy(),
+          peerModulusHex: () => sock.getPeerCertificate().modulus,
+        });
+      },
+    );
+    sock.on('error', reject);
+  });
+
+// ---- identity ------------------------------------------------------------
+
+function mintIdentity() {
+  if (fs.existsSync(ID_FILE)) {
+    log('reusing persisted identity');
+    return JSON.parse(fs.readFileSync(ID_FILE, 'utf8'));
+  }
+  log('minting RSA-2048 client cert (node-forge)…');
+  const t0 = Date.now();
+  const keys = forge.pki.rsa.generateKeyPair({ bits: 2048 });
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = '01';
+  cert.validity.notBefore = new Date(Date.now() - 86400000);
+  cert.validity.notAfter = new Date('2038-01-19T03:14:07Z');
+  const attrs = [{ name: 'commonName', value: 'couchside' }];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.setExtensions([
+    { name: 'basicConstraints', cA: true, pathLenConstraint: 0 },
+    { name: 'subjectAltName', altNames: [{ type: 2, value: 'couchside' }] },
+  ]);
+  cert.sign(keys.privateKey, forge.md.sha256.create());
+  let modulusHex = keys.publicKey.n.toString(16);
+  if (modulusHex.length % 2) modulusHex = '0' + modulusHex;
+  const id = {
+    certPem: forge.pki.certificateToPem(cert),
+    keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    modulusHex,
+  };
+  fs.writeFileSync(ID_FILE, JSON.stringify(id));
+  log(`minted in ${((Date.now() - t0) / 1000).toFixed(1)}s`);
+  return id;
+}
+
+// ---- run -----------------------------------------------------------------
+
+const identity = mintIdentity();
+const deps = { connect, sha256 };
+
+if (DO_PAIR) {
+  const session = await pairStart(HOST, identity, deps);
+  log('*** THE TV IS SHOWING A 6-DIGIT CODE ***');
+  log(`write it to ${CODE_FILE} — polled every 200ms`);
+  try { fs.unlinkSync(CODE_FILE); } catch {}
+  const shownAt = Date.now();
+  let code = '';
+  while (Date.now() - shownAt < 240000) {
+    try {
+      const v = fs.readFileSync(CODE_FILE, 'utf8').trim();
+      if (/^[0-9a-fA-F]{6}$/.test(v)) { code = v; break; }
+    } catch {}
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (!code) { session.cancel(); throw new Error('no code arrived'); }
+  log(`code ${code} after ${((Date.now() - shownAt) / 1000).toFixed(1)}s — finishing`);
+  await session.finish(code);
+  log('*** PAIRED (shipping module) ***');
+}
+
+const remote = new AtvSession(HOST, identity, deps);
+const seq = ['home', 'down', 'down', 'right', 'volume_up', 'volume_up'];
+log(`remote session: sending ${seq.join(', ')} (4s apart — watch the TV)`);
+for (const k of seq) {
+  await remote.sendKey(k);
+  log(`  sent ${k}`);
+  await new Promise((r) => setTimeout(r, 4000));
+}
+remote.close();
+log('DONE — a sent key is NOT an observed key; confirm on the screen.');

--- a/app/lib/__tests__/atvproto.test.ts
+++ b/app/lib/__tests__/atvproto.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Android TV protocol codec — lib/tvdirect/atvproto.ts + androidtv.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * WHY THIS FILE EXISTS. The protocol was proven against a real Google TV before
+ * it was written into the app (see lib/__tests__/atv-live.mjs, which drives
+ * these very modules over the LAN). What live hardware CANNOT give us is a
+ * regression gate: the TV is not on CI, and a wrong keycode looks identical to
+ * a TV that was asleep. So this file pins the parts that must never drift:
+ *
+ *  1. THE KEYCODES ARE DUPLICATED from the agent (_ATV_KEYS :8899,
+ *     _ATV_OP_KEY :8897) because remote-only mode has no agent to ask.
+ *  2. THE CODEC IS HAND-ROLLED, so its round-trip and its framing are pinned
+ *     against known-good bytes rather than against itself.
+ *  3. THE PAIRING CHECK-BYTE is the only local defence against a mistyped code
+ *     (the TV answers a wrong secret with silence), so it is tested in BOTH
+ *     directions with a real SHA-256.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+
+import {
+  ATV_FEATURES,
+  ATV_KEYS,
+  ATV_OP_KEY,
+  ATV_PAIR_PORT,
+  ATV_REMOTE_PORT,
+  checkByteMatches,
+  fb,
+  fv,
+  frame,
+  hexToBytes,
+  isPairingSecretAck,
+  isRemotePing,
+  isRemoteStart,
+  isValidPairCode,
+  keyInject,
+  makeFramer,
+  normalizeModulusHex,
+  parse,
+  pingValue,
+  readVarint,
+  remotePingReply,
+  secretPreimage,
+  varint,
+} from '../tvdirect/atvproto.ts';
+import { AtvSession, pairStart } from '../tvdirect/androidtv.ts';
+
+const sha256 = async (b: Uint8Array) => new Uint8Array(createHash('sha256').update(b).digest());
+const hex = (u: Uint8Array) => Buffer.from(u).toString('hex');
+
+// ------------------------------------------------------------- key tables
+
+test('Android TV keycodes match the agent VERBATIM (drift guard)', () => {
+  // agent/couchsided.py:8899 _ATV_KEYS. These are Android KEYCODE_* constants;
+  // a wrong number is a key that silently does something else on the TV.
+  assert.equal(ATV_KEYS.up, 19);
+  assert.equal(ATV_KEYS.down, 20);
+  assert.equal(ATV_KEYS.left, 21);
+  assert.equal(ATV_KEYS.right, 22);
+  assert.equal(ATV_KEYS.ok, 23);
+  assert.equal(ATV_KEYS.home, 3);
+  assert.equal(ATV_KEYS.back, 4);
+  assert.equal(ATV_KEYS.menu, 82);
+  assert.equal(ATV_KEYS.power, 26);
+  assert.equal(ATV_KEYS.volume_up, 24);
+  assert.equal(ATV_KEYS.volume_down, 25);
+  assert.equal(ATV_KEYS.mute, 91);
+  assert.equal(ATV_KEYS.play_pause, 85);
+  assert.equal(ATV_KEYS.play, 126);
+  assert.equal(ATV_KEYS.pause, 127);
+  assert.equal(ATV_KEYS.stop, 86);
+  assert.equal(ATV_KEYS.rewind, 89);
+  assert.equal(ATV_KEYS.fast_forward, 90);
+  assert.equal(ATV_KEYS.next, 87);
+  assert.equal(ATV_KEYS.previous, 88);
+  // agent/couchsided.py:8897 _ATV_OP_KEY.
+  assert.deepEqual({ ...ATV_OP_KEY }, { power_off: 26, volume_up: 24, volume_down: 25, mute: 91 });
+  assert.equal(ATV_FEATURES, 622);
+  assert.equal(ATV_PAIR_PORT, 6467);
+  assert.equal(ATV_REMOTE_PORT, 6466);
+});
+
+test('the source key is deliberately ABSENT (KI-031)', () => {
+  // KEYCODE_TV_INPUT (178) is in the agent's table but was MEASURED doing
+  // nothing on Google TV, twice, on this exact set — while the agent still
+  // answered ok. A key the TV silently drops must not be offerable here.
+  assert.equal((ATV_KEYS as Record<string, number>).source, undefined);
+  assert.ok(!(Object.values(ATV_KEYS) as number[]).includes(178));
+});
+
+// ----------------------------------------------------------------- codec
+
+test('varints round-trip, including multi-byte boundaries', () => {
+  for (const n of [0, 1, 3, 26, 127, 128, 300, 622, 16383, 16384, 1e6]) {
+    const [got, pos] = readVarint(varint(n), 0);
+    assert.equal(got, n, `varint ${n}`);
+    assert.equal(pos, varint(n).length);
+  }
+  // Known-good encodings, so this cannot pass by being self-consistent.
+  assert.equal(hex(varint(0)), '00');
+  assert.equal(hex(varint(127)), '7f');
+  assert.equal(hex(varint(128)), '8001');
+  assert.equal(hex(varint(622)), 'ee04');
+});
+
+test('field writers produce the documented wire bytes', () => {
+  // field 1, wiretype 0, value 3  ->  tag 0x08, value 0x03
+  assert.equal(hex(fv(1, 3)), '0803');
+  // field 2, wiretype 0, value 200 -> tag 0x10, varint 200 = c801
+  assert.equal(hex(fv(2, 200)), '10c801');
+  // field 1, wiretype 2, 2 bytes  -> tag 0x0a, len 0x02, payload
+  assert.equal(hex(fb(1, Uint8Array.from([0xaa, 0xbb]))), '0a02aabb');
+});
+
+test('keyInject carries the keycode AND the SHORT direction', () => {
+  // The TV ignores a key frame with no direction — this shipped correct only
+  // because the agent's frame was copied exactly.
+  // tag = (10<<3)|2 = 0x52, len 4, then key_code(1)=3 (0803) + direction(2)=3 (1003).
+  assert.equal(hex(keyInject(3)), '520408031003');
+  const f = parse(parse(keyInject(ATV_KEYS.home))[10]![0] as Uint8Array);
+  assert.equal(f[1]![0], 3, 'keycode');
+  assert.equal(f[2]![0], 3, 'direction SHORT');
+});
+
+test('parse walks fields and tolerates a frame it only partly understands', () => {
+  const buf = Buffer.concat([Buffer.from(fv(1, 42)), Buffer.from(fb(2, Uint8Array.from([1, 2])))]);
+  const f = parse(new Uint8Array(buf));
+  assert.equal(f[1]![0], 42);
+  assert.deepEqual(Array.from(f[2]![0] as Uint8Array), [1, 2]);
+  // A trailing unknown wire type stops the walk rather than throwing: the
+  // known fields are still usable, which is what the handshake relies on.
+  const weird = new Uint8Array([...fv(1, 7), 0x0d, 0xff]);
+  assert.equal(parse(weird)[1]![0], 7);
+});
+
+test('the framer reassembles frames split across chunk boundaries', () => {
+  const a = frame(fv(1, 1));
+  const b = frame(fv(2, 2));
+  const all = Buffer.concat([Buffer.from(a), Buffer.from(b)]);
+  // One byte at a time — the pathological TCP case, and the one a naive
+  // "read once per frame" implementation gets wrong.
+  const framer = makeFramer();
+  const out: Uint8Array[] = [];
+  for (const byte of all) out.push(...framer.push(Uint8Array.from([byte])));
+  assert.equal(out.length, 2);
+  assert.equal(parse(out[0])[1]![0], 1);
+  assert.equal(parse(out[1])[2]![0], 2);
+  // CONTROL: the whole buffer at once yields the same two frames.
+  assert.equal(makeFramer().push(new Uint8Array(all)).length, 2);
+});
+
+test('ping replies echo the value the TV sent', () => {
+  // A ping the TV does not get answered drops the channel, so the value has
+  // to survive the round trip intact.
+  const req = fb(8, fv(1, 7));
+  const fields = parse(req);
+  assert.ok(isRemotePing(fields));
+  assert.equal(pingValue(fields), 7);
+  assert.equal(parse(parse(remotePingReply(7))[9]![0] as Uint8Array)[1]![0], 7);
+  // A malformed ping falls back to 1 rather than throwing inside the reader.
+  assert.equal(pingValue(parse(fb(8, new Uint8Array(0)))), 1);
+});
+
+// --------------------------------------------------------------- pairing
+
+test('modulus hex is normalised to even-length lowercase', () => {
+  // Node hands back UPPERCASE and forge can produce an odd-length string; both
+  // must hash identically or the secret is silently wrong.
+  assert.equal(normalizeModulusHex('ABCD'), 'abcd');
+  assert.equal(normalizeModulusHex('ABC'), '0abc');
+  assert.equal(normalizeModulusHex('0xAB'), 'ab');
+  assert.deepEqual(Array.from(hexToBytes('0A0B')), [10, 11]);
+});
+
+test('the secret preimage is exactly clientMod ‖ 010001 ‖ serverMod ‖ 010001 ‖ nonce', () => {
+  const pre = secretPreimage('aabb', 'ccdd', '12e4f0');
+  // nonce is the code MINUS its first byte (the check byte).
+  assert.equal(hex(pre), 'aabb' + '010001' + 'ccdd' + '010001' + 'e4f0');
+});
+
+test('the check byte accepts the right code and rejects a wrong one', async () => {
+  const clientMod = 'aabb';
+  const serverMod = 'ccdd';
+  const nonce = 'e4f0';
+  // Derive the code the TV WOULD show: hash first, then take its first byte.
+  const probe = await sha256(secretPreimage(clientMod, serverMod, '00' + nonce));
+  const code = probe[0].toString(16).padStart(2, '0') + nonce;
+  const secret = await sha256(secretPreimage(clientMod, serverMod, code));
+  assert.ok(checkByteMatches(secret, code), 'the correct code must pass');
+  // A single wrong digit in the CHECK byte must fail — this is the only local
+  // defence, since the TV answers a bad secret with silence.
+  const wrongCheck = (((probe[0] + 1) & 0xff).toString(16).padStart(2, '0')) + nonce;
+  assert.ok(!checkByteMatches(secret, wrongCheck), 'a wrong check byte must fail');
+});
+
+test('pair codes are validated before anything is sent', () => {
+  assert.ok(isValidPairCode('27e0b0'));
+  assert.ok(isValidPairCode('27E0B0'));
+  assert.ok(!isValidPairCode('27e0b'));
+  assert.ok(!isValidPairCode('27e0b0a'));
+  assert.ok(!isValidPairCode('27e0bz'));
+  assert.ok(!isValidPairCode(''));
+});
+
+// ------------------------------------------------- session, on a fake socket
+
+/** A scripted socket: replies are queued, writes are recorded. */
+function fakeSocket(script: Uint8Array[]) {
+  const writes: Uint8Array[] = [];
+  const queue = [...script];
+  let closed = false;
+  return {
+    writes,
+    get closed() { return closed; },
+    sock: {
+      write: (b: Uint8Array) => {
+        if (closed) throw new Error('closed');
+        writes.push(b);
+      },
+      // An exhausted queue BLOCKS rather than throwing, because that is what a
+      // real idle socket does. Throwing made the session's reader loop treat
+      // "no more scripted frames" as "the TV hung up" and tear the connection
+      // down mid-test — a fake that lies about idleness invents a failure the
+      // production path does not have.
+      recv: () => {
+        const f = queue.shift();
+        return f ? Promise.resolve(f) : new Promise<Uint8Array>(() => {});
+      },
+      close: () => { closed = true; },
+      peerModulusHex: () => 'ccdd',
+    },
+  };
+}
+
+test('a session handshakes, then a key press writes exactly one inject frame', async () => {
+  // The TV drives the handshake: configure -> set_active -> start.
+  const f = fakeSocket([fb(1, fv(1, 1)), fb(2, fv(1, 1)), fb(40, fv(1, 1))]);
+  const session = new AtvSession(
+    '10.0.0.9',
+    { certPem: 'c', keyPem: 'k', modulusHex: 'aabb' },
+    { connect: async () => f.sock, sha256 },
+  );
+  await session.sendKey('home');
+  // 2 handshake replies + the key. The reader loop may add nothing else here.
+  assert.equal(f.writes.length, 3);
+  const injected = parse(parse(f.writes[2])[10]![0] as Uint8Array);
+  assert.equal(injected[1]![0], ATV_KEYS.home);
+  session.close();
+  assert.ok(f.closed);
+});
+
+test('an unknown key is refused locally and NOTHING is sent', async () => {
+  const f = fakeSocket([fb(1, fv(1, 1)), fb(2, fv(1, 1)), fb(40, fv(1, 1))]);
+  const session = new AtvSession(
+    '10.0.0.9',
+    { certPem: 'c', keyPem: 'k', modulusHex: 'aabb' },
+    { connect: async () => f.sock, sha256 },
+  );
+  await assert.rejects(() => session.sendKey('selfdestruct' as never), /unknown key/);
+  assert.equal(f.writes.length, 0, 'not even a connection was opened');
+  session.close();
+});
+
+test('pairing refuses a bad code WITHOUT sending a secret', async () => {
+  const f = fakeSocket([fb(11, fv(1, 1)), fb(20, fv(1, 1)), fb(31, fv(1, 1))]);
+  const session = await pairStart(
+    '10.0.0.9',
+    { certPem: 'c', keyPem: 'k', modulusHex: 'aabb' },
+    { connect: async () => f.sock, sha256 },
+  );
+  const beforeWrites = f.writes.length; // the 3 pairing steps
+  await assert.rejects(() => session.finish('nothex'), /6 hex digits/);
+  await assert.rejects(() => session.finish('000000'), /does not match/);
+  assert.equal(f.writes.length, beforeWrites, 'no secret frame was written');
+});
+
+test('a completed pairing returns the identity to persist', async () => {
+  const clientMod = 'aabb';
+  const nonce = 'e4f0';
+  const probe = await sha256(secretPreimage(clientMod, 'ccdd', '00' + nonce));
+  const code = probe[0].toString(16).padStart(2, '0') + nonce;
+  const f = fakeSocket([
+    fb(11, fv(1, 1)), fb(20, fv(1, 1)), fb(31, fv(1, 1)),
+    fb(41, fv(1, 1)), // secret ack
+  ]);
+  const identity = { certPem: 'CERT', keyPem: 'KEY', modulusHex: clientMod };
+  const session = await pairStart('10.0.0.9', identity, { connect: async () => f.sock, sha256 });
+  const out = await session.finish(code);
+  assert.deepEqual(out, identity);
+  assert.ok(isPairingSecretAck(parse(fb(41, fv(1, 1)))));
+  assert.ok(f.closed, 'the pairing socket is released');
+});
+
+test('handshake helpers identify the frames they name', () => {
+  assert.ok(isRemoteStart(parse(fb(40, fv(1, 1)))));
+  assert.ok(!isRemoteStart(parse(fb(8, fv(1, 1)))));
+  assert.ok(isRemotePing(parse(fb(8, fv(1, 1)))));
+  assert.ok(!isRemotePing(parse(fb(40, fv(1, 1)))));
+});

--- a/app/lib/tvdirect/androidtv.ts
+++ b/app/lib/tvdirect/androidtv.ts
@@ -1,0 +1,255 @@
+/**
+ * Android TV / Google TV client: pairing + a keepalive remote session.
+ * ZERO runtime imports — the socket and the crypto are both INJECTED.
+ *
+ * Why both are injected: Node has `tls` and `crypto`; React Native has neither,
+ * and react-native-tcp-socket cannot load in the bare-Node test runner. Keeping
+ * this module dependency-free is what lets the SAME code that ships be driven
+ * against the real TV from a test (see lib/__tests__/atv-live.mjs), so the only
+ * app-specific surface is a thin adapter.
+ *
+ * Protocol details, keycodes and the wire format live in ./atvproto.ts.
+ */
+
+import {
+  ATV_KEYS,
+  ATV_OP_KEY,
+  ATV_PAIR_PORT,
+  ATV_REMOTE_PORT,
+  type AtvConnect,
+  type AtvKey,
+  type AtvOp,
+  type AtvSocket,
+  checkByteMatches,
+  isPairingConfigurationAck,
+  isPairingRequestAck,
+  isPairingOptionsAck,
+  isPairingSecretAck,
+  isRemoteConfigure,
+  isRemotePing,
+  isRemoteSetActive,
+  isRemoteStart,
+  isValidPairCode,
+  keyInject,
+  normalizeModulusHex,
+  pairingConfiguration,
+  pairingOptions,
+  pairingRequest,
+  pairingSecret,
+  parse,
+  pingValue,
+  remoteConfigureReply,
+  remotePingReply,
+  remoteSetActiveReply,
+  secretPreimage,
+} from './atvproto.ts';
+
+/** An RSA keypair + self-signed cert, PEM encoded. Minted by the caller. */
+export type AtvIdentity = { certPem: string; keyPem: string; modulusHex: string };
+
+/** Everything platform-specific, supplied by the caller. */
+export type AtvDeps = {
+  connect: AtvConnect;
+  /** SHA-256. Node: crypto.createHash; RN: expo-crypto digest. */
+  sha256(data: Uint8Array): Promise<Uint8Array>;
+};
+
+export type PairSession = {
+  /** Send the code the TV is displaying. Resolves the identity to persist. */
+  finish(code: string): Promise<AtvIdentity>;
+  /** Abandon a pairing the user backed out of. */
+  cancel(): void;
+};
+
+/**
+ * Phase 1: open the pairing channel so the TV DISPLAYS its code, and return a
+ * handle that completes once the user reads it.
+ *
+ * THE DIALOG EXPIRES, AND FAST. Measured 2026-08-05 on a real Hisense Google
+ * TV: relaying the code took 39s and the TV never answered the secret — the
+ * next connect was refused `certificate unknown`, i.e. never paired. The same
+ * flow at 5.6s paired instantly. So the UI must show the code field the moment
+ * this resolves, with nothing in between.
+ */
+export async function pairStart(
+  host: string,
+  identity: AtvIdentity,
+  deps: AtvDeps,
+  clientName = 'Couchside',
+): Promise<PairSession> {
+  const sock = await deps.connect(host, ATV_PAIR_PORT, identity.certPem, identity.keyPem);
+  const serverModulusHex = normalizeModulusHex(sock.peerModulusHex());
+
+  const step = async (msg: Uint8Array, ok: (f: ReturnType<typeof parse>) => boolean, what: string) => {
+    sock.write(msg);
+    if (!ok(parse(await sock.recv()))) throw new Error(`androidtv pairing: no ${what}`);
+  };
+
+  try {
+    await step(pairingRequest(clientName), isPairingRequestAck, 'pairing_request_ack');
+    await step(pairingOptions(), isPairingOptionsAck, 'options ack');
+    await step(pairingConfiguration(), isPairingConfigurationAck, 'configuration_ack');
+  } catch (e) {
+    sock.close();
+    throw e;
+  }
+
+  let done = false;
+  return {
+    cancel() {
+      if (!done) {
+        done = true;
+        sock.close();
+      }
+    },
+    async finish(code: string): Promise<AtvIdentity> {
+      if (done) throw new Error('pairing session already finished');
+      if (!isValidPairCode(code)) throw new Error('the code is 6 hex digits');
+      const clean = code.trim().toLowerCase();
+      const secret = await deps.sha256(
+        secretPreimage(identity.modulusHex, serverModulusHex, clean),
+      );
+      // Catch a mistyped code locally: the TV answers a wrong secret with
+      // SILENCE, which is indistinguishable from a dead link.
+      if (!checkByteMatches(secret, clean)) {
+        throw new Error('that code does not match — check the digits on the TV');
+      }
+      try {
+        sock.write(pairingSecret(secret));
+        if (!isPairingSecretAck(parse(await sock.recv(45000)))) {
+          throw new Error('the TV rejected the pairing');
+        }
+      } catch (e) {
+        throw new Error(
+          `${(e as Error).message}. If the code had been on screen a while, the TV's own ` +
+            `dialog may have expired — start pairing again and enter it promptly.`,
+        );
+      } finally {
+        done = true;
+        sock.close();
+      }
+      return identity;
+    },
+  };
+}
+
+/**
+ * A live remote channel. The TV pings every ~5s and drops the channel if the
+ * pings go unanswered, so this owns a reader loop for the socket's lifetime
+ * rather than reconnecting per key (a fresh TLS handshake per press measured
+ * ~1s on the agent side — far too slow for a held D-pad).
+ */
+export class AtvSession {
+  private sock: AtvSocket | null = null;
+  private connecting: Promise<void> | null = null;
+  private host: string;
+  private identity: AtvIdentity;
+  private deps: AtvDeps;
+
+  // Fields are declared and assigned explicitly rather than via constructor
+  // parameter properties: those GENERATE code, and Node's
+  // --experimental-strip-types only ERASES types, so the shorthand makes this
+  // module unloadable by the bare-Node runner that drives it against real
+  // hardware. Same constraint as the rest of lib/__tests__.
+  constructor(host: string, identity: AtvIdentity, deps: AtvDeps) {
+    this.host = host;
+    this.identity = identity;
+    this.deps = deps;
+  }
+
+  /** Connect + handshake if needed. Safe to call concurrently. */
+  private async ensure(): Promise<AtvSocket> {
+    if (this.sock) return this.sock;
+    if (!this.connecting) {
+      this.connecting = this.open().finally(() => {
+        this.connecting = null;
+      });
+    }
+    await this.connecting;
+    if (!this.sock) throw new Error('androidtv: not connected');
+    return this.sock;
+  }
+
+  private async open(): Promise<void> {
+    const sock = await this.deps.connect(
+      this.host,
+      ATV_REMOTE_PORT,
+      this.identity.certPem,
+      this.identity.keyPem,
+    );
+    // Handshake: the TV drives it, we answer until remote_start arrives.
+    const deadline = Date.now() + 12000;
+    for (;;) {
+      if (Date.now() > deadline) {
+        sock.close();
+        throw new Error('androidtv remote handshake timed out');
+      }
+      const f = parse(await sock.recv(12000));
+      if (isRemoteConfigure(f)) sock.write(remoteConfigureReply());
+      else if (isRemoteSetActive(f)) sock.write(remoteSetActiveReply());
+      else if (isRemotePing(f)) sock.write(remotePingReply(pingValue(f)));
+      else if (isRemoteStart(f)) break;
+    }
+    this.sock = sock;
+    void this.readerLoop(sock);
+  }
+
+  /** Answer pings for as long as this socket is the live one. */
+  private async readerLoop(sock: AtvSocket): Promise<void> {
+    for (;;) {
+      let f;
+      try {
+        f = parse(await sock.recv(600000));
+      } catch {
+        break; // closed or idle past the ceiling: drop and reconnect on demand
+      }
+      if (this.sock !== sock) break;
+      if (isRemotePing(f)) {
+        try {
+          sock.write(remotePingReply(pingValue(f)));
+        } catch {
+          break;
+        }
+      }
+    }
+    if (this.sock === sock) this.sock = null;
+  }
+
+  /**
+   * Send a key. Reconnects once if the channel died since the last press —
+   * a TV that slept mid-session should not need the user to re-pair.
+   *
+   * NOTE: key inject is FIRE AND FORGET. The TV acknowledges nothing, so a
+   * resolved promise means "the frame was written", never "the TV acted".
+   * KI-031 is the scar: the agent reported ok for a source key Google TV
+   * silently drops. Do not surface this as confirmation.
+   */
+  async sendKey(key: AtvKey): Promise<void> {
+    const code = ATV_KEYS[key];
+    if (code === undefined) throw new Error(`unknown key ${key}`);
+    await this.send(keyInject(code));
+  }
+
+  async sendOp(op: AtvOp): Promise<void> {
+    const code = ATV_OP_KEY[op];
+    if (code === undefined) throw new Error(`unknown op ${op}`);
+    await this.send(keyInject(code));
+  }
+
+  private async send(msg: Uint8Array): Promise<void> {
+    let sock = await this.ensure();
+    try {
+      sock.write(msg);
+    } catch {
+      this.sock = null;
+      sock = await this.ensure();
+      sock.write(msg);
+    }
+  }
+
+  close(): void {
+    const s = this.sock;
+    this.sock = null;
+    s?.close();
+  }
+}

--- a/app/lib/tvdirect/atvproto.ts
+++ b/app/lib/tvdirect/atvproto.ts
@@ -1,0 +1,344 @@
+/**
+ * Android TV / Google TV Remote v2 protocol, in TypeScript. ZERO runtime imports.
+ *
+ * This is the half that was PROVEN against real hardware before any of it was
+ * written into the app: a JS spike drove the bedroom Hisense Google TV
+ * (10.1.1.98) on 2026-08-05 — paired, reconnected silently on the persisted
+ * cert, and injected keys the owner watched land (power toggled the TV, volume
+ * reached 30, and the on-screen selection moved). See
+ * docs/memory/project_remote-only-mode.md.
+ *
+ * PORTED VERBATIM from the agent's backend (agent/couchsided.py `_atv_*`,
+ * `_ATV_KEYS` :8899, `_ATV_OP_KEY` :8897). Duplicated rather than derived for
+ * the same reason as the Roku tables: in remote-only mode there is no agent to
+ * ask. lib/__tests__/atvproto.test.ts pins the keycodes against the agent so a
+ * one-sided "fix" fails CI.
+ *
+ * THE SOCKET IS INJECTED (see AtvSocket). Node's `tls` is not available in
+ * React Native and react-native-tcp-socket is not available in the bare-Node
+ * test runner, so neither may be imported here. That is what lets the tests
+ * drive this module against the REAL TV from Node while the app supplies its
+ * own adapter — the untested surface stays a thin adapter rather than the whole
+ * protocol.
+ */
+
+// ---------------------------------------------------------------- key tables
+
+/** Unified TV ops -> Android keycodes. VERBATIM from _ATV_OP_KEY (couchsided.py:8897). */
+export const ATV_OP_KEY = {
+  power_off: 26,
+  volume_up: 24,
+  volume_down: 25,
+  mute: 91,
+} as const;
+export type AtvOp = keyof typeof ATV_OP_KEY;
+
+/**
+ * Remote keys -> Android keycodes. VERBATIM from _ATV_KEYS (couchsided.py:8899).
+ *
+ * `source` (KEYCODE_TV_INPUT, 178) is deliberately ABSENT. It is in the agent's
+ * table but KI-031 measured it doing NOTHING on Google TV twice on this very
+ * set, while the agent still answered ok — a key the TV silently drops is worse
+ * than a missing one, and this table has no legacy callers to keep working.
+ */
+export const ATV_KEYS = {
+  up: 19,
+  down: 20,
+  left: 21,
+  right: 22,
+  ok: 23,
+  home: 3,
+  back: 4,
+  menu: 82,
+  power: 26,
+  volume_up: 24,
+  volume_down: 25,
+  mute: 91,
+  play_pause: 85,
+  play: 126,
+  pause: 127,
+  stop: 86,
+  rewind: 89,
+  fast_forward: 90,
+  next: 87,
+  previous: 88,
+} as const;
+export type AtvKey = keyof typeof ATV_KEYS;
+
+/** Feature bitmask echoed during the remote handshake (_ATV_FEATURES :8892). */
+export const ATV_FEATURES = 622;
+/** Key press direction: SHORT. The TV ignores a frame without it. */
+const DIRECTION_SHORT = 3;
+
+export const ATV_PAIR_PORT = 6467;
+export const ATV_REMOTE_PORT = 6466;
+
+// ------------------------------------------------------------ protobuf codec
+// Hand-rolled, matching the agent: the wire is varint-length-prefixed protobuf
+// and the message set used here is small enough that a real protobuf runtime
+// would be a dependency bought for nothing.
+
+export function varint(n: number): Uint8Array {
+  const out: number[] = [];
+  for (;;) {
+    const b = n & 0x7f;
+    n = Math.floor(n / 128);
+    if (n) out.push(b | 0x80);
+    else {
+      out.push(b);
+      break;
+    }
+  }
+  return Uint8Array.from(out);
+}
+
+export function readVarint(buf: Uint8Array, pos: number): [number, number] {
+  let shift = 0;
+  let val = 0;
+  for (;;) {
+    if (pos >= buf.length) throw new Error('truncated varint');
+    const b = buf[pos++];
+    val += (b & 0x7f) * 2 ** shift;
+    if (!(b & 0x80)) return [val, pos];
+    shift += 7;
+    if (shift > 63) throw new Error('varint too long');
+  }
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  let n = 0;
+  for (const p of parts) n += p.length;
+  const out = new Uint8Array(n);
+  let o = 0;
+  for (const p of parts) {
+    out.set(p, o);
+    o += p.length;
+  }
+  return out;
+}
+
+const tag = (field: number, wt: number) => varint((field << 3) | wt);
+/** varint field */
+export const fv = (field: number, val: number) => concat([tag(field, 0), varint(val)]);
+/** length-delimited field */
+export const fb = (field: number, data: Uint8Array) =>
+  concat([tag(field, 2), varint(data.length), data]);
+/** string field */
+export const fstr = (field: number, s: string) => fb(field, utf8(s));
+
+function utf8(s: string): Uint8Array {
+  // TextEncoder exists in RN 0.86 (Hermes) and in Node; avoids a Buffer import
+  // so this module stays runtime-agnostic.
+  return new TextEncoder().encode(s);
+}
+
+/** Field number -> occurrences. Values are numbers (varint) or byte slices. */
+export type AtvFields = Record<number, (number | Uint8Array)[]>;
+
+/** Parse one frame body. Unknown wire types stop the walk rather than throwing:
+ *  a frame we only partly understand is still useful for its known fields. */
+export function parse(buf: Uint8Array): AtvFields {
+  const fields: AtvFields = {};
+  let pos = 0;
+  while (pos < buf.length) {
+    let t: number;
+    try {
+      [t, pos] = readVarint(buf, pos);
+    } catch {
+      return fields;
+    }
+    const field = Math.floor(t / 8);
+    const wt = t % 8;
+    if (wt === 0) {
+      let v: number;
+      [v, pos] = readVarint(buf, pos);
+      (fields[field] ??= []).push(v);
+    } else if (wt === 2) {
+      let ln: number;
+      [ln, pos] = readVarint(buf, pos);
+      (fields[field] ??= []).push(buf.subarray(pos, pos + ln));
+      pos += ln;
+    } else {
+      return fields;
+    }
+  }
+  return fields;
+}
+
+/** Pairing messages ride an envelope carrying protocol version + status. */
+export const pairEnvelope = (innerField: number, inner: Uint8Array) =>
+  concat([fv(1, 2), fv(2, 200), fb(innerField, inner)]);
+
+// ------------------------------------------------------------- socket seam
+
+/**
+ * The transport this module needs. Deliberately tiny: connect with a client
+ * certificate, exchange length-prefixed frames, close.
+ *
+ * `connect` MUST NOT verify the TV's certificate against a public CA — every
+ * Android TV presents a self-signed cert it generated itself (measured: issuer
+ * == subject, `CN=atvremote/<MAC>`). Node does this with
+ * `rejectUnauthorized:false`; react-native-tcp-socket has no such flag and
+ * accepts a self-signed peer only by PINNING it as `ca`, which is why the app
+ * adapter fetches the cert first. That difference is the entire reason this
+ * seam exists.
+ */
+export type AtvSocket = {
+  /** Send one frame (the length prefix is added by the caller of this type). */
+  write(bytes: Uint8Array): void;
+  /** Resolve the next complete frame body, or reject on close/timeout. */
+  recv(timeoutMs?: number): Promise<Uint8Array>;
+  close(): void;
+  /** The peer's RSA modulus as hex — needed for the pairing secret. */
+  peerModulusHex(): string;
+};
+
+export type AtvConnect = (
+  host: string,
+  port: number,
+  certPem: string,
+  keyPem: string,
+) => Promise<AtvSocket>;
+
+/** Frame a message for the wire: varint length, then the body. */
+export function frame(msg: Uint8Array): Uint8Array {
+  return concat([varint(msg.length), msg]);
+}
+
+/**
+ * Split a growing byte stream into complete frames. Returned by reference so a
+ * transport adapter can feed it bytes as they arrive; it keeps the remainder.
+ */
+export function makeFramer(): {
+  push(chunk: Uint8Array): Uint8Array[];
+} {
+  // Typed as the concat() return so TS keeps the ArrayBuffer-backed variant;
+  // `new Uint8Array(0)` widens to ArrayBufferLike and then fails to reassign.
+  let buf: Uint8Array = concat([]);
+  return {
+    push(chunk: Uint8Array): Uint8Array[] {
+      buf = concat([buf, chunk]);
+      const out: Uint8Array[] = [];
+      for (;;) {
+        if (!buf.length) return out;
+        let ln: number;
+        let pos: number;
+        try {
+          [ln, pos] = readVarint(buf, 0);
+        } catch {
+          return out; // length prefix not fully arrived
+        }
+        if (buf.length < pos + ln) return out;
+        out.push(buf.subarray(pos, pos + ln));
+        buf = buf.subarray(pos + ln);
+      }
+    },
+  };
+}
+
+// --------------------------------------------------------------- pairing
+
+/** Even-length lowercase hex, which is what the secret hash is fed. */
+export function normalizeModulusHex(hex: string): string {
+  const h = hex.trim().toLowerCase().replace(/^0x/, '');
+  return h.length % 2 ? '0' + h : h;
+}
+
+export function hexToBytes(hex: string): Uint8Array {
+  const h = normalizeModulusHex(hex);
+  const out = new Uint8Array(h.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(h.substr(i * 2, 2), 16);
+  return out;
+}
+
+/**
+ * The bytes the pairing secret is the SHA-256 of:
+ *   clientModulus ‖ 010001 ‖ serverModulus ‖ 010001 ‖ nonce
+ * where 010001 is the RSA exponent 65537 zero-prefixed, and the nonce is the
+ * last four hex digits of the code the TV displays. Split out from the hashing
+ * so it is testable without a crypto implementation.
+ */
+export function secretPreimage(
+  clientModulusHex: string,
+  serverModulusHex: string,
+  code: string,
+): Uint8Array {
+  const exp = hexToBytes('010001');
+  return concat([
+    hexToBytes(clientModulusHex),
+    exp,
+    hexToBytes(serverModulusHex),
+    exp,
+    hexToBytes(code.slice(2)),
+  ]);
+}
+
+/**
+ * The TV shows `code` = <check byte><nonce>. The check byte is the first byte
+ * of the TV's own computed secret, so comparing it locally catches a mistyped
+ * code (and a mis-derived modulus) BEFORE sending — the TV answers a wrong
+ * secret with silence, which is indistinguishable from a dead link.
+ */
+export function checkByteMatches(secret: Uint8Array, code: string): boolean {
+  return secret.length > 0 && secret[0] === parseInt(code.slice(0, 2), 16);
+}
+
+export function isValidPairCode(code: string): boolean {
+  return /^[0-9a-fA-F]{6}$/.test(code.trim());
+}
+
+// -------------------------------------------------- message constructors
+
+/** pairing_request(10){ service_name(1), client_name(2) } */
+export const pairingRequest = (clientName: string) =>
+  pairEnvelope(10, concat([fstr(1, 'atvremote'), fstr(2, clientName)]));
+
+/** The encoding both options(20) and configuration(30) carry: HEX, 6 symbols. */
+const ENCODING = () => concat([fv(1, 3), fv(2, 6)]);
+
+/** pairing_option(20){ input_encodings(1), preferred_role(3)=1 } */
+export const pairingOptions = () => pairEnvelope(20, concat([fb(1, ENCODING()), fv(3, 1)]));
+
+/** pairing_configuration(30){ encoding(1), client_role(2)=1 } */
+export const pairingConfiguration = () =>
+  pairEnvelope(30, concat([fb(1, ENCODING()), fv(2, 1)]));
+
+/** pairing_secret(40){ secret(1) } */
+export const pairingSecret = (secret: Uint8Array) => pairEnvelope(40, fb(1, secret));
+
+/** Reply to remote_configure(1) with our device info. */
+export const remoteConfigureReply = () => {
+  const dev = concat([fv(3, 1), fstr(4, '1'), fstr(5, 'atvremote'), fstr(6, '1.0.0')]);
+  return fb(1, concat([fv(1, ATV_FEATURES), fb(2, dev)]));
+};
+
+/** Reply to remote_set_active(2). */
+export const remoteSetActiveReply = () => fb(2, fv(1, ATV_FEATURES));
+
+/** Answer a remote_ping_request(8) with the same value. The TV drops a channel
+ *  whose pings go unanswered, so this is mandatory, not optional politeness. */
+export const remotePingReply = (val: number) => fb(9, fv(1, val));
+
+/** remote_key_inject(10){ key_code(1), direction(2)=SHORT } */
+export const keyInject = (keycode: number) =>
+  fb(10, concat([fv(1, keycode), fv(2, DIRECTION_SHORT)]));
+
+/** Extract the ping value from a parsed remote_ping_request field. */
+export function pingValue(fields: AtvFields): number {
+  const raw = fields[8]?.[0];
+  if (raw instanceof Uint8Array) {
+    const inner = parse(raw)[1]?.[0];
+    if (typeof inner === 'number') return inner;
+  }
+  return 1;
+}
+
+/** Frame-kind helpers, so callers read as protocol rather than field numbers. */
+export const isRemoteConfigure = (f: AtvFields) => 1 in f;
+export const isRemoteSetActive = (f: AtvFields) => 2 in f;
+export const isRemotePing = (f: AtvFields) => 8 in f;
+export const isRemoteStart = (f: AtvFields) => 40 in f;
+export const isPairingRequestAck = (f: AtvFields) => 11 in f;
+export const isPairingOptionsAck = (f: AtvFields) => 20 in f;
+export const isPairingConfigurationAck = (f: AtvFields) => 31 in f;
+export const isPairingSecretAck = (f: AtvFields) => 41 in f;

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -46,8 +46,10 @@
         "react-native-worklets": "0.10.0"
       },
       "devDependencies": {
+        "@types/node-forge": "^1.3.14",
         "@types/qrcode": "^1.5.6",
         "@types/react": "~19.2.2",
+        "node-forge": "^1.3.1",
         "typescript": "~6.0.3"
       }
     },
@@ -1163,6 +1165,15 @@
       "license": "MIT",
       "dependencies": {
         "node-forge": "^1.3.3"
+      }
+    },
+    "node_modules/@expo/code-signing-certificates/node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
       }
     },
     "node_modules/@expo/config": {
@@ -3029,6 +3040,16 @@
         "undici-types": "~8.3.0"
       }
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.14.tgz",
+      "integrity": "sha512-mhVF2BnD4BO+jtOp7z1CdzaK4mbuK0LLQYAvdOLqHTavxFNq4zA1EmYkpnFjP8HOUzedfQkRnp0E2ulSAYSzAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qrcode": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
@@ -4763,6 +4784,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expo/node_modules/node-forge": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
     "node_modules/expo/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -6399,9 +6429,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
-      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "dev": true,
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/app/package.json
+++ b/app/package.json
@@ -41,8 +41,10 @@
     "react-native-worklets": "0.10.0"
   },
   "devDependencies": {
+    "@types/node-forge": "^1.3.14",
     "@types/qrcode": "^1.5.6",
     "@types/react": "~19.2.2",
+    "node-forge": "^1.3.1",
     "typescript": "~6.0.3"
   },
   "scripts": {


### PR DESCRIPTION
The portable half of app-direct Google TV control, ported from the agent and **driven against the real Hisense Google TV (10.1.1.98)** — before and after being written into the app. **No user-facing change**: nothing imports these modules yet, and no native dependency is added.

## What is proven, on hardware, through *this* code

`lib/__tests__/atv-live.mjs` drives `lib/tvdirect/androidtv.ts` over the LAN with a Node socket — the shipping module, not a spike. Tonight's 05:28 run completed the remote handshake and sent HOME, DOWN, DOWN, RIGHT and two VOLUME_UPs; the owner watched the selection move and the volume rise. Pairing through the same module was proven the same way earlier, and the persisted client cert then **reconnects silently** with no code re-entry.

## The socket and the hash are injected, and that is the design

Node has `tls` and `crypto`; React Native has neither, and `react-native-tcp-socket` cannot load in the bare-Node runner. Keeping these modules import-free is what lets the code that will ship be exercised against real hardware from a test — so when the RN adapter lands, **the untested surface is a thin adapter rather than an entire protocol**.

## Why no UI and no native module in this PR

`react-native-tcp-socket` was added, evaluated, and **removed again**. Shipping it needs three things that could not be verified tonight:

1. **TOFU cert pinning proven on iOS** — the library has no `rejectUnauthorized` escape hatch, and every Android TV presents a self-signed leaf.
2. **A second native module for CSPRNG entropy** — `node-forge` falls back to `Math.random` for RSA keygen without one, which would mint **weak client keys**.
3. **A measurement of keygen time on a phone** — unmeasured, and plausibly slow enough to freeze the pairing screen.

Landing that blind, in a build meant for testing, is how the expo-camera ABI mismatch reached build 97. `node-forge` is therefore a **dev** dependency: the live test mints certs, the app ships none.

## Allowlist discipline

Keycodes are looked up in frozen tables copied **verbatim** from the agent (`_ATV_KEYS` :8899, `_ATV_OP_KEY` :8897) and pinned by tests, since remote-only mode has no agent to ask. `KEYCODE_TV_INPUT` (178) is deliberately **absent** — KI-031 measured it doing nothing on Google TV twice on this exact set while the agent still answered `ok`.

## Verification

- **17 new tests** (191 suite-wide), `tsc` clean.
- **Mutation-checked**: a wrong `home` keycode fails 2 tests; a wrong key direction fails 1.
- Codec tests assert **known-good wire bytes** rather than self-consistency; the framer is driven **one byte at a time** (the split-frame case a naive reader gets wrong); the pairing check-byte is tested in **both directions** with a real SHA-256.

One test bug worth recording: the fake socket first **threw** on an exhausted queue, which made the session's reader loop treat "no more scripted frames" as "the TV hung up". A fake that lies about idleness invents a failure the real path does not have — it now blocks, like a real idle socket.

## NOT verified

Everything device-side: RN TLS pinning, forge keygen time on a phone, and the pairing UI (which does not exist yet). No store or site copy may claim Google TV support until those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
