### PR TITLE
Tour timing: skipped steps no longer stall, and the thank-you note actually renders

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 73
+      "versionCode": 74
     },
     "web": {
       "bundler": "metro",

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -1,13 +1,15 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { router, Tabs, useSegments } from 'expo-router';
-import { currentStep } from '@/lib/tour';
-import { useEffect, useRef } from 'react';
+import { currentStep, isFinalStep } from '@/lib/tour';
+import { useCallback, useEffect, useRef } from 'react';
 
 import { useCapsSync } from '@/hooks/useCapsSync';
 import { hapticSelection } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { FeatureTour } from '@/components/FeatureTour';
+import { TourThanks } from '@/components/TourThanks';
 import { useFeatureTour } from '@/hooks/useFeatureTour';
+import { showTourThanks, useTourThanks } from '@/hooks/useTourThanks';
 import { useBoxes } from '@/lib/SettingsContext';
 import { useTheme } from '@/lib/theme';
 
@@ -64,6 +66,17 @@ export default function TabLayout() {
   ];
   const tourEnabled = usePref('featureTour');
   const tour = useFeatureTour(boxes.length > 0, tourEnabled);
+  const thanksVisible = useTourThanks();
+
+  // Thank the people who actually WALKED it. Wrapping `next` rather than
+  // watching for state.done is deliberate: skipping and finishing both land on
+  // TOUR_FINISHED, and someone who pressed "Skip tour" has just asked to be
+  // left alone — which is the worst possible moment to show them a note about
+  // buying. Only the last GOT IT gets here.
+  const tourNext = useCallback(() => {
+    if (isFinalStep(tour.state)) showTourThanks();
+    tour.next();
+  }, [tour]);
 
   // Take the user TO the tab being described. A spotlight on "Console" while
   // they are looking at the Pad screen explains a screen they cannot see —
@@ -253,7 +266,7 @@ export default function TabLayout() {
       <FeatureTour
         state={tour.state}
         tabOrder={tabOrder}
-        onNext={tour.next}
+        onNext={tourNext}
         onSkip={tour.skip}
       />
     ) : null}

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -270,6 +270,10 @@ export default function TabLayout() {
         onSkip={tour.skip}
       />
     ) : null}
+    {/* Shown after the LAST step, never after Skip — see hooks/useTourThanks.ts.
+        Rendered after the tour so it sits above it during the frame the tour is
+        tearing down. */}
+    {thanksVisible ? <TourThanks /> : null}
     </>
   );
 }

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -31,7 +31,7 @@ import React from 'react';
 import { Pressable, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { measureAnchor, scrollTabBy, subscribeAnchorLayout } from '@/hooks/useTourAnchor';
+import { measureAnchor, screenHasAnchors, scrollTabBy, subscribeAnchorLayout } from '@/hooks/useTourAnchor';
 import { hapticLight } from '@/lib/haptics';
 import {
   anchorHole,
@@ -68,6 +68,12 @@ const RETRY_EVERY_MS = 100;
  *  genuinely absent element takes this long to skip, which nobody sees as
  *  anything but a slightly late card. */
 const RETRY_FOR_MS = 4000;
+/** Budget once the target's SCREEN is up and other anchors on it have reported.
+ *  At that point a missing anchor is missing, not late, so waiting the full
+ *  budget just makes a skipped step look like the app froze — a user watching
+ *  the tour reported a dead pause between steps 7 and 8, and 12 and 13, which
+ *  were precisely the two steps skipped on their box. */
+const READY_GIVE_UP_MS = 700;
 /** Let a scroll settle before trusting the second measurement. */
 const SCROLL_SETTLE_MS = 380;
 /** How many times one step may chase a moving anchor before giving up. */
@@ -146,10 +152,16 @@ export function FeatureTour({
 
     void (async () => {
       let rect: Rect | null = null;
-      for (let waited = 0; waited <= RETRY_FOR_MS; waited += RETRY_EVERY_MS) {
+      for (let waited = 0; ; waited += RETRY_EVERY_MS) {
         if (!live()) return;
         rect = await measureAnchor(anchor);
         if (rect) break;
+        // Stop early once the screen itself is clearly up: a sibling anchor on
+        // the same screen has registered, so this one is absent by design (a
+        // filter that needs 8+ games, an action group this box does not report)
+        // and no amount of waiting will conjure it.
+        const budget = screenHasAnchors(anchor) ? READY_GIVE_UP_MS : RETRY_FOR_MS;
+        if (waited >= budget) break;
         await delay(RETRY_EVERY_MS);
       }
       if (!live()) return;

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -160,7 +160,7 @@ export function FeatureTour({
         // the same screen has registered, so this one is absent by design (a
         // filter that needs 8+ games, an action group this box does not report)
         // and no amount of waiting will conjure it.
-        const budget = screenHasAnchors(anchor) ? READY_GIVE_UP_MS : RETRY_FOR_MS;
+        const budget = (await screenHasAnchors(anchor)) ? READY_GIVE_UP_MS : RETRY_FOR_MS;
         if (waited >= budget) break;
         await delay(RETRY_EVERY_MS);
       }

--- a/app/components/TourThanks.tsx
+++ b/app/components/TourThanks.tsx
@@ -1,0 +1,166 @@
+/**
+ * A word of thanks after someone walks the whole feature tour.
+ *
+ * THE PRICE COMES FROM THE STORE, and is never written down here.
+ * getProduct().displayPrice is what App Store Connect / Play Console actually
+ * charges, so changing the price there changes this line with no app release —
+ * the remote-config behaviour you would otherwise build, except it cannot
+ * disagree with the receipt, and it is already localised and in the reader's own
+ * currency. A hardcoded "$4.99" would be a false claim the day the price steps
+ * up and a wrong one today for anybody paying in euros; this app has already
+ * taken one App Review rejection over how IAP was presented.
+ *
+ * IF THE STORE DOES NOT ANSWER, THE SENTENCE LOSES ITS NUMBER rather than
+ * falling back to a guess. "The lifetime unlock is discounted while it is early"
+ * is true without a figure; a figure that might be wrong is not.
+ *
+ * IT DOES NOT SELL TO SOMEONE WHO ALREADY PAID. A supporter who reaches the end
+ * of the tour gets thanked; they do not get a discount pitch for a thing they
+ * have already bought. Same message, different second half.
+ *
+ * SHOWN ONCE, AND ONLY ON A REAL FINISH — never after "Skip tour", which is
+ * someone asking to be left alone. See hooks/useTourThanks.ts.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { dismissTourThanks } from '@/hooks/useTourThanks';
+import { isGenuinelyPurchased } from '@/lib/entitlement';
+import { useEntitlement } from '@/lib/EntitlementContext';
+import { hapticLight } from '@/lib/haptics';
+import { getProduct } from '@/lib/purchase';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function TourThanks() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const router = useRouter();
+  const { entitlement } = useEntitlement();
+
+  const owned = isGenuinelyPurchased(entitlement);
+
+  // The live store price. Null until it answers, and null forever if it cannot
+  // be reached — the copy below drops the number in that case rather than
+  // inventing one.
+  const [price, setPrice] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    if (owned) return;
+    let alive = true;
+    void (async () => {
+      const p = await getProduct();
+      if (alive && p?.displayPrice) setPrice(p.displayPrice);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [owned]);
+
+  const close = () => {
+    hapticLight();
+    dismissTourThanks();
+  };
+
+  return (
+    <View style={StyleSheet.absoluteFill} pointerEvents="box-none">
+      <Pressable style={styles.scrim} onPress={close} accessibilityLabel="Dismiss" />
+      <View style={styles.wrap} pointerEvents="box-none">
+        <View style={styles.card}>
+          <View style={styles.badge}>
+            <Ionicons name="heart" size={16} color={t.green} />
+          </View>
+
+          <Text style={styles.title}>Thanks for giving it a go</Text>
+
+          <Text style={styles.body}>
+            Couchside is a passion project. I hope you find it genuinely useful — and I am
+            committed to making it better as time goes on.
+          </Text>
+
+          {owned ? (
+            <Text style={styles.body}>
+              You have already bought the unlock, and that is the thing that keeps this going.
+              Thank you, sincerely.
+            </Text>
+          ) : (
+            <Text style={styles.body}>
+              Any purchase during these early days is appreciated more than you would guess.
+              The lifetime unlock is discounted{price ? ` to ${price}` : ''} while it is early —
+              one payment, no subscription, ever.
+            </Text>
+          )}
+
+          <View style={styles.actions}>
+            {owned ? null : (
+              <Pressable
+                onPress={() => {
+                  hapticLight();
+                  dismissTourThanks();
+                  router.push('/(tabs)/setup?tab=account');
+                }}
+                accessibilityRole="button"
+                style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}>
+                <Text style={styles.secondaryText}>SEE THE UNLOCK</Text>
+              </Pressable>
+            )}
+            <Pressable
+              onPress={close}
+              accessibilityRole="button"
+              style={({ pressed }) => [styles.primary, pressed && styles.pressed]}>
+              <Text style={styles.primaryText}>{owned ? 'THANKS' : 'NOT NOW'}</Text>
+            </Pressable>
+          </View>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    scrim: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: '#000000b0' },
+    wrap: { flex: 1, justifyContent: 'center', paddingHorizontal: 22 },
+    card: {
+      backgroundColor: t.card,
+      borderRadius: 18,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      padding: 20,
+      gap: 12,
+    },
+    badge: {
+      width: 34,
+      height: 34,
+      borderRadius: 17,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: t.inset,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+    },
+    title: { color: t.text, fontSize: 19, fontWeight: '800' },
+    body: { color: t.textDim, fontSize: 13.5, lineHeight: 20 },
+    actions: { flexDirection: 'row', gap: 10, marginTop: 6 },
+    secondary: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 12,
+      paddingVertical: 13,
+      backgroundColor: t.green,
+    },
+    secondaryText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    primary: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 12,
+      paddingVertical: 13,
+      backgroundColor: t.inset,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+    },
+    primaryText: { color: t.textDim, fontSize: 13, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+    pressed: { opacity: 0.75 },
+  });

--- a/app/hooks/useTourAnchor.ts
+++ b/app/hooks/useTourAnchor.ts
@@ -56,12 +56,21 @@ export function hasAnchor(id: string): boolean {
  * watching the tour saw a four-second dead pause between steps 7 and 8, and
  * again between 12 and 13 — exactly the steps skipped on their box.
  */
-export function screenHasAnchors(id: string): boolean {
+export async function screenHasAnchors(id: string): Promise<boolean> {
   const dot = id.indexOf('.');
   if (dot <= 0) return false;
   const prefix = id.slice(0, dot + 1);
   for (const key of anchors.keys()) {
-    if (key !== id && key.startsWith(prefix)) return true;
+    if (key === id || !key.startsWith(prefix)) continue;
+    // MEASURE the sibling; do not settle for it being registered. Several
+    // anchors wrap components that hide themselves (DisplayAudioCard and
+    // ScreenPreview both return null until the box answers), so the wrapper
+    // View is mounted and registered while rendering nothing at all. Treating
+    // that as "the screen is ready" made the three Console steps skip
+    // themselves on a cold pair — the exact bug the longer budget existed to
+    // fix, reintroduced from the other side. A sibling with real dimensions is
+    // the only honest evidence that this screen has content.
+    if (await measureAnchor(key)) return true;
   }
   return false;
 }

--- a/app/hooks/useTourAnchor.ts
+++ b/app/hooks/useTourAnchor.ts
@@ -45,6 +45,28 @@ export function hasAnchor(id: string): boolean {
 }
 
 /**
+ * Has the screen this anchor belongs to reported ANY anchor yet?
+ *
+ * Anchor ids are namespaced by screen ("launch.filter", "actions.routine"), so a
+ * registered sibling means that screen is mounted and laid out — and therefore
+ * that a missing anchor is genuinely missing rather than merely late.
+ *
+ * This is what lets the tour tell "not ready" from "not here". Without it both
+ * look identical and every skipped step has to burn the full wait: a user
+ * watching the tour saw a four-second dead pause between steps 7 and 8, and
+ * again between 12 and 13 — exactly the steps skipped on their box.
+ */
+export function screenHasAnchors(id: string): boolean {
+  const dot = id.indexOf('.');
+  if (dot <= 0) return false;
+  const prefix = id.slice(0, dot + 1);
+  for (const key of anchors.keys()) {
+    if (key !== id && key.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+/**
  * Where is it, in window coordinates? null when it is not mounted or has not
  * been laid out.
  *

--- a/app/hooks/useTourThanks.ts
+++ b/app/hooks/useTourThanks.ts
@@ -1,0 +1,106 @@
+/**
+ * The one-time thank-you shown after someone WALKS the whole feature tour.
+ *
+ * Same module-level external-store shape as lib/prefs.ts and useFeatureTour —
+ * it is written from the tabs layout and read by a component mounted alongside
+ * it, so a per-hook useState would have the same "the write is invisible"
+ * problem the tour state itself had.
+ *
+ * SHOWN ONCE, EVER, and only on a genuine finish. Pressing "Skip tour" is
+ * someone asking to be left alone; answering that with a note about buying is
+ * the exact move that makes an app feel like it wants something from you. The
+ * caller decides — see lib/tour.ts isFinalStep — and this module only remembers
+ * whether it has already happened.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useCallback, useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+const KEY = 'couchside.tour.thanks.v1';
+
+async function get(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem(k) : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function set(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(k, v);
+    } catch {
+      // storage unavailable: it may appear once more next launch, never worse
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+type Snapshot = {
+  /** True while the note should be on screen. */
+  visible: boolean;
+  /** True once it has been shown and dismissed, ever. */
+  done: boolean;
+  /** False until storage has been read — never show before we know. */
+  ready: boolean;
+};
+
+let snap: Snapshot = { visible: false, done: true, ready: false };
+const listeners = new Set<() => void>();
+
+function commit(next: Snapshot): void {
+  snap = next;
+  for (const l of listeners) l();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+const getSnapshot = () => snap;
+
+let loadStarted = false;
+export async function loadTourThanks(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  let done = false;
+  try {
+    done = (await get(KEY)) === '1';
+  } catch {
+    done = false;
+  }
+  commit({ visible: false, done, ready: true });
+}
+void loadTourThanks();
+
+/** Called when the tour is FINISHED (not skipped). No-op if already shown. */
+export function showTourThanks(): void {
+  if (!snap.ready || snap.done || snap.visible) return;
+  commit({ ...snap, visible: true });
+}
+
+/** Dismiss and never show again. */
+export function dismissTourThanks(): void {
+  commit({ visible: false, done: true, ready: true });
+  void set(KEY, '1');
+}
+
+export function useTourThanks(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot).visible;
+}
+
+/** Test/debug helper: forget that it was shown, so it can appear again. Paired
+ *  with the feature-tour reset, since replaying the tour should be able to end
+ *  the same way it did the first time. */
+export async function resetTourThanks(): Promise<void> {
+  commit({ visible: false, done: false, ready: true });
+  await set(KEY, '0');
+}

--- a/app/lib/__tests__/tour.test.ts
+++ b/app/lib/__tests__/tour.test.ts
@@ -15,6 +15,7 @@ import {
   currentStep,
   dimRects,
   dismissTour,
+  isFinalStep,
   scrollDeltaFor,
   shouldRun,
   spotlightRect,
@@ -208,4 +209,18 @@ test('every anchor a step names is registered by some screen', async () => {
 test('a step points at a tab that exists (control)', () => {
   const TABS = ['index', 'launch', 'pad', 'actions', 'setup'];
   for (const s of TOUR_STEPS) assert.ok(TABS.includes(s.tab), `unknown tab ${s.tab}`);
+});
+
+test('only the LAST step is final — skipping earlier must not count as finishing', () => {
+  // The thank-you note is gated on this. Skipping is someone asking to be left
+  // alone, and both skip and finish land on TOUR_FINISHED, so the difference has
+  // to be caught BEFORE the state is written or it is lost.
+  assert.equal(isFinalStep(TOUR_NOT_STARTED), false, 'step 1 of many is not the end');
+  let s = TOUR_NOT_STARTED;
+  for (let i = 0; i < TOUR_STEPS.length - 1; i += 1) {
+    assert.equal(isFinalStep(s), i === TOUR_STEPS.length - 1, `step ${i} finality`);
+    s = advanceTour(s);
+  }
+  assert.equal(isFinalStep(s), true, 'the last step reports final');
+  assert.equal(advanceTour(s).done, true, 'and advancing from it finishes the tour');
 });

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -204,6 +204,21 @@ export function dismissTour(): TourState {
   return TOUR_FINISHED;
 }
 
+/**
+ * Is this the LAST step — i.e. will the next tap finish the tour rather than
+ * advance it?
+ *
+ * Used for two things: the button says DONE instead of "GOT IT →", and the
+ * thank-you note is shown only to someone who actually reached the end. The
+ * state cannot tell you afterwards, because skipping and finishing both land on
+ * TOUR_FINISHED — and the difference matters, since pressing "Skip tour" is
+ * someone asking to be left alone, which is the worst possible moment to hand
+ * them a note about buying.
+ */
+export function isFinalStep(state: TourState): boolean {
+  return state.step === TOUR_STEPS.length - 1;
+}
+
 /** 1-based position for the "2 of 4" label. */
 export function stepLabel(state: TourState): string {
   const n = Math.min(state.step + 1, TOUR_STEPS.length);


### PR DESCRIPTION
Follow-up to #364, from driving the tour on a real Razr 2023.

## The 4-second stall (owner-reported)
A dead pause between steps 7→8 and 12→13 — exactly the steps skipped on that box
(the shuffle, and the ROUTINE action group). Cause was mine: the retry budget was
raised to 4s so Console steps would stop skipping before the first status poll, and
every skip then paid that full 4s with nothing on screen.

"Not ready yet" and "not here" were indistinguishable. Anchor ids are namespaced by
screen, so a sibling that MEASURES proves the screen has content; once one does, the
wait drops to 700ms. A screen that has reported nothing keeps the full 4s.

**Measured after the fix, walking all 14 steps on the Razr: every transition
0.8–2.6s. No stalls.**

## Registered is not rendered
The first version of that check asked whether a sibling was *registered*. Several
anchors wrap components that hide themselves (`DisplayAudioCard`, `ScreenPreview`
both return null until the box answers) and sit outside the status gate, so they
register while rendering nothing — which would have made Console look ready
instantly. Readiness now measures.

## The thank-you note was never mounted
It was wired to state and never rendered: the edit adding `<TourThanks />` to the
tabs layout matched nothing and silently did nothing. Caught by pressing DONE on
step 14 and watching nothing happen.

## Verified
- 14/14 steps walked on the Razr (release build, real box), transitions timed
- 309/309 tests, `tsc --noEmit` clean

## NOT verified
**The thank-you card itself has still never been seen rendering** — the fix above
landed after the last build. That is the next thing to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)