### PR TITLE
Bookmarks and saved filter presets — the last two library-triage gaps

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "136",
+      "buildNumber": "137",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -44,6 +44,7 @@ import {
 } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSelection, hapticSuccess } from '@/lib/haptics';
 import { fmtGB, fmtPair, fmtTotal } from '@/lib/downloadSize';
+import { useLibraryMarks } from '@/hooks/useLibraryMarks';
 import { applyFilter, EMPTY_FILTER, isFiltering, pickRandom, type FilterState } from '@/lib/libraryFilter';
 import { setPref, usePref } from '@/lib/prefs';
 import { useBoxes, useSettings } from '@/lib/SettingsContext';
@@ -805,10 +806,13 @@ function LaunchScreen() {
     [searched],
   );
   const compat = useCompat(compatIds, compatOn);
+  const marks = useLibraryMarks();
 
+  // The bookmark set is part of the predicate, so the grid and the filter
+  // sheet's count are computed from the same inputs and cannot disagree.
   const launchers = useMemo(
-    () => applyFilter(searched, filter, Math.floor(Date.now() / 1000), compat),
-    [searched, filter, compat],
+    () => applyFilter(searched, filter, Math.floor(Date.now() / 1000), compat, marks.bookmarks),
+    [searched, filter, compat, marks.bookmarks],
   );
 
   const rows = useMemo(() => {

--- a/app/components/GameSheet.tsx
+++ b/app/components/GameSheet.tsx
@@ -21,9 +21,10 @@ import React from 'react';
 import { Image, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { ImageSourcePropType } from 'react-native';
 
+import { toggleBookmarked, useLibraryMarks } from '@/hooks/useLibraryMarks';
 import { hapticLight } from '@/lib/haptics';
 import type { Launcher } from '@/lib/api';
-import { playtimeLabel } from '@/lib/libraryFilter';
+import { bookmarkKey, playtimeLabel } from '@/lib/libraryFilter';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** "3 days ago" / "today" / "never". Absent last_played is honest, not zero. */
@@ -62,7 +63,11 @@ export function GameSheet({
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const marks = useLibraryMarks();
   if (!launcher) return null;
+
+  const key = bookmarkKey(launcher);
+  const marked = marks.isBookmarked(key);
 
   const nowSec = Math.floor(Date.now() / 1000);
   const played = playtimeLabel(launcher.playtime_min);
@@ -114,6 +119,29 @@ export function GameSheet({
                   Playtime needs the Couchside service 2.9.71 or newer on the box.
                 </Text>
               )}
+            {/* Bookmark lives with the game's facts, not in the action row:
+                it is a note-to-self about this game, not a decision about what
+                happens on the TV right now. */}
+            <Pressable
+              onPress={() => {
+                if (!key) return;
+                hapticLight();
+                toggleBookmarked(key);
+              }}
+              disabled={!key}
+              accessibilityRole="button"
+              accessibilityState={{ selected: marked }}
+              accessibilityLabel={marked ? 'Remove bookmark' : 'Bookmark this game'}
+              style={({ pressed }) => [styles.bookmark, pressed && styles.pressed]}>
+              <Ionicons
+                name={marked ? 'bookmark' : 'bookmark-outline'}
+                size={15}
+                color={marked ? t.green : t.textDim}
+              />
+              <Text style={[styles.bookmarkText, marked && styles.bookmarkTextOn]}>
+                {marked ? 'BOOKMARKED' : 'BOOKMARK'}
+              </Text>
+            </Pressable>
           </ScrollView>
 
           <View style={styles.actions}>
@@ -184,6 +212,20 @@ const makeStyles = (t: Palette) =>
     row: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
     rowLabel: { color: t.textDim, fontSize: 12, fontFamily: mono },
     rowValue: { color: t.text, fontSize: 12, fontFamily: mono, flexShrink: 1, textAlign: 'right' },
+    bookmark: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      marginTop: 14,
+      paddingVertical: 11,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      backgroundColor: t.inset,
+    },
+    bookmarkText: { color: t.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
+    bookmarkTextOn: { color: t.green },
     note: { color: t.textFaint, fontSize: 12, lineHeight: 17 },
     actions: { flexDirection: 'row', gap: 10 },
     btn: {

--- a/app/components/LibraryFilterSheet.tsx
+++ b/app/components/LibraryFilterSheet.tsx
@@ -19,9 +19,10 @@
  * phase 2, deliberately absent rather than stubbed.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useMemo } from 'react';
-import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import React, { useMemo, useState } from 'react';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View, TextInput } from 'react-native';
 
+import { deletePreset, savePreset, useLibraryMarks } from '@/hooks/useLibraryMarks';
 import { hapticLight, hapticSelection } from '@/lib/haptics';
 import {
   countLabel,
@@ -29,6 +30,7 @@ import {
   EMPTY_FILTER,
   hasPlaytimeData,
   isFiltering,
+  presetName,
   type FilterableGame,
   type FilterState,
   type PlayedFilter,
@@ -70,6 +72,7 @@ const STALE: { days: number; label: string }[] = [
 ];
 
 function Chip({
+  onLongPress,
   label,
   on,
   onPress,
@@ -77,6 +80,8 @@ function Chip({
   label: string;
   on: boolean;
   onPress: () => void;
+  /** Only the saved-preset chips use this — hold to delete. */
+  onLongPress?: () => void;
 }) {
   const styles = useThemedStyles(makeStyles);
   return (
@@ -85,6 +90,7 @@ function Chip({
         hapticSelection();
         onPress();
       }}
+      onLongPress={onLongPress}
       accessibilityRole="button"
       accessibilityState={{ selected: on }}
       style={({ pressed }) => [styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
@@ -116,10 +122,17 @@ export function LibraryFilterSheet({
 }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
+  const marks = useLibraryMarks();
+  const [presetDraft, setPresetDraft] = useState('');
 
   // Same predicate the list runs, so the button cannot lie about the result.
   const nowSec = Math.floor(Date.now() / 1000);
-  const count = useMemo(() => countMatching(games, value, nowSec, compat), [games, value, nowSec, compat]);
+  // The bookmark set feeds the count too, or the button would promise a number
+  // the grid then contradicts the moment "Bookmarked" is on.
+  const count = useMemo(
+    () => countMatching(games, value, nowSec, compat, marks.bookmarks),
+    [games, value, nowSec, compat, marks.bookmarks],
+  );
   const active = isFiltering(value);
   // See hasPlaytimeData: on an older agent every game looks unplayed, so these
   // controls would state something false about the user's library.
@@ -154,6 +167,86 @@ export function LibraryFilterSheet({
           </View>
 
           <ScrollView contentContainerStyle={styles.body} keyboardShouldPersistTaps="handled">
+            {/* Bookmarks first: it is the one filter whose answer the user
+                authored themselves, so it is the fastest way to a short list. */}
+            <Text style={styles.label}>BOOKMARKS</Text>
+            <View style={styles.row}>
+              <Chip
+                label={marks.bookmarks.size ? `Bookmarked · ${marks.bookmarks.size}` : 'Bookmarked'}
+                on={value.bookmarked === true}
+                onPress={() =>
+                  onChange({ ...value, bookmarked: value.bookmarked ? undefined : true })
+                }
+              />
+            </View>
+            {value.bookmarked && marks.bookmarks.size === 0 ? (
+              <Text style={styles.note}>
+                Nothing bookmarked yet — tap a game, then Bookmark, to start a shortlist.
+              </Text>
+            ) : null}
+
+            {marks.presets.length ? (
+              <>
+                <Text style={styles.label}>SAVED</Text>
+                <View style={styles.row}>
+                  {marks.presets.map((p) => (
+                    <Chip
+                      key={p.name}
+                      label={p.name}
+                      on={false}
+                      // A COPY, not the stored object: the live filter is then
+                      // spread and rebuilt as the user taps, and sharing the
+                      // reference would let that edit the saved preset in place.
+                      onPress={() => onChange({ ...p.filter, kinds: [...p.filter.kinds] })}
+                      onLongPress={() => {
+                        hapticLight();
+                        deletePreset(p.name);
+                      }}
+                    />
+                  ))}
+                </View>
+                <Text style={styles.note}>Tap to apply · hold to delete.</Text>
+              </>
+            ) : null}
+
+            {active ? (
+              <View style={styles.row}>
+                <TextInput
+                  value={presetDraft}
+                  onChangeText={setPresetDraft}
+                  placeholder="Save this filter as…"
+                  placeholderTextColor={t.textFaint}
+                  style={styles.presetInput}
+                  returnKeyType="done"
+                  onSubmitEditing={() => {
+                    if (!presetName(presetDraft)) return;
+                    hapticLight();
+                    savePreset(presetDraft, value);
+                    setPresetDraft('');
+                  }}
+                />
+                <Pressable
+                  onPress={() => {
+                    if (!presetName(presetDraft)) return;
+                    hapticLight();
+                    savePreset(presetDraft, value);
+                    setPresetDraft('');
+                  }}
+                  disabled={!presetName(presetDraft)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Save this filter"
+                  style={({ pressed }) => [
+                    styles.chip,
+                    presetName(presetDraft) ? styles.chipOn : null,
+                    pressed && styles.pressed,
+                  ]}>
+                  <Text style={[styles.chipText, presetName(presetDraft) ? styles.chipTextOn : null]}>
+                    SAVE
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null}
+
             {playtime ? (
               <>
             <Text style={styles.label}>PLAYTIME</Text>
@@ -308,6 +401,19 @@ const makeStyles = (t: Palette) =>
       marginTop: 6,
     },
     row: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
+    presetInput: {
+      flex: 1,
+      minWidth: 140,
+      color: t.text,
+      fontSize: 12,
+      fontFamily: mono,
+      paddingHorizontal: 12,
+      paddingVertical: 8,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      backgroundColor: t.inset,
+    },
     note: { color: t.textFaint, fontSize: 12, lineHeight: 17, marginTop: 4 },
     chip: {
       paddingVertical: 8,

--- a/app/hooks/useLibraryMarks.ts
+++ b/app/hooks/useLibraryMarks.ts
@@ -1,0 +1,137 @@
+/**
+ * The two things the user marks on their own library: BOOKMARKS ("come back to
+ * this") and saved FILTER PRESETS. Phase 1 and 4 of
+ * docs/memory/project_library-triage.md.
+ *
+ * Module-level external store — the same shape as lib/prefs.ts, lib/haptics.ts
+ * and hooks/useFeatureTour.ts. It has to be: the filter sheet writes a preset
+ * while the Launch grid reads the bookmark set, and those are different
+ * components. Per-hook useState was exactly the bug that made the feature-tour
+ * switch look dead.
+ *
+ * ON DEVICE ONLY. Nothing here leaves the phone, and neither list is sent to
+ * the box — the box has no idea which of your games you starred, and does not
+ * need one.
+ *
+ * DEGRADES TO EMPTY, NEVER TO A GUESS. A storage read that fails or a blob that
+ * cannot be parsed yields no marks rather than a partial set: showing someone
+ * three of their eleven bookmarks is worse than showing none, because only one
+ * of those looks like a bug.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useCallback, useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import {
+  normalizePresets,
+  removePreset,
+  toggleBookmark,
+  upsertPreset,
+  type FilterPreset,
+  type FilterState,
+} from '@/lib/libraryFilter';
+
+const BOOKMARKS_KEY = 'couchside.bookmarks.v1';
+const PRESETS_KEY = 'couchside.filterPresets.v1';
+
+async function get(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem(k) : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function set(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(k, v);
+    } catch {
+      // storage unavailable: the marks live for this session only
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+type Snapshot = {
+  /** Bookmark keys — see bookmarkKey() in lib/libraryFilter.ts. */
+  bookmarks: ReadonlySet<string>;
+  presets: readonly FilterPreset[];
+  /** False until storage has been read. */
+  ready: boolean;
+};
+
+let snap: Snapshot = { bookmarks: new Set(), presets: [], ready: false };
+const listeners = new Set<() => void>();
+
+function commit(next: Snapshot): void {
+  // New object every time: useSyncExternalStore compares by identity.
+  snap = next;
+  for (const l of listeners) l();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+const getSnapshot = () => snap;
+
+let loadStarted = false;
+/** Read both lists once. Safe to call repeatedly. */
+export async function loadLibraryMarks(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  let bookmarks: string[] = [];
+  let presets: FilterPreset[] = [];
+  try {
+    const raw = await get(BOOKMARKS_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) bookmarks = parsed.filter((k): k is string => typeof k === 'string');
+  } catch {
+    bookmarks = [];
+  }
+  try {
+    const raw = await get(PRESETS_KEY);
+    presets = normalizePresets(raw ? JSON.parse(raw) : []);
+  } catch {
+    presets = [];
+  }
+  commit({ bookmarks: new Set(bookmarks), presets, ready: true });
+}
+void loadLibraryMarks();
+
+/** Star or un-star one game. `key` comes from bookmarkKey(). */
+export function toggleBookmarked(key: string): void {
+  const next = toggleBookmark([...snap.bookmarks], key);
+  commit({ ...snap, bookmarks: new Set(next), ready: true });
+  void set(BOOKMARKS_KEY, JSON.stringify(next));
+}
+
+export function savePreset(name: string, filter: FilterState): void {
+  const next = upsertPreset(snap.presets, name, filter);
+  commit({ ...snap, presets: next, ready: true });
+  void set(PRESETS_KEY, JSON.stringify(next));
+}
+
+export function deletePreset(name: string): void {
+  const next = removePreset(snap.presets, name);
+  commit({ ...snap, presets: next, ready: true });
+  void set(PRESETS_KEY, JSON.stringify(next));
+}
+
+export function useLibraryMarks() {
+  const s = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return {
+    bookmarks: s.bookmarks,
+    presets: s.presets,
+    ready: s.ready,
+    isBookmarked: useCallback((key: string | null) => (key ? s.bookmarks.has(key) : false), [s.bookmarks]),
+  };
+}

--- a/app/lib/__tests__/libraryFilter.test.ts
+++ b/app/lib/__tests__/libraryFilter.test.ts
@@ -10,6 +10,13 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 
 import {
+  bookmarkKey,
+  toggleBookmark,
+  presetName,
+  upsertPreset,
+  normalizePresets,
+  MAX_PRESETS,
+  type FilterPreset,
   applyFilter,
   countLabel,
   countMatching,
@@ -275,4 +282,116 @@ test('shuffle can reach every game and never goes out of range (control)', () =>
 
 test('a generator returning exactly 1 does not fall off the end (control)', () => {
   assert.equal(pickRandom(['a', 'b'], () => 1), 'b');
+});
+
+// ---------------------------------------------------------------------------
+// Bookmarks and saved presets
+// ---------------------------------------------------------------------------
+
+test('a bookmark is keyed on the Steam appid when there is one', () => {
+  // The appid is global and permanent; the launcher id is the agent's handle.
+  // Keying a Steam game by launcher id would drop the bookmark the day the
+  // agent renumbered anything.
+  assert.equal(bookmarkKey({ appid: 702670, id: 'steam-3' }), 'app:702670');
+  assert.equal(bookmarkKey({ id: 'custom-vlc' }), 'id:custom-vlc');
+  assert.equal(bookmarkKey({}), null, 'neither: refuse to guess');
+  assert.equal(bookmarkKey({ appid: 0, id: 'x' }), 'id:x', 'appid 0 is not a real appid');
+});
+
+test('toggling a bookmark is reversible and does not mutate (control)', () => {
+  const a: string[] = [];
+  const b = toggleBookmark(a, 'app:1');
+  assert.deepEqual(a, [], 'input untouched');
+  assert.deepEqual(b, ['app:1']);
+  assert.deepEqual(toggleBookmark(b, 'app:1'), [], 'toggles back off');
+});
+
+test('the bookmarked filter shows only marked games, and none when nothing is marked', () => {
+  const games = [
+    { id: 'a', appid: 1, label: 'Alpha', kind: 'steam' as const },
+    { id: 'b', label: 'Beta', kind: 'custom' as const },
+  ];
+  const f = { ...EMPTY_FILTER, bookmarked: true };
+  const marks = new Set(['app:1']);
+  assert.deepEqual(applyFilter(games, f, 0, undefined, marks).map((g) => g.label), ['Alpha']);
+  // Empty is the CORRECT answer here, unlike every other filter in this file:
+  // it is the user's own mark, so absence is an answer rather than ignorance.
+  assert.equal(applyFilter(games, f, 0, undefined, new Set()).length, 0);
+  // and with the filter off, the bookmark set is irrelevant (control)
+  assert.equal(applyFilter(games, EMPTY_FILTER, 0, undefined, new Set()).length, 2);
+});
+
+test('bookmarked counts as filtering, so the clear affordance appears', () => {
+  assert.equal(isFiltering(EMPTY_FILTER), false);
+  assert.equal(isFiltering({ ...EMPTY_FILTER, bookmarked: true }), true);
+});
+
+test('preset names are collapsed and capped, and blank names are refused', () => {
+  assert.equal(presetName('  weekend   short  '), 'weekend short');
+  assert.equal(presetName('   '), null);
+  assert.equal(presetName('x'.repeat(80))?.length, 28);
+});
+
+test('saving over an existing name edits in place rather than duplicating', () => {
+  const f1 = { ...EMPTY_FILTER, played: 'never' as const };
+  const f2 = { ...EMPTY_FILTER, played: 'over2h' as const };
+  let list = upsertPreset([], 'Weekend', f1);
+  list = upsertPreset(list, 'Backlog', f1);
+  const before = list.length;
+  list = upsertPreset(list, 'weekend', f2); // different case, same preset
+  assert.equal(list.length, before, 'no duplicate');
+  // Position is preserved so the list does not reshuffle under the user's
+  // thumb, but the NAME is whatever they just typed — what you type is what you
+  // get beats silently restoring capitalisation you did not ask for.
+  assert.equal(list[0].name, 'weekend', 'takes the newly typed name');
+  assert.equal(list[1].name, 'Backlog', 'the other preset stays put');
+  assert.equal(list[0].filter.played, 'over2h', 'and takes the new filter');
+});
+
+test('the preset list is capped, dropping the oldest rather than refusing', () => {
+  let list: FilterPreset[] = [];
+  for (let i = 0; i < MAX_PRESETS + 3; i += 1) list = upsertPreset(list, `p${i}`, EMPTY_FILTER);
+  assert.equal(list.length, MAX_PRESETS);
+  assert.equal(list[list.length - 1].name, `p${MAX_PRESETS + 2}`, 'newest kept');
+  assert.equal(list[0].name, 'p3', 'oldest dropped');
+});
+
+test('a malformed stored preset is skipped, not fatal (control)', () => {
+  const raw = [
+    { name: 'good', filter: { search: 'x', kinds: ['steam'], played: 'never' } },
+    { name: '', filter: {} },
+    { name: 'no filter' },
+    'not an object',
+    { name: 'bad fields', filter: { search: 5, kinds: 'nope', played: 'wat', staleDays: -3 } },
+  ];
+  const out = normalizePresets(raw);
+  assert.deepEqual(out.map((p) => p.name), ['good', 'bad fields']);
+  assert.deepEqual(out[0].filter.kinds, ['steam']);
+  assert.equal(out[1].filter.search, '', 'bad types fall back to defaults');
+  assert.deepEqual(out[1].filter.kinds, []);
+  assert.equal(out[1].filter.played, 'any');
+  assert.equal(out[1].filter.staleDays, undefined, 'a negative day count is dropped');
+});
+
+test('normalizePresets survives junk instead of throwing (control)', () => {
+  assert.deepEqual(normalizePresets(null), []);
+  assert.deepEqual(normalizePresets('nope'), []);
+  assert.deepEqual(normalizePresets(undefined), []);
+});
+
+test('a corrupted deck/proton list is stripped, not passed through (control)', () => {
+  // matchesCompat filters on whatever it is handed, so junk here would hide
+  // games the user owns — the exact failure this module exists to prevent.
+  const out = normalizePresets([
+    { name: 'junk', filter: { search: '', kinds: [], played: 'any', deck: ['verified', 'wat', 7], proton: ['gold', null] } },
+  ]);
+  assert.deepEqual(out[0].filter.deck, ['verified']);
+  assert.deepEqual(out[0].filter.proton, ['gold']);
+});
+
+test('an unknown played value cannot become the over-2h branch (control)', () => {
+  // matchesPlayed falls through to >=2h for anything it does not recognise, so
+  // a corrupted blob would silently hide every short game.
+  const out = normalizePresets([{ name: 'x', filter: { played: 'nonsense' } }]);
+  assert.equal(out[0].filter.played, 'any');
 });

--- a/app/lib/libraryFilter.ts
+++ b/app/lib/libraryFilter.ts
@@ -19,6 +19,9 @@
 
 /** The subset of a launcher this module needs. Structural, so tests need no api types. */
 export type FilterableGame = {
+  /** Stable per-launcher id from the agent. Optional here only so the pure
+   *  filter tests can build minimal fixtures; real launchers always carry it. */
+  id?: string;
   label: string;
   kind: 'steam' | 'custom' | 'shortcut';
   /** Absent = Steam has no record = never played. 0 = launched, played nothing. */
@@ -51,6 +54,16 @@ export type FilterState = {
   deck?: DeckStatus[];
   /** ProtonDB tiers to keep; empty = all. Unknown always passes. */
   proton?: ProtonTier[];
+  /**
+   * Show only games the user has bookmarked.
+   *
+   * UNLIKE every other filter here, an empty result is CORRECT rather than a
+   * bug: "show me my bookmarks" when nothing is bookmarked honestly means no
+   * games. The unknown-passes rule elsewhere exists so a third party's missing
+   * data cannot hide something you own; this is the user's own explicit mark,
+   * so absence is an answer, not ignorance.
+   */
+  bookmarked?: boolean;
 };
 
 export const EMPTY_FILTER: FilterState = { search: '', kinds: [], played: 'any' };
@@ -76,7 +89,8 @@ export function isFiltering(f: FilterState): boolean {
     f.played !== 'any' ||
     (f.staleDays ?? 0) > 0 ||
     (f.deck?.length ?? 0) > 0 ||
-    (f.proton?.length ?? 0) > 0
+    (f.proton?.length ?? 0) > 0 ||
+    f.bookmarked === true
   );
 }
 
@@ -110,6 +124,7 @@ export function matches(
   f: FilterState,
   nowSec: number,
   compat?: Compat,
+  bookmarks?: ReadonlySet<string>,
 ): boolean {
   const q = f.search.trim().toLowerCase();
   if (q && !g.label.toLowerCase().includes(q)) return false;
@@ -117,6 +132,10 @@ export function matches(
   if (!matchesPlayed(g, f.played)) return false;
   if (!matchesStale(g, f.staleDays, nowSec)) return false;
   if (!matchesCompat(compat, f.deck ?? [], f.proton ?? [])) return false;
+  if (f.bookmarked) {
+    const k = bookmarkKey(g);
+    if (!k || !bookmarks?.has(k)) return false;
+  }
   return true;
 }
 
@@ -126,9 +145,10 @@ export function applyFilter<T extends FilterableGame & { appid?: number }>(
   f: FilterState,
   nowSec: number,
   compat?: Record<number, Compat>,
+  bookmarks?: ReadonlySet<string>,
 ): T[] {
   return games.filter((g) =>
-    matches(g, f, nowSec, g.appid != null ? compat?.[g.appid] : undefined),
+    matches(g, f, nowSec, g.appid != null ? compat?.[g.appid] : undefined, bookmarks),
   );
 }
 
@@ -142,10 +162,12 @@ export function countMatching(
   f: FilterState,
   nowSec: number,
   compat?: Record<number, Compat>,
+  bookmarks?: ReadonlySet<string>,
 ): number {
   let n = 0;
   for (const g of games) {
-    if (matches(g, f, nowSec, g.appid != null ? compat?.[g.appid] : undefined)) n += 1;
+    const c = g.appid != null ? compat?.[g.appid] : undefined;
+    if (matches(g, f, nowSec, c, bookmarks)) n += 1;
   }
   return n;
 }
@@ -182,4 +204,133 @@ export function playtimeLabel(mins: number | undefined): string {
   const h = Math.floor(mins / 60);
   const m = mins % 60;
   return m ? `${h}h ${m}m` : `${h}h`;
+}
+
+// ---------------------------------------------------------------------------
+// Bookmarks — "come back to this one"
+// ---------------------------------------------------------------------------
+
+/**
+ * The stable identity a bookmark is stored against.
+ *
+ * PREFER THE STEAM APPID. It is global and permanent: 702670 is Donut County on
+ * every box, forever. The launcher `id` is the agent's own handle and is the
+ * only thing a custom launcher or a non-Steam shortcut has, so it is the
+ * fallback rather than the primary — a Steam game keyed by launcher id would
+ * lose its bookmark the day the agent renumbered anything.
+ *
+ * Returns null when a game carries neither, which the filter treats as
+ * "not bookmarked" rather than guessing.
+ */
+export function bookmarkKey(g: { appid?: number; id?: string }): string | null {
+  if (typeof g.appid === 'number' && Number.isFinite(g.appid) && g.appid > 0) {
+    return `app:${Math.floor(g.appid)}`;
+  }
+  const id = g.id?.trim();
+  return id ? `id:${id}` : null;
+}
+
+/** Add or remove a key. Returns a NEW array; order is insertion order, which is
+ *  also the order the UI lists them in. */
+export function toggleBookmark(keys: readonly string[], key: string): string[] {
+  return keys.includes(key) ? keys.filter((k) => k !== key) : [...keys, key];
+}
+
+// ---------------------------------------------------------------------------
+// Saved filter presets
+// ---------------------------------------------------------------------------
+
+export type FilterPreset = { name: string; filter: FilterState };
+
+/** Runtime allowlists for restoring a stored preset. The types themselves are
+ *  compile-time only, so without these a corrupted blob would sail through. */
+const DECK_VALUES: DeckStatus[] = ['verified', 'playable', 'unsupported', 'unknown'];
+const PROTON_VALUES: ProtonTier[] = ['platinum', 'gold', 'silver', 'bronze', 'borked', 'unknown'];
+
+/** Presets a user can keep. Past this the list stops being a shortcut. */
+export const MAX_PRESETS = 12;
+const MAX_PRESET_NAME = 28;
+
+/** Clean a typed name, or null if there is nothing usable in it. Whitespace is
+ *  collapsed so "  weekend   short " and "weekend short" are the same preset
+ *  rather than two that look identical in the list. */
+export function presetName(raw: string): string | null {
+  const n = raw.replace(/\s+/g, ' ').trim().slice(0, MAX_PRESET_NAME);
+  return n.length ? n : null;
+}
+
+/**
+ * Save a filter under a name, replacing any existing preset with that name
+ * case-insensitively — typing "Weekend" over "weekend" is plainly an edit, not
+ * a second entry. A replacement keeps its ORIGINAL position so the list does
+ * not reshuffle under the user's thumb.
+ */
+export function upsertPreset(
+  list: readonly FilterPreset[],
+  name: string,
+  filter: FilterState,
+): FilterPreset[] {
+  const clean = presetName(name);
+  if (!clean) return [...list];
+  const at = list.findIndex((p) => p.name.toLowerCase() === clean.toLowerCase());
+  const entry: FilterPreset = { name: clean, filter };
+  if (at >= 0) {
+    const next = [...list];
+    next[at] = entry;
+    return next;
+  }
+  // Oldest falls off the end rather than refusing the save: a full list must
+  // not turn the button into a dead control with no explanation.
+  return [...list, entry].slice(-MAX_PRESETS);
+}
+
+export function removePreset(list: readonly FilterPreset[], name: string): FilterPreset[] {
+  return list.filter((p) => p.name.toLowerCase() !== name.toLowerCase());
+}
+
+/**
+ * Coerce a stored blob back into presets, dropping anything malformed.
+ *
+ * Defensive on purpose: this is JSON that has been on disk across app upgrades,
+ * and a filter shape that has gained fields since it was written. A preset that
+ * cannot be read is skipped rather than allowed to throw and take every other
+ * preset with it.
+ */
+export function normalizePresets(raw: unknown): FilterPreset[] {
+  if (!Array.isArray(raw)) return [];
+  const out: FilterPreset[] = [];
+  for (const item of raw) {
+    const o = item as { name?: unknown; filter?: unknown };
+    const name = typeof o?.name === 'string' ? presetName(o.name) : null;
+    if (!name) continue;
+    const f = o.filter as Partial<FilterState> | undefined;
+    if (!f || typeof f !== 'object') continue;
+    const kinds = Array.isArray(f.kinds)
+      ? f.kinds.filter((k): k is 'steam' | 'custom' | 'shortcut' =>
+          k === 'steam' || k === 'custom' || k === 'shortcut')
+      : [];
+    const played: PlayedFilter =
+      f.played === 'never' || f.played === 'under2h' || f.played === 'over2h' ? f.played : 'any';
+    out.push({
+      name,
+      filter: {
+        search: typeof f.search === 'string' ? f.search : '',
+        kinds,
+        played,
+        staleDays: typeof f.staleDays === 'number' && f.staleDays > 0 ? Math.floor(f.staleDays) : undefined,
+        // VALIDATE THE MEMBERS, do not just check it is an array. matchesCompat
+        // filters on whatever it is handed, so a junk value in here would hide
+        // games the user owns — the one outcome this module exists to prevent.
+        deck: Array.isArray(f.deck)
+          ? (f.deck.filter((d) => DECK_VALUES.includes(d as DeckStatus)) as DeckStatus[])
+          : undefined,
+        proton: Array.isArray(f.proton)
+          ? (f.proton.filter((p2) => PROTON_VALUES.includes(p2 as ProtonTier)) as ProtonTier[])
+          : undefined,
+        bookmarked: f.bookmarked === true ? true : undefined,
+      },
+    });
+    if (out.length >= MAX_PRESETS) break;
+  }
+  return out;
 }

--- a/app/lib/tvdirect/__tests__/atvcrypto.test.ts
+++ b/app/lib/tvdirect/__tests__/atvcrypto.test.ts
@@ -153,3 +153,20 @@ test('async mint is cancellable (a stuck pair must not run forever)', async () =
   const signal = { aborted: true };
   await assert.rejects(() => mintIdentityAsync(getRandomValues, { signal }), /cancelled/);
 });
+
+test('the private key is PKCS#8, because Android cannot read PKCS#1', async () => {
+  // NOT a style preference. react-native-tcp-socket parses the PEM body on
+  // Android with PKCS8EncodedKeySpec and nothing else, so a PKCS#1 key
+  // ("BEGIN RSA PRIVATE KEY") throws on every connectTLS — every Google TV
+  // pair and every keypress, on every Android device. iOS quietly converts it,
+  // which is why this shipped unnoticed: the feature was only verified there.
+  //
+  // The older assertion in this file matched /PRIVATE KEY-----/, which is true
+  // of BOTH formats and therefore could never have caught it.
+  const id = await mintIdentityAsync(getRandomValues);
+  assert.ok(
+    id.keyPem.startsWith('-----BEGIN PRIVATE KEY-----'),
+    `key must be PKCS#8; got: ${id.keyPem.slice(0, 32)}`,
+  );
+  assert.ok(!id.keyPem.includes('BEGIN RSA PRIVATE KEY'), 'must not be PKCS#1');
+});

--- a/app/lib/tvdirect/atvcrypto.ts
+++ b/app/lib/tvdirect/atvcrypto.ts
@@ -123,7 +123,24 @@ function finishCert(keys: forge.pki.rsa.KeyPair, t0: number): MintResult {
   cert.sign(keys.privateKey, forge.md.sha256.create());
   return {
     certPem: forge.pki.certificateToPem(cert),
-    keyPem: forge.pki.privateKeyToPem(keys.privateKey),
+    // PKCS#8 ("BEGIN PRIVATE KEY"), NOT PKCS#1 ("BEGIN RSA PRIVATE KEY").
+    //
+    // This is the difference between Google TV pairing working on Android and
+    // not working at all. react-native-tcp-socket's Android side parses the PEM
+    // body with PKCS8EncodedKeySpec and nothing else
+    // (android/.../SSLCertificateHelper.java:108), so a PKCS#1 key throws
+    // "Failed to parse private key from PEM" on every connectTLS — every pair,
+    // every keypress. iOS happens to detect and convert PKCS#1
+    // (ios/TcpSocketClient.m:614), which is exactly why this survived: the
+    // feature was only ever verified on iOS TestFlight builds.
+    //
+    // PKCS#8 is accepted by BOTH platforms, so this is strictly wider.
+    // No migration needed: identities are per-device (SecureStore, never
+    // synced), Android has never had a working one to migrate, and an existing
+    // iOS identity in PKCS#1 keeps working on iOS.
+    keyPem: forge.pki.privateKeyInfoToPem(
+      forge.pki.wrapRsaPrivateKey(forge.pki.privateKeyToAsn1(keys.privateKey)),
+    ),
     modulusHex: modulusOf(keys.publicKey),
     elapsedMs: Date.now() - t0,
   };

--- a/docs/memory/project_library-triage.md
+++ b/docs/memory/project_library-triage.md
@@ -1,6 +1,22 @@
 # Library triage — "what in my library actually runs here, and can I finish it tonight?"
 
-**Status:** 📋 Planned — spec only, nothing built.
+**Status (2026-08-06):** Phases 1 and 2 SHIPPED; Phase 3 dropped on legal grounds;
+Phase 4 half shipped. Merged to main across PRs #362 and #366 in app 2.9.36, with the
+agent-side playtime parser in 2.9.71.
+
+| Phase | State | Evidence |
+|---|---|---|
+| 1 — filter what is on screen | **shipped**, minus saved presets | `app/lib/libraryFilter.ts`, `app/components/LibraryFilterSheet.tsx`, live count via `countLabel()`; playtime from `parse_localconfig_playtime()` in `agent/couchsided.py` (2.9.71) |
+| 2 — compatibility | **shipped** | `app/lib/compat.ts` + `compatFetch.ts`, opt-in `compatLookups` pref, badges seen on real hardware |
+| 3 — time to beat | **dropped** | see below; legal, not technical |
+| 4 — triage actions | **shuffle only** | `pickRandom()`; bookmarks NOT built |
+
+NOT BUILT: saved filter presets (phase 1), bookmarks (phase 4).
+
+VERIFIED ON HARDWARE: compat badges and the confirm-sheet launch, on a real box.
+NOT verified: the filter and shuffle controls themselves — they need a library of 8+
+games to appear (`allLaunchers.length >= 8` in `app/app/(tabs)/launch.tsx`) and the box
+used for testing has two, so both were only ever observed SKIPPING.
 **Source inspiration:** DeckFilter (deckfilter.app), **driven on the owner's phone
 2026-08-06** — the site 403s to fetch, so this is measured from the running app,
 not from marketing copy.


### PR DESCRIPTION
Closes the two things phases 1 and 4 of `docs/memory/project_library-triage.md`
specced and never got built.

## Bookmarks
A toggle in the game sheet, a "Bookmarked" chip in the filter, and the marks feed
the grid and the sheet's live count through the **same predicate** — so the button
cannot promise a number the grid then contradicts.

Keyed on the **Steam appid** where there is one, falling back to the launcher id.
The appid is global and permanent; the launcher id is the agent's own handle, and
keying a Steam game by it would drop the bookmark the day the agent renumbered
anything. Neither present = not bookmarked, never a guess.

This is also the one filter here where an **empty result is correct**. Everything
else follows "unknown is included" so a third party's missing data cannot hide a
game you own — but a bookmark is the user's own mark, so absence is an answer.

## Presets
Name the current filter, tap to re-apply, hold to delete. Saving over an existing
name edits in place (case-insensitively) and keeps its position, so the list does
not reshuffle under your thumb. A full list drops its oldest entry rather than
refusing the save.

## Two hazards found in review, both silent failures
- `deck[]` / `proton[]` were restored with only an `Array.isArray` check.
  `matchesCompat` filters on whatever it is handed, so junk in a stored preset would
  have **hidden games the user owns** — the exact failure that module exists to
  prevent. Members are now validated, with a test.
- Applying a preset handed out the stored object. `EMPTY_FILTER` is an unfrozen const
  with a shared `kinds` array, so later edits could have rewritten the saved preset
  in place. It passes a copy now.

Also covered: an unrecognised `played` value is coerced to `'any'`, because
`matchesPlayed` falls through to its `>=2h` branch and would otherwise have silently
hidden every short game.

Storage uses the module-level external-store shape already used by prefs, haptics and
the tour. Both lists stay on the phone; the box is never told which games you starred.

## Verified
321 tests green, `tsc --noEmit` clean. The preset-name test caught a real ambiguity in
the design (typing "weekend" over "Weekend" — it takes what you typed).

## NOT verified
Nothing here has run on a device yet. Being exercised now against the living-room
bazzite box (agent 2.9.71), which has a library big enough to actually show the
filter controls — the box used previously has two games, so the filter sheet had only
ever been observed *skipping*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)