### PR TITLE
release: 2.9.37 (vc 75 / iOS 138) + store notes

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.36",
+    "version": "2.9.37",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "137",
+      "buildNumber": "138",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 74
+      "versionCode": 75
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,9 @@
-Fixes the big one: switching your box between Game Mode and Desktop no longer freezes the app. The trackpad would stop moving the cursor while everything still looked connected, and the only way back was force-quitting or switching boxes. That's fixed — switch as often as you like.
+The controller goes full screen: turn the phone sideways on the Pad tab and every button, stick and d-pad spreads out like a real gamepad — no tab bar, no headers, just the controller. Rotate back to exit, or use the new orientation lock to pin it while you play.
 
-New: a Big Picture button for PCs that have Steam but no Game Mode session (Nobara, most desktop Linux). One tap opens Steam Big Picture on the TV; long-press the same button to come back to the desktop.
-
-Also: connection diagnostics are reachable in large-pad mode, and tap-to-retry does a deeper reset when a connection goes quiet.
+Also in this release:
+• Use Couchside as a plain TV remote for Roku and Google TV — no PC required
+• Bookmark games (hold a tile) and save your favorite library filters as presets
+• See each game's install size and filter by what's eating your disk
+• A toast tells you when a download finishes, whichever tab you're on
+• A guided setup walkthrough for new users — and an offer for existing users who never got one
+• Google TV pairing fixed on Android

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,5 +1,5 @@
-New: a Big Picture button for PCs that have Steam but no Game Mode session (Nobara, most desktop Linux). One tap opens Steam Big Picture on the TV; tap again to come back to the desktop.
+Turn the phone sideways on the Pad tab: the controller now fills the screen edge-to-edge, with an orientation lock for long sessions.
 
-The Console now shows which OS and version your box is running.
+New since last update: use the app as a plain TV remote (Roku and Google TV, no PC needed), bookmark games and save library filters, see each game's install size, get a heads-up when a download finishes, and a guided setup walkthrough — existing users can replay it from Setup.
 
-Also: connection diagnostics are reachable in large-pad mode, tap-to-retry does a deeper reset when a connection goes quiet, and the app does less redundant work after a session switch.
+Plus many fixes, including Google TV pairing on Android.


### PR DESCRIPTION
Version bump + both store changelogs for the release carrying #368 + #370. Play notes 473/500 chars, separate file per house rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)