### PR TITLE
iOS back-swipe vs stick drags; tour replay becomes a button

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "138",
+      "buildNumber": "139",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/remote.tsx
+++ b/app/app/(tabs)/remote.tsx
@@ -109,7 +109,9 @@ function TvPicker({ tvs, active }: { tvs: DirectTv[]; active: DirectTv | null })
             <Pressable
               onPress={() => {
                 setOpen(false);
-                router.push('/(tabs)/setup');
+                // navigate, not push — a push stacks a duplicate (tabs) entry
+                // that the iOS back-swipe can pop to. See _layout.tsx.
+                router.navigate('/(tabs)/setup');
               }}
               style={({ pressed }) => [styles.addRow, pressed && styles.pressed]}>
               <Ionicons name="add" size={16} color={t.blue} />
@@ -134,7 +136,7 @@ function NoTv() {
         over your Wi-Fi — nothing else has to be running.
       </Text>
       <Pressable
-        onPress={() => router.push('/(tabs)/setup')}
+        onPress={() => router.navigate('/(tabs)/setup')}
         style={({ pressed }) => [styles.emptyBtn, pressed && styles.pressed]}>
         <Text style={styles.emptyBtnText}>OPEN SETUP</Text>
       </Pressable>

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1445,16 +1445,29 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
-              <TogglePref
-                label="Feature tour"
-                sub="A short spotlight walkthrough of the tabs. Switch it back on to watch it again."
-                value={featureTour}
-                onValueChange={(v) => {
-                  void setPref('featureTour', v);
-                  // Switching it back ON means "show me again" — otherwise the
-                  // control is dead once the tour has run once.
-                  if (v) void resetFeatureTour();
-                  hapticSelection();
+              {/* A BUTTON, not a toggle — for the same reason as the welcome
+                  flow below, which this now matches.
+
+                  As a switch it read like a preference and was not one. "Off"
+                  had no meaning after the first run: the tour only plays while
+                  it is unfinished, and SKIP TOUR already ends it forever. So
+                  the only position that did anything was ON — and ON did not
+                  mean "enabled", it meant "play it now", because switching it
+                  back on resets the state and the tour immediately takes over
+                  the screen. A control whose two positions are "nothing" and
+                  "start a walkthrough" is a button wearing a switch. */}
+              <PrefAction
+                label="Replay the feature tour"
+                sub="The spotlight walkthrough of the tabs. It starts straight away, on the Console tab."
+                icon="footsteps-outline"
+                onPress={async () => {
+                  hapticLight();
+                  // Asking for a replay IS consent to run it, so re-enable the
+                  // gate as well as clearing the finished state. Anyone who
+                  // turned the old switch off would otherwise press this and
+                  // watch nothing happen — the same dead control, one layer down.
+                  await setPref('featureTour', true);
+                  await resetFeatureTour();
                 }}
               />
               {/* A BUTTON, not a toggle. There is nothing to switch off — the

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -12,6 +12,7 @@ import { UnlockToast } from '@/components/UnlockToast';
 import { TapCapture } from '@/components/TouchIndicatorLayer';
 import { DeepLinkHandler } from '@/lib/DeepLink';
 import { EntitlementProvider } from '@/lib/EntitlementContext';
+import { useImmersive } from '@/lib/immersive';
 import { SettingsProvider } from '@/lib/SettingsContext';
 import { useResolvedScheme, useTheme } from '@/lib/theme';
 
@@ -24,6 +25,9 @@ export const unstable_settings = {
 export default function RootLayout() {
   const t = useTheme();
   const scheme = useResolvedScheme();
+  // Full-screen controller on screen: NO dismissal gesture at all (see the
+  // Stack.Screen options below).
+  const immersive = useImmersive();
   const navTheme = useMemo(() => {
     const base = scheme === 'light' ? DefaultTheme : DarkTheme;
     return {
@@ -53,7 +57,34 @@ export default function RootLayout() {
               never become the responder. */}
           <TapCapture>
           <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            {/* THE BACK GESTURE IS A DRAG, AND THIS APP IS MADE OF DRAGS.
+                iOS ONLY — both options below are no-ops on Android, which is
+                exactly how the bug was reported: "only occurs in iOS, Android
+                works great."
+
+                `fullScreenGestureEnabled` DEFAULTS TO TRUE ON iOS 26+ (it was
+                false, edge-only, on every earlier version). So on a new iPhone
+                the swipe-back gesture is live across the ENTIRE screen — and a
+                JS PanResponder cannot veto a native UIKit recogniser, so both
+                run at once. Measured from a screen recording: dragging the
+                landscape pad's left stick tracked the stick (ring and nub
+                followed the finger) WHILE the navigator popped the screen out
+                from under it. Every drag surface in the app sits on this route
+                — both analog sticks, the trackpad, the swipe surface — so this
+                was never only a landscape problem. Pin it back to edge-only.
+
+                And while the immersive controller is up, refuse the gesture
+                outright: there is no drag on that screen that is not deliberate
+                game input, and it has its own ✕ EXIT. Same reasoning as
+                `onboarding` below, which has always set gestureEnabled false. */}
+            <Stack.Screen
+              name="(tabs)"
+              options={{
+                headerShown: false,
+                gestureEnabled: !immersive,
+                fullScreenGestureEnabled: false,
+              }}
+            />
             {/* First run. A sibling of (tabs), never inside it: the tab bar must
                 not render behind it and the tab layout's redirects must not race
                 it. See docs/memory/project_first-run-mode-chooser.md. */}

--- a/app/components/TourThanks.tsx
+++ b/app/components/TourThanks.tsx
@@ -97,7 +97,11 @@ export function TourThanks() {
                 onPress={() => {
                   hapticLight();
                   dismissTourThanks();
-                  router.push('/(tabs)/setup?tab=account');
+                  // navigate, NOT push: a push creates a SECOND (tabs) entry on the root
+                  // stack, and every duplicate entry arms the iOS back-swipe with a
+                  // screen to pop to — measured pulling the pad out from under a
+                  // stick drag (see _layout.tsx). navigate switches tabs in place.
+                  router.navigate('/(tabs)/setup?tab=account');
                 }}
                 accessibilityRole="button"
                 style={({ pressed }) => [styles.secondary, pressed && styles.pressed]}>

--- a/app/lib/__tests__/navStack.test.ts
+++ b/app/lib/__tests__/navStack.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Navigation-stack hygiene — the phantom-duplicate-(tabs) bug.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * REGRESSION UNDER TEST (owner video, 2026-08-07, iOS): dragging the landscape
+ * pad's left stick swiped the whole screen away to Setup. Two causes stacked:
+ *
+ *  1. `router.push('/(tabs)/...')` from inside the tab group creates a SECOND
+ *     `(tabs)` entry on the root stack. Tab switches must use `router.navigate`
+ *     (or `.replace`), which switch in place. Without a duplicate entry the
+ *     back gesture has nothing to pop to and cannot fire at all.
+ *  2. iOS 26 flipped `fullScreenGestureEnabled` to default TRUE, so the
+ *     back-swipe worked across the whole screen — and a JS PanResponder cannot
+ *     veto a native recogniser. Android has neither option; the report was
+ *     "only occurs in iOS", which is exactly that.
+ *
+ * Both halves are asserted here as source properties: no tab-internal push
+ * anywhere, and the root stack pinning the gesture options. Lint-grade, like
+ * the percentage guard in padLayout.test.ts, and for the same reason: the bug
+ * is trivially reintroducible by one innocent-looking line.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APP = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    if (e === 'node_modules' || e.startsWith('.')) continue;
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.(ts|tsx)$/.test(e) && !p.includes('__tests__')) out.push(p);
+  }
+  return out;
+}
+
+test('no router.push into the (tabs) group — tab switches must navigate', () => {
+  const offenders: string[] = [];
+  for (const p of [...walk(join(APP, 'app')), ...walk(join(APP, 'components')), ...walk(join(APP, 'lib')), ...walk(join(APP, 'hooks'))]) {
+    const src = readFileSync(p, 'utf8');
+    // push to any route inside the tab group, however quoted or templated.
+    if (/router\.push\(\s*[`'"]\/\(tabs\)/.test(src)) offenders.push(p.slice(APP.length + 1));
+  }
+  assert.deepEqual(offenders, [],
+    `push() stacks a duplicate (tabs) entry that the iOS back-swipe pops to: ${offenders.join(', ')}`);
+});
+
+test('CONTROL — the push detector actually matches the bad pattern', () => {
+  assert.ok(/router\.push\(\s*[`'"]\/\(tabs\)/.test("router.push('/(tabs)/setup?tab=account')"));
+  assert.ok(/router\.push\(\s*[`'"]\/\(tabs\)/.test('router.push(`/(tabs)/pad`)'));
+  assert.ok(!/router\.push\(\s*[`'"]\/\(tabs\)/.test("router.navigate('/(tabs)/setup')"));
+  assert.ok(!/router\.push\(\s*[`'"]\/\(tabs\)/.test("router.push('/onboarding')"));
+});
+
+test('the root stack pins the iOS back gesture', () => {
+  const src = readFileSync(join(APP, 'app', '_layout.tsx'), 'utf8');
+  assert.ok(src.includes('fullScreenGestureEnabled: false'),
+    'iOS 26 defaults fullScreenGestureEnabled to TRUE — the whole screen becomes a back gesture over an app made of drag surfaces');
+  assert.ok(/gestureEnabled:\s*!immersive/.test(src),
+    'the immersive controller must refuse the dismissal gesture outright; it has its own EXIT');
+});

--- a/tests/test_game_stop.py
+++ b/tests/test_game_stop.py
@@ -36,6 +36,15 @@ def check(name, got, want):
         FAILURES.append(name)
 
 
+# The fake's answer for "this process's own group" (getpgid(0)). A SENTINEL,
+# not os.getpid(): the fake used to hand back the real runner pid while the
+# tests hardcode the game's pgid as 4242 — so on any machine where the test
+# runner's pid happened to BE 4242, the agent's own-group guard fired and the
+# GROUP test failed with "got 'kill', want 'killpg'". CI containers recycle
+# low pids densely; it happened on the fifth run of the day. Same family as
+# the dated-fixture time bombs: a fixture quietly coupled to runtime state.
+OWN_PGID = 777777
+
 class Killed:
     """Capture what would have been signalled, instead of signalling.
 
@@ -68,7 +77,7 @@ class Killed:
                 raise outer._exc
 
         def fake_getpgid(pid):
-            return os.getpid() if pid == 0 else outer._pgid
+            return OWN_PGID if pid == 0 else outer._pgid
 
         os.kill, os.killpg, os.getpgid = fake_kill, fake_killpg, fake_getpgid
         cs._running_game = lambda: (
@@ -121,7 +130,7 @@ def test_never_signals_our_own_group():
     the game. Fall back to the single pid rather than signalling ourselves."""
     print("test_never_signals_our_own_group")
     game = {"appid": 570, "label": "Dota 2", "pid": 4242}
-    with Killed(game, pgid=os.getpid()) as k:
+    with Killed(game, pgid=OWN_PGID) as k:
         cs.stop_running_game()
         check("used kill, not killpg", k.sent[0][0], "kill")
 


### PR DESCRIPTION
## The bug (owner video, iOS only)

Dragging the landscape pad's left stick swipe-navigated out of the Pad view — ring and nub tracked the finger while the navigator popped the screen. Android unaffected, which was the tell: both culprits are iOS-only.

1. **Duplicate `(tabs)` stack entries.** `router.push('/(tabs)/setup…')` from TourThanks and the Remote tab pushes a second `(tabs)` instance onto the root stack — so the back gesture has a screen to pop to, and it shows Setup, exactly as in the video. Now `router.navigate` (in-place switch). The video reproduced right after finishing the tour because TourThanks's SEE THE UNLOCK is one of the push sites.
2. **iOS 26 defaults `fullScreenGestureEnabled` to true** (was edge-only before). Whole screen = back gesture, and a JS PanResponder can't veto a native recogniser. Root screen pins it edge-only and disables the gesture entirely in immersive mode (same reasoning as `onboarding`, which always had `gestureEnabled: false`).

`navStack.test.ts` guards both as source properties — observed FAILING on the pre-fix tree, naming both findings, then passing.

## Also

- Setup's "Feature tour" toggle → **"Replay the feature tour" button** (owner ask). OFF did nothing after the first run; ON meant "play it now". The button also re-enables the pref so it can't be dead for anyone who switched the old toggle off.
- buildNumber reconciled to 139 (autoIncrement at cloud-build kick).

## Verified

381/381 tests, tsc clean, guard exercised in both directions.

**NOT verified:** the gesture fix on a real iPhone — needs a device build; the harness cannot produce a native back-swipe. `fullScreenGestureEnabled: false` + `gestureEnabled: false` are documented react-native-screens behaviour, and with no duplicate stack entry there is nothing to pop to even if a gesture fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)