### PR TITLE
chore(agent/win): 0.4.5-win so the units fix reaches existing installs

### DIFF
--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -85,7 +85,7 @@ except ImportError:
 # Same app id the phone expects (AGENT_APPS in app/lib/api.ts); the Windows
 # agent versions independently of the Linux one.
 APP_NAME = "couchside-agent"
-VERSION = "0.4.4-win"
+VERSION = "0.4.5-win"
 
 _PROGRAMDATA = os.environ.get("ProgramData", r"C:\ProgramData")
 DEFAULT_CONFIG_PATH = os.path.join(_PROGRAMDATA, "Couchside", "config.json")


### PR DESCRIPTION
One-line version bump, but it is load-bearing.

**Measured against the live release first.** The published `couchsided-win.py` on `v2.9.29` is already tagged **0.4.4-win** and contains **zero** occurrences of `log_only` — while the repo's 0.4.4-win contains the fix.

Publishing under the same version would have shipped the fix to nobody: every existing Windows install compares versions, sees `0.4.4-win == 0.4.4-win`, and never updates. The permanent yellow `couchside-agent inactive/not-found` would have stayed on every box while the release notes claimed it was fixed.

This is the last prerequisite before the signed agent release that carries:
- the Steam Deck fresh-install fix (`install.sh` — currently **absent** from the published installer, verified by fetching it)
- the Windows units `log_only` fix

Verified: `py_compile` clean, `test_win_log_unit.py` and `test_win_launchers.py` pass.