### PR TITLE
Movement mode: a landscape layout for Vampire-Survivors-likes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/build-*.ipa
 # `eas build --local` leaves the staged project tarball behind next to the ipa.
 app/build-*.tar.gz
 scratchpad-atv/
+app/build-*.aab

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -45,9 +45,9 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 
 import { Gated } from '@/components/Gated';
-import { LandscapePad, LandscapePadTooSmall } from '@/components/LandscapePad';
+import { LandscapePad, LandscapePadTooSmall, MovePad } from '@/components/LandscapePad';
 import { setImmersive } from '@/lib/immersive';
-import { padLayout } from '@/lib/padLayout';
+import { moveLayout, padLayout } from '@/lib/padLayout';
 import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
 import { PadDiagnostics } from '@/components/PadDiagnostics';
@@ -943,15 +943,22 @@ function PadScreen() {
   // Depend on the inset NUMBERS, not the object: useSafeAreaInsets can hand
   // back a fresh object on any re-render, which would rebuild the layout (and
   // every PanResponder keyed off it) constantly.
+  // Which landscape layout: the full controller or the movement mode. A pref
+  // (survives sessions); toggled from the chrome row of either layout.
+  const padVariant = usePref('landscapePadVariant');
   const landGeom = useMemo(
-    () => padLayout({ width, height }, insets),
+    () => (padVariant === 'move' ? moveLayout : padLayout)({ width, height }, insets),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [width, height, insets.top, insets.right, insets.bottom, insets.left],
+    [width, height, insets.top, insets.right, insets.bottom, insets.left, padVariant],
   );
   const exitLandscape = useCallback(() => {
     setPadLock(false);
     setExited(true);
   }, []);
+  const toggleVariant = useCallback(() => {
+    void setPref('landscapePadVariant', getPref('landscapePadVariant') === 'move' ? 'pad' : 'move');
+  }, []);
+
 
   const [status, setStatus] = useState<GamepadStatus>('closed');
   // True when status is 'connected' but the socket has gone silent (half-dead):
@@ -1004,6 +1011,28 @@ function PadScreen() {
     clientRef.current = new GamepadClient();
   }
   const client = clientRef.current;
+  /**
+   * RELEASE EVERYTHING when the surface under the fingers changes. Toggling
+   * the layout variant, or leaving immersive mode (EXIT / rotate / mode
+   * switch), unmounts the pad components — and an unmount mid-drag destroys
+   * the responder WITHOUT firing its release. Nothing else zeroes the axis:
+   * the socket stays healthy, the agent trusts the last frame, and the game
+   * keeps walking in a direction nobody is pushing. One releaseAll() per
+   * surface change is cheap (a handful of zero frames) and idempotent.
+   */
+  // `mounted` is the full pad-on-screen predicate, not just `immersive`: a
+  // window can stay landscape-shaped while shrinking below the layout floors
+  // (Stage Manager, Android freeform), which swaps the pad for the too-small
+  // card — an unmount the immersive flag never sees. Found in review.
+  const padMounted = immersive && landGeom.ok;
+  const releasedFor = useRef({ padMounted, padVariant });
+  useEffect(() => {
+    const prev = releasedFor.current;
+    if (prev.padMounted !== padMounted || prev.padVariant !== padVariant) {
+      releasedFor.current = { padMounted, padVariant };
+      client.releaseAll();
+    }
+  }, [padMounted, padVariant, client]);
 
   // Latest settings for connect() calls. The lifecycle effect below keys on
   // the connection identity (host/port/token) only. A background patch to
@@ -1737,7 +1766,23 @@ function PadScreen() {
     return (
       <>
         <StatusBar hidden />
-        {landGeom.ok ? (
+        {!landGeom.ok ? (
+          <LandscapePadTooSmall reason={landGeom.reason} onExit={exitLandscape} />
+        ) : padVariant === 'move' ? (
+          // Movement mode: one big left-thumb zone driving the LEFT STICK, a
+          // small A/B/NAV/START cluster, nothing else. Same WS session, same
+          // protocol keys — the agent cannot tell the layouts apart.
+          <MovePad
+            layout={landGeom}
+            btn={btn}
+            stickMove={stickMove}
+            stickRelease={stickRelease}
+            locked={padLock}
+            onToggleLock={() => setPadLock((v) => !v)}
+            onExit={exitLandscape}
+            onVariant={toggleVariant}
+          />
+        ) : (
           <LandscapePad
             layout={landGeom}
             btn={btn}
@@ -1748,9 +1793,8 @@ function PadScreen() {
             locked={padLock}
             onToggleLock={() => setPadLock((v) => !v)}
             onExit={exitLandscape}
+            onVariant={toggleVariant}
           />
-        ) : (
-          <LandscapePadTooSmall reason={landGeom.reason} onExit={exitLandscape} />
         )}
         {/* Handoff survives immersive mode. Another phone asking for control is
             a decision only the person holding this one can make, and ignoring it

--- a/app/components/LandscapePad.tsx
+++ b/app/components/LandscapePad.tsx
@@ -22,8 +22,10 @@ import { hapticLight, hapticSelection as haptic } from '@/lib/haptics';
 import {
   DPAD,
   FACE,
+  NAV,
   STICK,
   dpadZone,
+  navZone,
   stickNubOffset,
   stickValue,
   type PadLayout,
@@ -61,6 +63,8 @@ export type LandscapePadProps = {
   locked: boolean;
   onToggleLock: () => void;
   onExit: () => void;
+  /** The PAD -> MOVE toggle in the chrome row. */
+  onVariant: () => void;
 };
 
 const abs = (r: Rect) => ({
@@ -135,7 +139,7 @@ function PadKey({
 // ---------- Analog stick: fixed container, floating origin ----------
 
 function FloatingStick({
-  node, u, onMove, onRelease, onClick, label,
+  node, u, onMove, onRelease, onClick, label, zoneOutline,
 }: {
   node: PadNode; u: number;
   onMove: (x: number, y: number) => void;
@@ -143,6 +147,11 @@ function FloatingStick({
   /** L3 / R3 — the stick CLICK, which is now a tap rather than its own button. */
   onClick: () => void;
   label: string;
+  /** Movement mode: the container is a large RECT zone, not a stick-sized
+      circle. Draw its outline faintly (so the zone is discoverable) plus a
+      standard-size resting ring at the node centre, instead of rounding the
+      whole node into a giant ellipse. */
+  zoneOutline?: boolean;
 }) {
   const t = useTheme();
   // Where in the container the finger landed. The ring is drawn there, not at
@@ -206,6 +215,33 @@ function FloatingStick({
       {/* Resting state: a faint ring where the stick nominally lives, so it can
           be found by eye the first time. Nothing else is drawn until touch. */}
       {origin === null ? (
+        zoneOutline ? (
+          <>
+            {/* The whole zone, barely visible — any touch inside starts a drag. */}
+            <View
+              pointerEvents="none"
+              style={[
+                inner(node),
+                { borderRadius: 4 * u, borderWidth: 1, borderColor: t.cardBorder, opacity: 0.35 },
+              ]}
+            />
+            {/* And a stick-sized ring at its centre as the visual anchor. */}
+            <View
+              pointerEvents="none"
+              style={{
+                position: 'absolute',
+                left: node.rect.x - node.hit.x + node.rect.w / 2 - ringR,
+                top: node.rect.y - node.hit.y + node.rect.h / 2 - ringR,
+                width: ringR * 2,
+                height: ringR * 2,
+                borderRadius: ringR,
+                borderWidth: 1,
+                borderColor: t.cardBorder,
+                opacity: 0.5,
+              }}
+            />
+          </>
+        ) : (
         <View
           pointerEvents="none"
           style={[
@@ -218,6 +254,7 @@ function FloatingStick({
             },
           ]}
         />
+        )
       ) : (
         <>
           <View
@@ -363,6 +400,92 @@ function Dpad({
   );
 }
 
+// ---------- Movement mode's 4-way NAV: angular, no centre action ----------
+
+function NavPad({
+  node, u, btn,
+}: {
+  node: PadNode; u: number; btn: (k: ButtonKey) => Down;
+}) {
+  const t = useTheme();
+  const [zone, setZone] = useState<ButtonKey | null>(null);
+  const held = useRef<ButtonKey | null>(null);
+  const bt = useRef(btn);
+  bt.current = btn;
+  const geom = useRef({ u, node });
+  geom.current = { u, node };
+
+  const to = useCallback((next: ButtonKey | null) => {
+    if (held.current === next) return;
+    if (held.current) bt.current(held.current).onUp();
+    held.current = next;
+    setZone(next);
+    if (next) {
+      bt.current(next).onDown();
+      hapticLight();
+    }
+  }, []);
+
+  const at = useCallback((e: GestureResponderEvent) => {
+    const { node: n, u: uu } = geom.current;
+    const cx = n.rect.x - n.hit.x + n.rect.w / 2;
+    const cy = n.rect.y - n.hit.y + n.rect.h / 2;
+    return navZone(e.nativeEvent.locationX - cx, e.nativeEvent.locationY - cy, uu);
+  }, []);
+
+  const responder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: (e) => to(at(e)),
+        onPanResponderMove: (e) => to(at(e)),
+        onPanResponderRelease: () => to(null),
+        onPanResponderTerminate: () => to(null),
+      }),
+    [at, to],
+  );
+
+  const r = node.rect.w / 2;
+  const outer = NAV.outerRU * u;
+  const arm = (k: ButtonKey, label: string, dx: number, dy: number) => (
+    <View
+      key={k}
+      pointerEvents="none"
+      style={{
+        position: 'absolute',
+        left: r + dx * (outer * 0.55) - 3 * u,
+        top: r + dy * (outer * 0.55) - 3 * u,
+        width: 6 * u,
+        height: 6 * u,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}>
+      <Text style={{ color: zone === k ? t.blue : t.textFaint, fontSize: 4 * u }}>{label}</Text>
+    </View>
+  );
+
+  return (
+    <View style={abs(node.hit)} {...responder.panHandlers} accessibilityLabel="Menu navigation">
+      <View pointerEvents="none" style={inner(node)}>
+        <View
+          style={{
+            position: 'absolute',
+            left: r - outer, top: r - outer, width: outer * 2, height: outer * 2,
+            borderRadius: outer, borderWidth: 1, borderColor: t.cardBorder,
+            backgroundColor: t.card,
+          }}
+        />
+        {arm('du', '▲', 0, -1)}
+        {arm('dd', '▼', 0, 1)}
+        {arm('dl', '◀', -1, 0)}
+        {arm('dr', '▶', 1, 0)}
+      </View>
+    </View>
+  );
+}
+
 // ---------- Face diamond: one responder, so a thumb can roll A -> B ----------
 
 function FaceCluster({
@@ -473,8 +596,45 @@ function FaceCluster({
 
 // ---------- The pad ----------
 
+/** One chrome-row button (LOCK / EXIT / the PAD⇄MOVE toggle). Layer 9: hit
+    rect = drawn rect, and a touch must start AND end inside. */
+function ChromeButton({
+  node, u, text, color, onPress, accessibilityLabel, checked,
+}: {
+  node: PadNode; u: number; text: string; color?: string;
+  onPress: () => void; accessibilityLabel: string; checked?: boolean;
+}) {
+  const t = useTheme();
+  return (
+    <Pressable
+      style={abs(node.hit)}
+      onPress={() => {
+        haptic();
+        onPress();
+      }}
+      accessibilityRole={checked === undefined ? 'button' : 'switch'}
+      accessibilityState={checked === undefined ? undefined : { checked }}
+      accessibilityLabel={accessibilityLabel}>
+      <View
+        style={[
+          inner(node),
+          {
+            borderRadius: 2.5 * u, borderWidth: 1,
+            borderColor: color ?? t.cardBorder,
+            backgroundColor: t.card,
+            alignItems: 'center', justifyContent: 'center',
+          },
+        ]}>
+        <Text style={{ color: color ?? t.textFaint, fontFamily: mono, fontSize: 2.6 * u }}>
+          {text}
+        </Text>
+      </View>
+    </Pressable>
+  );
+}
+
 export function LandscapePad({
-  layout, btn, trig, stickMove, stickRelease, qam, locked, onToggleLock, onExit,
+  layout, btn, trig, stickMove, stickRelease, qam, locked, onToggleLock, onExit, onVariant,
 }: LandscapePadProps) {
   const t = useTheme();
   const { byId, u } = layout;
@@ -518,55 +678,97 @@ export function LandscapePad({
       />
       <FaceCluster nodes={FACE_IDS.map((id) => byId[id])} u={u} btn={btn} colors={faceColors} />
 
-      {/* Chrome. Deliberately NOT auto-hiding on a timer: the two buttons cost
-          nothing (they sit in a band that is otherwise empty) and fading the
-          only exit on a screen nobody is looking at is a bad trade at any
+      {/* Chrome. Deliberately NOT auto-hiding on a timer: the three buttons
+          cost nothing (they sit in a band that is otherwise empty) and fading
+          the only exit on a screen nobody is looking at is a bad trade at any
           timeout. Steam Link fades its controls after 10s; not copied. */}
-      <Pressable
-        style={abs(byId.lock.hit)}
-        onPress={() => {
-          haptic();
-          onToggleLock();
-        }}
-        accessibilityRole="switch"
-        accessibilityState={{ checked: locked }}
-        accessibilityLabel={locked ? 'Orientation locked' : 'Orientation follows the phone'}>
-        <View
-          style={[
-            inner(byId.lock),
-            {
-              borderRadius: 2.5 * u, borderWidth: 1,
-              borderColor: locked ? t.amber : t.cardBorder,
-              backgroundColor: t.card,
-              alignItems: 'center', justifyContent: 'center',
-            },
-          ]}>
-          {/* State AND consequence: when it is on, ✕ is the only way out. */}
-          <Text style={{ color: locked ? t.amber : t.textFaint, fontFamily: mono, fontSize: 2.6 * u }}>
-            {locked ? '🔒 LOCKED' : '🔓 AUTO'}
-          </Text>
-        </View>
-      </Pressable>
+      <ChromeButton
+        node={byId.variant} u={u} text="⊕ MOVE"
+        onPress={onVariant}
+        accessibilityLabel="Switch to the movement layout"
+      />
+      <ChromeButton
+        node={byId.lock} u={u}
+        text={locked ? '🔒 LOCKED' : '🔓 AUTO'}
+        color={locked ? t.amber : undefined}
+        onPress={onToggleLock} checked={locked}
+        accessibilityLabel={locked ? 'Orientation locked' : 'Orientation follows the phone'}
+      />
+      <ChromeButton
+        node={byId.exit} u={u} text="✕ EXIT"
+        onPress={onExit}
+        accessibilityLabel="Exit full-screen controller"
+      />
+    </View>
+  );
+}
 
-      <Pressable
-        style={abs(byId.exit.hit)}
-        onPress={() => {
-          haptic();
-          onExit();
-        }}
-        accessibilityRole="button"
-        accessibilityLabel="Exit full-screen controller">
-        <View
-          style={[
-            inner(byId.exit),
-            {
-              borderRadius: 2.5 * u, borderWidth: 1, borderColor: t.cardBorder,
-              backgroundColor: t.card, alignItems: 'center', justifyContent: 'center',
-            },
-          ]}>
-          <Text style={{ color: t.textFaint, fontFamily: mono, fontSize: 3.4 * u }}>✕ EXIT</Text>
-        </View>
-      </Pressable>
+// ---------- Movement mode ----------
+
+export type MovePadProps = {
+  layout: Extract<PadLayout, { ok: true }>;
+  btn: (k: ButtonKey) => Down;
+  stickMove: (k: StickKey) => (x: number, y: number) => void;
+  stickRelease: (k: StickKey) => () => void;
+  locked: boolean;
+  onToggleLock: () => void;
+  onExit: () => void;
+  onVariant: () => void;
+};
+
+/**
+ * The movement layout: one enormous left-thumb zone driving the LEFT STICK,
+ * and a small right-hand cluster (A, B, 4-way NAV, START). For games that are
+ * almost entirely continuous movement — Vampire Survivors and its family.
+ * See moveLayout() in lib/padLayout.ts for why this is a separate mode and
+ * not a change to the controller.
+ *
+ * Same protocol keys as the gamepad — the zone emits {t:'s',k:'l'} frames and
+ * the buttons emit their normal ids — so the agent cannot tell the layouts
+ * apart and needs no change.
+ */
+export function MovePad({
+  layout, btn, stickMove, stickRelease, locked, onToggleLock, onExit, onVariant,
+}: MovePadProps) {
+  const t = useTheme();
+  const { byId, u } = layout;
+
+  return (
+    <View style={StyleSheet.absoluteFill}>
+      {/* The movement zone. A tap (no drag) is deliberately NOTHING here — in
+          the games this mode serves, a stray A press picks whatever upgrade is
+          highlighted. Confirm lives under the right thumb only. */}
+      <FloatingStick
+        node={byId.move} u={u} label="Move" zoneOutline
+        onMove={stickMove('l')} onRelease={stickRelease('l')}
+        onClick={NOOP}
+      />
+
+      {/* Right thumb: A at rest, B up-left, 4-way NAV above for menus. */}
+      <NavPad node={byId.nav} u={u} btn={btn} />
+      <PadKey node={byId.b} label="B" u={u} color={t.red} fontSize={4.4 * u} {...btn('b')} />
+      <PadKey node={byId.a} label="A" u={u} color={t.green} fontSize={4.4 * u} {...btn('a')} />
+
+      {/* Chrome: same row, same positions as the gamepad layout, so the toggle
+          never jumps under the thumb that pressed it. */}
+      <ChromeButton
+        node={byId.variant} u={u} text="🎮 PAD"
+        onPress={onVariant}
+        accessibilityLabel="Switch to the full controller"
+      />
+      <ChromeButton
+        node={byId.lock} u={u}
+        text={locked ? '🔒 LOCKED' : '🔓 AUTO'}
+        color={locked ? t.amber : undefined}
+        onPress={onToggleLock} checked={locked}
+        accessibilityLabel={locked ? 'Orientation locked' : 'Orientation follows the phone'}
+      />
+      <ChromeButton
+        node={byId.exit} u={u} text="✕ EXIT"
+        onPress={onExit}
+        accessibilityLabel="Exit full-screen controller"
+      />
+      <PadKey node={byId.start} label="START" u={u} fontSize={2.8 * u} {...btn('start')} />
     </View>
   );
 }

--- a/app/lib/__tests__/padLayout.test.ts
+++ b/app/lib/__tests__/padLayout.test.ts
@@ -31,6 +31,10 @@ import { dirname, join } from 'node:path';
 import {
   DPAD,
   EXIT_MOAT_U,
+  EXPAND_CAP_U,
+  moveLayout,
+  NAV,
+  navZone,
   MIN_SHORT_AXIS,
   MIN_TOUCH,
   dpadZone,
@@ -399,4 +403,169 @@ test('d-pad: centre is A, cardinals are exact, corners pick ONE direction', () =
   assert.ok(corner === 'dr' || corner === 'dd', `corner gave ${corner}`);
   // Outside the cluster: released, not latched to the last direction.
   assert.equal(dpadZone(30 * u, 0, u), null);
+});
+
+// ---------- Movement mode: the same properties, the second table ----------
+//
+// moveLayout is a different TABLE through the same builder, so every property
+// that makes the main table safe has to hold for it too — asserted by looping,
+// not by trusting the shared code path.
+
+const LAYOUTS: [string, (w: Size, i: Insets) => PadLayout][] = [
+  ['padLayout', padLayout],
+  ['moveLayout', moveLayout],
+];
+
+test('MOVE: every property holds for both tables on every device', () => {
+  for (const [name, fn] of LAYOUTS) {
+    for (const c of cases()) {
+      const l = ok(fn(c.win, c.insets));
+      for (const n of l.nodes) {
+        assert.ok(contains(l.play, n.rect), `${name}/${c.label}: ${n.id} escapes play`);
+        assert.ok(contains(l.play, n.hit), `${name}/${c.label}: ${n.id} hit escapes play`);
+        const min = Math.min(n.hit.w, n.hit.h);
+        assert.ok(min >= MIN_TOUCH - 1e-6, `${name}/${c.label}: ${n.id} is ${min.toFixed(1)}dp`);
+        if (n.shape === 'circle') assert.equal(n.rect.w, n.rect.h, `${name}/${c.label}: ${n.id} ellipse`);
+      }
+      for (let i = 0; i < l.nodes.length; i += 1) {
+        for (let j = i + 1; j < l.nodes.length; j += 1) {
+          assert.ok(
+            !rectsIntersect(l.nodes[i].hit, l.nodes[j].hit),
+            `${name}/${c.label}: ${l.nodes[i].id} and ${l.nodes[j].id} share a touch`,
+          );
+        }
+      }
+      for (const n of l.nodes) {
+        if (n.layer === 9) continue;
+        const gap = rectGap(l.byId.exit.hit, n.hit);
+        assert.ok(gap >= EXIT_MOAT_U * l.u - 1e-6,
+          `${name}/${c.label}: EXIT only ${(gap / l.u).toFixed(1)}U from ${n.id}`);
+      }
+    }
+  }
+});
+
+test('MOVE: the movement zone is the point of the mode — assert its size', () => {
+  const l = ok(moveLayout({ width: 852, height: 393 }, { top: 0, right: 59, bottom: 21, left: 0 }));
+  const move = l.byId.move;
+  const stick = ok(padLayout({ width: 852, height: 393 }, { top: 0, right: 59, bottom: 21, left: 0 })).byId.lstick;
+  const ratio = (move.hit.w * move.hit.h) / (stick.hit.w * stick.hit.h);
+  assert.ok(ratio >= 2.5, `the MOVE zone is only ${ratio.toFixed(1)}x the stick container — the mode adds nothing`);
+  // And in absolute terms: over a fifth of the whole screen is drag-startable
+  // movement surface. This is the ergonomic promise of the mode, stated as a
+  // number instead of adjectives.
+  const share = (move.hit.w * move.hit.h) / (l.play.w * l.play.h);
+  assert.ok(share >= 0.2, `MOVE covers only ${(share * 100).toFixed(0)}% of the play area`);
+});
+
+test('MOVE: chrome sits at identical positions in both tables', () => {
+  // The PAD<->MOVE toggle must not jump under the thumb that just pressed it,
+  // and LOCK/EXIT must stay where muscle memory left them.
+  const win = { width: 852, height: 393 };
+  const ins = { top: 0, right: 0, bottom: 21, left: 59 };
+  const a = ok(padLayout(win, ins));
+  const b = ok(moveLayout(win, ins));
+  for (const id of ['variant', 'lock', 'exit'] as const) {
+    assert.deepEqual(a.byId[id].rect, b.byId[id].rect, `${id} moves between layouts`);
+  }
+});
+
+test('MOVE: the move table contains exactly what the mode needs, nothing else', () => {
+  // An absent control cannot be mis-pressed. If this list ever grows a
+  // trigger or a second stick, that is a different feature and a new decision,
+  // not a drive-by addition.
+  const l = ok(moveLayout({ width: 852, height: 393 }, { top: 0, right: 0, bottom: 21, left: 59 }));
+  assert.deepEqual(
+    l.nodes.map((n) => n.id).sort(),
+    ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start', 'variant'],
+  );
+});
+
+test('MOVE: navZone has no centre action and releases outside the ring', () => {
+  const u = 3.93;
+  // Dead centre: NULL — A is a physical button here; latching an arbitrary
+  // direction on a centre tap would be a phantom input.
+  assert.equal(navZone(0, 0, u), null);
+  // Cardinals resolve, one direction only.
+  assert.equal(navZone(0, -10 * u, u), 'du');
+  assert.equal(navZone(0, 10 * u, u), 'dd');
+  assert.equal(navZone(-10 * u, 0, u), 'dl');
+  assert.equal(navZone(10 * u, 0, u), 'dr');
+  const corner = navZone(8 * u, 8 * u, u);
+  assert.ok(corner === 'dr' || corner === 'dd', `corner gave ${corner}`);
+  // Outside the ring: released, never latched.
+  assert.equal(navZone(20 * u, 0, u), null);
+});
+
+test('MOVE: every emitted id is a real protocol key', () => {
+  // The move/nav/variant NODES are layout-only; what goes on the wire is
+  // stick frames plus these buttons. Nothing here may invent a key.
+  const emitted = ['a', 'b', 'start', 'du', 'dd', 'dl', 'dr'];
+  const BUTTONS = new Set([
+    'a', 'b', 'x', 'y', 'lb', 'rb', 'l3', 'r3', 'start', 'select', 'guide',
+    'dl', 'dr', 'du', 'dd',
+  ]);
+  for (const k of emitted) assert.ok(BUTTONS.has(k), `${k} is not a ButtonKey`);
+});
+
+// ---------- Review regressions: the three geometry findings ----------
+
+test('REVIEW: angular sub-targets clear 44dp — sectors AND discs, both clusters', () => {
+  // The 44dp rule binds on what a thumb actually hits. For an angular control
+  // that is the radial THICKNESS of a sector (outer - inner), and the centre
+  // disc's DIAMETER where the centre is itself an action. The first cut of
+  // NAV claimed "15U of thickness" having forgotten to subtract innerRU, and
+  // the d-pad's A/OK disc had never been measured at all — both were 39-43dp
+  // on phones in this very device table.
+  for (const c of cases()) {
+    const l = ok(padLayout(c.win, c.insets));
+    const dpadSector = (DPAD.outerRU - DPAD.innerRU) * l.u;
+    const dpadDisc = 2 * DPAD.innerRU * l.u;
+    const navSector = NAV.thicknessU * l.u;
+    assert.ok(dpadSector >= MIN_TOUCH - 1e-6, `${c.label}: d-pad sector ${dpadSector.toFixed(1)}dp`);
+    assert.ok(dpadDisc >= MIN_TOUCH - 1e-6, `${c.label}: d-pad OK disc ${dpadDisc.toFixed(1)}dp`);
+    assert.ok(navSector >= MIN_TOUCH - 1e-6, `${c.label}: NAV sector ${navSector.toFixed(1)}dp`);
+  }
+});
+
+test('REVIEW: the EXIT moat survives the capped-u window band, both tables', () => {
+  // An adversarial sweep EXECUTING this module found moveLayout's moat at
+  // 23.07U in windows where u is capped (play.h 446-499) and the width sits
+  // near the long-axis floor — the expansion pass's best-separating-axis
+  // choice flipped for the (move, lock) pair and nothing clamped the giant
+  // node's growth toward the chrome. No shipping phone lives in that band,
+  // which is exactly why no device-table case caught it. Sweep the band.
+  for (let h = 440; h <= 510; h += 6) {
+    const u = Math.min(h, 430) / 100;
+    for (let wu = 176; wu <= 184; wu += 1) {
+      const w = Math.ceil(wu * u);
+      for (const [name, fn] of LAYOUTS) {
+        const l = fn({ width: w, height: h }, { top: 0, right: 0, bottom: 0, left: 0 });
+        if (!l.ok) continue;
+        for (const n of l.nodes) {
+          if (n.layer === 9) continue;
+          const gap = rectGap(l.byId.exit.hit, n.hit);
+          assert.ok(
+            gap >= EXIT_MOAT_U * l.u - 1e-6,
+            `${name} @ ${w}x${h}: EXIT only ${(gap / l.u).toFixed(2)}U from ${n.id}`,
+          );
+        }
+      }
+    }
+  }
+});
+
+test('REVIEW: expansion is capped — no node grows more than EXPAND_CAP_U per side', () => {
+  for (const [name, fn] of LAYOUTS) {
+    for (const c of cases()) {
+      const l = ok(fn(c.win, c.insets));
+      for (const n of l.nodes) {
+        const cap = EXPAND_CAP_U * l.u + 1e-6;
+        assert.ok(n.rect.x - n.hit.x <= cap, `${name}/${c.label}: ${n.id} left growth`);
+        assert.ok(n.hit.x + n.hit.w - (n.rect.x + n.rect.w) <= cap, `${name}/${c.label}: ${n.id} right growth`);
+        assert.ok(n.rect.y - n.hit.y <= cap, `${name}/${c.label}: ${n.id} top growth`);
+        assert.ok(n.hit.y + n.hit.h - (n.rect.y + n.rect.h) <= cap, `${name}/${c.label}: ${n.id} bottom growth`);
+      }
+    }
+  }
 });

--- a/app/lib/padLayout.ts
+++ b/app/lib/padLayout.ts
@@ -48,7 +48,11 @@ export type PadNodeId =
   | 'select' | 'steam' | 'qam' | 'start'
   | 'dpad' | 'lstick' | 'rstick'
   | 'a' | 'b' | 'x' | 'y'
-  | 'lock' | 'exit';
+  | 'lock' | 'exit'
+  // Movement mode (moveLayout): the big left-thumb zone, the 4-way menu
+  // cluster, and the PAD/MOVE toggle that lives in the chrome row of BOTH
+  // layouts.
+  | 'move' | 'nav' | 'variant';
 
 export type PadNode = {
   id: PadNodeId;
@@ -106,9 +110,11 @@ export const MIN_SHORT_AXIS = 326;
  *  1. The clusters. Left occupies 79U from the left edge (3 margin + 39 d-pad +
  *     7 gap + 30 stick), right occupies 85U (3 + 45 face + 7 + 30) — so under
  *     164U there is no centre channel and they would collide.
- *  2. The EXIT moat. EXIT's right edge sits at `P.w/2 + 16.5` and RB's touch
- *     rect begins at `P.w - 45.5`, so the moat is `P.w/2 - 62` U wide. Holding
- *     it at 26U requires 176U.
+ *  2. The EXIT moat. EXIT's right edge sits at `P.w/2 + 14.5` (the chrome
+ *     trio moved 2U left when NAV grew to a 44dp sector) and RB's touch rect
+ *     begins at `P.w - 45.5`, so the moat is `P.w/2 - 60` U wide — 28U at
+ *     this floor. 176 is kept rather than lowered: the slack is margin, and
+ *     the movement table's NAV needs it.
  *
  * 16:9 — the narrowest real phone shape — is 177.6U, so this admits every real
  * device and refuses only genuinely narrow windows (Android split-screen and
@@ -136,6 +142,9 @@ export const EXIT_MOAT_U = 26;
 
 /** Every touch target must be at least this, in dp. */
 export const MIN_TOUCH = 44;
+
+/** Hard per-side cap on hit-rect expansion, in U. See expandHits. */
+export const EXPAND_CAP_U = 8;
 
 // ---------- Stick behaviour (consumed by the Stick component) ----------
 
@@ -180,8 +189,13 @@ export const STICK = {
  * navigation has no use for them.
  */
 export const DPAD = {
-  outerRU: 19.5,
-  innerRU: 6,
+  // outer/inner sized so BOTH real targets — the 90-degree sectors (radial
+  // thickness outer - inner) and the centre A/OK disc (diameter 2 * inner) —
+  // are 13.5U, i.e. exactly 44dp at the MIN_SHORT_AXIS floor. The first cut
+  // used inner 6 (a 12U disc, 39dp at the floor): the floor derivation had
+  // only considered the sector and forgot the disc is a target too.
+  outerRU: 20.25,
+  innerRU: 6.75,
   /** Radial thickness of a sector — the real touch target, not the 39U box. */
   get sectorThicknessU() {
     return this.outerRU - this.innerRU;
@@ -221,11 +235,15 @@ const FACE_CX = 25.5;
 const FACE_CY = 26.5;
 
 const TABLE: Spec[] = [
-  // Row 1 — shoulders, and the two chrome buttons in the middle.
+  // Row 1 — shoulders, and the three chrome buttons in the middle. VARIANT
+  // (the PAD/MOVE toggle) sits leftmost of the chrome group; on the 176U
+  // long-axis floor its left edge lands at C − 34.5U, clear of LB's right
+  // edge at left + 41U by 12.5U.
   { id: 'lt', w: 18, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 10 }, layer: 1 },
   { id: 'lb', w: 18, h: 14, cx: { from: 'left', at: 32 }, cy: { from: 'top', at: 10 }, layer: 1 },
-  { id: 'lock', w: 15, h: 14, cx: { from: 'centre', at: -9 }, cy: { from: 'top', at: 10 }, layer: 9 },
-  { id: 'exit', w: 15, h: 14, cx: { from: 'centre', at: 9 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'variant', w: 15, h: 14, cx: { from: 'centre', at: -29 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'lock', w: 15, h: 14, cx: { from: 'centre', at: -11 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'exit', w: 15, h: 14, cx: { from: 'centre', at: 7 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'rb', w: 18, h: 14, cx: { from: 'right', at: 32 }, cy: { from: 'top', at: 10 }, layer: 1 },
   { id: 'rt', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 10 }, layer: 1 },
 
@@ -236,7 +254,7 @@ const TABLE: Spec[] = [
   { id: 'start', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 27 }, layer: 5 },
 
   // Thumb clusters.
-  { id: 'dpad', w: 39, h: 39, cx: { from: 'left', at: 22.5 }, cy: { from: 'bottom', at: 23.5 }, layer: 6 },
+  { id: 'dpad', w: 40.5, h: 40.5, cx: { from: 'left', at: 22.5 }, cy: { from: 'bottom', at: 23.5 }, layer: 6 },
   { id: 'lstick', w: 30, h: 30, cx: { from: 'left', at: 64 }, cy: { from: 'bottom', at: 26 }, layer: 7, shape: 'circle' },
   { id: 'rstick', w: 30, h: 30, cx: { from: 'right', at: 70 }, cy: { from: 'bottom', at: 26 }, layer: 8, shape: 'circle' },
 
@@ -248,6 +266,74 @@ const TABLE: Spec[] = [
   { id: 'x', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX + FACE.radiusU }, cy: { from: 'bottom', at: FACE_CY }, layer: 1, shape: 'circle' },
   { id: 'b', w: FACE.diaU, h: FACE.diaU, cx: { from: 'right', at: FACE_CX - FACE.radiusU }, cy: { from: 'bottom', at: FACE_CY }, layer: 1, shape: 'circle' },
 ];
+
+/**
+ * MOVEMENT MODE — the second table (spec: project_movement-mode.md).
+ *
+ * For games that are ~95% continuous movement and ~5% menus (Vampire
+ * Survivors and its family): one enormous left-thumb MOVE zone emitting left-
+ * stick frames, and a small right-hand cluster — A (confirm), B (back), a
+ * 4-way NAV for upgrade menus, START to pause. Everything the controller has
+ * beyond that is ABSENT, not hidden: an absent control cannot be mis-pressed,
+ * and the whole point of the mode is a surface small enough to use blind.
+ *
+ * The owner's ask was a movement pad "in between the joysticks". Deliberately
+ * not built that way: in a two-handed landscape grip the CENTRE of the screen
+ * is reachable by neither thumb — it is the grip zone, which is why the main
+ * table keeps it empty. The ask is really for a bigger left-thumb zone, so
+ * that is what this is: 49 x 68U anchored to the left edge — its touchable
+ * area is several times the main table's stick container and over a fifth of
+ * the whole screen (both asserted in the tests, so neither claim can rot).
+ *
+ * This half-screen-stick shape was explicitly REJECTED for the main pad
+ * ("it eats the d-pad, which is the control this product actually uses").
+ * That reasoning holds there and not here: during play in these games the
+ * d-pad is unused, so the trade flips. Hence a separate MODE — if the main
+ * pad ever grows a zone like this, that is a regression, not a feature.
+ */
+const MOVE_TABLE: Spec[] = [
+  // Chrome row. Same positions as the main table, so the toggle does not jump
+  // under the thumb that just pressed it. START joins the row (pause is
+  // deliberate, out-of-the-way) — its main-table slot at row 2 doesn't exist
+  // here.
+  { id: 'variant', w: 15, h: 14, cx: { from: 'centre', at: -29 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'lock', w: 15, h: 14, cx: { from: 'centre', at: -11 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'exit', w: 15, h: 14, cx: { from: 'centre', at: 7 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'start', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 10 }, layer: 5 },
+
+  // The movement zone: floating-origin left stick with a container covering
+  // the whole left thumb-arc. Top edge sits 18U below the chrome row's bottom
+  // so a drag can never begin on a chrome button.
+  { id: 'move', w: 49, h: 68, cx: { from: 'left', at: 27.5 }, cy: { from: 'bottom', at: 36 }, layer: 7 },
+
+  // Right-thumb cluster, laid along the thumb arc: A at the resting position,
+  // B up-left of it, NAV above both. 3U edge-to-edge between A and B — the
+  // same gap rule as the face diamond (shrink diameters, never the gap).
+  { id: 'nav', w: 33, h: 33, cx: { from: 'right', at: 22 }, cy: { from: 'bottom', at: 62 }, layer: 6 },
+  { id: 'b', w: 15, h: 15, cx: { from: 'right', at: 34 }, cy: { from: 'bottom', at: 28 }, layer: 1, shape: 'circle' },
+  { id: 'a', w: 15, h: 15, cx: { from: 'right', at: 16 }, cy: { from: 'bottom', at: 20 }, layer: 1, shape: 'circle' },
+];
+
+/**
+ * The 4-way NAV cluster's geometry. Same angular hit test as the d-pad but no
+ * centre disc: menus want pure directions, and A is a separate physical
+ * button an inch away. A small dead centre returns null — releasing rather
+ * than latching an arbitrary direction on a dead-centre tap.
+ */
+export const NAV = {
+  outerRU: 16.5,
+  innerRU: 3,
+  /** Radial thickness of one direction — the REAL touch target, and the
+   *  binding 44dp measure for an angular control. 13.5U, the same as the
+   *  d-pad sector, which is exactly what MIN_SHORT_AXIS = 326 was derived
+   *  from. The first cut was outerRU 15 with the docstring claiming "15U of
+   *  thickness" — it had forgotten to subtract innerRU, and the real 12U
+   *  target was 39-43dp on real phones. Caught in review by redoing the
+   *  arithmetic; asserted by a test now. */
+  get thicknessU() {
+    return this.outerRU - this.innerRU;
+  },
+} as const;
 
 // ---------- Geometry helpers ----------
 
@@ -273,6 +359,22 @@ export function rectGap(a: Rect, b: Rect): number {
 // ---------- The layout ----------
 
 export function padLayout(win: Size, insets: Insets): PadLayout {
+  return buildLayout(TABLE, win, insets);
+}
+
+/**
+ * Movement mode. Same play rect, same unit, same floors, same expansion pass,
+ * same property tests — a different table. The short-axis floor carries over
+ * unchanged because the binding controls are no tighter here: the chrome row
+ * (14U tall, hit = drawn) needs 314dp, and NAV's sector thickness (16.5 - 3 =
+ * 13.5U — thickness, not radius) needs exactly 326, the same bound as the
+ * d-pad sector it was matched to.
+ */
+export function moveLayout(win: Size, insets: Insets): PadLayout {
+  return buildLayout(MOVE_TABLE, win, insets);
+}
+
+function buildLayout(table: Spec[], win: Size, insets: Insets): PadLayout {
   const play: Rect = {
     x: insets.left,
     y: insets.top,
@@ -292,7 +394,7 @@ export function padLayout(win: Size, insets: Insets): PadLayout {
 
   const centreX = play.x + play.w / 2;
 
-  const base: PadNode[] = TABLE.map((s) => {
+  const base: PadNode[] = table.map((s) => {
     const w = s.w * u;
     const h = s.h * u;
     const cx =
@@ -349,11 +451,16 @@ function expandHits(nodes: PadNode[], play: Rect, u: number): PadNode[] {
     if (n.layer === 9) return { ...n, hit: { ...n.rect } };
 
     const r = n.rect;
-    // Start from the two limits that do not depend on other controls.
-    let l = Math.min(0.25 * r.w, r.x - play.x);
-    let rt = Math.min(0.25 * r.w, right(play) - right(r));
-    let t = Math.min(0.25 * r.h, r.y - play.y);
-    let b = Math.min(0.25 * r.h, bottom(play) - bottom(r));
+    // Start from the limits that do not depend on other controls: a quarter of
+    // the node's own extent, but never more than EXPAND_CAP_U — the quarter
+    // rule was meant for thumb-sized controls, and on the giant MOVE zone it
+    // granted enough growth to erode the EXIT moat in narrow capped-u windows.
+    const capX = Math.min(0.25 * r.w, EXPAND_CAP_U * u);
+    const capY = Math.min(0.25 * r.h, EXPAND_CAP_U * u);
+    let l = Math.min(capX, r.x - play.x);
+    let rt = Math.min(capX, right(play) - right(r));
+    let t = Math.min(capY, r.y - play.y);
+    let b = Math.min(capY, bottom(play) - bottom(r));
 
     for (const o of nodes) {
       if (o.id === n.id) continue;
@@ -413,6 +520,20 @@ export function dpadZone(px: number, py: number, u: number): DpadZone {
   if (mag <= DPAD.innerRU * u) return 'a';
   if (mag > DPAD.outerRU * u) return null;
   // No diagonals: whichever axis dominates wins outright.
+  if (Math.abs(px) >= Math.abs(py)) return px >= 0 ? 'dr' : 'dl';
+  return py >= 0 ? 'dd' : 'du';
+}
+
+/**
+ * Movement mode's 4-way NAV. Same angular idea, two differences: the centre
+ * returns NULL rather than A (A is its own physical button here — a dead-
+ * centre tap should release, never latch an arbitrary direction), and the
+ * radii are NAV's.
+ */
+export function navZone(px: number, py: number, u: number): DpadZone {
+  const mag = Math.hypot(px, py);
+  if (mag <= NAV.innerRU * u) return null;
+  if (mag > NAV.outerRU * u) return null;
   if (Math.abs(px) >= Math.abs(py)) return px >= 0 ? 'dr' : 'dl';
   return py >= 0 ? 'dd' : 'du';
 }

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -168,6 +168,12 @@ export type Prefs = {
   padKeyboardBar: boolean;
   /** Gesture hint text on the swipe/trackpad surfaces. */
   padHints: boolean;
+  /** Landscape full-screen layout: the full controller, or the movement mode
+   *  (one big left-thumb zone + a small menu cluster) for games that are
+   *  mostly continuous movement. Toggled from the pad's own chrome row; a
+   *  pref so the choice survives sessions — someone playing Vampire Survivors
+   *  nightly should not re-toggle every evening. */
+  landscapePadVariant: 'pad' | 'move';
   /** Collapse the pill + mode tabs + button/keyboard rows so the trackpad
    *  surface fills the pane for edge-to-edge scrolling. Trackpad mode only;
    *  a floating chip restores the chrome. */
@@ -293,6 +299,7 @@ export const DEFAULTS: Prefs = {
   padWinShortcuts: true,
   padKeyboardBar: true,
   padHints: true,
+  landscapePadVariant: 'pad',
   padTrackpadLarge: false,
   padLargeToggle: true,
   askToSwitchControl: true,
@@ -410,6 +417,7 @@ function normalize(raw: unknown): Prefs {
     padWinShortcuts: bool(o.padWinShortcuts, DEFAULTS.padWinShortcuts),
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
+    landscapePadVariant: o.landscapePadVariant === 'move' ? 'move' : 'pad',
     padTrackpadLarge: bool(o.padTrackpadLarge, DEFAULTS.padTrackpadLarge),
     padLargeToggle: bool(o.padLargeToggle, DEFAULTS.padLargeToggle),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),

--- a/docs/memory/project_movement-mode.md
+++ b/docs/memory/project_movement-mode.md
@@ -1,6 +1,16 @@
 # Movement mode — landscape, one big thumb-zone, for twin-stick-ish games (owner ask 2026-08-07)
 
-> **Status: SPEC ONLY, nothing built.** Roadmap entry is 📋 Planned.
+> **Status: BUILT 2026-08-07** (same day, owner pulled it into the 2.9.38
+> release). The as-built geometry differs from §B below — the tests forced two
+> corrections: MOVE grew to 52x68U @ (left+29, bottom−36) after the size
+> assertion showed the specced zone was only 2.6x the stick's touch area, and
+> NAV moved inboard to right−22 after the EXIT-moat assertion caught 25.1U on
+> 16:9. The table in `lib/padLayout.ts` (MOVE_TABLE) is the truth; §B is the
+> pre-build sketch. Entry mechanism shipped as the chrome-row toggle (option 2),
+> persisted as the `landscapePadVariant` pref. Phase-1 hardware verification
+> (Vampire Survivors run; Megabonk manual-aim question) was SKIPPED by owner
+> decision to ship in 2.9.38 — still worth doing, the answer decides whether a
+> second variant with a right stick is needed.
 >
 > Owner, after playing on the new landscape pad: *"is there a way to add a pad in
 > between the joystick buttons that acts like a pad for moving around like a left


### PR DESCRIPTION
The owner's ask after playing the landscape pad: a big movement surface for games that are ~95% continuous movement. One 49×68U left-thumb zone (floating-origin left stick, >20% of the screen — asserted), A/B/4-way NAV/START on the right, nothing else. Chrome-row toggle (⊕ MOVE / 🎮 PAD), persisted; same WS session and protocol keys — no agent change.

Second `padLayout` table through the same builder and property tests (now parameterised over both tables). Pre-merge adversarial review (3 lenses → refutation verify, two findings confirmed by *executing* the module) surfaced four defects, all fixed here and pinned by tests — details in the commit message: NAV/d-pad-disc sub-44dp targets, an EXIT-moat break in capped-u freeform windows, and an unmount path the releaseAll guard missed.

Wire-proven in the harness (fake pong-answering WS): MOVE drag → `s:l` frames with release zeroing, NAV sectors → single-cardinal pairs, centre → nothing, toggle round-trip with pref persisted through reload. NOT verified: Pressables on device (KI-057), real gameplay — the spec's phase-1 question (Megabonk manual aim?) stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)