### PR TITLE
The tour on Android: a stale hole, a lost tab, and the keyboard-bar shortcut

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -77,10 +77,27 @@ export default function TabLayout() {
       navigatedFor.current = null;
       return;
     }
-    if (navigatedFor.current === tourTab) return;
+    // ASSERT the tab, do not just fire once at it. `segments` is in the deps so
+    // this re-checks after navigation settles, because a single replace() can
+    // lose a race with the router's own initial route: on ANDROID the app comes
+    // up on Pad (unstable_settings.initialRouteName) and the tour's replace was
+    // silently overridden. The tour then sat on Pad while its step described
+    // Console — and worse, Console never mounted, so its anchors never
+    // registered and the first three steps skipped themselves as "absent".
+    // iOS did not show this; the comment below about index winning a cold start
+    // was measured in the web harness and is not true on every platform.
+    const leaf = segments[segments.length - 1];
+    // Console is the index route, so its leaf segment is the GROUP name — the
+    // typed-routes union has no 'index' member, which is the compiler telling
+    // you the same thing.
+    const onTourTab = tourTab === 'index' ? leaf === '(tabs)' : leaf === tourTab;
+    if (onTourTab) {
+      navigatedFor.current = tourTab;
+      return;
+    }
     navigatedFor.current = tourTab;
     router.replace(tourTab === 'index' ? '/(tabs)' : `/(tabs)/${tourTab}`);
-  }, [tourTab]);
+  }, [tourTab, segments]);
 
   // On true first run (persisted fleet loaded, but empty) send the user to
   // Setup to pair. Otherwise honour the landing-tab preference.

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -1557,15 +1557,21 @@ function PadScreen() {
   const kbEnter = useCallback(() => client.sendKey('enter'), [client]);
 
   const keyboardBar = showKeyboardBar ? (
-    <KeyboardBar
-      onText={kbText}
-      onBackspace={kbBackspace}
-      onEnter={kbEnter}
-      onSwipeMode={cycleMode}
-      autoOpenSignal={oskSignal}
-      onSearch={canSearch ? steamSearch : undefined}
-      onDismiss={closeSteamSearch}
-    />
+    // Anchored for the feature tour: swiping this bar cycles the pad mode, which
+    // is the thumb-reachable way to do what the selector at the very top of the
+    // screen does. Nobody discovers it on their own. The anchor is on the bar
+    // itself so the step disappears along with it when padKeyboardBar is off.
+    <TourAnchor id="pad.keybar">
+      <KeyboardBar
+        onText={kbText}
+        onBackspace={kbBackspace}
+        onEnter={kbEnter}
+        onSwipeMode={cycleMode}
+        autoOpenSignal={oskSignal}
+        onSearch={canSearch ? steamSearch : undefined}
+        onDismiss={closeSteamSearch}
+      />
+    </TourAnchor>
   ) : null;
 
   // One corner chip toggles large mode in a single tap, shared by the trackpad

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -31,7 +31,7 @@ import React from 'react';
 import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { measureAnchor, scrollTabBy } from '@/hooks/useTourAnchor';
+import { measureAnchor, scrollTabBy, subscribeAnchorLayout } from '@/hooks/useTourAnchor';
 import { hapticLight } from '@/lib/haptics';
 import {
   anchorHole,
@@ -70,6 +70,8 @@ const RETRY_EVERY_MS = 100;
 const RETRY_FOR_MS = 4000;
 /** Let a scroll settle before trusting the second measurement. */
 const SCROLL_SETTLE_MS = 380;
+/** How many times one step may chase a moving anchor before giving up. */
+const MAX_SCROLL_CORRECTIONS = 3;
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
@@ -101,6 +103,9 @@ export function FeatureTour({
    *  cannot land after the user has already moved on and draw a hole over the
    *  wrong element. */
   const runId = React.useRef(0);
+  /** Scroll corrections spent on the CURRENT step; reset when the step changes.
+   *  Bounds the chase-the-anchor loop below. */
+  const corrections = React.useRef(0);
 
   const bandTop = insets.top + HEADER_H;
   const bandBottom = height - insets.bottom - TAB_BAR_H;
@@ -111,6 +116,7 @@ export function FeatureTour({
   React.useEffect(() => {
     const mine = ++runId.current;
     const live = () => runId.current === mine;
+    corrections.current = 0;
     setHole(null);
 
     if (!step) return;
@@ -166,6 +172,57 @@ export function FeatureTour({
     })();
     // `order` covers a tab-bar reshuffle (caps arriving, remote-only flipping).
   }, [state.step, anchor, tab, idx, order, width, height, insets.bottom]);
+
+  // Follow the anchor if it MOVES after we measured it. The screen keeps
+  // filling in — downloads appear, a host list expands, art loads — and
+  // everything below slides down. Without this the ring stays where the element
+  // was when the step opened; on Android that put it around the queued and
+  // stream sections while the card talked about the library.
+  //
+  // Deliberately only updates the hole: it must never re-run the skip logic, or
+  // a transient zero-height layout mid-reflow would advance the step.
+  React.useEffect(() => {
+    if (!anchor || !hole) return;
+    return subscribeAnchorLayout((movedId) => {
+      if (movedId !== anchor) return;
+      void (async () => {
+        let r = await measureAnchor(anchor);
+        if (!r) return;
+        // If the shift pushed it out of the visible band, chase it — measuring
+        // alone would leave the hole off-screen and the user staring at a fully
+        // dimmed page with no spotlight anywhere. Seen on Android, where a long
+        // "Stream from PC" list pushed the library grid below the fold after the
+        // step had already scrolled to it.
+        //
+        // BOUNDED. Each correction can trigger another layout, and an unbounded
+        // chase would be a scroll loop the user cannot escape.
+        if (corrections.current < MAX_SCROLL_CORRECTIONS) {
+          const dy = scrollDeltaFor(r, bandTop, bandBottom);
+          if (dy !== 0 && scrollTabBy(tab as string, dy)) {
+            corrections.current += 1;
+            await delay(SCROLL_SETTLE_MS);
+            const settled = await measureAnchor(anchor);
+            if (settled) r = settled;
+          }
+        }
+        setHole((prev) => {
+          const next = anchorHole(r, ANCHOR_PAD, width, height);
+          // Ignore sub-pixel churn so a settling layout cannot cause a render
+          // loop; onLayout can fire repeatedly with effectively the same box.
+          if (
+            prev &&
+            Math.abs(prev.x - next.x) < 1 &&
+            Math.abs(prev.y - next.y) < 1 &&
+            Math.abs(prev.width - next.width) < 1 &&
+            Math.abs(prev.height - next.height) < 1
+          ) {
+            return prev;
+          }
+          return next;
+        });
+      })();
+    });
+  }, [anchor, hole, width, height]);
 
   if (!step) return null;
   // A tab this build does not show (remote-only hides the box tabs) has nothing

--- a/app/components/TourAnchor.tsx
+++ b/app/components/TourAnchor.tsx
@@ -15,7 +15,7 @@
 import React from 'react';
 import { View, type StyleProp, type ViewStyle } from 'react-native';
 
-import { useTourAnchor } from '@/hooks/useTourAnchor';
+import { notifyAnchorLayout, useTourAnchor } from '@/hooks/useTourAnchor';
 
 export function TourAnchor({
   id,
@@ -41,7 +41,17 @@ export function TourAnchor({
     // never fire or hand back zeros. iOS does not collapse, so this is the kind
     // of bug that ships green from a simulator and is broken on half the users'
     // phones.
-    <View ref={ref} style={style} hitSlop={hitSlop} collapsable={false}>
+    <View
+      ref={ref}
+      style={style}
+      hitSlop={hitSlop}
+      // Tell the tour when this box moves. Screens fill in asynchronously and
+      // push their contents around; without this the spotlight keeps the rect
+      // it measured on arrival. onLayout fires for a change of POSITION as well
+      // as size, which is the case that matters — the anchor itself is usually
+      // the same size, just further down the page than it was a moment ago.
+      onLayout={() => notifyAnchorLayout(id)}
+      collapsable={false}>
       {children}
     </View>
   );

--- a/app/hooks/useTourAnchor.ts
+++ b/app/hooks/useTourAnchor.ts
@@ -66,6 +66,33 @@ export async function measureAnchor(id: string): Promise<Rect | null> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Layout changes
+//
+// A measured rect goes STALE. Screens fill in asynchronously — the downloads
+// card appears, the "Stream from PC" host list expands, cover art loads — and
+// everything below shifts down. Measure once and the spotlight stays where the
+// element USED to be: seen on Android against a real box, where the ring sat
+// around the queued/stream sections while the card described the library.
+// Pointing confidently at the wrong thing is the one failure this whole module
+// exists to avoid, so anchors report their own movement.
+// ---------------------------------------------------------------------------
+
+const layoutListeners = new Set<(id: string) => void>();
+
+/** Called by TourAnchor whenever its box moves or resizes. */
+export function notifyAnchorLayout(id: string): void {
+  for (const l of layoutListeners) l(id);
+}
+
+/** Subscribe to anchor movement. Returns the unsubscribe function. */
+export function subscribeAnchorLayout(cb: (id: string) => void): () => void {
+  layoutListeners.add(cb);
+  return () => {
+    layoutListeners.delete(cb);
+  };
+}
+
 /** Register the scrollable container for a tab, so the tour can bring an
  *  off-screen anchor into view. `dy` is a DELTA, not an absolute offset. */
 export function registerScroller(tab: string, scrollBy: (dy: number) => void): () => void {

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -112,6 +112,15 @@ export const TOUR_STEPS: TourStep[] = [
     title: 'Trackpad, swipe, and a keyboard',
     body: 'SWIPE works like an Apple TV remote and MOUSE is a trackpad you can type through — for the login boxes and launcher updates a controller cannot handle.',
   },
+  // The shortcut for the switch two steps up. Worth its own step because the
+  // selector sits at the very top of the screen and this does the same job
+  // under your thumb — and nobody finds it by accident.
+  {
+    tab: 'pad',
+    anchor: 'pad.keybar',
+    title: 'Switch modes without reaching',
+    body: 'Swipe left or right across this bar to change mode — same as the buttons at the top, but where your thumb already is. Tap it to type on the box instead.',
+  },
 
   // ACTIONS — the rescue.
   {


### PR DESCRIPTION
Ran the feature tour on a real **Motorola Razr 2023** and on an emulator, against
the real `lenovodesktop` box. Three defects only Android exposed.

## The spotlight went stale
Screens fill in asynchronously — the downloads card appears, the "Stream from PC"
host list expands, cover art loads — and everything below slides down. The hole was
measured once, on arrival. On a real library that put the ring around the queued and
stream sections while the card described the game grid; later it drifted off-screen
and the page just dimmed with no spotlight anywhere.

Anchors now report their own movement (`onLayout` → `notifyAnchorLayout`), and the
tour re-measures and scrolls after a target that has left the visible band. Bounded
at three corrections per step so a settling layout cannot become a scroll loop.

## The tour lost its tab
Android comes up on Pad (`unstable_settings.initialRouteName`), and the tour's single
`router.replace` lost that race. It sat on Pad while its step described Console — and
because tab screens mount lazily, Console never mounted, so its anchors never
registered and the first three steps skipped themselves as "absent".

The navigation effect now **asserts** the tab against live `segments` rather than
firing once at it. Note the existing comment claiming the index route wins a cold
start was measured in the web harness; it is not true on Android.

## A shortcut worth showing
New step for the keyboard bar: swiping it cycles pad mode — the same job as the
selector at the top of the screen, but where your thumb already is. Nobody discovers
it on their own. 14 steps now.

## Verified on the Razr (real hardware, real box)
- 1/14 rings CPU TEMP · 3/14 rings the screen preview after scrolling to it
- 4/14 rings the game grid, scrolled past a long stream list — the exact case that
  previously showed no ring at all
- 8/14 the mode selector · 10/14 the keyboard bar
- Filter and shuffle still skip on a 2-game library

This also closes the Android gap the previous PR flagged as unverified:
`collapsable={false}` is doing its job — measurement works on Android.

309/309 tests, `tsc --noEmit` clean.

## Not verified
The ROUTINE action group (needs a Windows or Decky box) and the tour under
remote-only mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)