### PR TITLE
Google TV pairing on Android (PKCS#8), and the iOS build-number reconcile

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "136",
+      "buildNumber": "137",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/lib/tvdirect/__tests__/atvcrypto.test.ts
+++ b/app/lib/tvdirect/__tests__/atvcrypto.test.ts
@@ -153,3 +153,20 @@ test('async mint is cancellable (a stuck pair must not run forever)', async () =
   const signal = { aborted: true };
   await assert.rejects(() => mintIdentityAsync(getRandomValues, { signal }), /cancelled/);
 });
+
+test('the private key is PKCS#8, because Android cannot read PKCS#1', async () => {
+  // NOT a style preference. react-native-tcp-socket parses the PEM body on
+  // Android with PKCS8EncodedKeySpec and nothing else, so a PKCS#1 key
+  // ("BEGIN RSA PRIVATE KEY") throws on every connectTLS — every Google TV
+  // pair and every keypress, on every Android device. iOS quietly converts it,
+  // which is why this shipped unnoticed: the feature was only verified there.
+  //
+  // The older assertion in this file matched /PRIVATE KEY-----/, which is true
+  // of BOTH formats and therefore could never have caught it.
+  const id = await mintIdentityAsync(getRandomValues);
+  assert.ok(
+    id.keyPem.startsWith('-----BEGIN PRIVATE KEY-----'),
+    `key must be PKCS#8; got: ${id.keyPem.slice(0, 32)}`,
+  );
+  assert.ok(!id.keyPem.includes('BEGIN RSA PRIVATE KEY'), 'must not be PKCS#1');
+});

--- a/app/lib/tvdirect/atvcrypto.ts
+++ b/app/lib/tvdirect/atvcrypto.ts
@@ -123,7 +123,24 @@ function finishCert(keys: forge.pki.rsa.KeyPair, t0: number): MintResult {
   cert.sign(keys.privateKey, forge.md.sha256.create());
   return {
     certPem: forge.pki.certificateToPem(cert),
-    keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    // PKCS#8 ("BEGIN PRIVATE KEY"), NOT PKCS#1 ("BEGIN RSA PRIVATE KEY").
+    //
+    // This is the difference between Google TV pairing working on Android and
+    // not working at all. react-native-tcp-socket's Android side parses the PEM
+    // body with PKCS8EncodedKeySpec and nothing else
+    // (android/.../SSLCertificateHelper.java:108), so a PKCS#1 key throws
+    // "Failed to parse private key from PEM" on every connectTLS — every pair,
+    // every keypress. iOS happens to detect and convert PKCS#1
+    // (ios/TcpSocketClient.m:614), which is exactly why this survived: the
+    // feature was only ever verified on iOS TestFlight builds.
+    //
+    // PKCS#8 is accepted by BOTH platforms, so this is strictly wider.
+    // No migration needed: identities are per-device (SecureStore, never
+    // synced), Android has never had a working one to migrate, and an existing
+    // iOS identity in PKCS#1 keeps working on iOS.
+    keyPem: forge.pki.privateKeyInfoToPem(
+      forge.pki.wrapRsaPrivateKey(forge.pki.privateKeyToAsn1(keys.privateKey)),
+    ),
     modulusHex: modulusOf(keys.publicKey),
     elapsedMs: Date.now() - t0,
   };


### PR DESCRIPTION
Two commits, both CI-green.

## Google TV pairing was impossible on Android

We minted the TLS client key with `forge.pki.privateKeyToPem`, which emits PKCS#1
(`BEGIN RSA PRIVATE KEY`). react-native-tcp-socket's **Android** side parses the PEM
body with `PKCS8EncodedKeySpec` and nothing else
(`SSLCertificateHelper.java:108`), so `connectTLS` threw on every Google TV pair and
every keypress — for every Android user, always. **iOS** detects and converts PKCS#1
(`TcpSocketClient.m:614`), which is exactly why this shipped unnoticed: every device
verification of this feature was an iOS TestFlight build.

Now minted as PKCS#8, which both platforms accept — strictly wider.

No migration: identities are per-device in SecureStore and never synced, Android has
never had a working one, and an existing iOS PKCS#1 key keeps working on iOS.

The test that should have caught this asserted `/PRIVATE KEY-----/`, true of **both**
formats. Replaced with an exact header check and verified in both directions — revert
the mint to PKCS#1 and it fails.

Found by auditing what a five-release Android jump would actually ship, not by the
feature being exercised.

## iOS build number

`buildNumber` 136 → 137, read out of the built `.ipa`
(`CFBundleShortVersionString 2.9.36`, `CFBundleVersion 137`) rather than from
`app.json` — `autoIncrement` rewrites that file mid-build and has already done so once
today on a build that FAILED. Android `versionCode` stays 74 (Play is on 73).

## Verified
- CI green on both commits, including the node-forge `tvdirect` step
- On a real Razr 2023: logcat no longer shows any `parse private key` / `PKCS8` /
  `InvalidKeySpec` error where it previously threw on every attempt

## NOT verified
**An actual Android → Google TV pair has not been observed.** The phone could not route
to the TV (`NoRouteToHostException` — it is on an isolated SSID), so the handshake never
got far enough to try. The key format is fixed; the end-to-end pair remains unproven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)