### PR TITLE
release: reconcile versionCode 76 (autoIncrement at build kick)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 75
+      "versionCode": 76
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
The 2.9.37 AAB is vc 76; app.json said 75 pre-kick. Verified from artifact bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)