### PR TITLE
Landscape gamepad: provable geometry, immersive mode, LOCK/EXIT

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useCapsSync } from '@/hooks/useCapsSync';
 import { hapticSelection } from '@/lib/haptics';
+import { useImmersive } from '@/lib/immersive';
 import { usePref } from '@/lib/prefs';
 import { FeatureTour } from '@/components/FeatureTour';
 import { TourThanks } from '@/components/TourThanks';
@@ -35,6 +36,11 @@ export default function TabLayout() {
   // lib/tvdirect/) takes over. A pref rather than derived state, so a box owner
   // can flip to it while the box is off and flip back without the box answering.
   const remoteOnly = usePref('remoteOnlyMode');
+  // Landscape gamepad: the tab bar is the thing that was cutting off the d-pad's
+  // DOWN arrow, so hiding it is both the feature and half the bug fix. Derived
+  // from state here rather than set imperatively from pad.tsx, so there is no
+  // cleanup that can fail to run and leave the app with no tab bar at all.
+  const immersive = useImmersive();
   const segments = useSegments();
   // Always-mounted caps safety net: heals a stale persisted caps snapshot
   // (e.g. couchmode:false cached before the box became capable) no matter
@@ -214,10 +220,12 @@ export default function TabLayout() {
         headerShown: false,
         tabBarActiveTintColor: t.blue,
         tabBarInactiveTintColor: t.textFaint,
-        tabBarStyle: {
-          backgroundColor: t.tabBar,
-          borderTopColor: t.tabBarBorder,
-        },
+        tabBarStyle: immersive
+          ? { display: 'none' }
+          : {
+              backgroundColor: t.tabBar,
+              borderTopColor: t.tabBarBorder,
+            },
         sceneStyle: { backgroundColor: t.bg },
       }}>
       <Tabs.Screen

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -42,7 +42,12 @@ import {
 import * as Clipboard from 'expo-clipboard';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { StatusBar } from 'expo-status-bar';
+
 import { Gated } from '@/components/Gated';
+import { LandscapePad, LandscapePadTooSmall } from '@/components/LandscapePad';
+import { setImmersive } from '@/lib/immersive';
+import { padLayout } from '@/lib/padLayout';
 import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
 import { PadDiagnostics } from '@/components/PadDiagnostics';
@@ -896,7 +901,58 @@ function PadScreen() {
    * is the intended behaviour: the mode you switched to has no landscape layout
    * to show you.
    */
-  useLockOrientation(mode === 'gamepad' ? 'allow-landscape' : 'portrait');
+  /** LOCK button: pin the orientation so a shift in grip doesn't drop you out. */
+  const [padLock, setPadLock] = useState(false);
+  /**
+   * Set by the ✕ button. The phone is still PHYSICALLY sideways at that moment,
+   * so without forcing portrait it would flip straight back in and the button
+   * would look broken. Cleared as soon as portrait is actually observed, so a
+   * later deliberate rotation re-enters play.
+   */
+  const [exited, setExited] = useState(false);
+  useEffect(() => {
+    if (exited && !landscape) setExited(false);
+  }, [exited, landscape]);
+
+  useLockOrientation(
+    mode !== 'gamepad' || exited ? 'portrait'
+      : padLock ? 'landscape-locked'
+        : 'allow-landscape',
+  );
+
+  /**
+   * IMMERSIVE: the controller owns the whole screen — no tab bar, no box
+   * picker, no status pill, no mode row. This is not only the owner's feature
+   * request, it is half the bug fix: those four things are what ate the short
+   * axis until the controller overflowed it.
+   *
+   * Published to a store rather than set imperatively (see lib/immersive.ts),
+   * and reset on unmount so the app can never be left with no tab bar.
+   */
+  const immersive = landscape && mode === 'gamepad' && !exited;
+  useEffect(() => {
+    setImmersive(immersive);
+  }, [immersive]);
+  useEffect(() => () => setImmersive(false), []);
+
+  /**
+   * The landscape controller's geometry. Insets are subtracted exactly once,
+   * HERE — nothing downstream may look at them again, which is what stops the
+   * safe area being counted twice or counted on the wrong edge.
+   */
+  // Depend on the inset NUMBERS, not the object: useSafeAreaInsets can hand
+  // back a fresh object on any re-render, which would rebuild the layout (and
+  // every PanResponder keyed off it) constantly.
+  const landGeom = useMemo(
+    () => padLayout({ width, height }, insets),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [width, height, insets.top, insets.right, insets.bottom, insets.left],
+  );
+  const exitLandscape = useCallback(() => {
+    setPadLock(false);
+    setExited(true);
+  }, []);
+
   const [status, setStatus] = useState<GamepadStatus>('closed');
   // True when status is 'connected' but the socket has gone silent (half-dead):
   // polled from the client, it turns the pill amber + tap-to-retry live BEFORE
@@ -1663,6 +1719,78 @@ function PadScreen() {
     </Pressable>
   );
 
+  // ---------- Immersive: the controller, and nothing else ----------
+  //
+  // Returned BEFORE `styles.screen`. That is deliberate and load-bearing: that
+  // style carries `paddingHorizontal: 12` and `paddingBottom: max(insets.bottom,
+  // 10)`, and padLayout has ALREADY subtracted the insets. Rendering the
+  // controller inside it would count the safe area twice and pull every control
+  // 12dp inboard — the same double-count that helped clip the old layout.
+  //
+  // NOT a separate expo-router route, which is what every reference for this
+  // problem recommends. A route change unmounts PadScreen, tears down the
+  // gamepad WebSocket and makes the agent destroy and recreate its uinput
+  // device on EVERY rotation — the exact lifecycle churn this project's worst
+  // bugs live in (KI-053). Same component, chrome suppressed by state; the
+  // socket never notices the phone turned.
+  if (immersive) {
+    return (
+      <>
+        <StatusBar hidden />
+        {landGeom.ok ? (
+          <LandscapePad
+            layout={landGeom}
+            btn={btn}
+            trig={trig}
+            stickMove={stickMove}
+            stickRelease={stickRelease}
+            qam={qam}
+            locked={padLock}
+            onToggleLock={() => setPadLock((v) => !v)}
+            onExit={exitLandscape}
+          />
+        ) : (
+          <LandscapePadTooSmall reason={landGeom.reason} onExit={exitLandscape} />
+        )}
+        {/* Handoff survives immersive mode. Another phone asking for control is
+            a decision only the person holding this one can make, and ignoring it
+            long enough lets the other device force the takeover — so it cannot
+            be a piece of chrome that full-screen play hides. */}
+        {controlReq != null && (
+          <View style={styles.handoffOverlay}>
+            <Text style={styles.handoffText} numberOfLines={2}>
+              {controlReq} wants control
+            </Text>
+            <View style={styles.handoffBtns}>
+              <Pressable
+                onPress={() => {
+                  haptic();
+                  client.denyControl();
+                  setControlReq(null);
+                }}
+                style={({ pressed }) => [styles.handoffBtn, pressed && styles.btnPressed]}>
+                <Text style={styles.handoffBtnText}>KEEP</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => {
+                  haptic();
+                  client.grantControl();
+                  setControlReq(null);
+                }}
+                style={({ pressed }) => [
+                  styles.handoffBtn,
+                  styles.handoffBtnPass,
+                  pressed && styles.btnPressed,
+                ]}>
+                <Text style={[styles.handoffBtnText, styles.handoffBtnPassText]}>PASS</Text>
+              </Pressable>
+            </View>
+          </View>
+        )}
+      </>
+    );
+  }
+
   return (
     <View
       style={[
@@ -1948,95 +2076,6 @@ function PadScreen() {
           )}
           {!largePad && keyboardBar}
         </>
-      ) : landscape ? (
-        // ---------- Landscape gamepad: real-controller spread ----------
-        <View style={styles.landRoot}>
-          {/* Bumpers/triggers along the top */}
-          <View style={styles.landShoulderRow}>
-            <View style={styles.landShoulderSide}>
-              <PadButton label="LT" {...trig('lt')} style={styles.shoulderBtn} />
-              <PadButton label="LB" {...btn('lb')} style={styles.shoulderBtn} />
-            </View>
-            <View style={styles.landShoulderSide}>
-              <PadButton label="RB" {...btn('rb')} style={styles.shoulderBtn} />
-              <PadButton label="RT" {...trig('rt')} style={styles.shoulderBtn} />
-            </View>
-          </View>
-
-          <View style={styles.landMain}>
-            {/* LEFT: stick above d-pad */}
-            <View style={styles.landColumn}>
-              <Stick onMove={stickMove('l')} onRelease={stickRelease('l')} />
-              <View style={styles.dpad}>
-                <View style={styles.dpadRow}>
-                  <View style={styles.dpadSpacer} />
-                  <PadButton label="▲" {...btn('du')} style={styles.dpadBtn} />
-                  <View style={styles.dpadSpacer} />
-                </View>
-                <View style={styles.dpadRow}>
-                  <PadButton label="◀" {...btn('dl')} style={styles.dpadBtn} />
-                  {/* Center OK = A: opens/activates the highlighted item. */}
-                  <PadButton label="OK" {...btn('a')} style={styles.dpadBtn} color={t.green} fontSize={14} />
-                  <PadButton label="▶" {...btn('dr')} style={styles.dpadBtn} />
-                </View>
-                <View style={styles.dpadRow}>
-                  <View style={styles.dpadSpacer} />
-                  <PadButton label="▼" {...btn('dd')} style={styles.dpadBtn} />
-                  <View style={styles.dpadSpacer} />
-                </View>
-              </View>
-            </View>
-
-            {/* CENTER: menu cluster + thumb-clicks */}
-            <View style={styles.landCenter}>
-              <View style={styles.menuRow}>
-                <PadButton label="SELECT" {...btn('select')} style={styles.menuBtn} fontSize={11} />
-                <PadButton
-                  label="STEAM"
-                  {...btn('guide')}
-                  style={[styles.menuBtn, styles.guideBtn]}
-                  color={t.blue}
-                  fontSize={11}
-                />
-                <PadButton
-                  label="⋯"
-                  onDown={qam}
-                  onUp={NOOP}
-                  style={[styles.menuBtn, styles.qamBtn, styles.guideBtn]}
-                  color={t.blue}
-                  fontSize={20}
-                />
-                <PadButton label="START" {...btn('start')} style={styles.menuBtn} fontSize={11} />
-              </View>
-              <View style={styles.landThumbRow}>
-                <PadButton label="L3" {...btn('l3')} style={styles.thumbBtn} fontSize={11} />
-                <PadButton label="R3" {...btn('r3')} style={styles.thumbBtn} fontSize={11} />
-              </View>
-            </View>
-
-            {/* RIGHT: ABXY above right stick */}
-            <View style={styles.landColumn}>
-              <View style={styles.abxy}>
-                <View style={styles.abxyRow}>
-                  <View style={styles.faceSpacer} />
-                  <PadButton label="Y" {...btn('y')} style={styles.faceBtn} color={t.amber} />
-                  <View style={styles.faceSpacer} />
-                </View>
-                <View style={styles.abxyRow}>
-                  <PadButton label="X" {...btn('x')} style={styles.faceBtn} color={t.blue} />
-                  <View style={styles.faceSpacer} />
-                  <PadButton label="B" {...btn('b')} style={styles.faceBtn} color={t.red} />
-                </View>
-                <View style={styles.abxyRow}>
-                  <View style={styles.faceSpacer} />
-                  <PadButton label="A" {...btn('a')} style={styles.faceBtn} color={t.green} />
-                  <View style={styles.faceSpacer} />
-                </View>
-              </View>
-              <Stick onMove={stickMove('r')} onRelease={stickRelease('r')} />
-            </View>
-          </View>
-        </View>
       ) : (
         // ---------- Portrait gamepad: original stacked layout ----------
         <>
@@ -2756,37 +2795,30 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderWidth: 1,
   },
 
-  // ---------- Landscape gamepad layout ----------
-  landRoot: {
-    flex: 1,
-  },
-  landShoulderRow: {
+  // ---------- Landscape gamepad ----------
+  // The controls themselves are absolutely positioned from lib/padLayout.ts and
+  // drawn by components/LandscapePad.tsx; there are no styles for them here on
+  // purpose. What used to live at this spot was `landRoot` / `landShoulderRow` /
+  // `landMain` / `landColumn` / `landCenter` / `landThumbRow` — a flex tree
+  // whose fixed-pixel children added up to more than the screen was tall, which
+  // flex then overflowed in silence. That is the bug; the styles are gone with
+  // it.
+  //
+  // The one thing that still needs a style is the handoff prompt, because it
+  // has to float ABOVE the controller rather than take space in a column.
+  handoffOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
     flexDirection: 'row',
-    justifyContent: 'space-between',
-    marginBottom: 8,
-  },
-  landShoulderSide: {
-    flexDirection: 'row',
-    gap: 8,
-  },
-  landMain: {
-    flex: 1,
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  landColumn: {
     alignItems: 'center',
     justifyContent: 'center',
-    gap: 14,
-  },
-  landCenter: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 16,
-  },
-  landThumbRow: {
-    flexDirection: 'row',
-    gap: 16,
+    gap: 12,
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    backgroundColor: t.card,
+    borderBottomWidth: 1,
+    borderBottomColor: t.amber,
   },
 });

--- a/app/components/LandscapePad.tsx
+++ b/app/components/LandscapePad.tsx
@@ -1,0 +1,600 @@
+/**
+ * The landscape gamepad — a real controller, full screen, no app chrome.
+ *
+ * Every control is ABSOLUTELY positioned from `lib/padLayout.ts`. There is no
+ * flex here on purpose: the layout this replaces was a flex column of
+ * fixed-pixel children that demanded ~575dp inside a 393dp short axis, and flex
+ * neither clips nor warns, so it silently painted the left stick off the screen
+ * edge, RB into the gap between X and B, and the d-pad's DOWN arrow behind the
+ * tab bar. Positions come from one table that a test can check; see
+ * `lib/__tests__/padLayout.test.ts`.
+ *
+ * Nothing in this file may size a control off the window width, read insets, or
+ * use a percentage string. It gets a computed layout and draws it.
+ */
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { Animated, PanResponder, Pressable, StyleSheet, Text, View } from 'react-native';
+import type { GestureResponderEvent, PanResponderGestureState } from 'react-native';
+
+// Same routing as the portrait pad: every Pad haptic goes through the app-wide
+// gated emitter so the Settings toggle governs them.
+import { hapticLight, hapticSelection as haptic } from '@/lib/haptics';
+import {
+  DPAD,
+  FACE,
+  STICK,
+  dpadZone,
+  stickNubOffset,
+  stickValue,
+  type PadLayout,
+  type PadNode,
+  type Rect,
+} from '@/lib/padLayout';
+import type { ButtonKey, StickKey, TriggerKey } from '@/lib/gamepad';
+import { useTheme, mono, type Palette } from '@/lib/theme';
+
+/** Movement under this is still a tap (matches the swipe surface's rule). */
+const TAP_SLOP = 12;
+/** Touches longer than this aren't taps. */
+const TAP_MS = 450;
+
+type Down = { onDown: () => void; onUp: () => void };
+
+/** The four face buttons, as ids that are BOTH layout nodes and protocol keys. */
+const FACE_IDS = ['a', 'b', 'x', 'y'] as const;
+type FaceId = (typeof FACE_IDS)[number];
+
+export type LandscapePadProps = {
+  layout: Extract<PadLayout, { ok: true }>;
+  /**
+   * Momentary buttons. Typed to the protocol's frozen key union rather than
+   * `string`: these ids are looked up, never interpolated, and widening the
+   * parameter here would be the one place a typo could reach the wire.
+   */
+  btn: (k: ButtonKey) => Down;
+  /** Analog triggers. */
+  trig: (k: TriggerKey) => Down;
+  stickMove: (k: StickKey) => (x: number, y: number) => void;
+  stickRelease: (k: StickKey) => () => void;
+  /** Guide + A chord — the ⋯ Quick Access Menu. */
+  qam: () => void;
+  locked: boolean;
+  onToggleLock: () => void;
+  onExit: () => void;
+};
+
+const abs = (r: Rect) => ({
+  position: 'absolute' as const,
+  left: r.x,
+  top: r.y,
+  width: r.w,
+  height: r.h,
+});
+
+/** Where a node's DRAWN box sits inside its (anisotropically grown) hit box. */
+const inner = (n: PadNode) => ({
+  position: 'absolute' as const,
+  left: n.rect.x - n.hit.x,
+  top: n.rect.y - n.hit.y,
+  width: n.rect.w,
+  height: n.rect.h,
+});
+
+// ---------- A plain momentary button ----------
+
+function PadKey({
+  node, label, color, fontSize, onDown, onUp, u,
+}: {
+  node: PadNode; label: string; color?: string; fontSize?: number;
+  onDown: () => void; onUp: () => void; u: number;
+}) {
+  const t = useTheme();
+  const [held, setHeld] = useState(false);
+  return (
+    <Pressable
+      style={abs(node.hit)}
+      onPressIn={() => {
+        setHeld(true);
+        // Eyes-off, haptics ARE the pressed state — nobody is looking at the
+        // phone to see a colour change.
+        haptic();
+        onDown();
+      }}
+      onPressOut={() => {
+        setHeld(false);
+        onUp();
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={label}>
+      <View
+        style={[
+          inner(node),
+          {
+            borderRadius: node.shape === 'circle' ? node.rect.w / 2 : 2.5 * u,
+            borderWidth: 1,
+            borderColor: held ? (color ?? t.blue) : t.cardBorder,
+            backgroundColor: held ? t.cardBorder : t.card,
+            alignItems: 'center',
+            justifyContent: 'center',
+          },
+        ]}>
+        <Text
+          style={{
+            color: color ?? t.text,
+            fontFamily: mono,
+            fontWeight: '700',
+            fontSize: fontSize ?? 3.4 * u,
+          }}>
+          {label}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
+// ---------- Analog stick: fixed container, floating origin ----------
+
+function FloatingStick({
+  node, u, onMove, onRelease, onClick, label,
+}: {
+  node: PadNode; u: number;
+  onMove: (x: number, y: number) => void;
+  onRelease: () => void;
+  /** L3 / R3 — the stick CLICK, which is now a tap rather than its own button. */
+  onClick: () => void;
+  label: string;
+}) {
+  const t = useTheme();
+  // Where in the container the finger landed. The ring is drawn there, not at
+  // the container's centre: the thumb lands where it lands and there is nothing
+  // to look at to aim with.
+  const [origin, setOrigin] = useState<{ x: number; y: number } | null>(null);
+  const nub = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
+  const cb = useRef({ onMove, onRelease, onClick });
+  cb.current = { onMove, onRelease, onClick };
+  const geom = useRef({ u });
+  geom.current = { u };
+  const t0 = useRef(0);
+
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        // HOLD THE TOUCH. A competing responder that steals the gesture
+        // mid-drag strands the axis at its last value and the agent latches it
+        // — the pad keeps walking in a direction nobody is pushing. The
+        // trackpad and swipe surfaces both refuse for the same reason; the old
+        // Stick did not, and was the one that could be stolen.
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: (e: GestureResponderEvent) => {
+          setOrigin({ x: e.nativeEvent.locationX, y: e.nativeEvent.locationY });
+          t0.current = Date.now();
+          haptic();
+        },
+        onPanResponderMove: (_e, g: PanResponderGestureState) => {
+          // g.dx/g.dy are already relative to touch-down, which IS the floating
+          // origin — no bookkeeping needed.
+          const v = stickValue(g.dx, g.dy, geom.current.u);
+          const n = stickNubOffset(g.dx, g.dy, geom.current.u);
+          nub.setValue(n);
+          // +y down in screen coords matches the protocol directly.
+          cb.current.onMove(v.x, v.y);
+        },
+        onPanResponderRelease: (_e, g) => {
+          const tap =
+            Math.hypot(g.dx, g.dy) < TAP_SLOP && Date.now() - t0.current < TAP_MS;
+          setOrigin(null);
+          nub.setValue({ x: 0, y: 0 });
+          cb.current.onRelease();
+          if (tap) cb.current.onClick();
+        },
+        onPanResponderTerminate: () => {
+          setOrigin(null);
+          nub.setValue({ x: 0, y: 0 });
+          cb.current.onRelease();
+        },
+      }),
+    [nub],
+  );
+
+  const ringR = STICK.ringR * u;
+  const nubR = STICK.nubR * u;
+
+  return (
+    <View style={abs(node.hit)} {...responder.panHandlers} accessibilityLabel={label}>
+      {/* Resting state: a faint ring where the stick nominally lives, so it can
+          be found by eye the first time. Nothing else is drawn until touch. */}
+      {origin === null ? (
+        <View
+          pointerEvents="none"
+          style={[
+            inner(node),
+            {
+              borderRadius: node.rect.w / 2,
+              borderWidth: 1,
+              borderColor: t.cardBorder,
+              opacity: 0.5,
+            },
+          ]}
+        />
+      ) : (
+        <>
+          <View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              left: origin.x - ringR,
+              top: origin.y - ringR,
+              width: ringR * 2,
+              height: ringR * 2,
+              borderRadius: ringR,
+              borderWidth: 1,
+              borderColor: t.blue,
+              backgroundColor: t.card,
+            }}
+          />
+          <Animated.View
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              left: origin.x - nubR,
+              top: origin.y - nubR,
+              width: nubR * 2,
+              height: nubR * 2,
+              borderRadius: nubR,
+              backgroundColor: t.cardBorder,
+              borderWidth: 1,
+              borderColor: t.blue,
+              transform: nub.getTranslateTransform(),
+            }}
+          />
+        </>
+      )}
+    </View>
+  );
+}
+
+// ---------- D-pad: angular, no diagonals ----------
+
+function Dpad({
+  node, u, btn,
+}: {
+  node: PadNode; u: number; btn: (k: ButtonKey) => Down;
+}) {
+  const t = useTheme();
+  // dpadZone returns 'du' | 'dd' | 'dl' | 'dr' | 'a' — every one of them a
+  // ButtonKey, so nothing needs widening on the way to the wire.
+  const [zone, setZone] = useState<ButtonKey | null>(null);
+  const held = useRef<ButtonKey | null>(null);
+  const bt = useRef(btn);
+  bt.current = btn;
+  const geom = useRef({ u, node });
+  geom.current = { u, node };
+
+  const to = useCallback((next: ButtonKey | null) => {
+    if (held.current === next) return;
+    if (held.current) bt.current(held.current).onUp();
+    held.current = next;
+    setZone(next);
+    if (next) {
+      bt.current(next).onDown();
+      // One tick per SECTOR CHANGE, so a held direction that slides into
+      // another is felt. Not one per frame — that floods the generator.
+      hapticLight();
+    }
+  }, []);
+
+  const at = useCallback((e: GestureResponderEvent) => {
+    const { node: n, u: uu } = geom.current;
+    // Centre of the DRAWN box, in container coordinates.
+    const cx = n.rect.x - n.hit.x + n.rect.w / 2;
+    const cy = n.rect.y - n.hit.y + n.rect.h / 2;
+    return dpadZone(e.nativeEvent.locationX - cx, e.nativeEvent.locationY - cy, uu);
+  }, []);
+
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: (e) => to(at(e)),
+        onPanResponderMove: (e) => to(at(e)),
+        onPanResponderRelease: () => to(null),
+        onPanResponderTerminate: () => to(null),
+      }),
+    [at, to],
+  );
+
+  const r = node.rect.w / 2;
+  const outer = DPAD.outerRU * u;
+  const innerR = DPAD.innerRU * u;
+  const arm = (k: string, label: string, dx: number, dy: number) => (
+    <View
+      key={k}
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: r + dx * (outer * 0.62) - 3 * u,
+        top: r + dy * (outer * 0.62) - 3 * u,
+        width: 6 * u,
+        height: 6 * u,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Text style={{ color: zone === k ? t.blue : t.textFaint, fontSize: 4 * u }}>{label}</Text>
+    </View>
+  );
+
+  return (
+    <View style={abs(node.hit)} {...responder.panHandlers} accessibilityLabel="D-pad">
+      <View pointerEvents="none" style={inner(node)}>
+        {/* Ring: every pixel inside it does something — four 90° sectors with
+            no dead corners, because eyes-off there is nothing to aim at. */}
+        <View
+          style={{
+            position: 'absolute',
+            left: r - outer, top: r - outer, width: outer * 2, height: outer * 2,
+            borderRadius: outer, borderWidth: 1, borderColor: t.cardBorder,
+            backgroundColor: t.card,
+          }}
+        />
+        {arm('du', '▲', 0, -1)}
+        {arm('dd', '▼', 0, 1)}
+        {arm('dl', '◀', -1, 0)}
+        {arm('dr', '▶', 1, 0)}
+        {/* Centre disc = A/OK, keeping the existing centre-OK behaviour. */}
+        <View
+          style={{
+            position: 'absolute',
+            left: r - innerR, top: r - innerR, width: innerR * 2, height: innerR * 2,
+            borderRadius: innerR, borderWidth: 1,
+            borderColor: zone === 'a' ? t.green : t.cardBorder,
+            backgroundColor: zone === 'a' ? t.cardBorder : t.card,
+            alignItems: 'center', justifyContent: 'center',
+          }}>
+          <Text style={{ color: t.green, fontFamily: mono, fontWeight: '700', fontSize: 3.4 * u }}>
+            OK
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ---------- Face diamond: one responder, so a thumb can roll A -> B ----------
+
+function FaceCluster({
+  nodes, u, btn, colors,
+}: {
+  nodes: PadNode[]; u: number; btn: (k: ButtonKey) => Down; colors: Record<FaceId, string>;
+}) {
+  const t = useTheme();
+  const [zone, setZone] = useState<FaceId | null>(null);
+  const held = useRef<FaceId | null>(null);
+  const bt = useRef(btn);
+  bt.current = btn;
+
+  // Bounding box of the four hit rects. Slide-between is allowed WITHIN this
+  // cluster (they are one layer) and impossible outside it, because no other
+  // node's hit rect reaches in — which the layout test asserts.
+  const box = useMemo(() => {
+    const x = Math.min(...nodes.map((n) => n.hit.x));
+    const y = Math.min(...nodes.map((n) => n.hit.y));
+    return {
+      x, y,
+      w: Math.max(...nodes.map((n) => n.hit.x + n.hit.w)) - x,
+      h: Math.max(...nodes.map((n) => n.hit.y + n.hit.h)) - y,
+    };
+  }, [nodes]);
+
+  const geom = useRef({ nodes, box });
+  geom.current = { nodes, box };
+
+  const to = useCallback((next: FaceId | null) => {
+    if (held.current === next) return;
+    if (held.current) bt.current(held.current).onUp();
+    held.current = next;
+    setZone(next);
+    if (next) {
+      bt.current(next).onDown();
+      haptic();
+    }
+  }, []);
+
+  const at = useCallback((e: GestureResponderEvent): FaceId | null => {
+    const { nodes: ns, box: b } = geom.current;
+    // locationX/Y are relative to this responder View, which is positioned at
+    // the cluster's bounding box — so adding the box origin puts the touch back
+    // into the same coordinate space the node hit rects are in.
+    const px = e.nativeEvent.locationX + b.x;
+    const py = e.nativeEvent.locationY + b.y;
+    for (const n of ns) {
+      if (px >= n.hit.x && px <= n.hit.x + n.hit.w && py >= n.hit.y && py <= n.hit.y + n.hit.h) {
+        return n.id as FaceId;
+      }
+    }
+    return null;
+  }, []);
+
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: (e) => to(at(e)),
+        onPanResponderMove: (e) => to(at(e)),
+        onPanResponderRelease: () => to(null),
+        onPanResponderTerminate: () => to(null),
+      }),
+    [at, to],
+  );
+
+  return (
+    <View style={abs(box)} {...responder.panHandlers} accessibilityLabel="Face buttons">
+      {nodes.map((n) => {
+        const d = FACE.diaU * u;
+        const id = n.id as FaceId;
+        const on = zone === id;
+        return (
+          <View
+            key={id}
+            pointerEvents="none"
+            style={{
+              position: 'absolute',
+              left: n.rect.x - box.x,
+              top: n.rect.y - box.y,
+              width: d,
+              height: d,
+              borderRadius: d / 2,
+              borderWidth: 1,
+              borderColor: on ? colors[id] : t.cardBorder,
+              backgroundColor: on ? t.cardBorder : t.card,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+            <Text
+              style={{
+                color: colors[id],
+                fontFamily: mono,
+                fontWeight: '700',
+                fontSize: 4.4 * u,
+              }}>
+              {id.toUpperCase()}
+            </Text>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+// ---------- The pad ----------
+
+export function LandscapePad({
+  layout, btn, trig, stickMove, stickRelease, qam, locked, onToggleLock, onExit,
+}: LandscapePadProps) {
+  const t = useTheme();
+  const { byId, u } = layout;
+  const faceColors: Record<FaceId, string> = {
+    a: t.green, b: t.red, x: t.blue, y: t.amber,
+  };
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      {/* Row 1 — shoulders. */}
+      <PadKey node={byId.lt} label="LT" u={u} {...trig('lt')} />
+      <PadKey node={byId.lb} label="LB" u={u} {...btn('lb')} />
+      <PadKey node={byId.rb} label="RB" u={u} {...btn('rb')} />
+      <PadKey node={byId.rt} label="RT" u={u} {...trig('rt')} />
+
+      {/* Row 2 — menu cluster. */}
+      <PadKey node={byId.select} label="SELECT" u={u} fontSize={2.8 * u} {...btn('select')} />
+      <PadKey node={byId.steam} label="STEAM" u={u} color={t.blue} fontSize={2.8 * u} {...btn('guide')} />
+      <PadKey node={byId.qam} label="⋯" u={u} color={t.blue} fontSize={5 * u} onDown={qam} onUp={NOOP} />
+      <PadKey node={byId.start} label="START" u={u} fontSize={2.8 * u} {...btn('start')} />
+
+      {/* Thumb clusters. */}
+      <Dpad node={byId.dpad} u={u} btn={btn} />
+      <FloatingStick
+        node={byId.lstick} u={u} label="Left stick"
+        onMove={stickMove('l')} onRelease={stickRelease('l')}
+        onClick={() => {
+          // L3 is the stick TAP now. That removed a whole row of thumb buttons
+          // and bought back the short axis the layout needed.
+          btn('l3').onDown();
+          setTimeout(() => btn('l3').onUp(), 60);
+        }}
+      />
+      <FloatingStick
+        node={byId.rstick} u={u} label="Right stick"
+        onMove={stickMove('r')} onRelease={stickRelease('r')}
+        onClick={() => {
+          btn('r3').onDown();
+          setTimeout(() => btn('r3').onUp(), 60);
+        }}
+      />
+      <FaceCluster nodes={FACE_IDS.map((id) => byId[id])} u={u} btn={btn} colors={faceColors} />
+
+      {/* Chrome. Deliberately NOT auto-hiding on a timer: the two buttons cost
+          nothing (they sit in a band that is otherwise empty) and fading the
+          only exit on a screen nobody is looking at is a bad trade at any
+          timeout. Steam Link fades its controls after 10s; not copied. */}
+      <Pressable
+        style={abs(byId.lock.hit)}
+        onPress={() => {
+          haptic();
+          onToggleLock();
+        }}
+        accessibilityRole="switch"
+        accessibilityState={{ checked: locked }}
+        accessibilityLabel={locked ? 'Orientation locked' : 'Orientation follows the phone'}>
+        <View
+          style={[
+            inner(byId.lock),
+            {
+              borderRadius: 2.5 * u, borderWidth: 1,
+              borderColor: locked ? t.amber : t.cardBorder,
+              backgroundColor: t.card,
+              alignItems: 'center', justifyContent: 'center',
+            },
+          ]}>
+          {/* State AND consequence: when it is on, ✕ is the only way out. */}
+          <Text style={{ color: locked ? t.amber : t.textFaint, fontFamily: mono, fontSize: 2.6 * u }}>
+            {locked ? '🔒 LOCKED' : '🔓 AUTO'}
+          </Text>
+        </View>
+      </Pressable>
+
+      <Pressable
+        style={abs(byId.exit.hit)}
+        onPress={() => {
+          haptic();
+          onExit();
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="Exit full-screen controller">
+        <View
+          style={[
+            inner(byId.exit),
+            {
+              borderRadius: 2.5 * u, borderWidth: 1, borderColor: t.cardBorder,
+              backgroundColor: t.card, alignItems: 'center', justifyContent: 'center',
+            },
+          ]}>
+          <Text style={{ color: t.textFaint, fontFamily: mono, fontSize: 3.4 * u }}>✕ EXIT</Text>
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+const NOOP = () => {};
+
+/**
+ * Shown instead of the controller when the screen is too small to draw one that
+ * meets the 44dp touch floor. Refusing is the honest answer — a cramped
+ * controller that half-works is worse than being told to turn the phone back.
+ */
+export function LandscapePadTooSmall({ reason, onExit }: { reason: string; onExit: () => void }) {
+  const t = useTheme();
+  return (
+    <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center', padding: 24 }]}>
+      <Text style={{ color: t.text, fontFamily: mono, fontSize: 15, textAlign: 'center' }}>
+        {reason === 'too-narrow'
+          ? 'This window is too narrow for the controller.'
+          : 'This screen is too short for the controller.'}
+      </Text>
+      <Text style={{ color: t.textFaint, fontSize: 13, textAlign: 'center', marginTop: 8 }}>
+        Turn the phone back to portrait to keep playing.
+      </Text>
+      <Pressable onPress={onExit} style={{ marginTop: 16, padding: 12 }}>
+        <Text style={{ color: t.blue, fontFamily: mono, fontSize: 13 }}>✕ BACK TO PORTRAIT</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export type { Palette };

--- a/app/components/TabScreen.tsx
+++ b/app/components/TabScreen.tsx
@@ -10,19 +10,24 @@ import { StyleSheet, Text, View } from 'react-native';
 import { BoxSwitcher } from '@/components/BoxSwitcher';
 import { TrialNudge } from '@/components/TrialNudge';
 import { IS_BETA_BUILD } from '@/lib/entitlement';
+import { useImmersive } from '@/lib/immersive';
 import { mono, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 
 export function TabScreen({ children }: { children: React.ReactNode }) {
   const styles = useThemedStyles(makeStyles);
+  // Landscape gamepad owns the whole screen: no device picker, no trial nudge,
+  // no BETA badge. See lib/immersive.ts for why this is derived state rather
+  // than an imperative setOptions call with cleanup to forget.
+  const immersive = useImmersive();
   return (
     <View style={styles.root}>
-      <BoxSwitcher />
+      {!immersive && <BoxSwitcher />}
       {/* Near the end of the trial only, and never on Setup (which already
           carries the permanent unlock row). Self-hides otherwise. */}
-      <TrialNudge />
+      {!immersive && <TrialNudge />}
       <View style={styles.body}>{children}</View>
-      {IS_BETA_BUILD && (
+      {IS_BETA_BUILD && !immersive && (
         <View pointerEvents="none" style={styles.betaBadge}>
           <Text style={styles.betaText}>BETA</Text>
         </View>

--- a/app/hooks/useLockOrientation.ts
+++ b/app/hooks/useLockOrientation.ts
@@ -1,32 +1,49 @@
 /**
  * Per-screen orientation lock. Every tab is portrait-only except the Pad tab,
- * which allows landscape so the on-screen controller can spread out like a
- * real gamepad.
+ * which allows landscape so the on-screen controller can spread out like a real
+ * gamepad — and can PIN itself there while someone is playing.
  *
- * Usage: call `useLockOrientation('portrait')` in a portrait-only screen and
- * `useLockOrientation('allow-landscape')` in the Pad screen. The lock is
- * (re)applied every time the screen gains focus and is a no-op on web (where
- * orientation control is unsupported / undesirable).
+ * Usage: call `useLockOrientation('portrait')` in a portrait-only screen. The
+ * policy is (re)applied every time the screen gains focus and is a no-op on web
+ * (where orientation control is unsupported / undesirable).
+ *
+ * `app.json` sets `"orientation": "default"`, so nothing is locked natively and
+ * these calls are the only thing deciding what rotates. Every screen in the app
+ * states a policy — there is a test in lib/__tests__/onboarding.test.ts that
+ * fails if one forgets — which is what makes releasing the lock on blur safe.
  */
 import * as ScreenOrientation from 'expo-screen-orientation';
 import { useFocusEffect } from 'expo-router';
 import { useCallback } from 'react';
 import { Platform } from 'react-native';
 
-export type OrientationPolicy = 'portrait' | 'allow-landscape';
+export type OrientationPolicy =
+  /** Portrait only. */
+  | 'portrait'
+  /** Let the device decide — the Pad's gamepad mode follows the phone. */
+  | 'allow-landscape'
+  /** Pinned sideways: the user asked for it with the LOCK button. */
+  | 'landscape-locked';
 
 export function useLockOrientation(policy: OrientationPolicy): void {
   useFocusEffect(
     useCallback(() => {
       if (Platform.OS === 'web') return undefined;
 
-      let cancelled = false;
       const apply = async () => {
         try {
           if (policy === 'allow-landscape') {
             // DEFAULT policy = all orientations (minus upside-down on iOS),
             // so the device's own rotation drives the Pad layout.
             await ScreenOrientation.unlockAsync();
+          } else if (policy === 'landscape-locked') {
+            // LANDSCAPE, not LANDSCAPE_LEFT: both directions stay legal, so the
+            // lock never fights the user's grip or which side they turned the
+            // phone. Pinning one direction would flip the notch to the other
+            // edge for half of them.
+            await ScreenOrientation.lockAsync(
+              ScreenOrientation.OrientationLock.LANDSCAPE,
+            );
           } else {
             await ScreenOrientation.lockAsync(
               ScreenOrientation.OrientationLock.PORTRAIT_UP,
@@ -37,12 +54,18 @@ export function useLockOrientation(policy: OrientationPolicy): void {
           // failing to lock is non-fatal.
         }
       };
-      // Ignore the returned promise but guard against a focus/blur race.
       void apply();
 
       return () => {
-        cancelled = true;
-        void cancelled;
+        // RELEASE THE LOCK ON BLUR. This used to set a `cancelled` flag that
+        // nothing read, which was the same as no cleanup at all — and with the
+        // 'landscape-locked' policy added, no cleanup means leaving the Pad tab
+        // while pinned would pin the ENTIRE APP sideways, with the Console,
+        // Launch and Setup screens rendered into a shape none of them has a
+        // layout for. The next screen to focus applies its own policy
+        // immediately; every screen has one.
+        if (policy === 'portrait') return;
+        void ScreenOrientation.unlockAsync().catch(() => {});
       };
     }, [policy]),
   );

--- a/app/lib/__tests__/onboarding.test.ts
+++ b/app/lib/__tests__/onboarding.test.ts
@@ -126,7 +126,8 @@ test('every screen locks orientation except the Pad, which allows landscape', as
     if (rel === '+not-found.tsx') continue;
     const src = readFileSync(p, 'utf8');
     assert.ok(src.includes('useLockOrientation('), `${rel} must state an orientation policy`);
-    const mentionsLandscape = src.includes("'allow-landscape'");
+    const mentionsLandscape =
+      src.includes("'allow-landscape'") || src.includes("'landscape-locked'");
     assert.equal(
       mentionsLandscape,
       rel.endsWith('pad.tsx'),
@@ -136,9 +137,18 @@ test('every screen locks orientation except the Pad, which allows landscape', as
       // And even there it is CONDITIONAL on the gamepad mode. A flat
       // 'allow-landscape' rotated Swipe, Mouse, Remote and the Steam menus too —
       // none of which have a landscape layout. Reported from a device.
+      //
+      // Asserted as a PROPERTY rather than by matching the exact expression:
+      // the call site grew a third policy ('landscape-locked', for the LOCK
+      // button) and an `exited` term, and a test that pins one spelling just
+      // gets rewritten to whatever the code now says, which guards nothing.
       assert.ok(
-        /useLockOrientation\(\s*mode === 'gamepad'/.test(src),
-        'the Pad must allow landscape only in gamepad mode',
+        !/useLockOrientation\(\s*'(allow-landscape|landscape-locked)'\s*\)/.test(src),
+        'the Pad must not allow landscape unconditionally',
+      );
+      assert.ok(
+        /useLockOrientation\([^;]*\bmode\b[^;]*'gamepad'/.test(src),
+        'the Pad landscape policy must still be conditional on the gamepad mode',
       );
     }
   }

--- a/app/lib/__tests__/padLayout.test.ts
+++ b/app/lib/__tests__/padLayout.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Landscape gamepad geometry — lib/padLayout.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ * Picked up by the CI `app-input` job's existing glob; no workflow change.
+ *
+ * WHAT THIS IS FOR. The bug being fixed (owner screenshot 2026-08-07: left
+ * stick cut off by the screen edge, B clipped right, RB overlapping the X-B
+ * gap, the d-pad's DOWN arrow behind the tab bar) was a flex container silently
+ * overflowing. Flex does not clip, does not warn, and does not show up in a
+ * render check — which is exactly why "I looked at it and it seemed fine" is
+ * not evidence here and this file exists instead. Dolphin, a mature and widely
+ * shipped emulator, has a computable 43x66px double-fire corner between
+ * TRIGGER_R and BUTTON_Y in its default layout because nothing ever asserted
+ * the no-overlap property.
+ *
+ * Every size is run TWICE, notch left and notch right. In landscape on iPhone
+ * `insets.top` is 0 and the notch is `insets.left` OR `insets.right` depending
+ * on which way the phone was turned, so a layout that only handles `top` clips
+ * on exactly one of the two rotations and looks perfect on the other. That is
+ * how this class of bug survives review.
+ *
+ * This is the safety-critical input path (CLAUDE.md §4).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  DPAD,
+  EXIT_MOAT_U,
+  MIN_SHORT_AXIS,
+  MIN_TOUCH,
+  dpadZone,
+  padLayout,
+  rectGap,
+  rectsIntersect,
+  stickValue,
+  type Insets,
+  type PadLayout,
+  type Rect,
+  type Size,
+} from '../padLayout.ts';
+
+// ---------- Devices ----------
+// Landscape dp. Long axis first. `side` is the notch/cutout inset, applied to
+// ONE side at a time by the runner below; `bottom` is the home indicator or
+// gesture bar, which in landscape stays on the bottom edge.
+type Device = {
+  name: string; w: number; h: number; side: number; bottom: number;
+  /** Not a shipping device — a boundary probe. Exempt from the 100dp EXIT moat. */
+  synthetic?: boolean;
+};
+
+const DEVICES: Device[] = [
+  { name: 'iPhone SE (3rd gen)', w: 667, h: 375, side: 0, bottom: 0 },
+  { name: 'iPhone 13 mini', w: 812, h: 375, side: 50, bottom: 21 },
+  { name: 'iPhone 14', w: 844, h: 390, side: 47, bottom: 21 },
+  { name: 'iPhone 14 Pro', w: 852, h: 393, side: 59, bottom: 21 },
+  { name: 'iPhone 14 Pro Max', w: 932, h: 430, side: 59, bottom: 21 },
+  { name: 'iPhone 16 Pro Max', w: 956, h: 440, side: 62, bottom: 21 },
+  { name: 'Pixel 7', w: 892, h: 412, side: 0, bottom: 24 },
+  // 336dp of play after the gesture bar. The spec's 340 floor would have shown
+  // this phone the "turn it back" card; see MIN_SHORT_AXIS.
+  { name: 'Galaxy S21', w: 800, h: 360, side: 0, bottom: 24 },
+  { name: 'Razr 2023 (owner test device)', w: 917, h: 412, side: 0, bottom: 24 },
+  { name: 'iPad mini', w: 1133, h: 744, side: 0, bottom: 20 },
+  { name: 'iPad Pro 11"', w: 1194, h: 834, side: 0, bottom: 20 },
+  // The tightest thing that must still work: 16:9 — the narrowest real phone
+  // shape — at the exact short-axis floor. Both floors bind at once here, which
+  // is why it is the case that exposes the EXIT-moat conflict.
+  { name: 'floor 16:9 @ 326', w: 579, h: MIN_SHORT_AXIS, side: 0, bottom: 0, synthetic: true },
+];
+
+type Case = { label: string; win: Size; insets: Insets; synthetic: boolean };
+
+/** Both rotations of every device: notch on the left, then on the right. */
+function cases(): Case[] {
+  const out: Case[] = [];
+  for (const d of DEVICES) {
+    const win = { width: d.w, height: d.h };
+    out.push({
+      label: `${d.name} (notch left)`,
+      win,
+      insets: { top: 0, right: 0, bottom: d.bottom, left: d.side },
+      synthetic: d.synthetic ?? false,
+    });
+    out.push({
+      label: `${d.name} (notch right)`,
+      win,
+      insets: { top: 0, right: d.side, bottom: d.bottom, left: 0 },
+      synthetic: d.synthetic ?? false,
+    });
+  }
+  return out;
+}
+
+function ok(l: PadLayout): Extract<PadLayout, { ok: true }> {
+  assert.equal(l.ok, true, 'expected a layout');
+  return l as Extract<PadLayout, { ok: true }>;
+}
+
+const contains = (outer: Rect, inner: Rect) =>
+  inner.x >= outer.x - 1e-6 &&
+  inner.y >= outer.y - 1e-6 &&
+  inner.x + inner.w <= outer.x + outer.w + 1e-6 &&
+  inner.y + inner.h <= outer.y + outer.h + 1e-6;
+
+// ---------- Assertion 1 — kills clipping ----------
+
+test('every control is fully inside the play rect, both rotations', () => {
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      assert.ok(
+        contains(l.play, n.rect),
+        `${c.label}: ${n.id} escapes the play rect — ` +
+          `rect=${JSON.stringify(n.rect)} play=${JSON.stringify(l.play)}`,
+      );
+    }
+  }
+});
+
+test('touchable rects are inside the play rect too — expansion never overruns an edge', () => {
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      assert.ok(contains(l.play, n.hit), `${c.label}: ${n.id} hit rect escapes the play rect`);
+    }
+  }
+});
+
+// ---------- Assertion 2 — kills overlap ----------
+
+test('no two touchable rects intersect, both rotations', () => {
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (let i = 0; i < l.nodes.length; i += 1) {
+      for (let j = i + 1; j < l.nodes.length; j += 1) {
+        const a = l.nodes[i];
+        const b = l.nodes[j];
+        assert.ok(
+          !rectsIntersect(a.hit, b.hit),
+          `${c.label}: ${a.id} and ${b.id} both answer the same touch — ` +
+            `${JSON.stringify(a.hit)} vs ${JSON.stringify(b.hit)}`,
+        );
+      }
+    }
+  }
+});
+
+test('the specific pairs the screenshot showed colliding are apart', () => {
+  // RB over the X-B gap, and the left stick against the d-pad. Named because a
+  // generic all-pairs failure message does not say "this is the reported bug".
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const [p, q] of [['rb', 'x'], ['rb', 'b'], ['lstick', 'dpad'], ['dpad', 'a']] as const) {
+      assert.ok(
+        !rectsIntersect(l.byId[p].hit, l.byId[q].hit),
+        `${c.label}: ${p} overlaps ${q}`,
+      );
+    }
+  }
+});
+
+// ---------- Assertion 3 — kills unhittable targets ----------
+
+test('every touch target clears 44dp', () => {
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      const min = Math.min(n.hit.w, n.hit.h);
+      assert.ok(
+        min >= MIN_TOUCH - 1e-6,
+        `${c.label}: ${n.id} is ${min.toFixed(1)}dp, under the ${MIN_TOUCH}dp floor`,
+      );
+    }
+  }
+});
+
+test('a d-pad SECTOR clears 44dp, not just the 39U box around it', () => {
+  // The box would pass trivially at any size. What a thumb actually hits is the
+  // radial thickness of one sector, so that is what gets asserted.
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    const thickness = DPAD.sectorThicknessU * l.u;
+    assert.ok(
+      thickness >= MIN_TOUCH - 1e-6,
+      `${c.label}: d-pad sector is ${thickness.toFixed(1)}dp thick`,
+    );
+  }
+});
+
+// ---------- Assertion 4 — kills the accidental exit ----------
+
+test('EXIT keeps its moat from every game control, everywhere', () => {
+  // Stated in U, because that is the unit the layout is built in and it is the
+  // form that holds with no exception. See EXIT_MOAT_U for why the spec's flat
+  // 100dp could not also be true at the short-axis floor.
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      if (n.layer === 9) continue; // LOCK is its neighbour by design
+      const gap = rectGap(l.byId.exit.hit, n.hit);
+      assert.ok(
+        gap >= EXIT_MOAT_U * l.u - 1e-6,
+        `${c.label}: EXIT is only ${(gap / l.u).toFixed(1)}U from ${n.id} — a mis-press ends the session`,
+      );
+    }
+  }
+});
+
+test('on every real device that moat is the 100dp the spec asked for', () => {
+  // The U-based invariant above is the one that always holds; this asserts the
+  // stronger dp figure still holds everywhere it can, so quietly losing it on a
+  // shipping phone would fail rather than pass unnoticed.
+  for (const c of cases()) {
+    if (c.synthetic) continue;
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      if (n.layer === 9) continue;
+      const gap = rectGap(l.byId.exit.hit, n.hit);
+      assert.ok(gap >= 100, `${c.label}: EXIT is only ${gap.toFixed(1)}dp from ${n.id}`);
+    }
+  }
+});
+
+// ---------- Assertion 5 — refuses rather than cramps ----------
+
+const noInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+
+test('a screen under the short-axis floor is refused, not cramped', () => {
+  const l = padLayout({ width: 640, height: MIN_SHORT_AXIS - 1 }, noInsets);
+  assert.equal(l.ok, false);
+  assert.equal(l.ok === false && l.reason, 'too-short');
+});
+
+test('BOTH directions of the short-axis guard', () => {
+  // A floor observed only failing is half-verified. One dp either side of it.
+  assert.equal(padLayout({ width: 640, height: MIN_SHORT_AXIS }, noInsets).ok, true,
+    'the floor itself must render');
+  assert.equal(padLayout({ width: 640, height: MIN_SHORT_AXIS - 1 }, noInsets).ok, false,
+    'one dp under the floor must refuse');
+});
+
+test('insets can push a tall-enough window under the floor', () => {
+  // 360 of glass, but 40 of chrome leaves 320. The refusal has to be computed
+  // from the PLAY rect, not from the window.
+  const l = padLayout({ width: 800, height: 360 }, { top: 0, right: 0, bottom: 40, left: 0 });
+  assert.equal(l.ok, false, 'insets were not subtracted before the floor check');
+});
+
+test('a real 360dp Android phone in landscape is NOT refused', () => {
+  // Galaxy S21: 800x360 with a 24dp gesture bar. The other direction of the
+  // same guard, and the reason MIN_SHORT_AXIS is 326 rather than the spec's
+  // 340 — at 340 this phone gets a "turn it back" card for no reason.
+  const l = padLayout({ width: 800, height: 360 }, { top: 0, right: 0, bottom: 24, left: 0 });
+  assert.equal(l.ok, true, 'a shipping phone was refused');
+});
+
+test('a short, near-square window is refused too', () => {
+  // Reachable via Android split-screen / free-form. Under MIN_LONG_AXIS_U the
+  // thumb clusters have no centre channel and EXIT loses its moat.
+  const l = padLayout({ width: 500, height: 420 }, noInsets);
+  assert.equal(l.ok, false);
+  assert.equal(l.ok === false && l.reason, 'too-narrow');
+});
+
+test('BOTH directions of the long-axis guard, at 16:9', () => {
+  const h = 400;
+  assert.equal(padLayout({ width: Math.ceil(h * 16 / 9), height: h }, noInsets).ok, true,
+    '16:9 is the narrowest real phone shape and must render');
+  assert.equal(padLayout({ width: Math.floor(h * 1.7), height: h }, noInsets).ok, false,
+    'narrower than 16:9 must refuse');
+});
+
+// ---------- Controls: inputs whose answer is known in advance ----------
+
+test('CONTROL — the no-overlap check can actually fail', () => {
+  // Assertion 2 passing means nothing unless the predicate under it can return
+  // false. Two rects placed on top of each other must be reported as colliding.
+  const l = ok(padLayout({ width: 852, height: 393 }, { top: 0, right: 0, bottom: 21, left: 59 }));
+  const a = l.byId.lstick;
+  assert.ok(
+    rectsIntersect(a.hit, { ...a.hit, x: a.hit.x + 1 }),
+    'rectsIntersect never returns true — every no-overlap test above is vacuous',
+  );
+  assert.equal(rectGap(a.hit, { ...a.hit, x: a.hit.x + a.hit.w + 10 }), 10);
+});
+
+test('CONTROL — insets actually move the layout', () => {
+  // If insets were being ignored, the notch-left and notch-right runs would be
+  // identical and every "both rotations" test above would be one test twice.
+  const win = { width: 852, height: 393 };
+  const left = ok(padLayout(win, { top: 0, right: 0, bottom: 21, left: 59 }));
+  const right = ok(padLayout(win, { top: 0, right: 59, bottom: 21, left: 0 }));
+  assert.notEqual(left.byId.dpad.rect.x, right.byId.dpad.rect.x);
+  assert.equal(left.play.w, right.play.w);
+});
+
+// ---------- Sizing rule: nothing may be derived from the long axis ----------
+
+test('control geometry does not change when only the long axis changes', () => {
+  // Rule 1. Two windows with the same short axis and very different long axes
+  // must produce identically SIZED controls — only their positions differ. This
+  // is the assertion that would have caught Steam Link's bug, where the same
+  // A/B/X/Y diamond renders 289x240 on one phone and 346x292 on another.
+  const insets = { top: 0, right: 0, bottom: 0, left: 0 };
+  const narrow = ok(padLayout({ width: 720, height: 400 }, insets)); // 180U
+  const wide = ok(padLayout({ width: 1100, height: 400 }, insets)); // 275U
+  for (const n of narrow.nodes) {
+    const w = wide.byId[n.id];
+    assert.equal(n.rect.w, w.rect.w, `${n.id} width tracks the long axis`);
+    assert.equal(n.rect.h, w.rect.h, `${n.id} height tracks the long axis`);
+  }
+});
+
+test('circular controls stay circular', () => {
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    for (const n of l.nodes) {
+      if (n.shape !== 'circle') continue;
+      assert.equal(n.rect.w, n.rect.h, `${c.label}: ${n.id} is an ellipse`);
+    }
+  }
+});
+
+test('no percentage strings anywhere in the pad UI', () => {
+  // Lint-grade. In React Native the "size off the wrong axis" bug wears a
+  // percentage string, and `width: '12%'` is seductive because it LOOKS
+  // responsive. Circles become ellipses and diamonds stop being diamonds the
+  // moment one extent comes from width and its sibling from height. There are
+  // none today; this keeps it that way.
+  const here = dirname(fileURLToPath(import.meta.url));
+  for (const rel of [
+    ['..', '..', 'app', '(tabs)', 'pad.tsx'],
+    ['..', '..', 'components', 'LandscapePad.tsx'],
+  ]) {
+    const src = readFileSync(join(here, ...rel), 'utf8');
+    const hits = src.match(/(width|height|top|left|right|bottom|margin\w*|padding\w*|flexBasis)\s*:\s*['"]\d+(\.\d+)?%['"]/g);
+    assert.equal(hits, null, `percentage sizing in ${rel.at(-1)}: ${hits?.join(', ')}`);
+  }
+});
+
+test('CONTROL — the percentage guard can actually fire', () => {
+  // Otherwise "no matches" is indistinguishable from a regex that matches
+  // nothing at all, which is how a guard quietly stops guarding.
+  const re = /(width|height|top|left|right|bottom|margin\w*|padding\w*|flexBasis)\s*:\s*['"]\d+(\.\d+)?%['"]/g;
+  assert.notEqual("  width: '12%',".match(re), null, 'the guard would miss a real percentage');
+  assert.equal("  width: 12,".match(re), null, 'the guard fires on plain numbers');
+});
+
+test('the landscape pad never reads the window or the insets itself', () => {
+  // Rule 3: insets are subtracted exactly once, inside padLayout. A second
+  // reader is how the safe area gets counted twice — and in landscape it is
+  // `insets.left`/`insets.right` that carry the notch, so a component that
+  // reaches for `insets.top` looks correct on one rotation and clips on the
+  // other.
+  const here = dirname(fileURLToPath(import.meta.url));
+  const src = readFileSync(join(here, '..', '..', 'components', 'LandscapePad.tsx'), 'utf8');
+  for (const banned of ['useSafeAreaInsets', 'SafeAreaView', 'useWindowDimensions', 'Dimensions.get']) {
+    assert.ok(!src.includes(banned), `LandscapePad must not use ${banned} — it gets a computed layout`);
+  }
+});
+
+// ---------- Stick and d-pad behaviour ----------
+
+test('the stick is radially clamped — a diagonal never exceeds 1.0', () => {
+  const u = 3.93;
+  const far = 500; // well past saturation, in both axes at once
+  const v = stickValue(far, far, u);
+  assert.ok(Math.hypot(v.x, v.y) <= 1 + 1e-9, 'diagonals reach sqrt(2) — this is a square clamp');
+  assert.ok(Math.hypot(v.x, v.y) > 0.99, 'full deflection does not reach 1.0');
+});
+
+test('the deadzone renormalises rather than clipping the top of the range', () => {
+  const u = 3.93;
+  assert.deepEqual(stickValue(0, 0, u), { x: 0, y: 0 });
+  // Just inside the deadzone: silent.
+  const inside = stickValue(22 * u * 0.1, 0, u);
+  assert.equal(inside.x, 0);
+  // Just outside: alive, but near zero rather than jumping to 0.12.
+  const outside = stickValue(22 * u * 0.13, 0, u);
+  assert.ok(outside.x > 0 && outside.x < 0.05, `expected a small value, got ${outside.x}`);
+});
+
+test('d-pad: centre is A, cardinals are exact, corners pick ONE direction', () => {
+  const u = 3.93;
+  assert.equal(dpadZone(0, 0, u), 'a');
+  assert.equal(dpadZone(0, DPAD.innerRU * u * 0.5, u), 'a');
+  assert.equal(dpadZone(0, -15 * u, u), 'du');
+  assert.equal(dpadZone(0, 15 * u, u), 'dd');
+  assert.equal(dpadZone(-15 * u, 0, u), 'dl');
+  assert.equal(dpadZone(15 * u, 0, u), 'dr');
+  // A 45-degree press resolves to a single cardinal, never two at once.
+  const corner = dpadZone(10 * u, 10 * u, u);
+  assert.ok(corner === 'dr' || corner === 'dd', `corner gave ${corner}`);
+  // Outside the cluster: released, not latched to the last direction.
+  assert.equal(dpadZone(30 * u, 0, u), null);
+});

--- a/app/lib/immersive.ts
+++ b/app/lib/immersive.ts
@@ -1,0 +1,62 @@
+/**
+ * "Immersive" = the landscape gamepad is on screen and owns the whole display.
+ *
+ * WHY A STORE AND NOT `navigation.setOptions`.
+ *
+ * Three separate places have to stop drawing: the tab bar (owned by
+ * `app/(tabs)/_layout.tsx`), the BoxSwitcher and trial nudge (owned by
+ * `components/TabScreen.tsx`), and the Pad's own status pill and mode selector.
+ * The obvious way to do that from inside pad.tsx is an imperative
+ * `navigation.setOptions({ tabBarStyle: { display: 'none' } })` — and the
+ * obvious way is a trap, because it has to remember to undo itself. Cleanup
+ * that never runs, or that restores `undefined` instead of the real style,
+ * leaves the user on the Console tab with no tab bar and no way back. That is a
+ * shipped bug in a lot of apps and it would be a total failure here, where the
+ * promise is that the app works when the TV is black.
+ *
+ * So the flag is state, `_layout.tsx` derives `tabBarStyle` from it, and there
+ * is nothing to undo. The worst a bug can do is show chrome that should be
+ * hidden, which is visible and harmless, rather than hide chrome that should be
+ * shown.
+ *
+ * Module-level rather than a context provider so the tab layout can read it
+ * without wrapping `<Tabs>` in another component — and `useSyncExternalStore`
+ * rather than a hand-rolled subscription so React never tears between the tab
+ * bar and the screen inside it. No new dependency.
+ */
+import { useSyncExternalStore } from 'react';
+
+let immersive = false;
+const listeners = new Set<() => void>();
+
+/**
+ * Called from the Pad screen's render path as the derived value changes.
+ * Idempotent: setting the value it already has notifies nobody, which matters
+ * because this is driven from a render and a notify-on-every-render would loop.
+ */
+export function setImmersive(next: boolean): void {
+  if (next === immersive) return;
+  immersive = next;
+  for (const l of listeners) l();
+}
+
+function subscribe(l: () => void): () => void {
+  listeners.add(l);
+  return () => {
+    listeners.delete(l);
+  };
+}
+
+const getSnapshot = () => immersive;
+
+export function useImmersive(): boolean {
+  // Third argument is the server snapshot — the web harness renders this on the
+  // server side of expo-router and would otherwise throw.
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Test seam: drop back to chrome-visible without a render. */
+export function __resetImmersive(): void {
+  immersive = false;
+  for (const l of listeners) l();
+}

--- a/app/lib/padLayout.ts
+++ b/app/lib/padLayout.ts
@@ -1,0 +1,447 @@
+/**
+ * Landscape gamepad geometry — pure, no React, no imports.
+ *
+ * WHY THIS FILE EXISTS AT ALL.
+ *
+ * The landscape pad used to be a flex column of fixed-pixel children: a 132dp
+ * stick + 14dp gap + a 182dp d-pad = 328dp in a `landColumn`, inside a
+ * `landShoulderRow` (+56dp) inside a `styles.screen` that added ~31dp of its
+ * own padding — about 415dp of demand, with the header, the status pill, the
+ * mode selector and the tab bar still to pay for, against a 393dp short axis.
+ * Flexbox does not clip and does not warn: the children simply spilled and
+ * painted over each other. That is why the left stick was cut off by the screen
+ * edge, why RB landed in the gap between X and B, and why the d-pad's DOWN
+ * arrow hid behind the tab bar. One bug, three symptoms.
+ *
+ * So placement here is absolute and comes out of ONE table, in ONE unit, and
+ * `__tests__/padLayout.test.ts` proves over every device size that nothing
+ * leaves the play rect and no two hit rects touch. The point is not that the
+ * numbers are nicer than the flex ones. The point is that "does this clip?" is
+ * now a question arithmetic can answer, which it could not be before.
+ *
+ * THREE RULES, and every one of them is load-bearing:
+ *
+ *  1. NO extent may reference `play.w`. Every width, height, radius, gap and
+ *     margin below is `k * U`, where U is 1% of the usable SHORT axis. Sizing
+ *     one extent off width and its sibling off height is how circles become
+ *     ellipses on a different phone — Steam Link ships that bug and its own
+ *     guide admits it. In React Native the same mistake wears a percentage
+ *     string, which is why there are none in the landscape styles.
+ *  2. Anchor by CENTRE, with margin >= half-extent. Anchoring by top-left is
+ *     what lets a control cross the far edge.
+ *  3. Insets are subtracted EXACTLY ONCE, here, into `play`. Nothing
+ *     downstream may look at insets or at the window again. In landscape on
+ *     iPhone `insets.top` is 0 and the notch is `insets.left` OR `insets.right`
+ *     (59pt) depending on which way you turned the phone — so code that only
+ *     knows about `top` clips on exactly one of the two rotations and looks
+ *     perfect on the other. The test runs every size twice for that reason.
+ */
+
+export type Insets = { top: number; right: number; bottom: number; left: number };
+export type Size = { width: number; height: number };
+
+/** Screen-space rectangle, in dp, origin top-left. */
+export type Rect = { x: number; y: number; w: number; h: number };
+
+export type PadNodeId =
+  | 'lt' | 'lb' | 'rb' | 'rt'
+  | 'select' | 'steam' | 'qam' | 'start'
+  | 'dpad' | 'lstick' | 'rstick'
+  | 'a' | 'b' | 'x' | 'y'
+  | 'lock' | 'exit';
+
+export type PadNode = {
+  id: PadNodeId;
+  /** What is drawn. */
+  rect: Rect;
+  /** What is touchable — `rect` grown by the expansion pass below. */
+  hit: Rect;
+  /**
+   * Slide-between is allowed WITHIN a layer and blocked across layers, so a
+   * thumb can roll A->B mid-press but no drag can ever reach the d-pad or a
+   * menu button. Face buttons and shoulders share layer 1; everything else
+   * that must not be slid into gets its own.
+   */
+  layer: number;
+  shape: 'rect' | 'circle';
+};
+
+export type PadLayout =
+  | {
+      ok: true;
+      /** The usable rect: window minus insets, counted once. */
+      play: Rect;
+      /** 1% of the usable short axis, capped at 4.3. */
+      u: number;
+      nodes: PadNode[];
+      byId: Record<PadNodeId, PadNode>;
+    }
+  | { ok: false; reason: 'too-short' | 'too-narrow' };
+
+// ---------- Hard floors ----------
+
+/**
+ * Below this the 44dp touch floor cannot be met and we render a "rotate back"
+ * card instead. Refuse rather than cramp.
+ *
+ * THE BINDING CONTROL IS THE D-PAD SECTOR, at 13.5U of radial thickness:
+ * 44 / 13.5 = 3.26, so the short axis must be at least 326.
+ *
+ * The spec said 340, derived from the face button's DRAWN diameter of 13U. That
+ * is the wrong control to derive it from, because the 44dp rule is asserted
+ * against the HIT rect and the expansion pass below grows a face button to 16U.
+ * The d-pad is the one control the pass cannot help: its targets are angular
+ * sectors, so its thickness is whatever the table says and nothing more.
+ *
+ * This is not a technicality. At 340 a Galaxy S21 in landscape — 800x360 with a
+ * 24dp gesture bar, so 336 of play — would have been shown the "turn the phone
+ * back" card, on a phone whose controller fits perfectly well.
+ */
+export const MIN_SHORT_AXIS = 326;
+
+/**
+ * The long-axis floor, in U. Two things need room along it, and the second is
+ * the binding one:
+ *
+ *  1. The clusters. Left occupies 79U from the left edge (3 margin + 39 d-pad +
+ *     7 gap + 30 stick), right occupies 85U (3 + 45 face + 7 + 30) — so under
+ *     164U there is no centre channel and they would collide.
+ *  2. The EXIT moat. EXIT's right edge sits at `P.w/2 + 16.5` and RB's touch
+ *     rect begins at `P.w - 45.5`, so the moat is `P.w/2 - 62` U wide. Holding
+ *     it at 26U requires 176U.
+ *
+ * 16:9 — the narrowest real phone shape — is 177.6U, so this admits every real
+ * device and refuses only genuinely narrow windows (Android split-screen and
+ * free-form, which is exactly where refusing is right).
+ *
+ * NOT in the original spec, which derived its floor from the short axis alone.
+ */
+export const MIN_LONG_AXIS_U = 176;
+
+/**
+ * Designed clearance between EXIT and the nearest game control, in U.
+ *
+ * The spec asked for 100dp. That is achievable on every real device (the
+ * narrowest in the test table still gives 213U of long axis, so ~118dp and up)
+ * but NOT simultaneously with supporting 16:9 at the short-axis floor, where
+ * the same geometry yields 91dp. The two requirements are in conflict and the
+ * spec asserted both without checking.
+ *
+ * Rather than special-case the floor, the invariant is stated in the layout's
+ * own unit, where it holds everywhere with no exception. The moat is anyway
+ * defence in depth: EXIT also requires a touch to both START and END inside it,
+ * so a thumb sliding off RB cannot trigger it at any distance.
+ */
+export const EXIT_MOAT_U = 26;
+
+/** Every touch target must be at least this, in dp. */
+export const MIN_TOUCH = 44;
+
+// ---------- Stick behaviour (consumed by the Stick component) ----------
+
+/**
+ * Fixed container, floating origin. The "user is looking at the TV" argument is
+ * usually deployed to justify spawn-anywhere sticks, and it proves the wrong
+ * thing: eyes-off also means the d-pad and the face buttons have to be found by
+ * feel, and the only thing findable by feel on glass is an edge or a corner. A
+ * half-screen stick region would eat the d-pad — which is the control this
+ * product actually uses, since it drives Steam Big Picture. So the container is
+ * fixed and corner-anchored; only the ORIGIN floats, to wherever the thumb
+ * lands. That is the same split Xbox's Touch Adaptation Kit (`relative: true`
+ * in all six shipped sample layouts) and Dolphin (`JoystickRelCenter = true`)
+ * arrived at independently.
+ */
+export const STICK = {
+  /** Visual ring radius, in U. Drawn only while held. */
+  ringR: 15,
+  /** Nub radius, in U. */
+  nubR: 6,
+  /**
+   * Finger travel for full deflection, in U (~82dp). The old layout saturated
+   * at 38 PIXELS of travel, which is unusable without looking at the phone.
+   * 22U gives a 2.5:1 visual compression — the nub moves 33dp while the finger
+   * moves 82dp — and that is correct precisely BECAUSE nobody is watching the
+   * nub.
+   */
+  travelU: 22,
+  /** The nub pins to the rim at this radius while the finger keeps going. */
+  nubClampU: 9,
+  /** Radial, with the output renormalised so it still reaches 1.0. */
+  deadzone: 0.12,
+} as const;
+
+/**
+ * D-pad: an ANGULAR hit test, not a 3x3 grid of boxes. Every pixel of the
+ * cluster does something, which is what eyes-off requires — a grid leaves dead
+ * corners. Inside `innerRU` is the centre disc (A/OK, keeping the existing
+ * centre-OK behaviour, which is right for Steam navigation); outside it, four
+ * 90-degree sectors. NO DIAGONALS: a corner press that fires two directions at
+ * once is worse than one that fires the nearest cardinal, and Steam menu
+ * navigation has no use for them.
+ */
+export const DPAD = {
+  outerRU: 19.5,
+  innerRU: 6,
+  /** Radial thickness of a sector — the real touch target, not the 39U box. */
+  get sectorThicknessU() {
+    return this.outerRU - this.innerRU;
+  },
+} as const;
+
+/** Face buttons: diameter, and the diamond radius from the cluster centre. */
+export const FACE = { diaU: 13, radiusU: 16 } as const;
+
+// ---------- The table ----------
+
+/**
+ * Everything in U. `dx`/`dy` are offsets from an anchor edge of the play rect;
+ * a negative anchor means "measured back from the far edge".
+ *
+ * Three bands, and nothing crosses a boundary. Row 1 spans 3..17U from the top
+ * (shoulders + chrome), row 2 spans 20..34U (menu buttons), the middle 34..51U
+ * is deliberately empty because that is where a hand grips the phone, and the
+ * thumb clusters live in 51..96U. The face diamond's top edge is at 51U and
+ * row 2's bottom edge is at 34U, so there is a 17U dead gap between them.
+ * A shoulder button CANNOT reach a face button because they are not in the same
+ * band. That is the fix for the overlap, and it is arithmetic, not nudging.
+ */
+type Spec = {
+  id: PadNodeId;
+  w: number;
+  h: number;
+  /** Centre X in U: from `left`, from `right`, or from the horizontal centre. */
+  cx: { from: 'left' | 'right' | 'centre'; at: number };
+  /** Centre Y in U, from the top or from the bottom. */
+  cy: { from: 'top' | 'bottom'; at: number };
+  layer: number;
+  shape?: 'circle';
+};
+
+const FACE_CX = 25.5;
+const FACE_CY = 26.5;
+
+const TABLE: Spec[] = [
+  // Row 1 — shoulders, and the two chrome buttons in the middle.
+  { id: 'lt', w: 18, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 10 }, layer: 1 },
+  { id: 'lb', w: 18, h: 14, cx: { from: 'left', at: 32 }, cy: { from: 'top', at: 10 }, layer: 1 },
+  { id: 'lock', w: 15, h: 14, cx: { from: 'centre', at: -9 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'exit', w: 15, h: 14, cx: { from: 'centre', at: 9 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'rb', w: 18, h: 14, cx: { from: 'right', at: 32 }, cy: { from: 'top', at: 10 }, layer: 1 },
+  { id: 'rt', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 10 }, layer: 1 },
+
+  // Row 2 — menu buttons. Each gets its own layer so no drag can chain them.
+  { id: 'select', w: 18, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 27 }, layer: 2 },
+  { id: 'steam', w: 18, h: 14, cx: { from: 'left', at: 32 }, cy: { from: 'top', at: 27 }, layer: 3 },
+  { id: 'qam', w: 18, h: 14, cx: { from: 'right', at: 32 }, cy: { from: 'top', at: 27 }, layer: 4 },
+  { id: 'start', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 27 }, layer: 5 },
+
+  // Thumb clusters.
+  { id: 'dpad', w: 39, h: 39, cx: { from: 'left', at: 22.5 }, cy: { from: 'bottom', at: 23.5 }, layer: 6 },
+  { id: 'lstick', w: 30, h: 30, cx: { from: 'left', at: 64 }, cy: { from: 'bottom', at: 26 }, layer: 7, shape: 'circle' },
+  { id: 'rstick', w: 30, h: 30, cx: { from: 'right', at: 70 }, cy: { from: 'bottom', at: 26 }, layer: 8, shape: 'circle' },
+
+  // The face diamond, as its four real targets rather than one 45U box —
+  // otherwise the 44dp assertion would be checking a cluster nobody presses.
+  // All four share layer 1 so a thumb can roll A->B mid-press.
+  { id: 'y', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX }, cy: { from: 'bottom', at: FACE_CY + FACE.radiusU }, layer: 1, shape: 'circle' },
+  { id: 'a', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX }, cy: { from: 'bottom', at: FACE_CY - FACE.radiusU }, layer: 1, shape: 'circle' },
+  { id: 'x', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX + FACE.radiusU }, cy: { from: 'bottom', at: FACE_CY }, layer: 1, shape: 'circle' },
+  { id: 'b', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX - FACE.radiusU }, cy: { from: 'bottom', at: FACE_CY }, layer: 1, shape: 'circle' },
+];
+
+// ---------- Geometry helpers ----------
+
+const right = (r: Rect) => r.x + r.w;
+const bottom = (r: Rect) => r.y + r.h;
+
+/** True when two rects overlap on the given axis (touching edges do not count). */
+const spansOverlap = (aLo: number, aHi: number, bLo: number, bHi: number) =>
+  aLo < bHi && bLo < aHi;
+
+export function rectsIntersect(a: Rect, b: Rect): boolean {
+  return spansOverlap(a.x, right(a), b.x, right(b)) &&
+    spansOverlap(a.y, bottom(a), b.y, bottom(b));
+}
+
+/** Shortest edge-to-edge distance between two non-overlapping rects, in dp. */
+export function rectGap(a: Rect, b: Rect): number {
+  const dx = Math.max(0, Math.max(a.x - right(b), b.x - right(a)));
+  const dy = Math.max(0, Math.max(a.y - bottom(b), b.y - bottom(a)));
+  return Math.hypot(dx, dy);
+}
+
+// ---------- The layout ----------
+
+export function padLayout(win: Size, insets: Insets): PadLayout {
+  const play: Rect = {
+    x: insets.left,
+    y: insets.top,
+    w: win.width - insets.left - insets.right,
+    h: win.height - insets.top - insets.bottom,
+  };
+
+  // Degrade closed, both axes. A cramped controller that half-works is worse
+  // than an honest "turn the phone back".
+  if (play.h < MIN_SHORT_AXIS) return { ok: false, reason: 'too-short' };
+
+  // U caps at 4.3 so a tablet gets a BIGGER EMPTY MIDDLE rather than
+  // comic-book buttons — the clusters stay thumb-sized and move apart.
+  const u = Math.min(play.h, 430) / 100;
+
+  if (play.w / u < MIN_LONG_AXIS_U) return { ok: false, reason: 'too-narrow' };
+
+  const centreX = play.x + play.w / 2;
+
+  const base: PadNode[] = TABLE.map((s) => {
+    const w = s.w * u;
+    const h = s.h * u;
+    const cx =
+      s.cx.from === 'left' ? play.x + s.cx.at * u
+        : s.cx.from === 'right' ? right(play) - s.cx.at * u
+          : centreX + s.cx.at * u;
+    const cy =
+      s.cy.from === 'top' ? play.y + s.cy.at * u : bottom(play) - s.cy.at * u;
+    return {
+      id: s.id,
+      // Rule 2: centre-anchored, so the margin is measured to the EDGE of the
+      // control and a control can never cross the far side of the play rect.
+      rect: { x: cx - w / 2, y: cy - h / 2, w, h },
+      hit: { x: 0, y: 0, w: 0, h: 0 }, // filled by the expansion pass
+      layer: s.layer,
+      shape: s.shape ?? 'rect',
+    };
+  });
+
+  const nodes = expandHits(base, play, u);
+
+  const byId = {} as Record<PadNodeId, PadNode>;
+  for (const n of nodes) byId[n.id] = n;
+
+  return { ok: true, play, u, nodes, byId };
+}
+
+/**
+ * "No dead pixels": grow every control's touchable rect into the space around
+ * it, by a rule rather than by hand.
+ *
+ * Each side grows by the smallest of three things: a quarter of the control's
+ * own extent on that axis, HALF the gap to the nearest neighbour on that side,
+ * and the distance to the edge of the play rect. Taking half the gap is what
+ * makes the result non-overlapping by construction — both neighbours claim at
+ * most half of the space between them, so they can meet but never cross. The
+ * result is anisotropic for free: the left stick gains a lot of catch upward
+ * and inboard where there is room, and almost none toward the d-pad where there
+ * is not. (RetroArch authors these per-direction reaches by hand; computing
+ * them means they cannot drift out of sync with the layout.)
+ *
+ * LOCK and EXIT (layer 9) are deliberately EXCLUDED. They are looked-at,
+ * deliberate taps and the one thing that must not be pressed by accident —
+ * growing them is the opposite of what is wanted, and the 100dp exit moat is
+ * measured against their drawn size.
+ */
+function expandHits(nodes: PadNode[], play: Rect, u: number): PadNode[] {
+  // Floating point turns "these two exactly meet" into an overlap of 1e-13
+  // about a third of the time, which a strict intersection test then reports as
+  // a collision. Give every claim a hair of slack so meeting is unambiguous.
+  const EPS = 0.01;
+
+  return nodes.map((n) => {
+    if (n.layer === 9) return { ...n, hit: { ...n.rect } };
+
+    const r = n.rect;
+    // Start from the two limits that do not depend on other controls.
+    let l = Math.min(0.25 * r.w, r.x - play.x);
+    let rt = Math.min(0.25 * r.w, right(play) - right(r));
+    let t = Math.min(0.25 * r.h, r.y - play.y);
+    let b = Math.min(0.25 * r.h, bottom(play) - bottom(r));
+
+    for (const o of nodes) {
+      if (o.id === n.id) continue;
+      const q = o.rect;
+      // Gap on each axis; zero means the two already overlap on that axis.
+      const gx = Math.max(0, Math.max(r.x - right(q), q.x - right(r)));
+      const gy = Math.max(0, Math.max(r.y - bottom(q), q.y - bottom(r)));
+
+      // Two rects stay apart as long as they stay apart on ONE axis, so pick
+      // the axis that separates them best and spend the constraint there. This
+      // is what handles DIAGONAL neighbours, and getting it wrong is what let
+      // the face buttons collide on every single device: X sits below-left of
+      // Y with no shared row or column, so an axis-aligned neighbour search
+      // found nothing between them, both grew the full 25% in all four
+      // directions, and their expanded corners met in the middle.
+      const share = (g: number) => Math.max(0, g / 2 - EPS);
+      if (gx >= gy) {
+        if (right(q) <= r.x) l = Math.min(l, share(gx));
+        else if (q.x >= right(r)) rt = Math.min(rt, share(gx));
+      } else {
+        if (bottom(q) <= r.y) t = Math.min(t, share(gy));
+        else if (q.y >= bottom(r)) b = Math.min(b, share(gy));
+      }
+    }
+
+    return {
+      ...n,
+      hit: { x: r.x - l, y: r.y - t, w: r.w + l + rt, h: r.h + t + b },
+    };
+  });
+}
+
+// ---------- Hit testing ----------
+
+export function hitTest(layout: PadLayout, px: number, py: number): PadNode | null {
+  if (!layout.ok) return null;
+  // Reverse order so the later, higher-intent entries in the table (the thumb
+  // clusters) win over anything that happens to have grown under them.
+  for (let i = layout.nodes.length - 1; i >= 0; i -= 1) {
+    const n = layout.nodes[i];
+    const h = n.hit;
+    if (px >= h.x && px <= right(h) && py >= h.y && py <= bottom(h)) return n;
+  }
+  return null;
+}
+
+export type DpadZone = 'du' | 'dd' | 'dl' | 'dr' | 'a' | null;
+
+/**
+ * Angular d-pad. `px`/`py` are relative to the d-pad node's CENTRE, in dp.
+ * Inside the centre disc is A/OK; outside it, the nearest cardinal. Beyond the
+ * outer radius returns null so a drag that leaves the cluster releases rather
+ * than latching the last direction.
+ */
+export function dpadZone(px: number, py: number, u: number): DpadZone {
+  const mag = Math.hypot(px, py);
+  if (mag <= DPAD.innerRU * u) return 'a';
+  if (mag > DPAD.outerRU * u) return null;
+  // No diagonals: whichever axis dominates wins outright.
+  if (Math.abs(px) >= Math.abs(py)) return px >= 0 ? 'dr' : 'dl';
+  return py >= 0 ? 'dd' : 'du';
+}
+
+/**
+ * Radial stick value from finger travel, in dp. Magnitude-clamped, never
+ * per-axis — square clamping (which moonlight-ios does) lets diagonals reach
+ * sqrt(2) and makes a circle-strafe faster than a straight run.
+ */
+export function stickValue(dx: number, dy: number, u: number): { x: number; y: number } {
+  const t = STICK.travelU * u;
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return { x: 0, y: 0 };
+  const mag = Math.min(1, len / t);
+  if (mag <= STICK.deadzone) return { x: 0, y: 0 };
+  // Renormalise so the deadzone costs precision near centre, not range at full
+  // deflection: the stick still reaches exactly 1.0.
+  const out = (mag - STICK.deadzone) / (1 - STICK.deadzone);
+  return { x: (dx / len) * out, y: (dy / len) * out };
+}
+
+/**
+ * Where to draw the nub: same direction as the finger, but compressed 2.5:1 —
+ * the finger travels `travelU` (82dp) while the nub travels `nubClampU` (33dp),
+ * then pins to the rim while the finger keeps going.
+ */
+export function stickNubOffset(dx: number, dy: number, u: number): { x: number; y: number } {
+  const len = Math.hypot(dx, dy);
+  if (len === 0) return { x: 0, y: 0 };
+  const r = (Math.min(len, STICK.travelU * u) / (STICK.travelU * u)) * (STICK.nubClampU * u);
+  return { x: (dx / len) * r, y: (dy / len) * r };
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -167,50 +167,6 @@ becomes the allowlist.
 - **Do NOT start with the UI.** Problem 1 decides whether this feature is possible without
   an API key, and that answer changes the whole shape.
 
-### Landscape Pad = full-screen controller (owner ask 2026-08-07)
-- **priority:** P1 — raised from P2 after seeing it. This is not "cramped", it is
-  CLIPPED AND OVERLAPPING. · **risk:** medium (touches the input path — CLAUDE.md §4
-  calls it safety-critical and the source of most escaped bugs) · **affects:** app only ·
-  **depends_on:** none
-- **Observed on a real phone in landscape (owner screenshot 2026-08-07):**
-  - the LEFT STICK is cut off by the left screen edge, and the `L` trigger sits half
-    off-screen behind it
-  - `B` is clipped by the right edge; `Y`/`X`/`A`/`B` no longer form a diamond and `RB`
-    overlaps the gap between `X` and `B`
-  - the D-pad's DOWN arrow is cut off by the tab bar
-  - the mode row (PAD/SWIPE/MOUSE/REMOTE) is partly behind the left stick, and its own
-    `PAD` label is not visible
-  - the entire centre of the screen is dead space while the edges overflow
-- Three things eat the short axis at once: the header (box picker + Game Mode + volume),
-  the connected-pad pill plus the mode row, and the tab bar. The controller gets what is
-  left, then overflows it. Hiding the chrome is therefore not only the feature request —
-  it is the fix for the clipping.
-- **Owner:** "landscape pad mode should be straight up game mode" — rotating the phone
-  sideways on the Pad tab shows ONLY the controller, no tab bar, no header, no box
-  picker. Rotating back to portrait exits it. Plus a LOCK toggle on the controller so
-  the orientation can be pinned while playing.
-- Not from nothing: Pad is already the one tab that allows landscape
-  (`useLockOrientation('allow-landscape')`, pad.tsx:823) and the gamepad already has a
-  separate landscape layout (`landscape ? ... : ...`, derived from `width > height`).
-  What is missing is hiding the app chrome and the lock.
-- There is ALREADY a large-pad concept to reconcile with, not duplicate: `largePad`
-  (pad.tsx, computed from the `trackpadLarge` pref) hides the status pill and the mode
-  selector for trackpad/swipe. Landscape game mode should reuse that hiding, or the two
-  will fight over who owns the chrome.
-- **Open questions:** does the tab bar hide via the navigator (tabBarStyle) or by
-  rendering Pad outside the tab group in landscape — the second is a bigger change but
-  the only one that removes the bar completely. Does the lock persist across sessions
-  (a pref) or last only for the session? What happens to the lock when the user leaves
-  the Pad tab.
-- **Full spec: `docs/memory/project_landscape-pad.md`** — read it before starting. It
-  has the arithmetic for why it breaks (≈575dp of fixed-pixel children in a ≈393dp short
-  axis; flexbox overflows silently), a complete absolute-position layout table in units of
-  1% of the usable short axis, the fixed-container/floating-origin stick decision, and the
-  five assertions a pure layout test should make.
-- **Interacts with:** the "Landscape laptop mode" entry below, which claims the same
-  gesture on the same tab for a different purpose. One of the two has to win, or
-  landscape needs a mode switch of its own. Decide before building either.
-
 ### Remote-only mode: an "Apps" launcher grid (the TV's installed apps)
 - **priority:** P2 · **risk:** low · **affects:** app only (lib/tvdirect + the Remote tab) ·
   **depends_on:** Roku direct (shipped); LG direct (device-verify first)
@@ -896,6 +852,27 @@ recommendation was wrong, not merely superseded.
 ---
 
 ## ✅ Completed
+
+### Landscape Pad = full-screen controller — BUILT 2026-08-07, awaiting device pass
+- **was:** P1 (clipped + overlapping, owner screenshot 2026-08-07) · **affects:** app only
+- Built to `docs/memory/project_landscape-pad.md`: pure `lib/padLayout.ts` (absolute
+  table, U = 1% of usable short axis, computed hit-rect expansion, refuse-below-floor),
+  `components/LandscapePad.tsx` (floating-origin sticks, angular d-pad, slide-within-layer
+  face cluster, LOCK + EXIT), `lib/immersive.ts` store hiding tab bar / BoxSwitcher /
+  pill / mode row. Same PadScreen, no route change — WS/uinput untouched by rotation.
+- **Open-questions answered:** tab bar hides via tabBarStyle from a store (not a separate
+  route — that churns the uinput device, KI-053); lock is session-only, released on
+  blur/unmount by the fixed useLockOrientation cleanup.
+- **Spec deviations (arithmetic, documented at the constants):** short-axis floor 326
+  not 340 (binding control is the d-pad sector on HIT rects; 340 would refuse a Galaxy
+  S21); EXIT moat 26U (= >=100dp on every real device, asserted separately; flat 100dp
+  is unsatisfiable at the 16:9 floor).
+- Proven: 24 layout tests x 12 devices x notch left/right; wire-level press-through in
+  the harness via a pong-answering fake WebSocket (all PanResponder surfaces + lock/exit
+  + rotate round-trip). NOT yet: the eight Pressable buttons on a device (onPressIn is
+  mouse-dead on RNW — same as shipped portrait), real rotation, Android nav bar
+  (expo-navigation-bar deliberately not added; layout is inset-correct without it).
+
 
 ### Steam Deck install fix + Windows units fix — SHIPPED in agent 2.9.71 / 0.4.5-win
 

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -594,3 +594,32 @@ size by nature. They are not games of unknown size; they are entries the questio
 apply to. Every unit test passed before and after — the fixtures had sizes.
 
 Before adding another exception, get the number off a real box.
+
+## Full-screen (immersive) surfaces: geometry is a pure module, chrome is derived state
+
+Established by the landscape gamepad (2026-08-07, `lib/padLayout.ts` +
+`lib/immersive.ts`); follow it for any future full-screen surface (player,
+screensaver preview, a second controller layout).
+
+1. **Geometry lives in a pure module, absolute positions from ONE table, sized in
+   ONE unit** (a fraction of the relevant axis). No flexbox for control placement
+   — flex overflows silently, which is exactly the class of bug it shipped. The
+   module reads `useSafeAreaInsets()` output ONCE into a play rect; downstream
+   components never see insets, the window, or a percentage string (grep-guard in
+   the layout test). A screen too small for the layout returns `{ok:false}` and
+   the component renders a refusal card — never a cramped layout.
+2. **The layout test asserts properties, not pixels:** everything inside the play
+   rect, no two hit rects intersect, every target >= 44dp, dangerous controls keep
+   their moat, floors refuse in BOTH directions — each size run twice (notch left/
+   notch right, `insets.top` is 0 in landscape). Include a CONTROL proving each
+   predicate can fail.
+3. **Chrome visibility is a store (`lib/immersive.ts`), never `setOptions`.** The
+   tab bar, TabScreen chrome and screen-local chrome all DERIVE from it. An
+   imperative hide has to remember to undo itself; a derived value cannot strand
+   the app chrome-less.
+4. **Harness wire-proof for gamepad surfaces:** the web harness has no WS proxy —
+   install an in-page fake WebSocket that ANSWERS EVERY FRAME WITH A PONG and read
+   `send()`ed frames instead. A fake that stays silent is torn down by the
+   half-dead-socket watchdog every ~12s and clicks in the dead windows mimic
+   broken buttons. Known ceiling: onPressIn-only Pressables never fire from mouse
+   on react-native-web (portrait pad has the same gap) — those need a device.


### PR DESCRIPTION
## What

The P1 clipped-landscape-pad fix, built to `docs/memory/project_landscape-pad.md`. Stacked on #368 (`feat/library-marks`) — retarget to `main` after that merges.

- **`app/lib/padLayout.ts`** (new, pure): play rect from insets counted exactly once; every extent in one unit (1% of usable short axis, capped 4.3); absolute node table; computed anisotropic hit-rect expansion; refuses screens under the floors instead of cramping.
- **`app/components/LandscapePad.tsx`** (new): draws the computed layout. Floating-origin sticks (82dp to full deflection, radial clamp, renormalised deadzone, tap = L3/R3), angular d-pad (centre OK = A, no diagonals, no dead corners), face cluster with mid-press A→B rolls, LOCK + EXIT.
- **`app/lib/immersive.ts`** (new): store the tab bar, `TabScreen` chrome and pad chrome all *derive* from — nothing imperative to forget to undo.
- **`useLockOrientation`**: third policy `landscape-locked`; cleanup now really `unlockAsync()`s (the old one flipped a dead flag — with a lock policy that would have pinned the whole app sideways).
- Old flex landscape branch deleted (~90 lines + 6 styles).
- **Not a separate route** — same PadScreen, chrome suppressed by state, so the gamepad WS / uinput device never churns on rotation (KI-053).

## Spec deviations (arithmetic, documented at the constants)

- `MIN_SHORT_AXIS = 326`, not the spec's 340: the 44dp rule is asserted on **hit** rects, so the binding control is the d-pad sector (13.5U), not the face button's drawn 13U. At 340, a Galaxy S21 in landscape (336dp of play) is refused for no reason — test asserts it renders.
- EXIT moat stated in-unit (`EXIT_MOAT_U = 26`): a flat 100dp is unsatisfiable at the 16:9 short-axis floor (91dp). A second test still asserts ≥100dp on every real device in the table.

## Verified

- `padLayout.test.ts`: 24 tests × 12 device sizes × notch left/right — watched 8 fail first (caught 3 real bugs in the expansion pass and both spec floor errors). Suite 378/378, `tsc` clean.
- Harness at **852×393 and 667×375**, pressed not rendered: with no WS proxy in the harness, an in-page fake WebSocket that pongs every frame let each press be read off the wire — face singles, A→B slide roll (`a↓ a↑ b↓ b↑`), all four d-pad sectors + centre OK, corner press = one cardinal, stick drag with **release zeroing the axis**, stick tap = `r3`, LOCK toggle, EXIT → full chrome restored, portrait→landscape round trip re-entering immersive with lock cleared. Console free of render errors.

## NOT verified (device pass needed before release)

- The eight `onPressIn` Pressable buttons (LT/LB/RB/RT/SELECT/STEAM/⋯/START): mouse-dead on react-native-web — DOM events reach the element, Pressability never runs. The shipped portrait pad has the identical gap (tested), so this is the known harness ceiling, not a regression. KI-057.
- Real rotation and the OS orientation lock (harness resizes, it doesn't rotate); haptics.
- Android nav bar in immersive: `expo-navigation-bar` deliberately not added (spec: optional). Layout stays inset-correct; pad is 16–24dp shorter. Decide before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)