### PR TITLE
release: 2.9.38 (vc 77 / iOS 140)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.37",
+    "version": "2.9.38",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "139",
+      "buildNumber": "140",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 76
+      "versionCode": 77
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,9 +1,8 @@
-The controller goes full screen: turn the phone sideways on the Pad tab and every button, stick and d-pad spreads out like a real gamepad — no tab bar, no headers, just the controller. Rotate back to exit, or use the new orientation lock to pin it while you play.
+Two ways to play, sideways. Turn the phone on the Pad tab and the controller fills the screen — every stick, button and d-pad spread out like the real thing, with an orientation lock for long sessions. And for games that are mostly about moving — Vampire Survivors and friends — tap ⊕ MOVE for the new Movement mode: one huge thumb zone that works like a left stick, plus just A, B, a menu pad and pause. Nothing to mis-press, nothing in the way.
 
 Also in this release:
+• Fixed: on iOS, dragging a stick could swipe you out of the controller
 • Use Couchside as a plain TV remote for Roku and Google TV — no PC required
-• Bookmark games (hold a tile) and save your favorite library filters as presets
-• See each game's install size and filter by what's eating your disk
-• A toast tells you when a download finishes, whichever tab you're on
-• A guided setup walkthrough for new users — and an offer for existing users who never got one
-• Google TV pairing fixed on Android
+• Bookmark games (hold a tile) and save your favorite filters as presets
+• See each game's install size, and get a heads-up when a download finishes
+• A guided setup walkthrough — existing users can replay it from Setup

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,5 +1,5 @@
-Turn the phone sideways on the Pad tab: the controller now fills the screen edge-to-edge, with an orientation lock for long sessions.
+New: Movement mode. Tap ⊕ MOVE on the sideways controller for a huge movement zone plus just the buttons you need — made for games like Vampire Survivors where you mostly steer.
 
-New since last update: use the app as a plain TV remote (Roku and Google TV, no PC needed), bookmark games and save library filters, see each game's install size, get a heads-up when a download finishes, and a guided setup walkthrough — existing users can replay it from Setup.
+The full-screen controller also arrives in this update: turn the phone sideways on the Pad tab and every stick and button spreads out edge-to-edge, with an orientation lock.
 
-Plus many fixes, including Google TV pairing on Android.
+Plus: TV remote mode (Roku/Google TV), game bookmarks and filter presets, install sizes, download alerts, and many fixes.


### PR DESCRIPTION
Version bump + store notes for the release carrying movement mode (#375) and the iOS back-swipe fix (#374). Replaces cancelled 2.9.37 iOS submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)