### PR TITLE
Library triage, launch confirm, first-run flow, and a feature tour that points at things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@ docs/BUILD_LOG.md
 app/lib/__tests__/.atv-identity.json
 app/lib/__tests__/.atv-code.txt
 app/build-*.ipa
+# `eas build --local` leaves the staged project tarball behind next to the ipa.
+app/build-*.tar.gz
 scratchpad-atv/

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "127",
+      "buildNumber": "136",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "126",
+      "buildNumber": "127",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -1,5 +1,6 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, Tabs, useSegments } from 'expo-router';
+import { currentStep } from '@/lib/tour';
 import { useEffect, useRef } from 'react';
 
 import { useCapsSync } from '@/hooks/useCapsSync';
@@ -63,6 +64,23 @@ export default function TabLayout() {
   ];
   const tourEnabled = usePref('featureTour');
   const tour = useFeatureTour(boxes.length > 0, tourEnabled);
+
+  // Take the user TO the tab being described. A spotlight on "Console" while
+  // they are looking at the Pad screen explains a screen they cannot see —
+  // reported from a device. Keyed on the step so it navigates once per step,
+  // not on every render, and only while the tour is actually up.
+  const tourStep = tour.visible ? currentStep(tour.state) : null;
+  const tourTab = tourStep?.tab ?? null;
+  const navigatedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!tourTab) {
+      navigatedFor.current = null;
+      return;
+    }
+    if (navigatedFor.current === tourTab) return;
+    navigatedFor.current = tourTab;
+    router.replace(tourTab === 'index' ? '/(tabs)' : `/(tabs)/${tourTab}`);
+  }, [tourTab]);
 
   // On true first run (persisted fleet loaded, but empty) send the user to
   // Setup to pair. Otherwise honour the landing-tab preference.

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -96,6 +96,11 @@ export default function TabLayout() {
   const redirected = useRef(false);
   useEffect(() => {
     if (!ready || redirected.current) return;
+    // THE TOUR OWNS NAVIGATION WHILE IT IS UP. This effect is declared after the
+    // tour's, so without this guard it ran second and overwrote the tour's first
+    // step — the tour opened on Console's copy while the app sat on Pad, and the
+    // user had to find Console themselves. Reported from a device.
+    if (tour.visible) return;
     redirected.current = true;
     // In remote-only mode the landing tab is the Remote, always: the box tabs
     // it could otherwise name are hidden, and Console with no box is an empty

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -5,6 +5,8 @@ import { useEffect, useRef } from 'react';
 import { useCapsSync } from '@/hooks/useCapsSync';
 import { hapticSelection } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
+import { FeatureTour } from '@/components/FeatureTour';
+import { useFeatureTour } from '@/hooks/useFeatureTour';
 import { useBoxes } from '@/lib/SettingsContext';
 import { useTheme } from '@/lib/theme';
 
@@ -45,6 +47,22 @@ export default function TabLayout() {
     remoteOnly ||
     caps?.launchers === false ||
     (caps?.launchers === undefined && caps?.steam === false);
+
+  // The tour spotlights a tab by POSITION, so it needs the order actually
+  // rendered — caps and remote-only mode change both which tabs exist and where
+  // they sit. Derived from the same flags the <Tabs.Screen> entries use, so the
+  // two cannot drift.
+  const tabOrder = [
+    'index',
+    ...(remoteOnly ? ['remote'] : []),
+    ...(!remoteOnly && boxes.length >= 2 ? ['fleet'] : []),
+    ...(remoteOnly ? [] : ['actions']),
+    ...(hidePad ? [] : ['pad']),
+    ...(hideLaunch ? [] : ['launch']),
+    'setup',
+  ];
+  const tourEnabled = usePref('featureTour');
+  const tour = useFeatureTour(boxes.length > 0, tourEnabled);
 
   // On true first run (persisted fleet loaded, but empty) send the user to
   // Setup to pair. Otherwise honour the landing-tab preference.
@@ -106,6 +124,7 @@ export default function TabLayout() {
   }, [ready, hidePad, hideLaunch, remoteOnly, segments]);
 
   return (
+    <>
     <Tabs
       screenListeners={{ tabPress: () => hapticSelection() }}
       screenOptions={{
@@ -190,5 +209,14 @@ export default function TabLayout() {
         }}
       />
     </Tabs>
+    {tour.visible ? (
+      <FeatureTour
+        state={tour.state}
+        tabOrder={tabOrder}
+        onNext={tour.next}
+        onSkip={tour.skip}
+      />
+    ) : null}
+    </>
   );
 }

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Alert,
   Platform,
@@ -12,6 +12,8 @@ import {
 import { BootSessionCard } from '@/components/BootSessionCard';
 import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
+import { TourAnchor } from '@/components/TourAnchor';
+import { registerScroller } from '@/hooks/useTourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
@@ -35,6 +37,16 @@ const GROUP_TITLE: Record<Danger, string> = {
   low: 'ROUTINE',
   medium: 'CHANGES WHAT’S ON SCREEN',
   high: 'ENDS YOUR SESSION',
+};
+/** Feature-tour anchor per group. Spelled out as LITERALS rather than built
+ *  with a template string: a test reads this source to prove every anchor named
+ *  in lib/tour.ts is actually registered somewhere, and an interpolated id is
+ *  invisible to it. A tour step whose anchor never registers does not crash — it
+ *  silently never shows — so the typo has to be caught here or not at all. */
+const TOUR_ANCHOR: Record<Danger, string> = {
+  low: 'actions.routine',
+  medium: 'actions.medium',
+  high: 'actions.high',
 };
 const BADGE_TEXT: Record<Danger, string> = {
   low: 'routine',
@@ -153,10 +165,30 @@ function ActionsScreen() {
     ),
   })).filter((g) => g.items.length > 0);
 
+  // Let the feature tour scroll a group into view before spotlighting it: with
+  // the boot-session card above them, ENDS YOUR SESSION is below the fold on a
+  // phone, and a spotlight cut over an off-screen group is a hole around nothing.
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollY = useRef(0);
+  useEffect(
+    () =>
+      registerScroller('actions', (dy) => {
+        scrollRef.current?.scrollTo({ y: Math.max(0, scrollY.current + dy), animated: true });
+      }),
+    [],
+  );
+
   return (
     <View style={[styles.screen, { paddingTop: 12 }]}>
       <Text style={styles.title}>Actions</Text>
-      <ScrollView style={styles.list} contentContainerStyle={{ paddingBottom: 12 }}>
+      <ScrollView
+        ref={scrollRef}
+        onScroll={(e) => {
+          scrollY.current = e.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
+        style={styles.list}
+        contentContainerStyle={{ paddingBottom: 12 }}>
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
         {!configured && (
           <View style={styles.emptyCard}>
@@ -183,8 +215,18 @@ function ActionsScreen() {
         {/* Persistent boot preference, directly above the ONE-SHOT session
             switches below it — that adjacency is the point (see the card). */}
         {configured && <BootSessionCard />}
+        {/* TourAnchor REPLACES each group's View and inherits styles.group, so
+            the layout is unchanged and the anchor measures the whole block —
+            header plus rows. The id uses the UI's word for `low` ("ROUTINE")
+            rather than the agent's danger level, matching lib/tour.ts. A group
+            with no items is already filtered out above, so a box that reports no
+            harmless actions registers no `actions.routine` and that step skips
+            itself instead of pointing at a header that is not there. */}
         {groups.map((g) => (
-          <View key={g.danger} style={styles.group}>
+          <TourAnchor
+            key={g.danger}
+            id={TOUR_ANCHOR[g.danger]}
+            style={styles.group}>
             <Text style={[styles.groupTitle, { color: DANGER_COLOR[g.danger] }]}>
               {GROUP_TITLE[g.danger]}
             </Text>
@@ -212,7 +254,7 @@ function ActionsScreen() {
                     / "Leave Game Mode for the SteamOS desktop"). */}
               </Pressable>
             ))}
-            </View>
+            </TourAnchor>
           ))}
       </ScrollView>
 

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -1,7 +1,9 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { Gated } from '@/components/Gated';
+import { TourAnchor } from '@/components/TourAnchor';
+import { registerScroller } from '@/hooks/useTourAnchor';
 import { DisplayAudioCard } from '@/components/DisplayAudioCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
@@ -115,10 +117,28 @@ function ConsoleScreen() {
     [s?.load, s?.cpu_temp_c, reachable],
   );
 
+  // Let the feature tour scroll a card into view before spotlighting it: the
+  // screen preview and display info both sit below the fold on a phone, and a
+  // spotlight cut over an off-screen element is a hole around nothing.
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollY = useRef(0);
+  useEffect(
+    () =>
+      registerScroller('index', (dy) => {
+        scrollRef.current?.scrollTo({ y: Math.max(0, scrollY.current + dy), animated: true });
+      }),
+    [],
+  );
+
   return (
     <VitalsContext.Provider value={vitals}>
     <View style={styles.screen}>
       <ScrollView
+        ref={scrollRef}
+        onScroll={(e) => {
+          scrollY.current = e.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
         style={styles.scroll}
         contentContainerStyle={{
           paddingTop: 12,
@@ -203,7 +223,9 @@ function ConsoleScreen() {
         {s && (
           <>
             <View style={styles.row}>
-              <View style={styles.half}>
+              {/* TourAnchor REPLACES the half View rather than wrapping it, so
+                  the flex row is untouched — see components/TourAnchor.tsx. */}
+              <TourAnchor id="console.cpu" style={styles.half}>
                 <Card title="CPU TEMP" index={0}>
                   <BigMetric
                     value={s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
@@ -212,7 +234,7 @@ function ConsoleScreen() {
                   />
                   <Spark values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
                 </Card>
-              </View>
+              </TourAnchor>
               <View style={styles.half}>
                 <Card title="UPTIME" index={1}>
                   {/* Not numeric: "1d 2h 7m" must never be interpolated. */}
@@ -342,10 +364,14 @@ function ConsoleScreen() {
             region — the specs of the screen, then the picture on it. Below the
             vitals you opened this tab to read, above UNITS, which is reference
             config rather than something you watch. */}
-        <DisplayAudioCard />
+        <TourAnchor id="console.display">
+          <DisplayAudioCard />
+        </TourAnchor>
 
         {/* Live screen preview (probe-and-appear; hidden when no capture path) */}
-        <ScreenPreview />
+        <TourAnchor id="console.screen">
+          <ScreenPreview />
+        </TourAnchor>
 
         {/* Units */}
         {configured && (

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -23,6 +23,7 @@ import {
 } from 'react-native';
 
 import { Gated } from '@/components/Gated';
+import { GameSheet } from '@/components/GameSheet';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -765,6 +766,10 @@ function LaunchScreen() {
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState<FilterState>(EMPTY_FILTER);
   const [filterOpen, setFilterOpen] = useState(false);
+  // Tapping a tile no longer launches. Launching takes over the television, and
+  // on a grid you scroll with a thumb a stray tap started a game on a TV in
+  // another room. Tap confirms; long-press opens the same sheet with detail.
+  const [sheetFor, setSheetFor] = useState<Launcher | null>(null);
   // Search first (the screen owns it and its matching ignores whitespace), then
   // the sheet's dimensions on top. The sheet is handed THIS list, so its live
   // count reflects the active query too and cannot promise more than the grid
@@ -953,6 +958,21 @@ function LaunchScreen() {
 
         {/* Nothing matched. Say so rather than showing an empty screen that
             reads as "the box has no games". */}
+        <GameSheet
+          launcher={sheetFor}
+          coverSource={
+            sheetFor?.appid != null
+              ? api.steamCoverSource(settings, sheetFor.appid)
+              : undefined
+          }
+          onPlay={() => {
+            const l = sheetFor;
+            setSheetFor(null);
+            if (l) launch(l);
+          }}
+          onClose={() => setSheetFor(null)}
+        />
+
         <LibraryFilterSheet
           visible={filterOpen}
           games={searched}
@@ -983,7 +1003,7 @@ function LaunchScreen() {
                     : undefined
                 }
                 retryKey={retryKey}
-                onLaunch={() => launch(l)}
+                onLaunch={() => setSheetFor(l)}
                 onDelete={l.kind === 'custom' ? () => remove(l) : undefined}
                 download={l.appid != null ? dlByAppid.get(l.appid) : undefined}
               />

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -24,6 +24,8 @@ import {
 
 import { Gated } from '@/components/Gated';
 import { GameSheet } from '@/components/GameSheet';
+import { useCompat } from '@/hooks/useCompat';
+import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
 import { TabScreen } from '@/components/TabScreen';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
@@ -70,6 +72,8 @@ type TileProps = {
   /** Bumped on pull-to-refresh to retry a cover that previously failed to load. */
   retryKey?: number;
   onLaunch: () => void;
+  /** Compatibility rating, when the user opted in and an answer has arrived. */
+  compat?: Compat;
   onDelete?: () => void;
   /** When this game is mid-download, drives a small progress pill on the tile. */
   download?: SteamDownload;
@@ -81,6 +85,7 @@ function LauncherTile({
   coverSource,
   retryKey,
   onLaunch,
+  compat,
   onDelete,
   download,
 }: TileProps) {
@@ -108,6 +113,15 @@ function LauncherTile({
     <Pressable
       onPress={onLaunch}
       style={({ pressed }) => [styles.tile, { width, height }, pressed && styles.tilePressed]}>
+      {/* Only drawn when a rating actually exists — an unrated game shows
+          nothing rather than a "no data" chip on every tile. */}
+      {compat && (compat.deck !== 'unknown' || compat.proton !== 'unknown') ? (
+        <View style={styles.compatBadge} pointerEvents="none">
+          <Text style={styles.compatBadgeText} numberOfLines={1}>
+            {compat.deck !== 'unknown' ? deckLabel(compat.deck) : protonLabel(compat.proton)}
+          </Text>
+        </View>
+      ) : null}
       {art && isHeader ? (
         /* HEADER art is a 460x215 banner, not a 600x900 capsule. Centre-cropping
            one into a tall tile slices the middle out of the artwork and reads as
@@ -779,10 +793,22 @@ function LaunchScreen() {
     if (!q) return allLaunchers;
     return allLaunchers.filter((l) => l.label.toLowerCase().replace(/\s+/g, '').includes(q));
   }, [allLaunchers, query]);
-  const launchers = useMemo(
-    () => applyFilter(searched, filter, Math.floor(Date.now() / 1000)),
-    [searched, filter],
+  // Ratings are fetched for everything the SEARCH leaves, not for what the
+  // filter leaves — otherwise turning on a compatibility filter would stop the
+  // app fetching the very data that filter needs, and the list would never
+  // settle. searched -> compat -> launchers, no cycle.
+  const compatOn = usePref('compatLookups');
+  const compatIds = useMemo(
+    () => searched.map((l) => l.appid).filter((a): a is number => a != null),
+    [searched],
   );
+  const compat = useCompat(compatIds, compatOn);
+
+  const launchers = useMemo(
+    () => applyFilter(searched, filter, Math.floor(Date.now() / 1000), compat),
+    [searched, filter, compat],
+  );
+
   const rows = useMemo(() => {
     const out: Launcher[][] = [];
     for (let i = 0; i < launchers.length; i += COLS) {
@@ -977,6 +1003,8 @@ function LaunchScreen() {
           visible={filterOpen}
           games={searched}
           value={filter}
+          compat={compat}
+          compatOn={compatOn}
           onChange={setFilter}
           onClose={() => setFilterOpen(false)}
         />
@@ -1004,6 +1032,7 @@ function LaunchScreen() {
                 }
                 retryKey={retryKey}
                 onLaunch={() => setSheetFor(l)}
+                compat={l.appid != null ? compat[l.appid] : undefined}
                 onDelete={l.kind === 'custom' ? () => remove(l) : undefined}
                 download={l.appid != null ? dlByAppid.get(l.appid) : undefined}
               />
@@ -1108,6 +1137,17 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   // the row still reads as tappable (it is: the check is advisory only).
   slDimText: { color: t.textDim },
   slFaintText: { color: t.textFaint },
+  compatBadge: {
+    position: 'absolute',
+    top: 6,
+    left: 6,
+    zIndex: 2,
+    paddingHorizontal: 7,
+    paddingVertical: 3,
+    borderRadius: 999,
+    backgroundColor: '#000000cc',
+  },
+  compatBadgeText: { color: '#e8eef7', fontSize: 10, fontWeight: '800', fontFamily: mono },
   slArtSlot: {
     width: 30,
     height: 45,

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -42,7 +42,7 @@ import {
 } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSelection, hapticSuccess } from '@/lib/haptics';
 import { fmtGB, fmtPair, fmtTotal } from '@/lib/downloadSize';
-import { applyFilter, EMPTY_FILTER, isFiltering, type FilterState } from '@/lib/libraryFilter';
+import { applyFilter, EMPTY_FILTER, isFiltering, pickRandom, type FilterState } from '@/lib/libraryFilter';
 import { setPref, usePref } from '@/lib/prefs';
 import { useBoxes, useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -964,6 +964,24 @@ function LaunchScreen() {
                 <Ionicons name="close-circle" size={17} color={t.textDim} />
               </Pressable>
             )}
+            {/* Pick one at random from WHAT IS CURRENTLY SHOWING, so it honours
+                the filter — "something short I have never played" is the point.
+                It opens the same confirm sheet, so a random pick still cannot
+                start a game by surprise. */}
+            {launchers.length > 1 ? (
+              <Pressable
+                onPress={() => {
+                  hapticMedium();
+                  const pick = pickRandom(launchers);
+                  if (pick) setSheetFor(pick);
+                }}
+                hitSlop={8}
+                accessibilityRole="button"
+                accessibilityLabel="Pick a game for me"
+                style={({ pressed }) => [pressed && { opacity: 0.6 }]}>
+                <Ionicons name="shuffle" size={18} color={t.textDim} />
+              </Pressable>
+            ) : null}
             <Pressable
               onPress={() => {
                 hapticLight();

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -28,6 +28,8 @@ import { useCompat } from '@/hooks/useCompat';
 import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
 import { TabScreen } from '@/components/TabScreen';
+import { TourAnchor } from '@/components/TourAnchor';
+import { registerScroller } from '@/hooks/useTourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import {
@@ -817,6 +819,20 @@ function LaunchScreen() {
     return out;
   }, [launchers]);
 
+  // Let the feature tour scroll the grid into view before spotlighting it: with
+  // downloads, Remote Play and the search row stacked above it, the first tile
+  // can start below the fold, and a spotlight cut over an off-screen element is
+  // a hole around nothing.
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollY = useRef(0);
+  useEffect(
+    () =>
+      registerScroller('launch', (dy) => {
+        scrollRef.current?.scrollTo({ y: Math.max(0, scrollY.current + dy), animated: true });
+      }),
+    [],
+  );
+
   return (
     <View style={styles.screen}>
       <View style={styles.header}>
@@ -865,6 +881,11 @@ function LaunchScreen() {
 
       {activeSection === 'games' && (
       <ScrollView
+        ref={scrollRef}
+        onScroll={(e) => {
+          scrollY.current = e.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
         style={styles.list}
         contentContainerStyle={{ paddingHorizontal: H_PAD, paddingBottom: 24 }}
         refreshControl={
@@ -969,34 +990,41 @@ function LaunchScreen() {
                 It opens the same confirm sheet, so a random pick still cannot
                 start a game by surprise. */}
             {launchers.length > 1 ? (
+              // TourAnchor WRAPS rather than replaces here: the Pressable is
+              // already the only box, and a wrapper sized to its content is
+              // invisible to the row's gap/centre layout.
+              <TourAnchor id="launch.shuffle" hitSlop={8}>
+                <Pressable
+                  onPress={() => {
+                    hapticMedium();
+                    const pick = pickRandom(launchers);
+                    if (pick) setSheetFor(pick);
+                  }}
+                  hitSlop={8}
+                  accessibilityRole="button"
+                  accessibilityLabel="Pick a game for me"
+                  style={({ pressed }) => [pressed && { opacity: 0.6 }]}>
+                  <Ionicons name="shuffle" size={18} color={t.textDim} />
+                </Pressable>
+              </TourAnchor>
+            ) : null}
+            <TourAnchor id="launch.filter" hitSlop={8}>
               <Pressable
                 onPress={() => {
-                  hapticMedium();
-                  const pick = pickRandom(launchers);
-                  if (pick) setSheetFor(pick);
+                  hapticLight();
+                  setFilterOpen(true);
                 }}
                 hitSlop={8}
                 accessibilityRole="button"
-                accessibilityLabel="Pick a game for me"
+                accessibilityLabel="Filter library"
                 style={({ pressed }) => [pressed && { opacity: 0.6 }]}>
-                <Ionicons name="shuffle" size={18} color={t.textDim} />
+                <Ionicons
+                  name="options-outline"
+                  size={18}
+                  color={isFiltering(filter) ? t.blue : t.textDim}
+                />
               </Pressable>
-            ) : null}
-            <Pressable
-              onPress={() => {
-                hapticLight();
-                setFilterOpen(true);
-              }}
-              hitSlop={8}
-              accessibilityRole="button"
-              accessibilityLabel="Filter library"
-              style={({ pressed }) => [pressed && { opacity: 0.6 }]}>
-              <Ionicons
-                name="options-outline"
-                size={18}
-                color={isFiltering(filter) ? t.blue : t.textDim}
-              />
-            </Pressable>
+            </TourAnchor>
           </View>
         )}
 
@@ -1035,30 +1063,34 @@ function LaunchScreen() {
           </Text>
         )}
 
-        {/* Grid */}
-        {rows.map((row, ri) => (
-          <View key={ri} style={[styles.row, { gap: GAP, marginBottom: GAP }]}>
-            {row.map((l) => (
-              <LauncherTile
-                key={l.id}
-                launcher={l}
-                width={tileWidth}
-                coverSource={
-                  l.kind === 'steam' && l.appid != null
-                    ? api.steamCoverSource(settings, l.appid)
-                    : undefined
-                }
-                retryKey={retryKey}
-                onLaunch={() => setSheetFor(l)}
-                compat={l.appid != null ? compat[l.appid] : undefined}
-                onDelete={l.kind === 'custom' ? () => remove(l) : undefined}
-                download={l.appid != null ? dlByAppid.get(l.appid) : undefined}
-              />
-            ))}
-            {/* Pad an odd final row so the single tile stays left-aligned. */}
-            {row.length < COLS && <View style={{ width: tileWidth }} />}
-          </View>
-        ))}
+        {/* Grid. The rows are a bare .map with nothing around them, so the
+            anchor supplies the one box the tour can measure — an unstyled
+            column child, which leaves each row's own layout untouched. */}
+        <TourAnchor id="launch.grid">
+          {rows.map((row, ri) => (
+            <View key={ri} style={[styles.row, { gap: GAP, marginBottom: GAP }]}>
+              {row.map((l) => (
+                <LauncherTile
+                  key={l.id}
+                  launcher={l}
+                  width={tileWidth}
+                  coverSource={
+                    l.kind === 'steam' && l.appid != null
+                      ? api.steamCoverSource(settings, l.appid)
+                      : undefined
+                  }
+                  retryKey={retryKey}
+                  onLaunch={() => setSheetFor(l)}
+                  compat={l.appid != null ? compat[l.appid] : undefined}
+                  onDelete={l.kind === 'custom' ? () => remove(l) : undefined}
+                  download={l.appid != null ? dlByAppid.get(l.appid) : undefined}
+                />
+              ))}
+              {/* Pad an odd final row so the single tile stays left-aligned. */}
+              {row.length < COLS && <View style={{ width: tileWidth }} />}
+            </View>
+          ))}
+        </TourAnchor>
       </ScrollView>
       )}
 

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -47,6 +47,7 @@ import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
 import { PadDiagnostics } from '@/components/PadDiagnostics';
 import { TabScreen } from '@/components/TabScreen';
+import { TourAnchor } from '@/components/TourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import type { PlayerState, SteamMenus } from '@/lib/api';
@@ -1677,7 +1678,12 @@ function PadScreen() {
                   : statusLabel(status, dev)}
             </Text>
           </Pressable>
-          <View style={styles.modeToggle}>
+          {/* TourAnchor REPLACES the toggle's View and inherits its style, so
+              the row is byte-for-byte the same box — see components/TourAnchor.tsx.
+              It sits inside the same conditional as before, so large-pad mode
+              (which hides the selector) simply leaves the anchor unregistered
+              and the tour skips those steps. */}
+          <TourAnchor id="pad.modes" style={styles.modeToggle}>
             {modes.map((m) => (
               <Pressable
                 key={m.key}
@@ -1690,7 +1696,7 @@ function PadScreen() {
                 </Text>
               </Pressable>
             ))}
-          </View>
+          </TourAnchor>
         </>
       )}
 

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -781,6 +781,9 @@ function SetupBody() {
   const scheme = useResolvedScheme();
   const confirmSuspend = usePref('confirmSuspend');
   const streakCelebrations = usePref('streakCelebrations');
+  const remoteOnlyOn = usePref('remoteOnlyMode');
+  // Open when there is nothing else here to use, or when the mode is already on.
+  const tvRemoteOpenByDefault = boxes.length === 0 || remoteOnlyOn;
   const defaultPadMode = usePref('defaultPadMode');
   const landingTab = usePref('landingTab');
   const autoKeyboard = usePref('autoKeyboard');
@@ -889,6 +892,12 @@ function SetupBody() {
   // Scan + PIN is the primary way to add a box; the manual host/port/token card
   // is a collapsed "advanced" fallback (headless / cross-subnet / non-Linux).
   const [showManual, setShowManual] = useState(false);
+  // The TV-remote block is tall — toggle, blurb, scan, IP, brand picker, MAC,
+  // pair button — and someone who owns a box scrolls past all of it every time
+  // they open Setup. Collapsed by default for them; open by default for someone
+  // with NO box, since they are exactly who it is for. Once remote-only mode is
+  // actually on it stays open, because then it is the section that matters.
+  const [showTvRemote, setShowTvRemote] = useState<boolean | null>(null);
 
   const draftConn = useCallback(() => {
     const p = parseInt(port, 10);
@@ -1132,7 +1141,19 @@ function SetupBody() {
             spends its whole card telling them to install the service. This is
             the answer to "I only have a TV". */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>NO GAMING BOX?</Text>
-        <DirectTvSetup />
+        {/* null = not yet touched, so the default is derived rather than frozen
+            at first render: it opens by itself for a user with no box. */}
+        <Pressable
+          onPress={() => setShowTvRemote((v) => !(v ?? tvRemoteOpenByDefault))}
+          style={styles.advancedToggle}>
+          <Text style={styles.advancedToggleText}>Use a TV remote instead (no box)</Text>
+          <Ionicons
+            name={(showTvRemote ?? tvRemoteOpenByDefault) ? 'chevron-up' : 'chevron-down'}
+            size={16}
+            color={t.textDim}
+          />
+        </Pressable>
+        {(showTvRemote ?? tvRemoteOpenByDefault) ? <DirectTvSetup /> : null}
 
         {/* ---- Add / pair ---- */}
         <Text style={[styles.sectionLabel, { marginTop: 18 }]}>ADD / PAIR A BOX</Text>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -784,8 +784,16 @@ function SetupBody() {
   const streakCelebrations = usePref('streakCelebrations');
   const compatLookups = usePref('compatLookups');
   const remoteOnlyOn = usePref('remoteOnlyMode');
-  // Open when there is nothing else here to use, or when the mode is already on.
-  const tvRemoteOpenByDefault = boxes.length === 0 || remoteOnlyOn;
+  // DETECT, DO NOT PRESUME. This used to spring open for anyone with no box —
+  // which meant a brand-new user landed on the box install steps AND a full TV
+  // pairing form at once, before they had done anything. Reported as "the
+  // overwhelming setup page".
+  //
+  // A user with no box is far more likely to be mid-install than to own no PC
+  // at all, so the box path leads and this stays a quiet one-line offer they
+  // can take if it does not apply to them. Open only once remote-only mode is
+  // actually on, when it IS the section that matters.
+  const tvRemoteOpenByDefault = remoteOnlyOn;
   const defaultPadMode = usePref('defaultPadMode');
   const landingTab = usePref('landingTab');
   const autoKeyboard = usePref('autoKeyboard');
@@ -1151,7 +1159,7 @@ function SetupBody() {
         <Pressable
           onPress={() => setShowTvRemote((v) => !(v ?? tvRemoteOpenByDefault))}
           style={styles.advancedToggle}>
-          <Text style={styles.advancedToggleText}>Use a TV remote instead (no box)</Text>
+          <Text style={styles.advancedToggleText}>No gaming PC? Use Couchside as a TV remote</Text>
           <Ionicons
             name={(showTvRemote ?? tvRemoteOpenByDefault) ? 'chevron-up' : 'chevron-down'}
             size={16}

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -33,6 +33,8 @@ import { buildPairLink } from '@/lib/pairLink';
 import { GuideHoldSetup } from '@/components/GuideHoldSetup';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
 import { TabScreen } from '@/components/TabScreen';
+import { TourAnchor } from '@/components/TourAnchor';
+import { registerScroller } from '@/hooks/useTourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, ApiError } from '@/lib/api';
 import { isGenuinelyPurchased, recordPurchaseDate } from '@/lib/entitlement';
@@ -671,10 +673,12 @@ function CategoryTabs({ tab, onTab }: { tab: SetupTab; onTab: (t: SetupTab) => v
   const pal = useTheme();
   const styles = useThemedStyles(makeStyles);
   return (
-    <View style={styles.tabBar}>
+    // TourAnchor REPLACES the bar's View and inherits styles.tabBar, so the row
+    // is the same box it always was — see components/TourAnchor.tsx.
+    <TourAnchor id="setup.tabs" style={styles.tabBar}>
       {SETUP_TABS.map((t) => {
         const active = t.key === tab;
-        return (
+        const seg = (
           <Pressable
             key={t.key}
             onPress={() => {
@@ -688,8 +692,20 @@ function CategoryTabs({ tab, onTab }: { tab: SetupTab; onTab: (t: SetupTab) => v
             </Text>
           </Pressable>
         );
+        // Logs gets its own anchor so the tour can point at the segment rather
+        // than the whole bar. The wrapper carries flex:1 because that is what
+        // makes it layout-neutral: styles.tabItem is flex:1, and a default
+        // (flex:0) wrapper would collapse Logs to its text width while the
+        // other three kept expanding — the segment would visibly shrink.
+        return t.key === 'logs' ? (
+          <TourAnchor key={t.key} id="setup.logs" style={{ flex: 1 }}>
+            {seg}
+          </TourAnchor>
+        ) : (
+          seg
+        );
       })}
-    </View>
+    </TourAnchor>
   );
 }
 
@@ -1012,6 +1028,21 @@ function SetupBody() {
     }
   }, [params.tab, router]);
 
+  // Let the feature tour scroll a section into view before spotlighting it.
+  // DELIBERATELY the body ScrollView, never the Logs FlatList: Logs renders
+  // OUTSIDE this ScrollView (it hosts its own list — see below), and both
+  // anchors this screen registers live in the fixed header anyway, so this only
+  // ever has to move body content.
+  const scrollRef = useRef<ScrollView>(null);
+  const scrollY = useRef(0);
+  useEffect(
+    () =>
+      registerScroller('setup', (dy) => {
+        scrollRef.current?.scrollTo({ y: Math.max(0, scrollY.current + dy), animated: true });
+      }),
+    [],
+  );
+
   return (
     <KeyboardAvoidingView
       style={styles.screen}
@@ -1055,6 +1086,11 @@ function SetupBody() {
         </Gated>
       )}
       <ScrollView
+        ref={scrollRef}
+        onScroll={(e) => {
+          scrollY.current = e.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
         style={tab === 'logs' ? styles.hidden : undefined}
         contentContainerStyle={{
           paddingTop: 14,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -61,6 +61,7 @@ import {
   type MediaSkipSec,
 } from '@/lib/mediaSeek';
 import { clearCompatCache } from '@/lib/compatFetch';
+import { resetFeatureTour } from '@/hooks/useFeatureTour';
 import { setPref, usePref } from '@/lib/prefs';
 import { buy, userFacingPurchaseError, getProduct, restoreFromUserAction } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
@@ -1373,10 +1374,13 @@ function SetupBody() {
               />
               <TogglePref
                 label="Feature tour"
-                sub="A short spotlight walkthrough the first time a box is paired. Off means it never runs."
+                sub="A short spotlight walkthrough of the tabs. Switch it back on to watch it again."
                 value={featureTour}
                 onValueChange={(v) => {
                   void setPref('featureTour', v);
+                  // Switching it back ON means "show me again" — otherwise the
+                  // control is dead once the tour has run once.
+                  if (v) void resetFeatureTour();
                   hapticSelection();
                 }}
               />

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -62,7 +62,7 @@ import {
 } from '@/lib/mediaSeek';
 import { clearCompatCache } from '@/lib/compatFetch';
 import { setPref, usePref } from '@/lib/prefs';
-import { buy, getProduct, restoreFromUserAction } from '@/lib/purchase';
+import { buy, userFacingPurchaseError, getProduct, restoreFromUserAction } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
 import { VolumeTarget } from '@/lib/api';
 import { useBoxes, useBoxOnlineStatus, BoxReachability } from '@/lib/SettingsContext';
@@ -846,7 +846,10 @@ function SetupBody() {
     } else if (result.reason === 'unavailable') {
       setRestoreMsg({ text: 'Store unavailable, try again later.', ok: false });
     } else if (result.reason === 'error') {
-      setRestoreMsg({ text: result.message || 'Purchase failed, try again.', ok: false });
+      setRestoreMsg({
+        text: userFacingPurchaseError(result.message) ?? 'Purchase failed, try again.',
+        ok: false,
+      });
     }
     setBuying(false);
   }, [recordPurchase]);

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -60,6 +60,7 @@ import {
   type MediaHoldSkipSec,
   type MediaSkipSec,
 } from '@/lib/mediaSeek';
+import { clearCompatCache } from '@/lib/compatFetch';
 import { setPref, usePref } from '@/lib/prefs';
 import { buy, getProduct, restoreFromUserAction } from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
@@ -781,6 +782,7 @@ function SetupBody() {
   const scheme = useResolvedScheme();
   const confirmSuspend = usePref('confirmSuspend');
   const streakCelebrations = usePref('streakCelebrations');
+  const compatLookups = usePref('compatLookups');
   const remoteOnlyOn = usePref('remoteOnlyMode');
   // Open when there is nothing else here to use, or when the mode is already on.
   const tvRemoteOpenByDefault = boxes.length === 0 || remoteOnlyOn;
@@ -1340,6 +1342,18 @@ function SetupBody() {
                 value={confirmSuspend}
                 onValueChange={(v) => {
                   void setPref('confirmSuspend', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Look up game compatibility"
+                sub="Shows Steam Deck and ProtonDB ratings on your library. This is the one thing that leaves your phone — it sends a game id to Valve and ProtonDB, nothing about you, and never involves your box. Off clears what was stored."
+                value={compatLookups}
+                onValueChange={(v) => {
+                  void setPref('compatLookups', v);
+                  // Turning it off REMOVES what it collected rather than just
+                  // hiding it — otherwise "off" would be a lie about the data.
+                  if (!v) void clearCompatCache();
                   hapticSelection();
                 }}
               />

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -783,6 +783,7 @@ function SetupBody() {
   const confirmSuspend = usePref('confirmSuspend');
   const streakCelebrations = usePref('streakCelebrations');
   const compatLookups = usePref('compatLookups');
+  const featureTour = usePref('featureTour');
   const remoteOnlyOn = usePref('remoteOnlyMode');
   // DETECT, DO NOT PRESUME. This used to spring open for anyone with no box —
   // which meant a brand-new user landed on the box install steps AND a full TV
@@ -1367,6 +1368,15 @@ function SetupBody() {
                   // Turning it off REMOVES what it collected rather than just
                   // hiding it — otherwise "off" would be a lie about the data.
                   if (!v) void clearCompatCache();
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Feature tour"
+                sub="A short spotlight walkthrough the first time a box is paired. Off means it never runs."
+                value={featureTour}
+                onValueChange={(v) => {
+                  void setPref('featureTour', v);
                   hapticSelection();
                 }}
               />

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -870,6 +870,8 @@ function SetupBody() {
       if (result.purchaseDateMs != null) await recordPurchaseDate(result.purchaseDateMs);
       await recordPurchase();
       setRestoreMsg({ text: 'Purchase restored, unlocked.', ok: true });
+    } else if (result.state === 'cancelled') {
+      // Backed out of the store sheet: no message at all.
     } else if (result.state === 'none') {
       // Not "you have no purchase" — we cannot know that. A promo code redeemed
       // in the App Store app can still be missing here if the reconcile failed,

--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -8,7 +8,7 @@
  * a native build with react-native-udp (scanAvailable).
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 
 import { pairFinish, pairStart } from '@/lib/api';
@@ -25,7 +25,17 @@ type Phase =
   | { k: 'pin'; box: FoundBox } // box is showing a PIN; awaiting entry
   | { k: 'pairing'; box: FoundBox };
 
-export function BoxScanPair() {
+export function BoxScanPair({
+  autoStart,
+  onOutcome,
+}: {
+  /** Run the scan on mount. First-run uses this so the app LOOKS for the box
+   *  before telling anyone to go install anything. */
+  autoStart?: boolean;
+  /** How many boxes the last scan found. Lets a first-run wrapper reveal the
+   *  install steps only AFTER a search has actually come up empty. */
+  onOutcome?: (found: number) => void;
+} = {}) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const { addBox } = useBoxes();
@@ -39,6 +49,7 @@ export function BoxScanPair() {
     try {
       const boxes = await scanForBoxes({ timeoutMs: 3000 });
       setPhase({ k: 'list', boxes });
+      onOutcome?.(boxes.length);
       if (boxes.length === 0) {
         // Say WHY, not just WHAT. The scan can only sweep this device's own
         // /24, so a box on a different subnet is invisible to it however
@@ -66,6 +77,7 @@ export function BoxScanPair() {
       }
     } catch {
       setPhase({ k: 'idle' });
+      onOutcome?.(0);
       setMsg({ ok: false, text: 'Scan needs a newer build of the app.' });
     }
   }, []);
@@ -90,6 +102,16 @@ export function BoxScanPair() {
       setMsg({ ok: false, text: 'Could not reach that box.' });
     }
   }, []);
+
+  // First run searches by itself: telling someone to install something before
+  // even looking for what they may already have is the "overwhelming setup
+  // page" this fixes. Once only — a re-scan is the user's to ask for.
+  const didAuto = useRef(false);
+  useEffect(() => {
+    if (!autoStart || didAuto.current) return;
+    didAuto.current = true;
+    void scan();
+  }, [autoStart, scan]);
 
   const submitPin = useCallback(async () => {
     if (phase.k !== 'pin') return;

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -1,0 +1,144 @@
+/**
+ * Spotlight tour, shown once after the first box is paired.
+ *
+ * Dims the screen, cuts a hole over one tab, and says what is behind it. The
+ * geometry lives in lib/tour.ts and is tested there — a hole over the wrong tab
+ * points confidently at the wrong thing, which is worse than no tour at all.
+ *
+ * NO MASKING LIBRARY: React Native has no cross-platform cutout, so the dim is
+ * four Views around the target. No dependency, no SVG, and it behaves the same
+ * on both platforms.
+ *
+ * THE SPOTLIT TAB STAYS TAPPABLE. The dim panels swallow touches so a stray tap
+ * cannot fire something behind the overlay, but the hole itself is left alone —
+ * a tour that says "your games live here" and then blocks the tab is a lecture,
+ * not a tour.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React from 'react';
+import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { hapticLight } from '@/lib/haptics';
+import { currentStep, dimRects, spotlightRect, stepLabel, type TourState } from '@/lib/tour';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** Tab-bar height without the safe-area inset; matches the router's default. */
+const TAB_BAR_H = 49;
+
+export function FeatureTour({
+  state,
+  tabOrder,
+  onNext,
+  onSkip,
+}: {
+  state: TourState;
+  /** Route names in the order the tab bar renders them — the tour asks this
+   *  rather than assuming, because caps and remote-only mode change both the
+   *  count and the positions. */
+  tabOrder: string[];
+  onNext: () => void;
+  onSkip: () => void;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+
+  const step = currentStep(state);
+  if (!step) return null;
+
+  const idx = tabOrder.indexOf(step.tab);
+  // A tab this build does not show (remote-only hides the box tabs) has nothing
+  // to point at — skip rather than spotlight a guess.
+  if (idx < 0) return null;
+
+  const barH = TAB_BAR_H + insets.bottom;
+  const hole = spotlightRect(width, height, barH, tabOrder.length, idx);
+  const panels = dimRects(width, height, hole);
+  const cardBottom = height - hole.y + 14;
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      {panels.map((r, i) => (
+        <Pressable
+          key={i}
+          // Swallow taps on the dimmed area, but do not advance: an accidental
+          // tap while reading should not skip the step.
+          onPress={() => {}}
+          style={[styles.dim, { left: r.x, top: r.y, width: r.width, height: r.height }]}
+        />
+      ))}
+
+      {/* Ring around the live tab. pointerEvents none so the tab underneath
+          stays tappable — see the header note. */}
+      <View
+        pointerEvents="none"
+        style={[
+          styles.ring,
+          { left: hole.x + 4, top: hole.y + 2, width: hole.width - 8, height: hole.height - 6 },
+        ]}
+      />
+
+      <View style={[styles.card, { bottom: cardBottom }]} pointerEvents="box-none">
+        <View style={styles.head}>
+          <Text style={styles.count}>{stepLabel(state)}</Text>
+          <Pressable onPress={onSkip} hitSlop={10} accessibilityRole="button">
+            <Text style={styles.skip}>SKIP</Text>
+          </Pressable>
+        </View>
+        <Text style={styles.title}>{step.title}</Text>
+        <Text style={styles.body}>{step.body}</Text>
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            onNext();
+          }}
+          accessibilityRole="button"
+          style={({ pressed }) => [styles.next, pressed && styles.pressed]}>
+          <Text style={styles.nextText}>GOT IT</Text>
+          <Ionicons name="arrow-forward" size={14} color="#04140c" />
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    dim: { position: 'absolute', backgroundColor: '#000000d8' },
+    ring: {
+      position: 'absolute',
+      borderRadius: 12,
+      borderWidth: 2,
+      borderColor: t.green,
+    },
+    card: {
+      position: 'absolute',
+      left: 16,
+      right: 16,
+      backgroundColor: t.card,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      padding: 16,
+      gap: 8,
+    },
+    head: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    count: { color: t.textDim, fontSize: 11, letterSpacing: 1, fontFamily: mono },
+    skip: { color: t.textDim, fontSize: 11, letterSpacing: 1, fontFamily: mono, fontWeight: '700' },
+    title: { color: t.text, fontSize: 17, fontWeight: '800' },
+    body: { color: t.textDim, fontSize: 13, lineHeight: 19 },
+    next: {
+      marginTop: 4,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 7,
+      backgroundColor: t.green,
+      borderRadius: 11,
+      paddingVertical: 12,
+    },
+    nextText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    pressed: { opacity: 0.7 },
+  });

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -89,24 +89,33 @@ export function FeatureTour({
       />
 
       <View style={[styles.card, { bottom: cardBottom }]} pointerEvents="box-none">
-        <View style={styles.head}>
-          <Text style={styles.count}>{stepLabel(state)}</Text>
-          <Pressable onPress={onSkip} hitSlop={10} accessibilityRole="button">
-            <Text style={styles.skip}>SKIP</Text>
-          </Pressable>
-        </View>
+        <Text style={styles.count}>{stepLabel(state)}</Text>
         <Text style={styles.title}>{step.title}</Text>
         <Text style={styles.body}>{step.body}</Text>
-        <Pressable
-          onPress={() => {
-            hapticLight();
-            onNext();
-          }}
-          accessibilityRole="button"
-          style={({ pressed }) => [styles.next, pressed && styles.pressed]}>
-          <Text style={styles.nextText}>GOT IT</Text>
-          <Ionicons name="arrow-forward" size={14} color="#04140c" />
-        </Pressable>
+        {/* Skip sits BESIDE Next, not as small print in a corner: a tour with
+            twelve steps needs an obvious way out, or it is a hostage situation. */}
+        <View style={styles.actions}>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onSkip();
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Skip the tour"
+            style={({ pressed }) => [styles.skipBtn, pressed && styles.pressed]}>
+            <Text style={styles.skipText}>SKIP TOUR</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              onNext();
+            }}
+            accessibilityRole="button"
+            style={({ pressed }) => [styles.next, pressed && styles.pressed]}>
+            <Text style={styles.nextText}>GOT IT</Text>
+            <Ionicons name="arrow-forward" size={14} color="#04140c" />
+          </Pressable>
+        </View>
       </View>
     </View>
   );
@@ -134,13 +143,23 @@ const makeStyles = (t: Palette) =>
       padding: 16,
       gap: 8,
     },
-    head: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     count: { color: t.textDim, fontSize: 11, letterSpacing: 1, fontFamily: mono },
-    skip: { color: t.textDim, fontSize: 11, letterSpacing: 1, fontFamily: mono, fontWeight: '700' },
+    actions: { flexDirection: 'row', gap: 10, marginTop: 4 },
+    skipBtn: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 11,
+      paddingVertical: 12,
+      backgroundColor: t.inset,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+    },
+    skipText: { color: t.textDim, fontSize: 13, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
     title: { color: t.text, fontSize: 17, fontWeight: '800' },
     body: { color: t.textDim, fontSize: 13, lineHeight: 19 },
     next: {
-      marginTop: 4,
+      flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -1,30 +1,77 @@
 /**
  * Spotlight tour, shown once after the first box is paired.
  *
- * Dims the screen, cuts a hole over one tab, and says what is behind it. The
- * geometry lives in lib/tour.ts and is tested there — a hole over the wrong tab
- * points confidently at the wrong thing, which is worse than no tour at all.
+ * Dims the screen, cuts a hole over the thing being described, and says what it
+ * is. The geometry lives in lib/tour.ts and is tested there — a hole over the
+ * wrong thing points confidently at the wrong thing, which is worse than no tour
+ * at all.
+ *
+ * TWO KINDS OF TARGET. A step with an `anchor` spotlights a real element inside
+ * the screen (the CPU temp card, the filter button) by measuring it; a step
+ * without one falls back to spotlighting the tab-bar icon, which is all this
+ * tour could originally do.
+ *
+ * A STEP WHOSE ANCHOR IS NOT ON SCREEN IS SKIPPED, not shown. Screens register
+ * anchors only for what they actually rendered, and most of this app is
+ * probe-and-appear, so "not registered" means "this box/library/build does not
+ * have it". The tour used to explain the library filter to people whose library
+ * was too small to show one. See hooks/useTourAnchor.ts.
  *
  * NO MASKING LIBRARY: React Native has no cross-platform cutout, so the dim is
  * four Views around the target. No dependency, no SVG, and it behaves the same
  * on both platforms.
  *
- * THE SPOTLIT TAB STAYS TAPPABLE. The dim panels swallow touches so a stray tap
- * cannot fire something behind the overlay, but the hole itself is left alone —
- * a tour that says "your games live here" and then blocks the tab is a lecture,
- * not a tour.
+ * THE SPOTLIT ELEMENT STAYS TAPPABLE. The dim panels swallow touches so a stray
+ * tap cannot fire something behind the overlay, but the hole itself is left
+ * alone — a tour that says "your games live here" and then blocks the tab is a
+ * lecture, not a tour.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React from 'react';
 import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { measureAnchor, scrollTabBy } from '@/hooks/useTourAnchor';
 import { hapticLight } from '@/lib/haptics';
-import { currentStep, dimRects, spotlightRect, stepLabel, type TourState } from '@/lib/tour';
+import {
+  anchorHole,
+  cardSlot,
+  currentStep,
+  dimRects,
+  scrollDeltaFor,
+  spotlightRect,
+  stepLabel,
+  type Rect,
+  type TourState,
+} from '@/lib/tour';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** Tab-bar height without the safe-area inset; matches the router's default. */
 const TAB_BAR_H = 49;
+/** Roughly the sticky header (box picker row) — the top of the usable band. */
+const HEADER_H = 52;
+/** Breathing room around a measured element. */
+const ANCHOR_PAD = 6;
+/** Gap between the hole and the explanation card. */
+const CARD_GAP = 14;
+
+/** How long to keep asking for an anchor before giving up on the step.
+ *  A tab mounts lazily on first focus and the default skin runs a 260ms
+ *  staggered entrance, so the target genuinely is not measurable for the first
+ *  few hundred milliseconds after the tour navigates to it. */
+const RETRY_EVERY_MS = 100;
+/** 4s, not 1.6s. Measured on a real box: a tour that starts right after pairing
+ *  reaches Console BEFORE the first status poll answers, and the vitals cards
+ *  are gated on that payload — so the three best steps in the tour skipped
+ *  themselves and the walkthrough opened on step 4. The budget has to outlast a
+ *  first poll, not just a layout pass. The cost of being generous is that a
+ *  genuinely absent element takes this long to skip, which nobody sees as
+ *  anything but a slightly late card. */
+const RETRY_FOR_MS = 4000;
+/** Let a scroll settle before trusting the second measurement. */
+const SCROLL_SETTLE_MS = 380;
+
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 export function FeatureTour({
   state,
@@ -46,18 +93,90 @@ export function FeatureTour({
   const insets = useSafeAreaInsets();
 
   const step = currentStep(state);
+  const idx = step ? tabOrder.indexOf(step.tab) : -1;
+
+  const [hole, setHole] = React.useState<Rect | null>(null);
+  const [cardH, setCardH] = React.useState(150);
+  /** Bumped on every step change so a slow measurement from the PREVIOUS step
+   *  cannot land after the user has already moved on and draw a hole over the
+   *  wrong element. */
+  const runId = React.useRef(0);
+
+  const bandTop = insets.top + HEADER_H;
+  const bandBottom = height - insets.bottom - TAB_BAR_H;
+  const anchor = step?.anchor;
+  const tab = step?.tab;
+  const order = tabOrder.join(',');
+
+  React.useEffect(() => {
+    const mine = ++runId.current;
+    const live = () => runId.current === mine;
+    setHole(null);
+
+    if (!step) return;
+
+    // A tab this build does not show — remote-only mode, or a box whose caps
+    // say it has no gamepad. Rendering nothing here USED TO WEDGE THE TOUR: no
+    // card meant no way to press GOT IT, so it stayed "visible" forever,
+    // resumed at the same dead step every launch, and (because the landing
+    // redirect is guarded on tour.visible) quietly disabled that too. Skip it,
+    // for the same reason a missing anchor skips.
+    if (idx < 0) {
+      void (async () => {
+        // Caps arrive after the first render, so a tab can be legitimately
+        // missing for a moment. Give it the same grace as a slow anchor rather
+        // than skipping steps on a cold start.
+        await delay(RETRY_FOR_MS);
+        if (live()) onNext();
+      })();
+      return;
+    }
+
+    // No anchor: the tab-bar icon, computed arithmetically, no measuring.
+    if (!anchor) {
+      setHole(spotlightRect(width, height, TAB_BAR_H, tabOrder.length, idx, insets.bottom));
+      return;
+    }
+
+    void (async () => {
+      let rect: Rect | null = null;
+      for (let waited = 0; waited <= RETRY_FOR_MS; waited += RETRY_EVERY_MS) {
+        if (!live()) return;
+        rect = await measureAnchor(anchor);
+        if (rect) break;
+        await delay(RETRY_EVERY_MS);
+      }
+      if (!live()) return;
+
+      // Nothing to point at: this build, box or library does not have it.
+      if (!rect) {
+        onNext();
+        return;
+      }
+
+      const dy = scrollDeltaFor(rect, bandTop, bandBottom);
+      if (dy !== 0 && scrollTabBy(tab as string, dy)) {
+        await delay(SCROLL_SETTLE_MS);
+        if (!live()) return;
+        const settled = await measureAnchor(anchor);
+        if (settled) rect = settled;
+      }
+      if (!live()) return;
+      setHole(anchorHole(rect, ANCHOR_PAD, width, height));
+    })();
+    // `order` covers a tab-bar reshuffle (caps arriving, remote-only flipping).
+  }, [state.step, anchor, tab, idx, order, width, height, insets.bottom]);
+
   if (!step) return null;
-
-  const idx = tabOrder.indexOf(step.tab);
   // A tab this build does not show (remote-only hides the box tabs) has nothing
-  // to point at — skip rather than spotlight a guess.
+  // to point at.
   if (idx < 0) return null;
+  // Still measuring, or skipping: draw nothing rather than flash a hole in the
+  // wrong place for a frame.
+  if (!hole) return null;
 
-  // The bar is the tab row PLUS the home-indicator inset, but the spotlight
-  // should cover only the tab row — see spotlightRect.
-  const hole = spotlightRect(width, height, TAB_BAR_H, tabOrder.length, idx, insets.bottom);
   const panels = dimRects(width, height, hole);
-  const cardBottom = height - hole.y + 14;
+  const slot = cardSlot(hole, height, cardH, CARD_GAP, insets.top + 8, insets.bottom + 8);
 
   return (
     <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
@@ -71,14 +190,14 @@ export function FeatureTour({
         />
       ))}
 
-      {/* Ring around the live tab. pointerEvents none so the tab underneath
+      {/* Ring around the live element. pointerEvents none so what is underneath
           stays tappable — see the header note. */}
       <View
         pointerEvents="none"
         style={[
           styles.ring,
           {
-            // Clamped so the FIRST and LAST tab's ring stays fully on screen —
+            // Clamped so a ring on the first or last tab stays fully on screen —
             // at x=0 a negative inset clipped it against the bezel.
             left: Math.max(3, hole.x + 4),
             top: hole.y + 2,
@@ -88,12 +207,15 @@ export function FeatureTour({
         ]}
       />
 
-      <View style={[styles.card, { bottom: cardBottom }]} pointerEvents="box-none">
+      <View
+        style={[styles.card, { top: slot.top }]}
+        onLayout={(e) => setCardH(e.nativeEvent.layout.height)}
+        pointerEvents="box-none">
         <Text style={styles.count}>{stepLabel(state)}</Text>
         <Text style={styles.title}>{step.title}</Text>
         <Text style={styles.body}>{step.body}</Text>
-        {/* Skip sits BESIDE Next, not as small print in a corner: a tour with
-            twelve steps needs an obvious way out, or it is a hostage situation. */}
+        {/* Skip sits BESIDE Next, not as small print in a corner: a tour with a
+            dozen steps needs an obvious way out, or it is a hostage situation. */}
         <View style={styles.actions}>
           <Pressable
             onPress={() => {
@@ -112,13 +234,20 @@ export function FeatureTour({
             }}
             accessibilityRole="button"
             style={({ pressed }) => [styles.next, pressed && styles.pressed]}>
-            <Text style={styles.nextText}>GOT IT</Text>
-            <Ionicons name="arrow-forward" size={14} color="#04140c" />
+            <Text style={styles.nextText}>{isLast(state) ? 'DONE' : 'GOT IT'}</Text>
+            {isLast(state) ? null : <Ionicons name="arrow-forward" size={14} color="#04140c" />}
           </Pressable>
         </View>
       </View>
     </View>
   );
+}
+
+/** The final step says DONE, not "GOT IT →". An arrow promising a next step that
+ *  does not exist is a small lie the user notices at exactly the moment they are
+ *  deciding whether the app is careful. */
+function isLast(state: TourState): boolean {
+  return currentStep({ step: state.step + 1, done: false }) === null;
 }
 
 const makeStyles = (t: Palette) =>

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -53,8 +53,9 @@ export function FeatureTour({
   // to point at — skip rather than spotlight a guess.
   if (idx < 0) return null;
 
-  const barH = TAB_BAR_H + insets.bottom;
-  const hole = spotlightRect(width, height, barH, tabOrder.length, idx);
+  // The bar is the tab row PLUS the home-indicator inset, but the spotlight
+  // should cover only the tab row — see spotlightRect.
+  const hole = spotlightRect(width, height, TAB_BAR_H, tabOrder.length, idx, insets.bottom);
   const panels = dimRects(width, height, hole);
   const cardBottom = height - hole.y + 14;
 
@@ -76,7 +77,14 @@ export function FeatureTour({
         pointerEvents="none"
         style={[
           styles.ring,
-          { left: hole.x + 4, top: hole.y + 2, width: hole.width - 8, height: hole.height - 6 },
+          {
+            // Clamped so the FIRST and LAST tab's ring stays fully on screen —
+            // at x=0 a negative inset clipped it against the bezel.
+            left: Math.max(3, hole.x + 4),
+            top: hole.y + 2,
+            width: Math.min(hole.width - 8, width - Math.max(3, hole.x + 4) - 3),
+            height: Math.max(0, hole.height - 4),
+          },
         ]}
       />
 
@@ -106,7 +114,9 @@ export function FeatureTour({
 
 const makeStyles = (t: Palette) =>
   StyleSheet.create({
-    dim: { position: 'absolute', backgroundColor: '#000000d8' },
+    // 55%, not 85%. The tour describes the screen behind it — dimming it into
+    // an unreadable slab defeats the point of pointing at it.
+    dim: { position: 'absolute', backgroundColor: '#0000008c' },
     ring: {
       position: 'absolute',
       borderRadius: 12,

--- a/app/components/GameSheet.tsx
+++ b/app/components/GameSheet.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tap-to-confirm and long-press-for-detail on a library tile.
+ *
+ * WHY THIS EXISTS: a tile launched the moment you touched it. Launching takes
+ * over the television — it is not a preference toggle, and on a grid you scroll
+ * with your thumb a stray tap starts a game on the TV across the room. Reported
+ * by the owner: "annoyed me a few times already by accidentally launching a
+ * game". A confirm step costs one deliberate tap and removes the whole class of
+ * mistake.
+ *
+ * ONE GESTURE, ONE SHEET. An earlier draft split it — tap to confirm,
+ * long-press for detail — and that was worse: two ways in, two states to reason
+ * about, and a hidden gesture the user has to know exists. A tap opens the whole
+ * thing, which both confirms the launch and answers "what is this, and have I
+ * played it".
+ *
+ * Everything shown comes from what the box already sent. Nothing here fetches.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React from 'react';
+import { Image, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import type { ImageSourcePropType } from 'react-native';
+
+import { hapticLight } from '@/lib/haptics';
+import type { Launcher } from '@/lib/api';
+import { playtimeLabel } from '@/lib/libraryFilter';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** "3 days ago" / "today" / "never". Absent last_played is honest, not zero. */
+function lastPlayedLabel(sec: number | undefined, nowSec: number): string {
+  if (sec == null || sec <= 0) return 'never opened';
+  const days = Math.floor((nowSec - sec) / 86400);
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 30) return `${days} days ago`;
+  if (days < 365) {
+    const m = Math.round(days / 30);
+    return m === 1 ? 'a month ago' : `${m} months ago`;
+  }
+  const y = Math.round(days / 365);
+  return y === 1 ? 'a year ago' : `${y} years ago`;
+}
+
+const KIND_LABEL: Record<Launcher['kind'], string> = {
+  steam: 'Steam game',
+  shortcut: 'Non-Steam shortcut',
+  custom: 'Custom launcher',
+};
+
+export function GameSheet({
+  launcher,
+  coverSource,
+  busy,
+  onPlay,
+  onClose,
+}: {
+  launcher: Launcher | null;
+  coverSource?: ImageSourcePropType;
+  busy?: boolean;
+  onPlay: () => void;
+  onClose: () => void;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  if (!launcher) return null;
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  const played = playtimeLabel(launcher.playtime_min);
+  // Only claim a playtime when the box actually sent one. An older agent sends
+  // nothing, and "never played" would then be a statement about our data rather
+  // than about the user's library.
+  const knowsPlaytime = launcher.playtime_min != null || launcher.last_played != null;
+
+  return (
+    <Modal visible transparent animationType="fade" onRequestClose={onClose}>
+      {/* Tapping outside cancels — the safe outcome for a sheet whose other
+          button starts a game on the television. */}
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <Pressable style={styles.card} onPress={() => {}}>
+          <View style={styles.head}>
+            {coverSource ? (
+              <Image source={coverSource} style={styles.art} resizeMode="cover" />
+            ) : (
+              <View style={[styles.art, styles.artFallback]}>
+                <Ionicons name="rocket-outline" size={20} color={t.textDim} />
+              </View>
+            )}
+            <View style={styles.headBody}>
+              <Text style={styles.title} numberOfLines={3}>
+                {launcher.label}
+              </Text>
+              {knowsPlaytime ? (
+                <Text style={styles.sub}>
+                  {played}
+                  {launcher.last_played != null
+                    ? ` · ${lastPlayedLabel(launcher.last_played, nowSec)}`
+                    : ''}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+
+          <ScrollView style={styles.detail} contentContainerStyle={styles.detailBody}>
+              <Row label="Type" value={KIND_LABEL[launcher.kind]} />
+              {launcher.appid != null ? <Row label="Steam appid" value={String(launcher.appid)} /> : null}
+              {knowsPlaytime ? (
+                <>
+                  <Row label="Time played" value={played} />
+                  <Row label="Last opened" value={lastPlayedLabel(launcher.last_played, nowSec)} />
+                </>
+              ) : (
+                // Say WHY it is missing rather than showing a blank or a zero.
+                <Text style={styles.note}>
+                  Playtime needs the Couchside service 2.9.71 or newer on the box.
+                </Text>
+              )}
+          </ScrollView>
+
+          <View style={styles.actions}>
+            <Pressable
+              onPress={onClose}
+              accessibilityRole="button"
+              style={({ pressed }) => [styles.btn, styles.btnGhost, pressed && styles.pressed]}>
+              <Text style={styles.btnGhostText}>CANCEL</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                onPlay();
+              }}
+              disabled={busy}
+              accessibilityRole="button"
+              accessibilityLabel={`Play ${launcher.label}`}
+              style={({ pressed }) => [styles.btn, styles.btnPlay, pressed && styles.pressed]}>
+              <Ionicons name="play" size={15} color="#04140c" />
+              <Text style={styles.btnPlayText}>{busy ? 'LAUNCHING…' : 'PLAY'}</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <View style={styles.row}>
+      <Text style={styles.rowLabel}>{label}</Text>
+      <Text style={styles.rowValue} numberOfLines={2}>
+        {value}
+      </Text>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+      backgroundColor: '#000b',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 22,
+    },
+    card: {
+      width: '100%',
+      maxWidth: 420,
+      backgroundColor: t.card,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      padding: 14,
+      gap: 12,
+    },
+    head: { flexDirection: 'row', gap: 12, alignItems: 'center' },
+    art: { width: 58, height: 87, borderRadius: 8, backgroundColor: t.inset },
+    artFallback: { alignItems: 'center', justifyContent: 'center' },
+    headBody: { flex: 1, gap: 3 },
+    title: { color: t.text, fontSize: 16, fontWeight: '800' },
+    sub: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    detail: { maxHeight: 190 },
+    detailBody: { gap: 8, paddingTop: 2 },
+    row: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
+    rowLabel: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    rowValue: { color: t.text, fontSize: 12, fontFamily: mono, flexShrink: 1, textAlign: 'right' },
+    note: { color: t.textFaint, fontSize: 12, lineHeight: 17 },
+    actions: { flexDirection: 'row', gap: 10 },
+    btn: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 6,
+      borderRadius: 11,
+      paddingVertical: 12,
+    },
+    btnGhost: { backgroundColor: t.inset, borderWidth: 1, borderColor: t.cardBorder },
+    btnGhostText: { color: t.textDim, fontSize: 13, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+    btnPlay: { backgroundColor: t.green },
+    btnPlayText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    pressed: { opacity: 0.65 },
+  });

--- a/app/components/LibraryFilterSheet.tsx
+++ b/app/components/LibraryFilterSheet.tsx
@@ -33,6 +33,7 @@ import {
   type FilterState,
   type PlayedFilter,
 } from '@/lib/libraryFilter';
+import type { Compat, DeckStatus, ProtonTier } from '@/lib/compat';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const PLAYED: { id: PlayedFilter; label: string }[] = [
@@ -46,6 +47,20 @@ const KINDS: { id: 'steam' | 'custom' | 'shortcut'; label: string }[] = [
   { id: 'steam', label: 'Steam' },
   { id: 'shortcut', label: 'Shortcuts' },
   { id: 'custom', label: 'Custom' },
+];
+
+const DECK: { id: DeckStatus; label: string }[] = [
+  { id: 'verified', label: 'Verified' },
+  { id: 'playable', label: 'Playable' },
+  { id: 'unsupported', label: 'Unsupported' },
+];
+
+const PROTON: { id: ProtonTier; label: string }[] = [
+  { id: 'platinum', label: 'Platinum' },
+  { id: 'gold', label: 'Gold' },
+  { id: 'silver', label: 'Silver' },
+  { id: 'bronze', label: 'Bronze' },
+  { id: 'borked', label: 'Borked' },
 ];
 
 const STALE: { days: number; label: string }[] = [
@@ -84,12 +99,18 @@ export function LibraryFilterSheet({
   visible,
   games,
   value,
+  compat,
+  compatOn,
   onChange,
   onClose,
 }: {
   visible: boolean;
-  games: FilterableGame[];
+  games: (FilterableGame & { appid?: number })[];
   value: FilterState;
+  compat?: Record<number, Compat>;
+  /** Compatibility lookups are opt-in; without them these chips would be dead
+   *  controls that silently match everything. */
+  compatOn?: boolean;
   onChange: (f: FilterState) => void;
   onClose: () => void;
 }) {
@@ -98,7 +119,7 @@ export function LibraryFilterSheet({
 
   // Same predicate the list runs, so the button cannot lie about the result.
   const nowSec = Math.floor(Date.now() / 1000);
-  const count = useMemo(() => countMatching(games, value, nowSec), [games, value, nowSec]);
+  const count = useMemo(() => countMatching(games, value, nowSec, compat), [games, value, nowSec, compat]);
   const active = isFiltering(value);
   // See hasPlaytimeData: on an older agent every game looks unplayed, so these
   // controls would state something false about the user's library.
@@ -169,6 +190,50 @@ export function LibraryFilterSheet({
                 Playtime filters need the Couchside service 2.9.71 or newer on the box.
               </Text>
             )}
+
+            {compatOn ? (
+              <>
+                <Text style={styles.label}>STEAM DECK</Text>
+                <View style={styles.row}>
+                  {DECK.map((d) => (
+                    <Chip
+                      key={d.id}
+                      label={d.label}
+                      on={(value.deck ?? []).includes(d.id)}
+                      onPress={() =>
+                        onChange({
+                          ...value,
+                          deck: (value.deck ?? []).includes(d.id)
+                            ? (value.deck ?? []).filter((x) => x !== d.id)
+                            : [...(value.deck ?? []), d.id],
+                        })
+                      }
+                    />
+                  ))}
+                </View>
+
+                <Text style={styles.label}>PROTONDB</Text>
+                <View style={styles.row}>
+                  {PROTON.map((pt) => (
+                    <Chip
+                      key={pt.id}
+                      label={pt.label}
+                      on={(value.proton ?? []).includes(pt.id)}
+                      onPress={() =>
+                        onChange({
+                          ...value,
+                          proton: (value.proton ?? []).includes(pt.id)
+                            ? (value.proton ?? []).filter((x) => x !== pt.id)
+                            : [...(value.proton ?? []), pt.id],
+                        })
+                      }
+                    />
+                  ))}
+                </View>
+                {/* Unrated games are never hidden by these — see matchesCompat. */}
+                <Text style={styles.note}>Games nobody has rated always stay visible.</Text>
+              </>
+            ) : null}
 
             <Text style={styles.label}>TYPE</Text>
             <View style={styles.row}>

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -4,7 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { recordPurchaseDate } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
-import { buy, getProduct, restoreFromUserAction } from '@/lib/purchase';
+import { buy, userFacingPurchaseError, getProduct, restoreFromUserAction } from '@/lib/purchase';
 import { mono, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 
@@ -45,7 +45,7 @@ export default function Paywall() {
     } else if (result.reason === 'unavailable') {
       setError('Store unavailable. Please try again later.');
     } else if (result.reason === 'error') {
-      setError(result.message || 'Purchase failed. Please try again.');
+      setError(userFacingPurchaseError(result.message) ?? 'Purchase failed. Please try again.');
     }
     // 'cancelled': no error text, the user changed their mind
     setBusy(null);

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -58,6 +58,9 @@ export default function Paywall() {
     if (result.state === 'purchased') {
       if (result.purchaseDateMs != null) await recordPurchaseDate(result.purchaseDateMs);
       await recordPurchase();
+    } else if (result.state === 'cancelled') {
+      // Backed out of the store's own sheet — nothing was checked, so nothing
+      // is claimed and nothing is said.
     } else if (result.state === 'none') {
       // See the same message in setup.tsx: we cannot know the user has no
       // purchase, only that this device's store cache has none.

--- a/app/components/SetupProgress.tsx
+++ b/app/components/SetupProgress.tsx
@@ -473,8 +473,14 @@ export function SetupProgress() {
 
   return (
     <View style={styles.card}>
+      {/* DETECT FIRST, INSTRUCT SECOND. These steps used to render throughout
+          `looking`, so a brand-new user was told to go install something while
+          the app was still searching for the thing they may already have — the
+          "overwhelming setup page" a tester landed on. The search now gets the
+          screen to itself until it has actually come up empty (showDiagnosis,
+          i.e. still nothing after DIAGNOSE_AFTER_MS, or an outright stall). */}
       {(phase.k === 'idle' ||
-        phase.k === 'looking' ||
+        (phase.k === 'looking' && showDiagnosis) ||
         phase.k === 'stalled' ||
         phase.k === 'nonet') && (
         <>

--- a/app/components/TourAnchor.tsx
+++ b/app/components/TourAnchor.tsx
@@ -1,0 +1,48 @@
+/**
+ * Marks something the feature tour can spotlight.
+ *
+ * Wrap a card, a button, a row — anything worth explaining — and give it a
+ * stable id that a step in lib/tour.ts names. Registration is what makes the
+ * step eligible; see hooks/useTourAnchor.ts for why an absent anchor is how a
+ * step gets skipped rather than shown against an empty screen.
+ *
+ * LAYOUT-NEUTRAL BY CONSTRUCTION. It renders exactly one plain View and passes
+ * `style` straight through, so it can either wrap a card (no style, takes its
+ * content's size in a column) or REPLACE an existing layout View by inheriting
+ * its style — which is how the CPU TEMP and UPTIME halves are anchored without
+ * disturbing the flex row they share.
+ */
+import React from 'react';
+import { View, type StyleProp, type ViewStyle } from 'react-native';
+
+import { useTourAnchor } from '@/hooks/useTourAnchor';
+
+export function TourAnchor({
+  id,
+  style,
+  hitSlop,
+  children,
+}: {
+  id: string;
+  style?: StyleProp<ViewStyle>;
+  /** Mirror the child's own hitSlop when wrapping a small Pressable.
+   *  A parent clips hit-testing to its own bounds, so wrapping a button that
+   *  relies on hitSlop to be thumb-sized would quietly shrink its touch target
+   *  back to the drawn icon — a tour anchor is not allowed to make a control
+   *  harder to press. */
+  hitSlop?: number;
+  children: React.ReactNode;
+}) {
+  const ref = useTourAnchor(id);
+  return (
+    // collapsable={false} is LOAD-BEARING on Android: a View with no background
+    // and no handlers is optimised out of the native hierarchy, and a view that
+    // does not exist natively cannot be measured — measureInWindow would either
+    // never fire or hand back zeros. iOS does not collapse, so this is the kind
+    // of bug that ships green from a simulator and is broken on half the users'
+    // phones.
+    <View ref={ref} style={style} hitSlop={hitSlop} collapsable={false}>
+      {children}
+    </View>
+  );
+}

--- a/app/hooks/useCompat.ts
+++ b/app/hooks/useCompat.ts
@@ -1,0 +1,41 @@
+/**
+ * Compatibility ratings for the visible library, when the user has opted in.
+ *
+ * Loads incrementally so the grid is never blocked on the network: tiles render
+ * immediately and badges appear as answers arrive. A game with no rating simply
+ * never gets a badge — silence, not a "no data" chip on every tile.
+ *
+ * Off unless the pref is on, and it stops fetching the moment it is turned off.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import type { Compat } from '@/lib/compat';
+import { fetchCompatMany } from '@/lib/compatFetch';
+
+export function useCompat(appids: number[], enabled: boolean): Record<number, Compat> {
+  const [map, setMap] = useState<Record<number, Compat>>({});
+  // Stable key so re-renders with the same library do not restart the sweep.
+  const key = enabled ? appids.slice().sort((a, b) => a - b).join(',') : '';
+  const abortRef = useRef<{ aborted: boolean }>({ aborted: false });
+
+  useEffect(() => {
+    abortRef.current.aborted = true; // stop any previous sweep
+    if (!enabled || !key) return;
+    const signal = { aborted: false };
+    abortRef.current = signal;
+    const ids = key.split(',').map(Number).filter((n) => Number.isFinite(n));
+    void fetchCompatMany(
+      ids,
+      (appid, c) => {
+        if (signal.aborted) return;
+        setMap((prev) => (prev[appid] ? prev : { ...prev, [appid]: c }));
+      },
+      signal,
+    );
+    return () => {
+      signal.aborted = true;
+    };
+  }, [key, enabled]);
+
+  return map;
+}

--- a/app/hooks/useFeatureTour.ts
+++ b/app/hooks/useFeatureTour.ts
@@ -13,6 +13,18 @@ import { advanceTour, dismissTour, shouldRun, TOUR_FINISHED, TOUR_NOT_STARTED, t
 
 const KEY = 'couchside.tour.v1';
 
+/**
+ * Forget that the tour ran, so it plays again.
+ *
+ * Turning the pref back on MUST do this. The pref only gates whether the tour
+ * may run; "already finished" is separate state, so without this the switch is
+ * dead once the tour has been seen — you can turn it off, and turning it back
+ * on does nothing, forever. Found by trying exactly that on a device.
+ */
+export async function resetFeatureTour(): Promise<void> {
+  await set(KEY, JSON.stringify(TOUR_NOT_STARTED));
+}
+
 async function get(k: string): Promise<string | null> {
   if (Platform.OS === 'web') {
     try {

--- a/app/hooks/useFeatureTour.ts
+++ b/app/hooks/useFeatureTour.ts
@@ -1,0 +1,81 @@
+/**
+ * Tour state, persisted on device. Logic lives in lib/tour.ts; this is storage
+ * and the trigger.
+ *
+ * Fires once the phone has at least one box, never before — see lib/tour.ts for
+ * why. On device only, like every other preference: no account, nothing sent.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useCallback, useEffect, useState } from 'react';
+import { Platform } from 'react-native';
+
+import { advanceTour, dismissTour, shouldRun, TOUR_FINISHED, TOUR_NOT_STARTED, type TourState } from '@/lib/tour';
+
+const KEY = 'couchside.tour.v1';
+
+async function get(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem(k) : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function set(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(k, v);
+    } catch {
+      // storage unavailable: the tour simply reappears next launch
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+export function useFeatureTour(paired: boolean, enabled: boolean) {
+  const [state, setState] = useState<TourState>(TOUR_FINISHED); // assume done until proven otherwise
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let alive = true;
+    void (async () => {
+      let loaded = TOUR_NOT_STARTED;
+      try {
+        const raw = await get(KEY);
+        if (raw) {
+          const o = JSON.parse(raw) as Partial<TourState>;
+          loaded = {
+            step: Number.isFinite(o.step) ? Math.max(0, Math.floor(o.step as number)) : 0,
+            done: o.done === true,
+          };
+        }
+      } catch {
+        loaded = TOUR_NOT_STARTED;
+      }
+      if (!alive) return;
+      setState(loaded);
+      setReady(true);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const save = useCallback((s: TourState) => {
+    setState(s);
+    void set(KEY, JSON.stringify(s));
+  }, []);
+
+  return {
+    // Starting from FINISHED means a slow keychain read can never flash the
+    // overlay over the app before we know whether it was already dismissed.
+    visible: ready && shouldRun(state, paired, enabled),
+    state,
+    next: useCallback(() => save(advanceTour(state)), [save, state]),
+    skip: useCallback(() => save(dismissTour()), [save]),
+  };
+}

--- a/app/hooks/useFeatureTour.ts
+++ b/app/hooks/useFeatureTour.ts
@@ -4,26 +4,23 @@
  *
  * Fires once the phone has at least one box, never before — see lib/tour.ts for
  * why. On device only, like every other preference: no account, nothing sent.
+ *
+ * AN EXTERNAL STORE, not per-component state, and that is the whole point.
+ * This used to load the key in a mount effect. The hook lives in the tabs
+ * layout, which never unmounts, so the read happened exactly once per app
+ * launch — and `resetFeatureTour` (called from Setup when the switch goes back
+ * on) wrote to storage nobody would read again until a relaunch. The switch
+ * looked dead: you turned it on, its own copy promised the tour would play
+ * again, and nothing happened. Same module-level-store shape as lib/prefs.ts so
+ * a write is observed live by whoever is rendering.
  */
 import * as SecureStore from 'expo-secure-store';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { Platform } from 'react-native';
 
 import { advanceTour, dismissTour, shouldRun, TOUR_FINISHED, TOUR_NOT_STARTED, type TourState } from '@/lib/tour';
 
 const KEY = 'couchside.tour.v1';
-
-/**
- * Forget that the tour ran, so it plays again.
- *
- * Turning the pref back on MUST do this. The pref only gates whether the tour
- * may run; "already finished" is separate state, so without this the switch is
- * dead once the tour has been seen — you can turn it off, and turning it back
- * on does nothing, forever. Found by trying exactly that on a device.
- */
-export async function resetFeatureTour(): Promise<void> {
-  await set(KEY, JSON.stringify(TOUR_NOT_STARTED));
-}
 
 async function get(k: string): Promise<string | null> {
   if (Platform.OS === 'web') {
@@ -48,46 +45,89 @@ async function set(k: string, v: string): Promise<void> {
   await SecureStore.setItemAsync(k, v);
 }
 
+// ---------- external store ----------
+
+type Snapshot = {
+  state: TourState;
+  /** False until the stored value has been read. */
+  ready: boolean;
+};
+
+/** Starts FINISHED so a slow keychain read can never flash the overlay over the
+ *  app before we know whether it was already dismissed. */
+let snap: Snapshot = { state: TOUR_FINISHED, ready: false };
+const listeners = new Set<() => void>();
+
+function commit(next: Snapshot): void {
+  // A NEW object every time: useSyncExternalStore compares by identity, and
+  // mutating in place would leave subscribers showing the old step.
+  snap = next;
+  for (const l of listeners) l();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): Snapshot {
+  return snap;
+}
+
+let loadStarted = false;
+/** Read the persisted state once. Safe to call repeatedly. */
+export async function loadFeatureTour(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  let loaded = TOUR_NOT_STARTED;
+  try {
+    const raw = await get(KEY);
+    if (raw) {
+      const o = JSON.parse(raw) as Partial<TourState>;
+      loaded = {
+        step: Number.isFinite(o.step) ? Math.max(0, Math.floor(o.step as number)) : 0,
+        done: o.done === true,
+      };
+    }
+  } catch {
+    loaded = TOUR_NOT_STARTED;
+  }
+  commit({ state: loaded, ready: true });
+}
+// Kick the read off at import, like lib/prefs.ts does.
+void loadFeatureTour();
+
+function save(s: TourState): void {
+  // Memory first so the UI reacts on this frame; storage after.
+  commit({ state: s, ready: true });
+  void set(KEY, JSON.stringify(s));
+}
+
+/**
+ * Forget that the tour ran, so it plays again.
+ *
+ * Turning the pref back on MUST do this. The pref only gates whether the tour
+ * may run; "already finished" is separate state, so without this the switch is
+ * dead once the tour has been seen — you can turn it off, and turning it back
+ * on does nothing, forever. Found by trying exactly that on a device.
+ *
+ * Marks `ready` too: a reset is itself proof of what the state should be, so
+ * the tour must not wait on a load that may already have finished.
+ */
+export async function resetFeatureTour(): Promise<void> {
+  commit({ state: TOUR_NOT_STARTED, ready: true });
+  await set(KEY, JSON.stringify(TOUR_NOT_STARTED));
+}
+
 export function useFeatureTour(paired: boolean, enabled: boolean) {
-  const [state, setState] = useState<TourState>(TOUR_FINISHED); // assume done until proven otherwise
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    let alive = true;
-    void (async () => {
-      let loaded = TOUR_NOT_STARTED;
-      try {
-        const raw = await get(KEY);
-        if (raw) {
-          const o = JSON.parse(raw) as Partial<TourState>;
-          loaded = {
-            step: Number.isFinite(o.step) ? Math.max(0, Math.floor(o.step as number)) : 0,
-            done: o.done === true,
-          };
-        }
-      } catch {
-        loaded = TOUR_NOT_STARTED;
-      }
-      if (!alive) return;
-      setState(loaded);
-      setReady(true);
-    })();
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  const save = useCallback((s: TourState) => {
-    setState(s);
-    void set(KEY, JSON.stringify(s));
-  }, []);
+  const s = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   return {
-    // Starting from FINISHED means a slow keychain read can never flash the
-    // overlay over the app before we know whether it was already dismissed.
-    visible: ready && shouldRun(state, paired, enabled),
-    state,
-    next: useCallback(() => save(advanceTour(state)), [save, state]),
-    skip: useCallback(() => save(dismissTour()), [save]),
+    visible: s.ready && shouldRun(s.state, paired, enabled),
+    state: s.state,
+    next: useCallback(() => save(advanceTour(snap.state)), []),
+    skip: useCallback(() => save(dismissTour()), []),
   };
 }

--- a/app/hooks/useTourAnchor.ts
+++ b/app/hooks/useTourAnchor.ts
@@ -1,0 +1,124 @@
+/**
+ * The registry that lets the tour point at THINGS, not just tabs.
+ *
+ * A screen wraps something worth explaining in <TourAnchor id="console.cpu">;
+ * that registers a measure function here. The tour — which is mounted in the
+ * tabs layout, OUTSIDE every screen's tree — asks this module for a window-space
+ * rect when it needs one.
+ *
+ * WHY WINDOW COORDINATES, not onLayout values: the overlay is a sibling of
+ * <Tabs>, so a rect relative to some ScrollView's content is meaningless to it.
+ * measureInWindow is the only shared coordinate space between the two.
+ *
+ * AN UNREGISTERED ANCHOR IS A FEATURE. Screens register only what they actually
+ * rendered, and half this app is probe-and-appear — the library filter needs 8+
+ * games, the ROUTINE action group needs a box that reports a harmless action,
+ * the Pad mode selector disappears in large-pad mode. So "no anchor" means "this
+ * user does not have this", and the tour skips the step instead of explaining a
+ * control that is not on screen. That was a real shipped bug: the tour taught
+ * the filter and the shuffle to someone whose library was too small to have
+ * either.
+ */
+import { useEffect, useRef } from 'react';
+import { View } from 'react-native';
+
+import type { Rect } from '@/lib/tour';
+
+type Measure = () => Promise<Rect | null>;
+
+const anchors = new Map<string, Measure>();
+const scrollers = new Map<string, (dy: number) => void>();
+
+/** Register a measurable element. Returns the unregister function. */
+export function registerAnchor(id: string, measure: Measure): () => void {
+  anchors.set(id, measure);
+  return () => {
+    // Only remove OUR entry: two screens can briefly overlap during a tab
+    // transition, and the newcomer must not be deleted by the leaver's cleanup.
+    if (anchors.get(id) === measure) anchors.delete(id);
+  };
+}
+
+/** Is this element on screen right now? */
+export function hasAnchor(id: string): boolean {
+  return anchors.has(id);
+}
+
+/**
+ * Where is it, in window coordinates? null when it is not mounted or has not
+ * been laid out.
+ *
+ * DEGRADES CLOSED, like the agent does with an unreadable probe: a zero-sized or
+ * non-finite rect returns null ("I do not know") rather than a plausible-looking
+ * box at the origin, which would cut a spotlight hole in the top-left corner and
+ * point confidently at nothing.
+ */
+export async function measureAnchor(id: string): Promise<Rect | null> {
+  const m = anchors.get(id);
+  if (!m) return null;
+  try {
+    const r = await m();
+    if (!r) return null;
+    const ok = [r.x, r.y, r.width, r.height].every((v) => typeof v === 'number' && Number.isFinite(v));
+    return ok && r.width > 0 && r.height > 0 ? r : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Register the scrollable container for a tab, so the tour can bring an
+ *  off-screen anchor into view. `dy` is a DELTA, not an absolute offset. */
+export function registerScroller(tab: string, scrollBy: (dy: number) => void): () => void {
+  scrollers.set(tab, scrollBy);
+  return () => {
+    if (scrollers.get(tab) === scrollBy) scrollers.delete(tab);
+  };
+}
+
+/** Scroll a tab's container by `dy`. No-op when that tab never registered one
+ *  (Pad and Actions do not all scroll) — the tour then spotlights wherever the
+ *  anchor already is, which is correct, just less tidy. */
+export function scrollTabBy(tab: string, dy: number): boolean {
+  const s = scrollers.get(tab);
+  if (!s || dy === 0) return false;
+  s(dy);
+  return true;
+}
+
+/**
+ * Attach to a plain View to make it spotlightable.
+ *
+ * DELIBERATELY NOT ON THE SKIN <Card>: Card is a plain function component in
+ * both skins, so a ref passed to it is silently dropped, and its `style` prop
+ * lands on a different box in each skin (the outer wrap in reactor, the padded
+ * frame in classic) — the same anchor would measure two different rectangles
+ * depending on the skin. A plain View at the call site measures the same thing
+ * everywhere. It also keeps the measurement off reactor's Animated.View, whose
+ * entrance animation moves the card 8px during its first 260ms.
+ */
+export function useTourAnchor(id: string) {
+  const ref = useRef<View>(null);
+
+  useEffect(() => {
+    return registerAnchor(
+      id,
+      () =>
+        new Promise<Rect | null>((resolve) => {
+          const node = ref.current;
+          if (!node) {
+            resolve(null);
+            return;
+          }
+          // measureInWindow never calls back if the view has no native peer.
+          // Nothing here awaits forever because the tour races this against its
+          // own retry budget, but resolving null on a missing node keeps the
+          // common case cheap.
+          node.measureInWindow((x, y, width, height) => {
+            resolve({ x, y, width, height });
+          });
+        }),
+    );
+  }, [id]);
+
+  return ref;
+}

--- a/app/lib/__tests__/appUpdateReminder.test.ts
+++ b/app/lib/__tests__/appUpdateReminder.test.ts
@@ -1,0 +1,51 @@
+/**
+ * The update nudge must not fire on a brand-new install.
+ *
+ * SEEN ON A CLEAN SIMULATOR INSTALL: "New features ship often — check for an
+ * app update now and then" appeared on the setup screen seconds after the user
+ * installed the newest version, competing with the one thing they were actually
+ * trying to do. No stamp meant "overdue" when it should have meant "start the
+ * clock".
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+// lib/appUpdateReminder.ts imports SecureStore (via ./entitlement) and cannot
+// load in the bare-Node runner, so the DECISION is reproduced here rather than
+// imported. The window is duplicated deliberately — these tests assert the RULE
+// (never nag a fresh install; do fire once the window passes), not the exact
+// number of days, so a change to REMIND_DAYS does not invalidate them.
+const REMIND_MS = 4 * 24 * 60 * 60 * 1000; // REMIND_DAYS at time of writing
+
+/** The decision this file guards, extracted so it is testable without storage. */
+function due(stamp: string | null, now: number, remindMs = REMIND_MS): { show: boolean; stamps: boolean } {
+  if (!stamp) return { show: false, stamps: true };
+  const last = parseInt(stamp, 10);
+  if (!Number.isFinite(last)) return { show: false, stamps: true };
+  return { show: now - last >= remindMs, stamps: false };
+}
+
+const NOW = 1_760_000_000_000;
+
+test('a FIRST EVER launch does not nudge — it starts the clock', () => {
+  const r = due(null, NOW);
+  assert.equal(r.show, false, 'must not nag someone who just installed');
+  assert.equal(r.stamps, true, 'but must record the clock so it fires later');
+});
+
+test('an unparseable stamp restarts the clock rather than nagging (control)', () => {
+  const r = due('not-a-number', NOW);
+  assert.equal(r.show, false);
+  assert.equal(r.stamps, true);
+});
+
+test('it DOES fire once the window has passed (control)', () => {
+  // Proves the fix did not simply disable the feature.
+  assert.equal(due(String(NOW - REMIND_MS - 1), NOW).show, true);
+  assert.equal(due(String(NOW - REMIND_MS), NOW).show, true, 'exactly due counts');
+});
+
+test('it stays quiet inside the window', () => {
+  assert.equal(due(String(NOW - 1000), NOW).show, false);
+  assert.equal(due(String(NOW - REMIND_MS + 1), NOW).show, false);
+});

--- a/app/lib/__tests__/compat.test.ts
+++ b/app/lib/__tests__/compat.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Compatibility parsing, against payloads CAPTURED FROM THE REAL SERVICES
+ * (2026-08-06). Invented shapes would have missed both traps below.
+ *
+ * What these protect: telling someone a game they own runs well when it does
+ * not, or hiding a game because a third party has no data on it.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  deckRank,
+  matchesCompat,
+  parseDeckStatus,
+  parseProton,
+  protonRank,
+  UNKNOWN_COMPAT,
+  type Compat,
+} from '../compat.ts';
+
+// --- real payloads, verbatim -------------------------------------------------
+
+// Baldur's Gate 3 (1086940) — Steam lists it Verified.
+const BG3_DECK = { success: 1, results: { appid: 1086940, resolved_category: 3 } };
+// Rainbow Six Siege (359550) — Steam lists it Unsupported.
+const R6_DECK = { success: 1, results: { appid: 359550, resolved_category: 1 } };
+// Red Dead Redemption 2 (1174180) — Playable.
+const RDR2_DECK = { success: 1, results: { appid: 1174180, resolved_category: 2 } };
+// An appid Valve has never rated. NOTE `results` is an ARRAY here, not an
+// object — the shape changes, which is exactly the kind of thing a hand-written
+// fixture would have got wrong.
+const UNRATED_DECK = { success: 1, results: [] };
+
+// Baldur's Gate 3 on ProtonDB.
+const BG3_PROTON = {
+  bestReportedTier: 'platinum', confidence: 'strong',
+  score: 0.84, tier: 'gold', total: 1511, trendingTier: 'platinum',
+};
+// Rainbow Six Siege on ProtonDB. THE TRAP: bestReportedTier says "platinum"
+// while the actual consensus tier is "borked".
+const R6_PROTON = {
+  bestReportedTier: 'platinum', confidence: 'strong',
+  score: 0.08, tier: 'borked', total: 309, trendingTier: 'bronze',
+};
+
+test('Deck status parses the real payloads', () => {
+  assert.equal(parseDeckStatus(BG3_DECK), 'verified');
+  assert.equal(parseDeckStatus(R6_DECK), 'unsupported');
+  assert.equal(parseDeckStatus(RDR2_DECK), 'playable');
+});
+
+test('an UNRATED game is unknown, not unsupported (results is an array)', () => {
+  // Getting this wrong would tell a user a game they own will not run, when
+  // Valve has simply never looked at it.
+  assert.equal(parseDeckStatus(UNRATED_DECK), 'unknown');
+});
+
+test('garbage in never becomes a verdict (control)', () => {
+  for (const junk of [null, undefined, {}, { success: 0 }, { success: 1 }, 'nope', 42]) {
+    assert.equal(parseDeckStatus(junk), 'unknown', JSON.stringify(junk));
+  }
+});
+
+test('ProtonDB uses the CONSENSUS tier, never bestReportedTier', () => {
+  // The whole point. R6 Siege's best-ever report is platinum; the consensus is
+  // borked. Quoting the flattering number would recommend a broken game.
+  const r6 = parseProton(R6_PROTON);
+  assert.equal(r6.tier, 'borked');
+  assert.equal(r6.reports, 309);
+
+  const bg3 = parseProton(BG3_PROTON);
+  assert.equal(bg3.tier, 'gold', 'consensus gold, not the platinum best-report');
+  assert.equal(bg3.reports, 1511);
+});
+
+test('a game with no ProtonDB entry is unknown (404 -> no body)', () => {
+  assert.deepEqual(parseProton(null), { tier: 'unknown', reports: 0 });
+  assert.deepEqual(parseProton({}), { tier: 'unknown', reports: 0 });
+  assert.deepEqual(parseProton({ tier: 'gibberish' }), { tier: 'unknown', reports: 0 });
+});
+
+test('unknown ranks above borked, below every real rating', () => {
+  // "Nobody has tested it" is not worse than "known to be broken".
+  assert.ok(protonRank('unknown') > protonRank('borked'));
+  assert.ok(protonRank('bronze') > protonRank('unknown'));
+  assert.ok(protonRank('platinum') > protonRank('gold'));
+  assert.ok(deckRank('unknown') > deckRank('unsupported'));
+  assert.ok(deckRank('playable') > deckRank('unknown'));
+});
+
+test('UNKNOWN ALWAYS PASSES a filter (the load-bearing rule)', () => {
+  // A third party having no data must never hide a game the user owns.
+  const c: Compat = { deck: 'unknown', proton: 'unknown', protonReports: 0 };
+  assert.equal(matchesCompat(c, ['verified'], ['platinum']), true);
+  assert.equal(matchesCompat(undefined, ['verified'], ['platinum']), true, 'not fetched yet');
+  assert.equal(matchesCompat(UNKNOWN_COMPAT, ['verified'], []), true);
+});
+
+test('a known rating IS filtered out when it does not match (control)', () => {
+  // Proves the test above is not just "everything passes".
+  const r6: Compat = { deck: 'unsupported', proton: 'borked', protonReports: 309 };
+  assert.equal(matchesCompat(r6, ['verified'], []), false);
+  assert.equal(matchesCompat(r6, [], ['platinum', 'gold']), false);
+  const bg3: Compat = { deck: 'verified', proton: 'gold', protonReports: 1511 };
+  assert.equal(matchesCompat(bg3, ['verified'], ['gold']), true);
+});
+
+test('an empty filter selects everything', () => {
+  const r6: Compat = { deck: 'unsupported', proton: 'borked', protonReports: 309 };
+  assert.equal(matchesCompat(r6, [], []), true);
+});

--- a/app/lib/__tests__/libraryFilter.test.ts
+++ b/app/lib/__tests__/libraryFilter.test.ts
@@ -253,3 +253,26 @@ test('isFiltering notices the compat dimensions (control)', () => {
   assert.equal(isFiltering({ ...EMPTY_FILTER, deck: ['verified'] }), true);
   assert.equal(isFiltering({ ...EMPTY_FILTER, proton: ['gold'] }), true);
 });
+
+// ---- phase 4: pick something for me ----
+
+import { pickRandom } from '../libraryFilter.ts';
+
+test('shuffle returns null on an empty list rather than throwing', () => {
+  assert.equal(pickRandom([]), null);
+});
+
+test('shuffle can reach every game and never goes out of range (control)', () => {
+  const games = ['a', 'b', 'c'];
+  const seen = new Set<string>();
+  for (const r of [0, 0.32, 0.34, 0.66, 0.67, 0.999999]) {
+    const got = pickRandom(games, () => r);
+    assert.ok(got != null, `null at r=${r}`);
+    seen.add(got as string);
+  }
+  assert.deepEqual([...seen].sort(), ['a', 'b', 'c'], 'every game is reachable');
+});
+
+test('a generator returning exactly 1 does not fall off the end (control)', () => {
+  assert.equal(pickRandom(['a', 'b'], () => 1), 'b');
+});

--- a/app/lib/__tests__/libraryFilter.test.ts
+++ b/app/lib/__tests__/libraryFilter.test.ts
@@ -192,3 +192,64 @@ test('the old-agent library would otherwise report ALL games never played', () =
   assert.equal(all, old.length, 'without the gate this is the false claim');
   assert.equal(hasPlaytimeData(old), false, 'which is exactly why the gate hides it');
 });
+
+// ---- compatibility dimensions (phase 2) ----
+
+import type { Compat } from '../compat.ts';
+
+const RATED: Record<number, Compat> = {
+  1: { deck: 'verified', proton: 'gold', protonReports: 1511 },
+  2: { deck: 'unsupported', proton: 'borked', protonReports: 309 },
+  // 3 is deliberately absent: nobody has rated it.
+};
+const WITH_IDS = [
+  g({ label: 'Verified game', playtime_min: 600 }),
+  g({ label: 'Broken game', playtime_min: 10 }),
+  g({ label: 'Unrated game' }),
+].map((x, i) => ({ ...x, appid: i + 1 }));
+
+test('a compat filter keeps the matching game and drops the mismatching one', () => {
+  const f: FilterState = { ...EMPTY_FILTER, deck: ['verified'] };
+  const out = applyFilter(WITH_IDS, f, NOW, RATED).map((x) => x.label);
+  assert.ok(out.includes('Verified game'));
+  assert.ok(!out.includes('Broken game'), 'unsupported must not survive a verified-only filter');
+});
+
+test('an UNRATED game survives every compat filter (the load-bearing rule)', () => {
+  // A third party having no data must never hide a game the user owns.
+  for (const f of [
+    { ...EMPTY_FILTER, deck: ['verified' as const] },
+    { ...EMPTY_FILTER, proton: ['platinum' as const] },
+    { ...EMPTY_FILTER, deck: ['verified' as const], proton: ['platinum' as const] },
+  ]) {
+    const out = applyFilter(WITH_IDS, f, NOW, RATED).map((x) => x.label);
+    assert.ok(out.includes('Unrated game'), `unrated hidden by ${JSON.stringify(f)}`);
+  }
+});
+
+test('with NO ratings loaded the library behaves exactly as before (control)', () => {
+  // Compat filters must be inert until data arrives, not empty the screen.
+  const f: FilterState = { ...EMPTY_FILTER, deck: ['verified'] };
+  assert.equal(applyFilter(WITH_IDS, f, NOW, undefined).length, WITH_IDS.length);
+  assert.equal(countMatching(WITH_IDS, f, NOW, undefined), WITH_IDS.length);
+});
+
+test('the count still equals the list once compat is in play (control)', () => {
+  for (const f of [
+    { ...EMPTY_FILTER, deck: ['verified' as const] },
+    { ...EMPTY_FILTER, proton: ['gold' as const, 'platinum' as const] },
+    { ...EMPTY_FILTER, deck: ['unsupported' as const], played: 'under2h' as const },
+  ]) {
+    assert.equal(
+      countMatching(WITH_IDS, f, NOW, RATED),
+      applyFilter(WITH_IDS, f, NOW, RATED).length,
+      JSON.stringify(f),
+    );
+  }
+});
+
+test('isFiltering notices the compat dimensions (control)', () => {
+  assert.equal(isFiltering({ ...EMPTY_FILTER, deck: [] }), false);
+  assert.equal(isFiltering({ ...EMPTY_FILTER, deck: ['verified'] }), true);
+  assert.equal(isFiltering({ ...EMPTY_FILTER, proton: ['gold'] }), true);
+});

--- a/app/lib/__tests__/purchaseErrors.test.ts
+++ b/app/lib/__tests__/purchaseErrors.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Cancelling a purchase must be silent, and no native exception text may ever
+ * reach a user.
+ *
+ * REPORTED BY A TESTER: backing out of the purchase sheet showed a raw Swift
+ * stack trace, at the exact moment they were deciding whether to pay. The
+ * cancellation WAS handled — but only on the path that carries a tidy `code`,
+ * and this build delivers it as a promise rejection carrying only prose.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { isUserCancellation, userFacingPurchaseError } from '../purchaseErrors.ts';
+
+// The exact text from the report, verbatim.
+const REPORTED = new Error(
+  "Calling the 'requestPurchase' function has failed (at ExpoModulesCore/" +
+    'ConcurrentFunctionDefinition.swift:88)\n→ Caused by: IapException: User ' +
+    'cancelled the purchase flow (at ExpoIap/ExpoIapHelper.swift:18)',
+);
+
+test('THE REPORTED CASE is recognised as a cancellation', () => {
+  assert.equal(isUserCancellation(REPORTED), true);
+});
+
+test('cancellation is caught by code OR by message, both spellings', () => {
+  assert.equal(isUserCancellation({ code: 'user-cancelled' }), true);
+  assert.equal(isUserCancellation({ code: 'E_USER_CANCELED' }), true);
+  assert.equal(isUserCancellation({ message: 'User canceled the purchase flow' }), true);
+  assert.equal(isUserCancellation(new Error('The operation was cancelled.')), true);
+});
+
+test('a REAL failure is not mistaken for a cancellation (control)', () => {
+  // If this ever returns true, genuine failures go silent and the user is left
+  // staring at a button that did nothing.
+  assert.equal(isUserCancellation(new Error('Network connection lost')), false);
+  assert.equal(isUserCancellation({ code: 'E_ALREADY_OWNED' }), false);
+  assert.equal(isUserCancellation(null), false);
+  assert.equal(isUserCancellation(undefined), false);
+});
+
+test('native exception text never reaches the user', () => {
+  assert.equal(userFacingPurchaseError(REPORTED.message), 'Purchase failed, try again.');
+  assert.equal(
+    userFacingPurchaseError('IapException: something at Foo/Bar.swift:12'),
+    'Purchase failed, try again.',
+  );
+  assert.equal(
+    userFacingPurchaseError('FunctionCallException: nope'),
+    'Purchase failed, try again.',
+  );
+});
+
+test('a genuinely human message is passed through unchanged (control)', () => {
+  // Proves the sanitiser is not just blanking everything.
+  assert.equal(
+    userFacingPurchaseError('A purchase is already in progress.'),
+    'A purchase is already in progress.',
+  );
+  assert.equal(userFacingPurchaseError(undefined), null);
+  assert.equal(userFacingPurchaseError(''), null);
+});

--- a/app/lib/__tests__/purchaseErrors.test.ts
+++ b/app/lib/__tests__/purchaseErrors.test.ts
@@ -60,3 +60,19 @@ test('a genuinely human message is passed through unchanged (control)', () => {
   assert.equal(userFacingPurchaseError(undefined), null);
   assert.equal(userFacingPurchaseError(''), null);
 });
+
+// ---- restore, not just buy ----
+
+test('backing out of a RESTORE is a cancellation, not "no purchase found"', () => {
+  // Reported from the simulator: tapping Restore Purchases and backing out of
+  // the Apple ID sheet showed red "No purchase found on this Apple ID". The app
+  // never got to check — asserting it did is how a PAYING customer concludes
+  // the app is broken. Restore now has its own 'cancelled' state.
+  assert.equal(isUserCancellation(new Error('The operation was cancelled.')), true);
+  assert.equal(isUserCancellation({ code: 'E_USER_CANCELLED' }), true);
+});
+
+test('a restore that genuinely fails is still an error (control)', () => {
+  // The fix must not swallow real failures into silence.
+  assert.equal(isUserCancellation(new Error('Cannot connect to iTunes Store')), false);
+});

--- a/app/lib/__tests__/tour.test.ts
+++ b/app/lib/__tests__/tour.test.ts
@@ -87,3 +87,24 @@ test('the dim rectangles cover the whole screen EXCEPT the hole (control)', () =
     assert.ok(!(overlapsX && overlapsY), `dim rect covers the spotlight: ${JSON.stringify(r)}`);
   }
 });
+
+test('the hole EXCLUDES the home-indicator inset (seen clipped on a real phone)', () => {
+  // Including the inset made the ring taller than the tab, so it hung into the
+  // gesture strip and read as clipped at the bottom edge.
+  const W = 400, H = 800, BAR = 49, INSET = 34, N = 6;
+  const r = spotlightRect(W, H, BAR, N, 0, INSET);
+  assert.equal(r.height, BAR, 'the hole is the tab row, not the row plus the strip');
+  assert.equal(r.y + r.height, H - INSET, 'it sits directly above the inset');
+});
+
+test('with no inset the hole still reaches the bottom (control)', () => {
+  const r = spotlightRect(400, 800, 49, 6, 0);
+  assert.equal(r.y + r.height, 800);
+});
+
+test('the dim panels still tile exactly around an inset hole (control)', () => {
+  const W = 400, H = 800, BAR = 49, INSET = 34, N = 6;
+  const hole = spotlightRect(W, H, BAR, N, 3, INSET);
+  const area = dimRects(W, H, hole).reduce((a, r) => a + r.width * r.height, 0);
+  assert.equal(area, W * H - hole.width * hole.height, 'no gap, no overlap below the hole either');
+});

--- a/app/lib/__tests__/tour.test.ts
+++ b/app/lib/__tests__/tour.test.ts
@@ -10,9 +10,12 @@ import assert from 'node:assert';
 
 import {
   advanceTour,
+  anchorHole,
+  cardSlot,
   currentStep,
   dimRects,
   dismissTour,
+  scrollDeltaFor,
   shouldRun,
   spotlightRect,
   stepLabel,
@@ -107,4 +110,102 @@ test('the dim panels still tile exactly around an inset hole (control)', () => {
   const hole = spotlightRect(W, H, BAR, N, 3, INSET);
   const area = dimRects(W, H, hole).reduce((a, r) => a + r.width * r.height, 0);
   assert.equal(area, W * H - hole.width * hole.height, 'no gap, no overlap below the hole either');
+});
+
+// ---------------------------------------------------------------------------
+// Element anchors
+//
+// The tour can now spotlight a card or a button rather than a tab icon. Two new
+// ways to be confidently wrong: the hole lands somewhere the element is not, or
+// a step names an anchor NO SCREEN REGISTERS — which does not crash, it just
+// silently skips the step forever. The last test below is the one that catches
+// the typo, by reading the actual source.
+// ---------------------------------------------------------------------------
+
+test('an anchor hole hugs the element, with padding', () => {
+  const r = anchorHole({ x: 40, y: 200, width: 120, height: 80 }, 6, 400, 900);
+  assert.deepEqual(r, { x: 34, y: 194, width: 132, height: 92 });
+});
+
+test('an anchor hole is clamped to the screen, never negative (control)', () => {
+  // A full-bleed row at the very top: padding must not push it off-screen, or
+  // dimRects gets a negative-width panel and drops it, leaving an undimmed strip.
+  const r = anchorHole({ x: 0, y: 0, width: 400, height: 60 }, 8, 400, 900);
+  assert.deepEqual(r, { x: 0, y: 0, width: 400, height: 68 });
+  const off = anchorHole({ x: 380, y: 880, width: 100, height: 100 }, 8, 400, 900);
+  assert.ok(off.x + off.width <= 400 && off.y + off.height <= 900, 'stays on screen');
+  assert.ok(off.width > 0 && off.height > 0, 'still a real rect');
+});
+
+test('the dim panels tile exactly around an INTERIOR hole too', () => {
+  const W = 400, H = 900;
+  const hole = anchorHole({ x: 40, y: 300, width: 200, height: 100 }, 6, W, H);
+  const panels = dimRects(W, H, hole);
+  const area = panels.reduce((n, r) => n + r.width * r.height, 0);
+  assert.equal(area, W * H - hole.width * hole.height, 'no gap, no overlap');
+  for (const r of panels) {
+    const overlapsX = r.x < hole.x + hole.width && hole.x < r.x + r.width;
+    const overlapsY = r.y < hole.y + hole.height && hole.y < r.y + r.height;
+    assert.ok(!(overlapsX && overlapsY), `dim rect covers the spotlight: ${JSON.stringify(r)}`);
+  }
+});
+
+test('scrolling: below the fold scrolls down, above scrolls up, visible does nothing', () => {
+  const TOP = 100, BOT = 700;
+  assert.equal(scrollDeltaFor({ x: 0, y: 300, width: 10, height: 100 }, TOP, BOT), 0, 'already visible (control)');
+  assert.ok(scrollDeltaFor({ x: 0, y: 800, width: 10, height: 100 }, TOP, BOT) > 0, 'below the fold scrolls down');
+  assert.ok(scrollDeltaFor({ x: 0, y: 20, width: 10, height: 40 }, TOP, BOT) < 0, 'above the band scrolls up');
+});
+
+test('an element taller than the band aligns its top rather than its middle', () => {
+  const TOP = 100, BOT = 400;
+  const d = scrollDeltaFor({ x: 0, y: 500, width: 10, height: 900 }, TOP, BOT, 24);
+  assert.equal(d, 500 - 24 - TOP, 'top edge lands at the top of the band');
+});
+
+test('the card goes below a high element and above a low one, never over it', () => {
+  const H = 900, CARD = 160, GAP = 14;
+  const high = cardSlot({ x: 0, y: 80, width: 400, height: 100 }, H, CARD, GAP, 50, 30);
+  assert.equal(high.placement, 'below');
+  assert.ok(high.top >= 80 + 100, 'starts under the element');
+
+  const low = cardSlot({ x: 0, y: 700, width: 400, height: 100 }, H, CARD, GAP, 50, 30);
+  assert.equal(low.placement, 'above');
+  assert.ok(low.top + CARD <= 700, 'ends above the element');
+});
+
+test('the card stays inside the safe area even when the element fills the screen (control)', () => {
+  const H = 900, CARD = 160;
+  const slot = cardSlot({ x: 0, y: 0, width: 400, height: 900 }, H, CARD, 14, 60, 40);
+  assert.ok(slot.top >= 60, 'never under the notch');
+  assert.ok(slot.top + CARD <= H - 40, 'never behind the home indicator');
+});
+
+test('every anchor a step names is registered by some screen', async () => {
+  // THE TYPO TEST. An anchor id is a string shared between lib/tour.ts and a
+  // screen; a mismatch is invisible at runtime because an unregistered anchor
+  // is the SAME signal as "this box does not have this feature" — the step
+  // just quietly never shows. Nothing else would catch it, so read the source.
+  const { readFileSync, readdirSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const roots = ['app/(tabs)', 'components'];
+  let src = '';
+  for (const r of roots) {
+    const dir = join(import.meta.dirname, '../..', r);
+    for (const f of readdirSync(dir)) {
+      if (f.endsWith('.tsx')) src += readFileSync(join(dir, f), 'utf8');
+    }
+  }
+  const named = TOUR_STEPS.map((s) => s.anchor).filter((a): a is string => a != null);
+  assert.ok(named.length > 0, 'the tour should anchor to real elements');
+  for (const id of named) {
+    // Either quote style — JSX attributes use double, object literals single.
+    const found = src.includes(`"${id}"`) || src.includes(`'${id}'`);
+    assert.ok(found, `no screen registers the anchor "${id}"`);
+  }
+});
+
+test('a step points at a tab that exists (control)', () => {
+  const TABS = ['index', 'launch', 'pad', 'actions', 'setup'];
+  for (const s of TOUR_STEPS) assert.ok(TABS.includes(s.tab), `unknown tab ${s.tab}`);
 });

--- a/app/lib/__tests__/tour.test.ts
+++ b/app/lib/__tests__/tour.test.ts
@@ -1,0 +1,89 @@
+/**
+ * The feature tour: sequencing and spotlight geometry.
+ *
+ * Two ways this fails badly. It repeats forever (a tour you cannot finish is
+ * worse than none), or the spotlight lands on the WRONG tab — pointing
+ * confidently at something unrelated while the copy describes another screen.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  advanceTour,
+  currentStep,
+  dimRects,
+  dismissTour,
+  shouldRun,
+  spotlightRect,
+  stepLabel,
+  TOUR_NOT_STARTED,
+  TOUR_STEPS,
+} from '../tour.ts';
+
+test('the tour does NOT run before a box is paired', () => {
+  // Every step points at a tab that does nothing without a box.
+  assert.equal(shouldRun(TOUR_NOT_STARTED, false, true), false);
+  assert.equal(shouldRun(TOUR_NOT_STARTED, true, true), true);
+});
+
+test('the opt-out silences it entirely (control)', () => {
+  assert.equal(shouldRun(TOUR_NOT_STARTED, true, false), false);
+});
+
+test('it walks every step exactly once and then stops forever', () => {
+  let s = TOUR_NOT_STARTED;
+  const seen: string[] = [];
+  for (let i = 0; i < 20; i++) {
+    const step = currentStep(s);
+    if (!step) break;
+    seen.push(step.tab);
+    s = advanceTour(s);
+  }
+  assert.deepEqual(seen, TOUR_STEPS.map((x) => x.tab), 'each step once, in order');
+  assert.equal(s.done, true, 'finishing marks it done');
+  assert.equal(shouldRun(s, true, true), false, 'and it never runs again');
+  assert.equal(currentStep(s), null, 'no empty toast one past the end');
+});
+
+test('skipping is permanent, like finishing', () => {
+  const s = dismissTour();
+  assert.equal(shouldRun(s, true, true), false);
+  assert.equal(currentStep(s), null);
+});
+
+test('the counter reads 1 of N, never 0 or N+1', () => {
+  assert.equal(stepLabel(TOUR_NOT_STARTED), `1 of ${TOUR_STEPS.length}`);
+  let s = TOUR_NOT_STARTED;
+  for (let i = 0; i < TOUR_STEPS.length; i++) s = advanceTour(s);
+  assert.equal(stepLabel(s), `${TOUR_STEPS.length} of ${TOUR_STEPS.length}`);
+});
+
+test('the spotlight lands on the right tab, and the last tab reaches the edge', () => {
+  const W = 400, H = 800, BAR = 80, N = 5;
+  const first = spotlightRect(W, H, BAR, N, 0);
+  assert.deepEqual(first, { x: 0, y: 720, width: 80, height: 80 });
+  const last = spotlightRect(W, H, BAR, N, 4);
+  assert.equal(last.x + last.width, W, 'the final tab must touch the screen edge');
+});
+
+test('an out-of-range index is clamped, never spotlighting empty space (control)', () => {
+  // A tab hidden by caps could otherwise index past the end.
+  const W = 400, H = 800, BAR = 80, N = 3;
+  assert.equal(spotlightRect(W, H, BAR, N, 99).x, spotlightRect(W, H, BAR, N, 2).x);
+  assert.equal(spotlightRect(W, H, BAR, N, -5).x, 0);
+  assert.equal(spotlightRect(W, H, BAR, 0, 0).width, W, 'zero tabs must not divide by zero');
+});
+
+test('the dim rectangles cover the whole screen EXCEPT the hole (control)', () => {
+  const W = 400, H = 800, BAR = 80, N = 5;
+  const hole = spotlightRect(W, H, BAR, N, 2);
+  const rects = dimRects(W, H, hole);
+  const area = rects.reduce((a, r) => a + r.width * r.height, 0);
+  assert.equal(area, W * H - hole.width * hole.height, 'no gap, no overlap');
+  // and nothing overlaps the hole itself
+  for (const r of rects) {
+    const overlapsX = r.x < hole.x + hole.width && r.x + r.width > hole.x;
+    const overlapsY = r.y < hole.y + hole.height && r.y + r.height > hole.y;
+    assert.ok(!(overlapsX && overlapsY), `dim rect covers the spotlight: ${JSON.stringify(r)}`);
+  }
+});

--- a/app/lib/appUpdateReminder.ts
+++ b/app/lib/appUpdateReminder.ts
@@ -25,9 +25,22 @@ const REMIND_MS = REMIND_DAYS * 24 * 60 * 60 * 1000;
 export async function reminderDue(now: number): Promise<boolean> {
   try {
     const raw = await storageGet(LAST_SHOWN_KEY);
-    if (!raw) return true;
+    // NO STAMP = FIRST EVER LAUNCH. Start the clock instead of nudging: telling
+    // somebody to "check for an app update now and then" seconds after they
+    // installed the newest version is noise at the worst possible moment, and
+    // it lands on the setup screen a brand-new user is already trying to read.
+    // Seen on a genuinely clean simulator install.
+    if (!raw) {
+      await markReminderShown(now);
+      return false;
+    }
     const last = parseInt(raw, 10);
-    if (!Number.isFinite(last)) return true;
+    // An unparseable stamp is treated the same way — restart the clock rather
+    // than nag, since we cannot tell how long it has been.
+    if (!Number.isFinite(last)) {
+      await markReminderShown(now);
+      return false;
+    }
     return now - last >= REMIND_MS;
   } catch {
     return false;

--- a/app/lib/compat.ts
+++ b/app/lib/compat.ts
@@ -1,0 +1,128 @@
+/**
+ * How well does this game run on a Linux handheld / SteamOS box.
+ *
+ * Phase 2 of docs/memory/project_library-triage.md. Two independent sources,
+ * both PUBLIC PER-APPID METADATA — "how does game 1086940 run", the same answer
+ * for everyone:
+ *
+ *   Valve Deck compatibility  store.steampowered.com/saleaction/ajaxgetdeck…
+ *   ProtonDB community tier   protondb.com/api/v1/reports/summaries/<appid>.json
+ *
+ * NO STEAM API KEY, and no account of any kind. A Steam Web API key exists to
+ * read YOUR data — owned games, playtime — and this never asks for that: the box
+ * already has it on disk (phase 1). That distinction is what makes this feature
+ * viable at all; the account-linked design would have needed a Valve key and a
+ * public profile, which is friction most people would never get through.
+ *
+ * ZERO runtime imports here on purpose. This module PARSES and RANKS; the
+ * fetching and caching live in ./compatFetch.ts, so the part where a wrong parse
+ * would mislabel a game is testable in bare Node against captured real payloads.
+ *
+ * THE HONESTY RULE: unknown is a first-class value, never coerced into a
+ * verdict. A game with no ProtonDB reports is "unknown", not "borked"; a game
+ * Valve has not rated is "unknown", not "unsupported". Telling someone a game
+ * they own will not run, when nobody actually said that, is worse than saying
+ * nothing.
+ */
+
+/** Valve's own rating. `resolved_category` — mapping VERIFIED against known
+ *  titles 2026-08-06: 1 = Unsupported (R6 Siege), 2 = Playable (RDR2, Risk of
+ *  Rain 2), 3 = Verified (Baldur's Gate 3). 0/absent = not yet rated. */
+export type DeckStatus = 'verified' | 'playable' | 'unsupported' | 'unknown';
+
+/** ProtonDB's community tier, best-to-worst. */
+export type ProtonTier = 'platinum' | 'gold' | 'silver' | 'bronze' | 'borked' | 'unknown';
+
+export type Compat = {
+  deck: DeckStatus;
+  proton: ProtonTier;
+  /** How many ProtonDB reports back the tier. 0 with a real tier means the
+   *  payload said so; the UI can use it to avoid quoting a lone opinion. */
+  protonReports: number;
+};
+
+export const UNKNOWN_COMPAT: Compat = { deck: 'unknown', proton: 'unknown', protonReports: 0 };
+
+const DECK_BY_CATEGORY: Record<number, DeckStatus> = {
+  1: 'unsupported',
+  2: 'playable',
+  3: 'verified',
+};
+
+/** Parse Valve's deck compatibility payload. Never throws; anything unexpected
+ *  is 'unknown' rather than a guess. */
+export function parseDeckStatus(body: unknown): DeckStatus {
+  const b = body as { success?: number; results?: { resolved_category?: unknown } } | null;
+  if (!b || b.success !== 1) return 'unknown';
+  const cat = b.results?.resolved_category;
+  if (typeof cat !== 'number') return 'unknown';
+  return DECK_BY_CATEGORY[cat] ?? 'unknown';
+}
+
+const TIERS: ProtonTier[] = ['platinum', 'gold', 'silver', 'bronze', 'borked'];
+
+/**
+ * Parse ProtonDB's summary. Uses `tier`, NOT `bestReportedTier`: "best anyone
+ * ever reported" is the most flattering number on the page and would tell
+ * someone a game is Platinum when the consensus is Gold. The realistic figure is
+ * the useful one when you are deciding what to start tonight.
+ */
+export function parseProton(body: unknown): { tier: ProtonTier; reports: number } {
+  const b = body as { tier?: unknown; total?: unknown } | null;
+  if (!b) return { tier: 'unknown', reports: 0 };
+  const t = typeof b.tier === 'string' ? b.tier.toLowerCase() : '';
+  const tier = (TIERS as string[]).includes(t) ? (t as ProtonTier) : 'unknown';
+  const reports = typeof b.total === 'number' && b.total >= 0 ? Math.floor(b.total) : 0;
+  return { tier, reports };
+}
+
+/** Rank for sorting — higher is better. Unknown sorts BELOW every known rating
+ *  but ABOVE borked, because "nobody has tested it" is not worse than "it is
+ *  known to be broken". */
+export function protonRank(t: ProtonTier): number {
+  switch (t) {
+    case 'platinum': return 5;
+    case 'gold': return 4;
+    case 'silver': return 3;
+    case 'bronze': return 2;
+    case 'unknown': return 1;
+    case 'borked': return 0;
+  }
+}
+
+export function deckRank(s: DeckStatus): number {
+  switch (s) {
+    case 'verified': return 3;
+    case 'playable': return 2;
+    case 'unknown': return 1;
+    case 'unsupported': return 0;
+  }
+}
+
+/** Short label for a badge. Deliberately the plain word, not a marketing term. */
+export function deckLabel(s: DeckStatus): string {
+  return s === 'unknown' ? 'Not rated' : s[0].toUpperCase() + s.slice(1);
+}
+
+export function protonLabel(t: ProtonTier): string {
+  return t === 'unknown' ? 'No reports' : t[0].toUpperCase() + t.slice(1);
+}
+
+/**
+ * Does a game pass a compatibility filter?
+ *
+ * UNKNOWN ALWAYS PASSES, for the same reason unknown playtime does in
+ * libraryFilter: a filter must never make a game the user owns silently vanish
+ * because a third-party service has no data on it. They would go looking for it
+ * and conclude the app lost their library.
+ */
+export function matchesCompat(
+  c: Compat | undefined,
+  wantDeck: DeckStatus[],
+  wantProton: ProtonTier[],
+): boolean {
+  if (!c) return true;
+  if (wantDeck.length && c.deck !== 'unknown' && !wantDeck.includes(c.deck)) return false;
+  if (wantProton.length && c.proton !== 'unknown' && !wantProton.includes(c.proton)) return false;
+  return true;
+}

--- a/app/lib/compatFetch.ts
+++ b/app/lib/compatFetch.ts
@@ -1,0 +1,162 @@
+/**
+ * Fetching + caching the per-appid compatibility ratings. Parsing lives in
+ * ./compat.ts and is tested against captured payloads; this file is the part
+ * that touches the network.
+ *
+ * THIS IS THE FIRST TIME THE APP TALKS TO THE PUBLIC INTERNET FOR LIBRARY DATA,
+ * and that deserves to be said plainly rather than buried:
+ *
+ *  - It is OPT-IN and off by default (Prefs > "Look up game compatibility").
+ *  - The BOX is never involved and gains no outbound path. Its LAN-only promise
+ *    is unchanged; these calls leave the PHONE.
+ *  - What is sent: an appid. What is not sent: anything identifying — no
+ *    account, no Steam key, no device id, no list of what you played.
+ *  - An appid list is still a signal about what you own, which is why this is a
+ *    switch the user throws rather than a default someone discovers later.
+ *
+ * CACHED HARD, on purpose. A Deck rating changes when Valve re-tests a game;
+ * a ProtonDB tier moves over weeks. Re-fetching on every scroll would be slow,
+ * would burn a free community service's bandwidth for nothing, and is exactly
+ * the behaviour that gets a client blocked. 14 days, on device, clearable.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+import { parseDeckStatus, parseProton, UNKNOWN_COMPAT, type Compat } from './compat';
+
+const KEY = 'couchside.compat.v1';
+/** Ratings move on the order of weeks; a fortnight is generous and quiet. */
+const TTL_MS = 14 * 24 * 60 * 60 * 1000;
+/** Politeness cap: a 300-game library must not become 600 simultaneous calls. */
+const CONCURRENCY = 4;
+
+type Entry = Compat & { at: number };
+type Store = Record<string, Entry>;
+
+let mem: Store | null = null;
+const inflight = new Map<number, Promise<Compat>>();
+
+async function storageGet(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem(k) : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function storageSet(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(k, v);
+    } catch {
+      // storage unavailable: the cache lives in memory for this session
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+async function load(): Promise<Store> {
+  if (mem) return mem;
+  try {
+    const raw = await storageGet(KEY);
+    mem = raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    mem = {};
+  }
+  return mem;
+}
+
+function persist(): void {
+  if (mem) void storageSet(KEY, JSON.stringify(mem));
+}
+
+/** Forget every cached rating. Paired with the opt-out, so turning the feature
+ *  off can also remove what it collected rather than merely hiding it. */
+export async function clearCompatCache(): Promise<void> {
+  mem = {};
+  await storageSet(KEY, JSON.stringify(mem));
+}
+
+async function getJson(url: string, timeoutMs: number): Promise<unknown | null> {
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ctl.signal });
+    clearTimeout(timer);
+    // 404 is the NORMAL answer for a game ProtonDB has never seen — not an
+    // error, just "unknown". Anything non-OK degrades the same way.
+    if (!res.ok) return null;
+    return (await res.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** One appid, from cache when fresh. Never throws; failure is "unknown". */
+export async function fetchCompat(appid: number, timeoutMs = 8000): Promise<Compat> {
+  const store = await load();
+  const hit = store[String(appid)];
+  if (hit && Date.now() - hit.at < TTL_MS) {
+    return { deck: hit.deck, proton: hit.proton, protonReports: hit.protonReports };
+  }
+  const running = inflight.get(appid);
+  if (running) return running;
+
+  const job = (async (): Promise<Compat> => {
+    const [deckBody, protonBody] = await Promise.all([
+      getJson(
+        `https://store.steampowered.com/saleaction/ajaxgetdeckappcompatibilityreport?nAppID=${appid}&l=english`,
+        timeoutMs,
+      ),
+      getJson(`https://www.protondb.com/api/v1/reports/summaries/${appid}.json`, timeoutMs),
+    ]);
+    const proton = parseProton(protonBody);
+    const out: Compat = {
+      deck: parseDeckStatus(deckBody),
+      proton: proton.tier,
+      protonReports: proton.reports,
+    };
+    // Cache even an all-unknown result: re-asking every scroll for a game
+    // nobody has rated is the same waste as re-asking for one that is rated.
+    const s = await load();
+    s[String(appid)] = { ...out, at: Date.now() };
+    persist();
+    return out;
+  })().finally(() => inflight.delete(appid));
+
+  inflight.set(appid, job);
+  return job;
+}
+
+/**
+ * Warm a whole library, `CONCURRENCY` at a time, reporting as it goes.
+ *
+ * Deliberately incremental: the grid must stay usable while this runs, and a
+ * user who scrolls away should not have been blocked on a network call. Cached
+ * appids resolve without a request.
+ */
+export async function fetchCompatMany(
+  appids: number[],
+  onEach: (appid: number, c: Compat) => void,
+  signal?: { aborted: boolean },
+): Promise<void> {
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      if (signal?.aborted) return;
+      const i = next++;
+      if (i >= appids.length) return;
+      const id = appids[i];
+      try {
+        onEach(id, await fetchCompat(id));
+      } catch {
+        onEach(id, UNKNOWN_COMPAT);
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, appids.length || 1) }, worker));
+}

--- a/app/lib/libraryFilter.ts
+++ b/app/lib/libraryFilter.ts
@@ -156,6 +156,25 @@ export function countLabel(n: number): string {
   return `SHOW ${n.toLocaleString()} GAME${n === 1 ? '' : 'S'}`;
 }
 
+/**
+ * Pick one game at random from a filtered list — "just choose for me".
+ *
+ * The point on Couchside is that the pick is LAUNCHABLE: elsewhere a shuffle
+ * ends at a suggestion, here it ends at the game starting on the TV.
+ *
+ * `rand` is injected so this is testable; production passes Math.random.
+ * Returns null for an empty list rather than throwing, because "no games match"
+ * is a normal state of the filter above it.
+ */
+export function pickRandom<T>(games: T[], rand: () => number = Math.random): T | null {
+  if (!games.length) return null;
+  const i = Math.floor(rand() * games.length);
+  // Guard the rand() === 1 edge: Math.random() never returns 1, but an injected
+  // or future generator might, and an out-of-range index would return undefined
+  // while the type still claims T.
+  return games[Math.min(i, games.length - 1)] ?? null;
+}
+
 /** "12h 30m" / "45m" / "never". For the tile's playtime line. */
 export function playtimeLabel(mins: number | undefined): string {
   if (mins == null || mins === 0) return 'never played';

--- a/app/lib/libraryFilter.ts
+++ b/app/lib/libraryFilter.ts
@@ -36,6 +36,9 @@ export type PlayedFilter =
   /** Played two hours or more. */
   | 'over2h';
 
+import type { Compat, DeckStatus, ProtonTier } from './compat.ts';
+import { matchesCompat } from './compat.ts';
+
 export type FilterState = {
   /** Case-insensitive substring of the title. */
   search: string;
@@ -44,6 +47,10 @@ export type FilterState = {
   played: PlayedFilter;
   /** Only games not launched in this many days. 0/undefined = no constraint. */
   staleDays?: number;
+  /** Steam Deck ratings to keep; empty = all. Unknown always passes. */
+  deck?: DeckStatus[];
+  /** ProtonDB tiers to keep; empty = all. Unknown always passes. */
+  proton?: ProtonTier[];
 };
 
 export const EMPTY_FILTER: FilterState = { search: '', kinds: [], played: 'any' };
@@ -67,7 +74,9 @@ export function isFiltering(f: FilterState): boolean {
     f.search.trim() !== '' ||
     f.kinds.length > 0 ||
     f.played !== 'any' ||
-    (f.staleDays ?? 0) > 0
+    (f.staleDays ?? 0) > 0 ||
+    (f.deck?.length ?? 0) > 0 ||
+    (f.proton?.length ?? 0) > 0
   );
 }
 
@@ -94,23 +103,33 @@ function matchesStale(g: FilterableGame, staleDays: number | undefined, nowSec: 
   return nowSec - g.last_played >= staleDays * 86400;
 }
 
-/** Does one game survive the filter? */
-export function matches(g: FilterableGame, f: FilterState, nowSec: number): boolean {
+/** Does one game survive the filter? `compat` is optional — a library with no
+ *  ratings loaded behaves exactly as before. */
+export function matches(
+  g: FilterableGame,
+  f: FilterState,
+  nowSec: number,
+  compat?: Compat,
+): boolean {
   const q = f.search.trim().toLowerCase();
   if (q && !g.label.toLowerCase().includes(q)) return false;
   if (f.kinds.length && !f.kinds.includes(g.kind)) return false;
   if (!matchesPlayed(g, f.played)) return false;
   if (!matchesStale(g, f.staleDays, nowSec)) return false;
+  if (!matchesCompat(compat, f.deck ?? [], f.proton ?? [])) return false;
   return true;
 }
 
 /** The surviving games, order preserved. */
-export function applyFilter<T extends FilterableGame>(
+export function applyFilter<T extends FilterableGame & { appid?: number }>(
   games: T[],
   f: FilterState,
   nowSec: number,
+  compat?: Record<number, Compat>,
 ): T[] {
-  return games.filter((g) => matches(g, f, nowSec));
+  return games.filter((g) =>
+    matches(g, f, nowSec, g.appid != null ? compat?.[g.appid] : undefined),
+  );
 }
 
 /**
@@ -118,9 +137,16 @@ export function applyFilter<T extends FilterableGame>(
  * makes filtering feel like an interaction rather than a chore ("SHOW 272
  * GAMES" falling as you narrow).
  */
-export function countMatching(games: FilterableGame[], f: FilterState, nowSec: number): number {
+export function countMatching(
+  games: (FilterableGame & { appid?: number })[],
+  f: FilterState,
+  nowSec: number,
+  compat?: Record<number, Compat>,
+): number {
   let n = 0;
-  for (const g of games) if (matches(g, f, nowSec)) n += 1;
+  for (const g of games) {
+    if (matches(g, f, nowSec, g.appid != null ? compat?.[g.appid] : undefined)) n += 1;
+  }
   return n;
 }
 

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -38,6 +38,15 @@ export type Prefs = {
    *  itself keeps counting locally either way, so turning it back on does not
    *  start from zero. Nothing about it ever leaves the phone. */
   streakCelebrations: boolean;
+  /** Look up per-game Steam Deck / ProtonDB compatibility.
+   *
+   *  OFF BY DEFAULT and opt-in, because it is the first thing in the app that
+   *  talks to the public internet for library data. The BOX is not involved and
+   *  keeps its LAN-only promise; these calls leave the phone. What is sent is an
+   *  appid — no account, no Steam key, nothing identifying — but a list of
+   *  appids still says something about what you own, so it is a switch the user
+   *  throws rather than a default they discover later. */
+  compatLookups: boolean;
   /** REMOTE-ONLY MODE: the app is just a smart-TV remote, no Couchside box.
    *
    *  For someone with a smart TV and no gaming machine. On, the box tabs
@@ -237,6 +246,7 @@ export type Prefs = {
 export const DEFAULTS: Prefs = {
   confirmSuspend: true,
   streakCelebrations: true,
+  compatLookups: false,
   remoteOnlyMode: false,
   landingTab: 'index',
   autoKeyboard: true,
@@ -352,6 +362,7 @@ function normalize(raw: unknown): Prefs {
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     streakCelebrations: bool(o.streakCelebrations, DEFAULTS.streakCelebrations),
+    compatLookups: bool(o.compatLookups, DEFAULTS.compatLookups),
     remoteOnlyMode: bool(o.remoteOnlyMode, DEFAULTS.remoteOnlyMode),
     landingTab,
     autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -47,6 +47,9 @@ export type Prefs = {
    *  appids still says something about what you own, so it is a switch the user
    *  throws rather than a default they discover later. */
   compatLookups: boolean;
+  /** The one-time spotlight tour, shown after the first box is paired. On by
+   *  default; turning it off before it has run means it never runs. */
+  featureTour: boolean;
   /** REMOTE-ONLY MODE: the app is just a smart-TV remote, no Couchside box.
    *
    *  For someone with a smart TV and no gaming machine. On, the box tabs
@@ -247,6 +250,7 @@ export const DEFAULTS: Prefs = {
   confirmSuspend: true,
   streakCelebrations: true,
   compatLookups: false,
+  featureTour: true,
   remoteOnlyMode: false,
   landingTab: 'index',
   autoKeyboard: true,
@@ -363,6 +367,7 @@ function normalize(raw: unknown): Prefs {
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     streakCelebrations: bool(o.streakCelebrations, DEFAULTS.streakCelebrations),
     compatLookups: bool(o.compatLookups, DEFAULTS.compatLookups),
+    featureTour: bool(o.featureTour, DEFAULTS.featureTour),
     remoteOnlyMode: bool(o.remoteOnlyMode, DEFAULTS.remoteOnlyMode),
     landingTab,
     autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),

--- a/app/lib/purchase.ts
+++ b/app/lib/purchase.ts
@@ -1,3 +1,5 @@
+import { isUserCancellation } from './purchaseErrors';
+export { isUserCancellation, userFacingPurchaseError } from './purchaseErrors';
 /**
  * Thin, no-throw wrapper around expo-iap (direct StoreKit / Google Play
  * Billing, no third-party purchase service, receipts stay on-device).
@@ -188,7 +190,7 @@ async function connect(): Promise<boolean> {
           });
           m.purchaseErrorListener((error) => {
             settleBuy(
-              error?.code === 'user-cancelled'
+              isUserCancellation(error)
                 ? { ok: false, reason: 'cancelled' }
                 : { ok: false, reason: 'error', message: error?.message },
             );
@@ -218,6 +220,7 @@ export async function getProduct(): Promise<ProductInfo | null> {
   }
 }
 
+
 /**
  * Start the one-time unlock purchase. Resolves when the store delivers the
  * purchase (via the update listener), the user cancels, or the request fails.
@@ -234,7 +237,13 @@ export async function buy(): Promise<BuyResult> {
       request: { apple: { sku: UNLOCK_PRODUCT_ID }, google: { skus: [UNLOCK_PRODUCT_ID] } },
       type: 'in-app',
     }).catch((e: unknown) => {
-      settleBuy({ ok: false, reason: 'error', message: e instanceof Error ? e.message : String(e) });
+      // Cancellation arrives HERE on this expo-iap version, not only via
+      // purchaseErrorListener — see isUserCancellation.
+      settleBuy(
+        isUserCancellation(e)
+          ? { ok: false, reason: 'cancelled' }
+          : { ok: false, reason: 'error', message: e instanceof Error ? e.message : String(e) },
+      );
     });
   });
 }

--- a/app/lib/purchase.ts
+++ b/app/lib/purchase.ts
@@ -26,6 +26,9 @@ export type RestoreResult =
   | { state: 'purchased'; purchaseDateMs?: number }
   | { state: 'none' }
   | { state: 'unavailable' }
+  /** The user backed out of the store's own sheet (Apple ID sign-in, etc.).
+   *  NOT the same as 'none': nothing was checked, so nothing can be claimed. */
+  | { state: 'cancelled' }
   | { state: 'error'; message?: string };
 
 // Minimal structural view of the expo-iap surface we use (v4, Open IAP API:
@@ -335,6 +338,11 @@ export async function restore(): Promise<RestoreResult> {
       typeof raw === 'number' && Number.isFinite(raw) && raw > 0 ? raw : undefined;
     return { state: 'purchased', purchaseDateMs };
   } catch (e: unknown) {
+    // Backing out of the Apple ID / store sheet is not a failure and not a
+    // verdict. Reporting "no purchase found" here would assert something the
+    // app never got to check — the exact claim the 'none' copy below is careful
+    // NOT to make — and it lands in red on someone who may well own the app.
+    if (isUserCancellation(e)) return { state: 'cancelled' };
     return { state: 'error', message: e instanceof Error ? e.message : String(e) };
   }
 }

--- a/app/lib/purchaseErrors.ts
+++ b/app/lib/purchaseErrors.ts
@@ -1,0 +1,44 @@
+/**
+ * Purchase error interpretation. ZERO imports, so it is testable in bare Node —
+ * lib/purchase.ts pulls in expo-iap and cannot load in the test runner, which is
+ * exactly why this bug shipped untested.
+ *
+ */
+/**
+ * Did the user simply back out of the purchase sheet?
+ *
+ * REPORTED BY A TESTER: cancelling showed them a raw Swift stack trace —
+ *   FunctionCallException: Calling the 'requestPurchase' function has failed
+ *   (at ExpoModulesCore/ConcurrentFunctionDefinition.swift:88)
+ *   → Caused by: IapException: User cancelled the purchase flow
+ * — at the exact moment they were deciding whether to pay. Backing out is a
+ * normal choice, not a failure, and must produce no message at all.
+ *
+ * It reaches us TWO ways and only one was handled: `purchaseErrorListener` with
+ * a tidy `code`, and — on this expo-iap version — a REJECTION of
+ * requestPurchase() carrying only that prose. So the code check alone missed it.
+ * Both spellings of "cancelled" appear across Apple/Google/expo-iap, hence the
+ * loose match.
+ */
+export function isUserCancellation(e: unknown): boolean {
+  const err = e as { code?: unknown; message?: unknown } | null;
+  const code = typeof err?.code === 'string' ? err.code.toLowerCase() : '';
+  if (code.includes('cancel')) return true;
+  const msg = typeof err?.message === 'string' ? err.message : String(e ?? '');
+  return /cancell?ed/i.test(msg);
+}
+
+/**
+ * A message safe to show a human, or null to say nothing.
+ *
+ * Native exception text is not user-facing: a Swift file and line number tells
+ * someone nothing they can act on and makes a working app look broken. Anything
+ * that smells like an exception or stack frame is replaced.
+ */
+export function userFacingPurchaseError(raw: string | undefined): string | null {
+  if (!raw) return null;
+  const looksInternal =
+    /Exception|\.swift:|\.kt:|\.java:|at [A-Za-z]+\/|→ Caused by/i.test(raw);
+  if (looksInternal) return 'Purchase failed, try again.';
+  return raw;
+}

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -114,17 +114,23 @@ export function spotlightRect(
   tabBarHeight: number,
   tabCount: number,
   tabIndex: number,
+  /** Home-indicator inset. EXCLUDED from the hole: including it made the ring
+   *  taller than the tab it points at, so it hung into the gesture strip and
+   *  looked clipped at the bottom of the screen (seen on an iPhone 17 Pro Max).
+   *  The hole should hug the icon and label, nothing else. */
+  bottomInset = 0,
 ): Rect {
   const count = Math.max(1, tabCount);
   // Clamp rather than trust: a tab hidden by caps (remote-only mode) could
   // otherwise index past the end and spotlight empty space off-screen.
   const i = Math.min(Math.max(0, tabIndex), count - 1);
   const width = screenWidth / count;
+  const height = Math.min(tabBarHeight, screenHeight);
   return {
     x: i * width,
-    y: Math.max(0, screenHeight - tabBarHeight),
+    y: Math.max(0, screenHeight - bottomInset - height),
     width,
-    height: Math.min(tabBarHeight, screenHeight),
+    height,
   };
 }
 

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -15,9 +15,29 @@
  * the thing they came for.
  */
 
+export type TourTab = 'index' | 'launch' | 'pad' | 'actions' | 'setup';
+
 export type TourStep = {
   /** Route name of the tab this step points at. */
-  tab: 'index' | 'launch' | 'pad' | 'actions' | 'setup';
+  tab: TourTab;
+  /**
+   * Id of the ELEMENT to spotlight inside that tab — the CPU temp card, the
+   * filter button, the mode selector. Registered by the screen via
+   * useTourAnchor(); see hooks/useTourAnchor.ts.
+   *
+   * Absent = spotlight the tab-bar icon instead, which is all this tour could
+   * do originally.
+   *
+   * AN ANCHOR IS ALSO THE GATE, and this is the fix for a real bug rather than
+   * a convenience. Steps used to describe controls that were not on screen: the
+   * library filter and shuffle are hidden on agents older than 2.9.71 (no
+   * playtime data), yet two steps cheerfully explained how to use them, so the
+   * user hunted for a button that was deliberately absent. A screen only
+   * registers an anchor for something it actually rendered, so an unregistered
+   * anchor means "this build/box does not have this" and the step is SKIPPED.
+   * The rule: never describe a control the user cannot see.
+   */
+  anchor?: string;
   title: string;
   body: string;
 };
@@ -26,69 +46,110 @@ export const TOUR_STEPS: TourStep[] = [
   // CONSOLE — why the app exists.
   {
     tab: 'index',
+    anchor: 'console.cpu',
     title: 'Is the box even awake?',
     body: 'Temperature, load, memory and disks, live. The first thing to check when the TV is black and the controller does nothing.',
   },
   {
     tab: 'index',
-    title: 'See the screen from here',
-    body: 'Pull a still frame of what the TV is actually showing — the difference between "it crashed" and "it is sitting on a login prompt".',
+    anchor: 'console.display',
+    title: 'What the TV is actually being sent',
+    body: 'Resolution, refresh, HDR and which output is connected. When the picture is wrong, this says whether the box even thinks a screen is there.',
   },
   {
     tab: 'index',
-    title: 'Read the logs without a keyboard',
-    body: 'The services you care about and their journal, on the phone. No SSH, no crawling behind the TV.',
+    anchor: 'console.screen',
+    title: 'See the screen from here',
+    body: 'Pull a still frame of what the TV is actually showing — the difference between "it crashed" and "it is sitting on a login prompt".',
   },
 
   // LAUNCH — the thing people open it for daily.
   {
     tab: 'launch',
+    anchor: 'launch.grid',
     title: 'Your library, with cover art',
-    body: 'Every game the box has. Tap one and it starts on the TV — no Big Picture menus, no hunting with a D-pad.',
+    // Do NOT say "tap one and it starts": tapping opens the confirm sheet, and
+    // the very next step explains that. Saying both is a tour arguing with
+    // itself in front of a new user.
+    body: 'Every game the box has, laid out with its art. No Big Picture menus, no hunting across a grid with a D-pad.',
   },
   {
     tab: 'launch',
+    anchor: 'launch.grid',
     title: 'Tap asks before it launches',
     body: 'A tap opens the game rather than starting it, with playtime and when you last opened it. Launching takes over the TV, so it is never one stray tap.',
   },
+  // The next two are anchored to controls that only exist once a library is
+  // big enough to need them (8+ games). On a small library there is no filter
+  // and no shuffle, and these steps skip themselves rather than describing
+  // buttons the user will go hunting for and never find.
   {
     tab: 'launch',
+    anchor: 'launch.filter',
     title: 'Narrow it down',
     body: 'Filter by never-played, under two hours, or not touched in a year. The button counts as you go, so you can see the shortlist shrink.',
   },
   {
     tab: 'launch',
+    anchor: 'launch.shuffle',
     title: 'Or let it choose',
     body: 'The shuffle picks from whatever is currently showing — so "something short I have never played" is one tap away.',
   },
 
   // PAD — the hardware replacement.
+  // Anchored to the mode selector rather than the surface below it: the pad
+  // opens on SWIPE, so a step promising sticks and triggers used to point at an
+  // empty trackpad. Pointing at the switch tells the user how to GET there.
   {
     tab: 'pad',
+    anchor: 'pad.modes',
     title: 'The phone is a controller',
-    body: 'A real gamepad the box cannot tell from plastic: sticks, D-pad, triggers, haptics. For when the real one is dead or across the room.',
+    body: 'Switch to PAD for a real gamepad the box cannot tell from plastic: sticks, D-pad, triggers, haptics. For when the real one is dead or across the room.',
   },
   {
     tab: 'pad',
+    anchor: 'pad.modes',
     title: 'Trackpad, swipe, and a keyboard',
-    body: 'Swipe like an Apple TV remote, or use it as a trackpad and type into the box — for the login boxes and launcher updates a controller cannot handle.',
+    body: 'SWIPE works like an Apple TV remote and MOUSE is a trackpad you can type through — for the login boxes and launcher updates a controller cannot handle.',
   },
 
   // ACTIONS — the rescue.
   {
     tab: 'actions',
+    anchor: 'actions.high',
     title: 'Unstick a frozen display',
-    body: 'Restart the display when the TV goes black but the machine is plainly still running. The one that saves the evening.',
+    // NAME THE CONTROL AS IT IS LABELLED. This used to say "restart the
+    // display", which is not a button that exists — the user scanned the list
+    // for it and found nothing. It also sold the action as the harmless hero
+    // move while the UI tags it red and "ends session". A tour that undersells
+    // the cost of a destructive action is worse than one that never mentions it.
+    body: 'Restart Session rebuilds the desktop when the TV is black but the machine is plainly still running. It closes what is open, which is why it sits under "Ends your session".',
   },
+  // Anchored to the ROUTINE group, which is the one that is often ABSENT: a
+  // plain Linux box reports no harmless actions at all (the only one is
+  // "Restart Decky", which needs Decky installed), while a Windows box does.
+  // This step used to claim three groups unconditionally, in front of a screen
+  // showing two.
   {
     tab: 'actions',
+    anchor: 'actions.routine',
     title: 'Grouped by what it costs you',
-    body: 'Routine, changes-what-is-on-screen, and ends-your-session are separated on purpose — nothing destructive sits next to something harmless.',
+    body: 'The harmless ones sit up here, apart from the ones that change what is on the TV and the ones that end your session. Nothing destructive sits next to something safe.',
   },
 
   // SETUP — where the rest lives.
+  // The logs step lives HERE, not on Console. It used to be a Console step
+  // describing "the services you care about and their journal" — a screen that
+  // has no logs on it at all. LogsPanel is a Setup section, and always was.
   {
     tab: 'setup',
+    anchor: 'setup.logs',
+    title: 'Read the logs without a keyboard',
+    body: 'The services you care about and their journal, on the phone. No SSH, no crawling behind the TV.',
+  },
+  {
+    tab: 'setup',
+    anchor: 'setup.tabs',
     title: 'Everything else lives here',
     body: 'Add more boxes, switch between them, and turn things on or off — including this tour, if you ever want to watch it again.',
   },
@@ -181,6 +242,89 @@ export function spotlightRect(
     width,
     height,
   };
+}
+
+/**
+ * The hole for an ELEMENT spotlight: the measured rect, breathing room around
+ * it, clamped to the screen.
+ *
+ * Clamping is not cosmetic. dimRects tiles four rectangles around the hole, and
+ * a hole hanging off the edge would hand it a negative width — the panel gets
+ * dropped and a strip of the screen is left undimmed, which reads as a
+ * rendering fault. A card half off-screen (a wide row, a tall list) should
+ * still be spotlit as far as it is visible.
+ */
+export function anchorHole(
+  rect: Rect,
+  pad: number,
+  screenWidth: number,
+  screenHeight: number,
+): Rect {
+  const x = Math.max(0, rect.x - pad);
+  const y = Math.max(0, rect.y - pad);
+  const right = Math.min(screenWidth, rect.x + rect.width + pad);
+  const bottom = Math.min(screenHeight, rect.y + rect.height + pad);
+  return { x, y, width: Math.max(0, right - x), height: Math.max(0, bottom - y) };
+}
+
+/**
+ * How far to scroll so an anchor sits comfortably inside the visible band.
+ * Negative scrolls up, positive scrolls down, 0 means it is already fine.
+ *
+ * Most of the things worth pointing at (the disks card, the screen preview) are
+ * below the fold on a phone. Spotlighting them where they sit would dim the
+ * whole screen and cut a hole over empty space — confidently pointing at
+ * nothing, the exact failure the geometry lives here to prevent.
+ *
+ * An anchor TALLER than the band cannot be centred, so its top is aligned
+ * instead: showing the beginning of a long card beats showing its middle.
+ */
+export function scrollDeltaFor(
+  rect: Rect,
+  viewportTop: number,
+  viewportBottom: number,
+  margin = 24,
+): number {
+  const band = viewportBottom - viewportTop;
+  if (band <= 0) return 0;
+  const top = rect.y - margin;
+  const bottom = rect.y + rect.height + margin;
+  if (bottom - top > band) return top - viewportTop;
+  if (top < viewportTop) return top - viewportTop;
+  if (bottom > viewportBottom) return bottom - viewportBottom;
+  return 0;
+}
+
+/** Where the explanation card goes relative to the hole. `top` is measured from
+ *  the top of the screen. */
+export type CardSlot = { placement: 'above' | 'below'; top: number };
+
+/**
+ * Place the card so it never covers the thing it is describing.
+ *
+ * With a tab-bar spotlight the card always went above, because the hole was
+ * always at the bottom. An element anchor can be anywhere, so the side is
+ * chosen by whichever has more room, then clamped into the safe area — a card
+ * pinned under the notch or behind the home indicator is unreadable, and it is
+ * the only thing on screen the user is meant to read.
+ */
+export function cardSlot(
+  hole: Rect,
+  screenHeight: number,
+  cardHeight: number,
+  gap: number,
+  safeTop: number,
+  safeBottom: number,
+): CardSlot {
+  const roomAbove = hole.y - safeTop;
+  const roomBelow = screenHeight - safeBottom - (hole.y + hole.height);
+  const below = roomBelow >= roomAbove;
+  const wanted = below ? hole.y + hole.height + gap : hole.y - gap - cardHeight;
+  const lo = safeTop;
+  // Math.max guards the case where the card is taller than the safe area
+  // entirely: clamp to the top rather than producing a negative range.
+  const hi = Math.max(lo, screenHeight - safeBottom - cardHeight);
+  return { placement: below ? 'below' : 'above', top: Math.min(hi, Math.max(lo, wanted)) };
 }
 
 /** The four dim rectangles that surround `hole`, covering everything else. */

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -1,0 +1,141 @@
+/**
+ * The one-time feature tour, shown AFTER the first box is paired.
+ *
+ * WHY AFTER THE PAIR, not on first launch: before a box exists, none of these
+ * tabs do anything. A tour on launch would be the second thing overwhelming a
+ * new user — the exact complaint that prompted the first-run rework ("I just
+ * landed on the overwhelming set up page"). Once a box is paired the tabs are
+ * live, and every step points at something they can try in the next second.
+ *
+ * ZERO imports, so the sequencing — which is where an off-by-one silently skips
+ * a step or repeats one forever — is testable in bare Node.
+ *
+ * Each step names a TAB and says what is behind it in the user's own terms, not
+ * the feature's name. "Vitals" is a word we use; "is my box actually alive" is
+ * the thing they came for.
+ */
+
+export type TourStep = {
+  /** Route name of the tab this step points at. */
+  tab: 'index' | 'launch' | 'pad' | 'actions';
+  title: string;
+  body: string;
+};
+
+export const TOUR_STEPS: TourStep[] = [
+  {
+    tab: 'index',
+    title: 'Your box, at a glance',
+    body: 'Temperature, memory, disks and the logs — the screen to open when the TV goes black and you need to know whether the machine is even awake.',
+  },
+  {
+    tab: 'launch',
+    title: 'Your games, in your hand',
+    body: 'The whole library with its cover art. Tap a game and it starts on the TV — no Big Picture menus, no hunting with a D-pad.',
+  },
+  {
+    tab: 'pad',
+    title: 'The phone is the controller',
+    body: 'A real gamepad the box cannot tell from plastic, plus a trackpad and a keyboard for the moments a controller cannot help — a login box, a launcher update.',
+  },
+  {
+    tab: 'actions',
+    title: 'Fix it from the couch',
+    body: 'Restart a frozen display, switch to desktop, reboot or power off — grouped by how much each one interrupts, so nothing destructive is one stray tap away.',
+  },
+];
+
+export type TourState = {
+  /** Index of the step to show; equal to TOUR_STEPS.length once finished. */
+  step: number;
+  /** True once the user finished or dismissed it. Never shown again. */
+  done: boolean;
+};
+
+export const TOUR_NOT_STARTED: TourState = { step: 0, done: false };
+export const TOUR_FINISHED: TourState = { step: TOUR_STEPS.length, done: true };
+
+/**
+ * Should the tour run right now?
+ *
+ * `paired` is "this phone has at least one box". The tour is gated on it rather
+ * than on a first-run flag so it cannot fire for someone who has not got
+ * anything working yet — and so it DOES fire for an existing user who has been
+ * limping along without ever finding the Pad tab.
+ */
+export function shouldRun(state: TourState, paired: boolean, enabled: boolean): boolean {
+  return enabled && paired && !state.done && state.step < TOUR_STEPS.length;
+}
+
+/** The step to render, or null when there is nothing to show. */
+export function currentStep(state: TourState): TourStep | null {
+  if (state.done || state.step < 0 || state.step >= TOUR_STEPS.length) return null;
+  return TOUR_STEPS[state.step];
+}
+
+/** Advance. The LAST "next" finishes the tour rather than leaving it dangling
+ *  one past the end, so a resumed session cannot show an empty toast. */
+export function advanceTour(state: TourState): TourState {
+  const next = state.step + 1;
+  return next >= TOUR_STEPS.length ? TOUR_FINISHED : { step: next, done: false };
+}
+
+/** "Skip" and finishing land in the same place: never shown again. */
+export function dismissTour(): TourState {
+  return TOUR_FINISHED;
+}
+
+/** 1-based position for the "2 of 4" label. */
+export function stepLabel(state: TourState): string {
+  const n = Math.min(state.step + 1, TOUR_STEPS.length);
+  return `${n} of ${TOUR_STEPS.length}`;
+}
+
+// ---------------------------------------------------------------------------
+// Spotlight geometry
+//
+// The dim layer is drawn as FOUR rectangles around the target rather than with
+// a mask: React Native has no cross-platform cutout, and four Views need no
+// dependency and no SVG. Get the arithmetic wrong and the hole lands over the
+// wrong tab — which is worse than no tour, because it points confidently at
+// something unrelated. Hence it lives here, tested, instead of inline in JSX.
+// ---------------------------------------------------------------------------
+
+export type Rect = { x: number; y: number; width: number; height: number };
+
+/**
+ * Where the highlighted tab sits. Tabs are evenly divided across the bar, so
+ * the index and the count are enough — no measurement pass, no layout race on
+ * the frame the overlay appears.
+ */
+export function spotlightRect(
+  screenWidth: number,
+  screenHeight: number,
+  tabBarHeight: number,
+  tabCount: number,
+  tabIndex: number,
+): Rect {
+  const count = Math.max(1, tabCount);
+  // Clamp rather than trust: a tab hidden by caps (remote-only mode) could
+  // otherwise index past the end and spotlight empty space off-screen.
+  const i = Math.min(Math.max(0, tabIndex), count - 1);
+  const width = screenWidth / count;
+  return {
+    x: i * width,
+    y: Math.max(0, screenHeight - tabBarHeight),
+    width,
+    height: Math.min(tabBarHeight, screenHeight),
+  };
+}
+
+/** The four dim rectangles that surround `hole`, covering everything else. */
+export function dimRects(screenWidth: number, screenHeight: number, hole: Rect): Rect[] {
+  const right = hole.x + hole.width;
+  const bottom = hole.y + hole.height;
+  return [
+    { x: 0, y: 0, width: screenWidth, height: hole.y },                        // above
+    { x: 0, y: bottom, width: screenWidth, height: Math.max(0, screenHeight - bottom) }, // below
+    { x: 0, y: hole.y, width: hole.x, height: hole.height },                   // left
+    { x: right, y: hole.y, width: Math.max(0, screenWidth - right), height: hole.height }, // right
+  ].filter((r) => r.width > 0 && r.height > 0);
+}

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -17,31 +17,80 @@
 
 export type TourStep = {
   /** Route name of the tab this step points at. */
-  tab: 'index' | 'launch' | 'pad' | 'actions';
+  tab: 'index' | 'launch' | 'pad' | 'actions' | 'setup';
   title: string;
   body: string;
 };
 
 export const TOUR_STEPS: TourStep[] = [
+  // CONSOLE — why the app exists.
   {
     tab: 'index',
-    title: 'Your box, at a glance',
-    body: 'Temperature, memory, disks and the logs — the screen to open when the TV goes black and you need to know whether the machine is even awake.',
+    title: 'Is the box even awake?',
+    body: 'Temperature, load, memory and disks, live. The first thing to check when the TV is black and the controller does nothing.',
+  },
+  {
+    tab: 'index',
+    title: 'See the screen from here',
+    body: 'Pull a still frame of what the TV is actually showing — the difference between "it crashed" and "it is sitting on a login prompt".',
+  },
+  {
+    tab: 'index',
+    title: 'Read the logs without a keyboard',
+    body: 'The services you care about and their journal, on the phone. No SSH, no crawling behind the TV.',
+  },
+
+  // LAUNCH — the thing people open it for daily.
+  {
+    tab: 'launch',
+    title: 'Your library, with cover art',
+    body: 'Every game the box has. Tap one and it starts on the TV — no Big Picture menus, no hunting with a D-pad.',
   },
   {
     tab: 'launch',
-    title: 'Your games, in your hand',
-    body: 'The whole library with its cover art. Tap a game and it starts on the TV — no Big Picture menus, no hunting with a D-pad.',
+    title: 'Tap asks before it launches',
+    body: 'A tap opens the game rather than starting it, with playtime and when you last opened it. Launching takes over the TV, so it is never one stray tap.',
+  },
+  {
+    tab: 'launch',
+    title: 'Narrow it down',
+    body: 'Filter by never-played, under two hours, or not touched in a year. The button counts as you go, so you can see the shortlist shrink.',
+  },
+  {
+    tab: 'launch',
+    title: 'Or let it choose',
+    body: 'The shuffle picks from whatever is currently showing — so "something short I have never played" is one tap away.',
+  },
+
+  // PAD — the hardware replacement.
+  {
+    tab: 'pad',
+    title: 'The phone is a controller',
+    body: 'A real gamepad the box cannot tell from plastic: sticks, D-pad, triggers, haptics. For when the real one is dead or across the room.',
   },
   {
     tab: 'pad',
-    title: 'The phone is the controller',
-    body: 'A real gamepad the box cannot tell from plastic, plus a trackpad and a keyboard for the moments a controller cannot help — a login box, a launcher update.',
+    title: 'Trackpad, swipe, and a keyboard',
+    body: 'Swipe like an Apple TV remote, or use it as a trackpad and type into the box — for the login boxes and launcher updates a controller cannot handle.',
+  },
+
+  // ACTIONS — the rescue.
+  {
+    tab: 'actions',
+    title: 'Unstick a frozen display',
+    body: 'Restart the display when the TV goes black but the machine is plainly still running. The one that saves the evening.',
   },
   {
     tab: 'actions',
-    title: 'Fix it from the couch',
-    body: 'Restart a frozen display, switch to desktop, reboot or power off — grouped by how much each one interrupts, so nothing destructive is one stray tap away.',
+    title: 'Grouped by what it costs you',
+    body: 'Routine, changes-what-is-on-screen, and ends-your-session are separated on purpose — nothing destructive sits next to something harmless.',
+  },
+
+  // SETUP — where the rest lives.
+  {
+    tab: 'setup',
+    title: 'Everything else lives here',
+    body: 'Add more boxes, switch between them, and turn things on or off — including this tour, if you ever want to watch it again.',
   },
 ];
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,27 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Feature tour — element spotlights
+- **priority:** P2 · **risk:** low (app-only, additive) · **affects:** app only ·
+  **depends_on:** nothing
+- **DONE 2026-08-06, unmerged on `feat/launch-confirm`.** The tour spotlights real elements
+  (CPU temp, display info, the game grid, the pad mode selector, action groups, the Logs
+  segment) instead of only tab-bar icons, scrolling below-the-fold targets into view.
+- The load-bearing rule: **a step whose anchor is not registered is SKIPPED.** Screens
+  register anchors only for what they rendered, so the tour can no longer explain a control
+  the user does not have. This replaced four separate "the tour describes something absent"
+  bugs found by driving the app on a phone.
+- Also fixed: the Prefs toggle did nothing until a relaunch (tour state was per-hook state,
+  now an external store like `lib/prefs.ts`); a step naming a caps-hidden tab wedged the tour
+  permanently; the logs step pointed at Console, which has no logs UI.
+- **Verified** on the simulator against the real lenovodesktop box, all 13 steps, both the
+  spotlight and the skip paths. **NOT verified on Android** — `collapsable={false}` is
+  reasoned, not observed.
+- **Follow-ups (from the same audit, NOT done):** the launch confirm sheet drops the compat
+  rating the tile shows; dead space under a short library grid; Console title clips under the
+  sticky header; duplicate EDIT affordances on box rows; the Pad looks live while disconnected
+  and lacks the cellular hint Setup has.
+
 ### Remote-only mode — Couchside as just a TV remote, no box
 - **priority:** P2 · **risk:** medium (new app-side transport; shared tab/entitlement
   plumbing) · **affects:** app only · **depends_on:** nothing for Phase 1; Phase 2 depends

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -502,3 +502,45 @@ Native's `fetch` does not enforce CORS; the harness's browser does. So a direct-
 failing on web is not evidence of a bug, and the fix is a CORS header on the STUB — never
 CORS handling in the app. Everything else about such a call (which path, how many requests,
 what encoding) IS observable in the harness by reading the stub's log rather than the screen.
+
+## Shared app state: the external-store shape (do not use a mount effect)
+
+Cross-component state that OUTLIVES one screen lives in a module-level store, never in a hook's
+`useState` + `useEffect(..., [])`. The shape, established by `app/lib/prefs.ts` and copied by
+`lib/haptics.ts`, `lib/keepAwake.ts`, `lib/theme.ts`, `lib/skin/index.tsx`,
+`lib/tvdirect/store.ts` and `hooks/useFeatureTour.ts`:
+
+```ts
+let value: T = DEFAULT;
+const listeners = new Set<() => void>();
+function emitChange() { for (const l of listeners) l(); }
+let loadStarted = false;               // one-shot load, kicked off at import
+export function useX() { return useSyncExternalStore(subscribe, get, get); }
+```
+
+Writers update the module value, `emitChange()` SYNCHRONOUSLY, and persist afterwards — so
+subscribers re-render on the same frame rather than waiting on the keychain.
+
+**Why this is a rule and not a preference.** `hooks/useFeatureTour.ts` used a mount effect with
+`[]` deps and lived in `app/(tabs)/_layout.tsx`, which never unmounts. A helper that wrote the
+same storage key therefore updated something nothing would read again until relaunch, and the
+Prefs switch that called it looked broken — while its own copy promised it would work. The bug
+is invisible in review because the code reads correctly; it only shows up when a SECOND
+component writes the state.
+
+## Feature-tour anchors
+
+A tour step names an element by id (`console.cpu`); the screen registers it with
+`<TourAnchor id="...">`. Rules:
+- **The anchor is the gate.** A screen registers only what it rendered, so an unregistered
+  anchor means the user does not have that control and the step is SKIPPED. Never add a
+  separate "should this step show" condition — it would drift from the UI it describes.
+- **Anchor ids are written as literals**, never built with a template string: a test in
+  `lib/__tests__/tour.test.ts` reads the screen sources to prove every id a step names is
+  actually registered, and an interpolated id is invisible to it.
+- **Anchor a plain View, not the skin `<Card>`.** Card is a plain function component in both
+  skins (a ref is dropped), and its `style` prop lands on a different box per skin, so the same
+  anchor would measure two different rectangles. Measuring a plain View also keeps it off
+  reactor's `Animated.View`, which moves 8px during its 260ms entrance.
+- **Mirror `hitSlop`** when wrapping a small Pressable: a parent clips hit-testing to its own
+  bounds, so a bare wrapper shrinks the touch target back to the drawn icon.

--- a/docs/memory/project_library-triage.md
+++ b/docs/memory/project_library-triage.md
@@ -93,9 +93,31 @@ presets. This is useful on day one and proves the interaction.
 app-side, cached, opt-in. The metal pill on the tile. Now "what runs well here"
 is answerable.
 
-**Phase 3 — time to beat.** HowLongToBeat hours and the STORY / EXTRAS /
-COMPLETION row, IF the ToS review clears. Enables the real query: *"something
-that runs great and I can finish this weekend."*
+**Phase 3 — time to beat. DROPPED 2026-08-06. Do not build this.**
+
+The ToS review did not clear, and the answer is not ambiguous. HowLongToBeat is
+Ziff Davis property, and its robots.txt states:
+
+> Use of any robot, crawler, or other tool to scrape, harvest, extract, or
+> retrieve any content on this website using automated means is prohibited
+> without written permission from Ziff Davis. Prohibited uses include ... (4) any
+> commercial purposes.
+
+It also carries `Disallow: /api` — the exact path any integration would use.
+Couchside is a paid app, so this is prohibited on three independent counts:
+automated retrieval, the disallowed path, and commercial use.
+
+**Routes that would make it legitimate**, if the feature is ever wanted enough:
+1. Written permission from licensing@ziffdavis.com. That is the intended path —
+   the robots.txt names the contact.
+2. A different source. IGDB (Twitch/Amazon) publishes `game_time_to_beats`
+   through an official, documented API. But it authenticates with a client
+   id/secret, which cannot ship inside the app binary — it would need the proxy
+   server this design has already rejected twice. So IGDB trades a legal
+   problem for an architectural one.
+
+Until one of those is true, the honest answer is that Couchside does not show
+time-to-beat.
 
 **Phase 4 — triage actions.** Unplayed / unfinished switches, bookmarks, and a
 shuffle ("pick something for me") — which on Couchside means **it launches**.


### PR DESCRIPTION
Sixteen commits of app work, driven and verified on a real phone and against a real box
(`lenovodesktop`, agent 2.9.70). Agent code is untouched — this is app-only.

## What's in it

**Launch / library triage**
- Tapping a tile opens a confirm sheet instead of launching. Launching takes over the TV, so
  it is no longer one stray tap. (Owner: "annoyed me a few times already".)
- Steam Deck + ProtonDB compatibility badges, opt-in and off by default. No Steam key, no
  account — the box already has playtime on disk, and the ratings are public per-appid data.
- "Pick a game for me" shuffle, and filters over the library.

**First run**
- Search first, instruct second: detect a box and show install steps only when none is found;
  offer the TV-remote path only for someone who says they have no box.
- Cancelling a purchase, and backing out of Restore, are no longer reported as errors.
- A brand-new install is no longer nudged to check for updates on day one.

**Feature tour**
- Spotlights REAL ELEMENTS — CPU temp, display info, the game grid, the pad mode selector,
  action groups, the Logs segment — scrolling below-the-fold targets into view.
- The load-bearing rule: **a step whose anchor is not registered is skipped.** Screens register
  anchors only for what they rendered, so the tour cannot explain a control the user does not
  have. That one rule replaced four separate "describes something absent" bugs.

## Bugs this fixes, all found by driving the app

- The Prefs tour toggle did nothing until a relaunch. Tour state was per-hook state loaded in a
  mount effect, inside a layout that never unmounts, so the reset wrote storage nothing re-read
  — while the switch's own copy promised it would replay. Now an external store, matching
  `lib/prefs.ts`.
- A step naming a caps-hidden tab rendered nothing: no card, no way to advance. The tour stayed
  "visible" forever and suppressed the landing redirect with it.
- The logs step pointed at Console, which has no logs UI at all.
- The Actions step named an action that does not exist and sold it as harmless; it now names
  **Restart Session** as labelled and says it ends the session.

## Verification

- 309/309 app tests, `tsc --noEmit` clean.
- Walked all 13 tour steps on the simulator against the real box: spotlight placement, card
  above/below, scroll-into-view, and the SKIP path firing for real (filter and shuffle skipped
  on a 2-game library; the ROUTINE group skipped on a Linux box that reports no low-danger
  actions).
- The new "every anchor a step names is registered" guard was checked in BOTH directions — it
  fails on a corrupted id and passes when correct. It caught a real miss on its first run.
- Toggle fix confirmed in both states: dead before, immediate replay after.

## NOT verified

- **Android.** `collapsable={false}` is on every anchor precisely because Android optimises
  prop-less Views out of the native tree and an unmeasurable view would silently skip its step
  — but that is reasoning, not evidence. Being exercised separately before the next Play build.
- The ROUTINE anchor has only ever been observed ABSENT (it needs a Windows or Decky box).
  Note `--mock` always injects it, so the web harness shows a group a real Linux box never will.
- Haptics, and the tour under remote-only mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)