### PR TITLE
docs: vertical MOVE mode + per-game themes intake

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,6 +130,26 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### Vertical MOVE: one-handed portrait movement mode (owner ask 2026-08-07, refined same day)
+- **priority:** P2 (owner is actively playing with the landscape one) · **risk:** medium
+  (extends the immersive gate to portrait for the first time; input path) ·
+  **affects:** app only · **depends_on:** movement mode (shipped 2.9.38)
+- Entered by a BUTTON from the pad mode panel alongside SWIPE; once open it is
+  IMMERSIVE with the same 🔒 LOCK / ✕ EXIT chrome as the landscape layouts. One mode,
+  two tables: portrait = new one-handed vertical layout, landscape = existing MovePad.
+  Orientation policy gains 'portrait-locked'. Reconcile the landscapePadVariant toggle
+  (one source of truth for movement-vs-controller).
+- **Full spec: `docs/memory/project_vertical-move-mode.md`**
+
+### Per-game themes, auto-applied from the running game (owner ask 2026-08-07)
+- **priority:** P3 / future · **risk:** low (pure app-side lookup; agent untouched) ·
+  **affects:** app only · **depends_on:** nothing; layers on feat/theming when that ships
+- Agent already reports the running appid; theme = frozen app-internal
+  appid -> Palette map, pad surfaces first. Pilot: Vampire Survivors + Megabonk —
+  the same bazzite session should answer movement-mode's open Megabonk aim question.
+- **Full spec: `docs/memory/project_game-themes.md`**
+
+
 ### Movement mode: landscape, one big thumb-zone, for Vampire-Survivors-likes (owner ask 2026-08-07)
 - **priority:** P2 · **risk:** low-medium (touches the input path, but adds a TABLE
   rather than changing the shipped one) · **affects:** app only ·

--- a/docs/memory/project_game-themes.md
+++ b/docs/memory/project_game-themes.md
@@ -1,0 +1,40 @@
+# Per-game themes — the app dresses for the game that is running (owner ask 2026-08-07)
+
+> **Status: SPEC ONLY, future work.** Owner: *"in the future can we build out
+> themes for different games so when the app detects a certain game is playing
+> it applies that theme. a good pilot for this would be vampire survivor and
+> megabonk."*
+
+## Mechanism (all pieces exist)
+
+1. **Detection is already shipped.** The agent reports the running game
+   (appid + label) on the status/gaming payloads the app already polls. No new
+   endpoint, no new capability, nothing client-supplied reaches the agent —
+   the appid flows box → phone, and the theme is a pure app-side lookup.
+2. **Theming is already an architecture.** `useTheme`/`useThemedStyles` and the
+   Palette type (see memory: theming-architecture, branch feat/theming). A game
+   theme = a Palette override (accent, card, glow) applied while that appid is
+   the running game, reverting on exit. The pad surfaces (LandscapePad, MovePad,
+   the vertical mode) are the primary canvas — they already take every colour
+   from the theme hook.
+3. **Registry: a frozen app-internal map** `appid -> PaletteOverride`, exactly
+   the allowlist shape the project uses everywhere. Unknown appid = default
+   theme, never a fetch. No remote theme delivery in v1 (that would be a
+   content-injection surface); themes ship in the app binary.
+
+## Pilot
+
+- **Vampire Survivors (appid 1794680):** gold-on-dark, red accents.
+- **Megabonk:** appid + palette TBD — and the same hardware session should
+  answer the OPEN question from project_movement-mode.md (does it need manual
+  aim / a right stick?). One evening on bazzite covers both.
+
+## Open questions
+
+- Flash risk: theme swap mid-session must not re-render the pad mid-gesture
+  (palette changes rebuild themed styles — verify the PanResponders survive, or
+  gate the swap on no-touch).
+- Does the theme apply app-wide or only to pad/immersive surfaces? Lean: pad
+  surfaces only in v1 — the Console staying stable is a feature.
+- Interaction with the unshipped feat/theming branch (user-selectable themes):
+  game themes should layer ON TOP of the user's base theme choice, not fight it.

--- a/docs/memory/project_vertical-move-mode.md
+++ b/docs/memory/project_vertical-move-mode.md
@@ -1,0 +1,65 @@
+# Vertical movement mode — one-handed, a real pad MODE (owner ask 2026-08-07)
+
+> **Status: SPEC ONLY.** Owner, after playing movement mode on TestFlight 141
+> ("controller mode works great, the vampire survivor input"): *"could we make a
+> one handed vertical version of this that can be clicked into from the pad
+> swipe panel."*
+
+## What it is
+
+The landscape movement mode's idea — one big floating-origin zone driving the
+left stick, plus the four things Vampire-Survivors-likes actually need — but
+PORTRAIT, designed for one thumb, and entered from the Pad tab's mode selector
+like any other mode. Phone in one hand on the couch arm; the whole interaction
+is the thumb.
+
+## Design shape (owner refined 2026-08-07 evening)
+
+Owner: *"basically move gamepad as an alternative to swipe and you click a
+button to open it and then once inside you can lock it and have the exit
+buttons like it currently has inside the gamepad move horizontal view."*
+
+1. **Entered by a BUTTON from the pad mode panel, alongside SWIPE — and once
+   open it is IMMERSIVE, portrait included.** Same interaction contract as the
+   landscape controller: full screen, no tab bar, no pill, no selector; a
+   chrome row with 🔒 LOCK and ✕ EXIT exactly like the landscape layouts. EXIT
+   returns to the mode panel you came from. This extends the immersive store
+   to portrait for the first time — the gate stops being landscape-only and
+   becomes "a full-screen surface is open".
+2. **One mode, two tables.** Inside MOVE, orientation picks the table:
+   portrait → the vertical one-handed layout below; landscape → the existing
+   MovePad. LOCK pins whichever orientation you are in (the orientation policy
+   gains 'portrait-locked' as the mirror of 'landscape-locked'). The
+   `landscapePadVariant` chrome toggle should then be reconciled — two sources
+   of truth for "movement vs controller" must not survive the build.
+3. **The entry button.** A segment or chip in the mode panel next to SWIPE.
+   The row already carries up to five segments with STEAM; measure in the
+   harness before committing (shorter labels / icon segment are the fallback).
+4. **Layout sketch (third table, PORTRAIT floors).** One-thumb reach on a
+   6.9" phone is the bottom ~55% and the right ~70% (assume right thumb;
+   mirror later if asked). Zone: full-width-ish, bottom half. Above it, one
+   row within thumb stretch: NAV (4-way, same navZone), A, B. START top-right
+   corner (deliberate reach). `buildLayout` needs orientation-aware floors —
+   the current MIN_LONG_AXIS_U assumes landscape; a portrait table binds on
+   WIDTH ≥ ~140U instead. Same builder, same expansion pass, same property
+   tests parameterised over a third table.
+4. **All existing invariants carry:** 44dp on real targets (sector thickness
+   and disc diameters, not boxes — the review findings), EXPAND_CAP_U, every
+   press has a guaranteed release (the mode joins the padMounted releaseAll
+   predicate), protocol keys unchanged (agent never knows).
+
+## What it reuses
+
+`FloatingStick` (zoneOutline), `NavPad`, `PadKey`, `navZone`, the builder and
+the whole test harness. The new work is one table, portrait floors, and the
+mode-selector plumbing (`PadMode` union + settings + keyboardMode fallback +
+selector row + the useLockOrientation call site: mode `move` is
+portrait-allowed AND landscape-allowed — the one mode with layouts in both).
+
+## Verification plan
+
+Property tests over the third table (both notch sides — portrait notch is
+`insets.top`, so the table finally exercises a nonzero top inset); harness
+press-through of the selector entry + zone drag + NAV; device pass one-handed
+on the Razr and an iPhone. The success criterion is the same as landscape
+MOVE's: a 20-minute run is comfortable with one hand.


### PR DESCRIPTION
Two specs + Planned entries from tonight's TestFlight feedback. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)