### PR TITLE
Vertical one-handed MOVE: movement becomes a real pad mode

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -47,7 +47,8 @@ import { StatusBar } from 'expo-status-bar';
 import { Gated } from '@/components/Gated';
 import { LandscapePad, LandscapePadTooSmall, MovePad } from '@/components/LandscapePad';
 import { setImmersive } from '@/lib/immersive';
-import { moveLayout, padLayout } from '@/lib/padLayout';
+import { surfaceChanged, type PadSurface } from '@/lib/padSurface';
+import { moveLayout, padLayout, verticalMoveLayout } from '@/lib/padLayout';
 import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
 import { PadDiagnostics } from '@/components/PadDiagnostics';
@@ -55,7 +56,7 @@ import { TabScreen } from '@/components/TabScreen';
 import { TourAnchor } from '@/components/TourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
-import type { PlayerState, SteamMenus } from '@/lib/api';
+import type { Gaming, PlayerState, SteamMenus } from '@/lib/api';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { useVolumeButtons } from '@/hooks/useVolumeButtons';
 import { api, hostKey, Status } from '@/lib/api';
@@ -839,6 +840,11 @@ export default function PadTab() {
 const MODES: { key: PadMode; label: string }[] = [
   { key: 'gamepad', label: 'PAD' },
   { key: 'swipe', label: 'SWIPE' },
+  // Movement mode: conditional — see `modes`. Only offered while a game is
+  // actually RUNNING on the box (owner ask): the layout exists for in-game
+  // steering, and a segment that opens a full-screen stick with nothing to
+  // steer would be the dead control this app keeps hunting down.
+  { key: 'move', label: 'MOVE' },
   // "MOUSE", not "TRACK": the surface IS a mouse — drag moves the pointer, tap
   // clicks. "Track" named the mechanism and left people guessing at the effect.
   { key: 'trackpad', label: 'MOUSE' },
@@ -886,7 +892,9 @@ function PadScreen() {
     : localMode;
   // In keyboard mode the agent is asked NOT to create a pad, so the PAD screen
   // has nothing to drive. Fall back rather than render sticks that go nowhere.
-  const mode: PadMode = keyboardMode && rawMode === 'gamepad' ? 'swipe' : rawMode;
+  // Keyboard mode covers 'move' too: the movement zone drives the virtual
+  // pad's left stick, which a no-pad handshake never creates.
+  const mode: PadMode = keyboardMode && (rawMode === 'gamepad' || rawMode === 'move') ? 'swipe' : rawMode;
   /**
    * ONLY THE GAMEPAD ROTATES.
    *
@@ -915,9 +923,13 @@ function PadScreen() {
   }, [exited, landscape]);
 
   useLockOrientation(
-    mode !== 'gamepad' || exited ? 'portrait'
-      : padLock ? 'landscape-locked'
-        : 'allow-landscape',
+    // MOVE is the one mode with layouts in BOTH orientations, so it never
+    // forces portrait — LOCK pins whichever way the phone is currently held.
+    mode === 'move'
+      ? (padLock ? (landscape ? 'landscape-locked' : 'portrait-locked') : 'allow-landscape')
+      : mode !== 'gamepad' || exited ? 'portrait'
+        : padLock ? 'landscape-locked'
+          : 'allow-landscape',
   );
 
   /**
@@ -929,10 +941,29 @@ function PadScreen() {
    * Published to a store rather than set imperatively (see lib/immersive.ts),
    * and reset on unmount so the app can never be left with no tab bar.
    */
-  const immersive = landscape && mode === 'gamepad' && !exited;
+  // Gamepad immerses in landscape only (rotating back is its exit).
+  // MOVE immerses in BOTH orientations — portrait gets the one-handed
+  // vertical table — so its only exits are ✕ and the mode switch.
+  const immersive = mode === 'move' || (landscape && mode === 'gamepad' && !exited);
+  /**
+   * PUBLISHED ONLY WHILE THE PAD TAB IS FOCUSED.
+   *
+   * This screen stays mounted after its first visit, so the derived value
+   * survives leaving the tab. That was harmless while every immersive state
+   * required landscape: every other screen forces portrait, the rotation
+   * flipped `landscape` here, and the flag cleared itself. MOVE has no
+   * orientation dependency, so that self-heal is gone — and a programmatic
+   * navigation off the Pad (the caps bounce in _layout when a box reports no
+   * gamepad, the tour's replace on a cold start) would strand the whole app
+   * with no tab bar, no BoxSwitcher and, because `gestureEnabled: !immersive`
+   * pins the stack, no way back on iOS. Exactly the failure lib/immersive.ts
+   * was written to make unrepresentable.
+   */
+  const [padFocused, setPadFocused] = useState(true);
+  const immersiveLive = immersive && padFocused;
   useEffect(() => {
-    setImmersive(immersive);
-  }, [immersive]);
+    setImmersive(immersiveLive);
+  }, [immersiveLive]);
   useEffect(() => () => setImmersive(false), []);
 
   /**
@@ -943,21 +974,27 @@ function PadScreen() {
   // Depend on the inset NUMBERS, not the object: useSafeAreaInsets can hand
   // back a fresh object on any re-render, which would rebuild the layout (and
   // every PanResponder keyed off it) constantly.
-  // Which landscape layout: the full controller or the movement mode. A pref
-  // (survives sessions); toggled from the chrome row of either layout.
-  const padVariant = usePref('landscapePadVariant');
+  // Which table: movement mode picks by orientation (portrait = the vertical
+  // one-handed layout, landscape = the spread MovePad); the gamepad is the
+  // full controller. Movement stopped being a pref in 2.9.39 — it is a real
+  // PadMode now, persisted per-box like every other mode.
   const landGeom = useMemo(
-    () => (padVariant === 'move' ? moveLayout : padLayout)({ width, height }, insets),
+    () => (mode === 'move'
+      ? (landscape ? moveLayout : verticalMoveLayout)
+      : padLayout)({ width, height }, insets),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [width, height, insets.top, insets.right, insets.bottom, insets.left, padVariant],
+    [width, height, insets.top, insets.right, insets.bottom, insets.left, mode, landscape],
   );
+  /** ✕ in the LANDSCAPE GAMEPAD: force portrait and let rotation re-enter. */
   const exitLandscape = useCallback(() => {
     setPadLock(false);
     setExited(true);
   }, []);
-  const toggleVariant = useCallback(() => {
-    void setPref('landscapePadVariant', getPref('landscapePadVariant') === 'move' ? 'pad' : 'move');
-  }, []);
+  /** Last non-move mode, so ✕ in MOVE returns to the panel you came from. */
+  const preMoveRef = useRef<PadMode>('swipe');
+  useEffect(() => {
+    if (mode !== 'move') preMoveRef.current = mode;
+  }, [mode]);
 
 
   const [status, setStatus] = useState<GamepadStatus>('closed');
@@ -1024,15 +1061,17 @@ function PadScreen() {
   // window can stay landscape-shaped while shrinking below the layout floors
   // (Stage Manager, Android freeform), which swaps the pad for the too-small
   // card — an unmount the immersive flag never sees. Found in review.
-  const padMounted = immersive && landGeom.ok;
-  const releasedFor = useRef({ padMounted, padVariant });
+  const surface: PadSurface = { mounted: immersiveLive && landGeom.ok, mode, landscape };
+  const releasedFor = useRef(surface);
   useEffect(() => {
-    const prev = releasedFor.current;
-    if (prev.padMounted !== padMounted || prev.padVariant !== padVariant) {
-      releasedFor.current = { padMounted, padVariant };
+    if (surfaceChanged(releasedFor.current, surface)) {
+      releasedFor.current = surface;
       client.releaseAll();
     }
-  }, [padMounted, padVariant, client]);
+    // The signature is rebuilt every render; compare by VALUE (surfaceChanged)
+    // rather than listing it as a dep, which would fire on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surface.mounted, surface.mode, surface.landscape, client]);
 
   // Latest settings for connect() calls. The lifecycle effect below keys on
   // the connection identity (host/port/token) only. A background patch to
@@ -1112,6 +1151,7 @@ function PadScreen() {
 
     const connect = () => {
       focusedRef.current = true;
+      setPadFocused(true);
       client.connect(settingsRef.current, {
         handoffAsk: askToSwitchRef.current,
         deviceName: DEVICE_LABEL,
@@ -1124,6 +1164,8 @@ function PadScreen() {
     };
     const disconnect = () => {
       focusedRef.current = false;
+      // Chrome comes back the moment the Pad loses focus — see immersiveLive.
+      setPadFocused(false);
       client.close();
       // evaluateWakeLock would also release (focused=false), but call it
       // directly: leaving the Pad must never depend on the poll running.
@@ -1316,6 +1358,14 @@ function PadScreen() {
   const playerRunningRef = useRef(playerRunning);
   playerRunningRef.current = playerRunning;
 
+  // Running-game probe for the MOVE segment. Slow: a game starting or quitting
+  // is a once-in-minutes event. api.gaming is caps-gated, so a box that cannot
+  // report it resolves null and the segment simply never appears — probe-and-
+  // appear, the house pattern.
+  const gamingPoll = usePoll<Gaming | null>(
+    () => api.gaming(settings), 15000, true, hostKey(settings));
+  const runningGame = gamingPoll.data?.game != null;
+
   const steamMenus = menusPoll.data?.menus ?? [];
   const hasSteamMenus = steamMenus.length > 0;
   // Declared BEFORE `modes` because the Steam segment depends on it.
@@ -1336,9 +1386,15 @@ function PadScreen() {
   const modes = useMemo(
     () => MODES.filter(
       (m) => (m.key !== 'menus' || (hasSteamMenus && inGameMode))
-        && (m.key !== 'gamepad' || !keyboardMode),
+        && (m.key !== 'gamepad' || !keyboardMode)
+        // MOVE appears only while a game is running (and needs the virtual
+        // pad, so keyboard mode hides it like the gamepad). A box already
+        // PERSISTED on 'move' keeps working if the game quits — yanking the
+        // surface out from under someone on a poll flap would be worse than
+        // an idle stick — but the segment hides, so EXIT is the way back.
+        && (m.key !== 'move' || (runningGame && !keyboardMode) || mode === 'move'),
     ),
-    [hasSteamMenus, inGameMode, keyboardMode],
+    [hasSteamMenus, inGameMode, keyboardMode, runningGame, mode],
   );
   const desk = useCallback(
     (name: DesktopKey | 'esc') => () =>
@@ -1403,6 +1459,21 @@ function PadScreen() {
     },
     [mode, update],
   );
+
+  /** ✕ in MOVE: back to whatever mode the panel was on before. Unlike the
+      gamepad there is no rotate-out — MOVE is immersive in both orientations
+      — so the button is the exit, not a fallback. */
+  const exitMove = useCallback(() => {
+    setPadLock(false);
+    // `exited` is the GAMEPAD's flag and is cleared only by observing portrait
+    // — which never happens where the forced-portrait lock is a no-op (iPad,
+    // Android freeform). Leaving it set would make a return to 'gamepad' land
+    // on the non-immersive portrait layout instead of the controller, from a
+    // button labelled "switch to the full controller". Clear it on every exit
+    // out of MOVE, which is the only path that can carry a stale one.
+    setExited(false);
+    setMode(preMoveRef.current === 'move' ? 'swipe' : preMoveRef.current);
+  }, [setMode]);
 
   // Horizontal swipe on the keyboard bar cycles PAD -> SWIPE -> TRACK -> REMOTE
   // (wrapping), matching the segmented control's order.
@@ -1762,16 +1833,21 @@ function PadScreen() {
   // device on EVERY rotation — the exact lifecycle churn this project's worst
   // bugs live in (KI-053). Same component, chrome suppressed by state; the
   // socket never notices the phone turned.
-  if (immersive) {
+  if (immersiveLive) {
     return (
       <>
         <StatusBar hidden />
         {!landGeom.ok ? (
-          <LandscapePadTooSmall reason={landGeom.reason} onExit={exitLandscape} />
-        ) : padVariant === 'move' ? (
-          // Movement mode: one big left-thumb zone driving the LEFT STICK, a
-          // small A/B/NAV/START cluster, nothing else. Same WS session, same
-          // protocol keys — the agent cannot tell the layouts apart.
+          <LandscapePadTooSmall
+            reason={landGeom.reason}
+            orientation={landscape ? 'landscape' : 'portrait'}
+            onExit={mode === 'move' ? exitMove : exitLandscape}
+          />
+        ) : mode === 'move' ? (
+          // Movement mode: one big thumb zone driving the LEFT STICK plus a
+          // small A/B/NAV/START cluster — the landscape spread or the vertical
+          // one-handed table, picked by orientation in landGeom. Same WS
+          // session, same protocol keys — the agent cannot tell modes apart.
           <MovePad
             layout={landGeom}
             btn={btn}
@@ -1779,8 +1855,11 @@ function PadScreen() {
             stickRelease={stickRelease}
             locked={padLock}
             onToggleLock={() => setPadLock((v) => !v)}
-            onExit={exitLandscape}
-            onVariant={toggleVariant}
+            onExit={exitMove}
+            onVariant={landscape ? () => {
+              setExited(false); // same stale-flag reason as exitMove
+              setMode('gamepad');
+            } : undefined}
           />
         ) : (
           <LandscapePad
@@ -1793,7 +1872,7 @@ function PadScreen() {
             locked={padLock}
             onToggleLock={() => setPadLock((v) => !v)}
             onExit={exitLandscape}
-            onVariant={toggleVariant}
+            onVariant={() => setMode('move')}
           />
         )}
         {/* Handoff survives immersive mode. Another phone asking for control is

--- a/app/components/LandscapePad.tsx
+++ b/app/components/LandscapePad.tsx
@@ -713,7 +713,11 @@ export type MovePadProps = {
   locked: boolean;
   onToggleLock: () => void;
   onExit: () => void;
-  onVariant: () => void;
+  /** Landscape only: the 🎮 PAD toggle back to the full controller. The
+      VERTICAL table has no variant node (rotating IS the way to the landscape
+      layout), so this is optional and the button renders only when the layout
+      carries the node. */
+  onVariant?: () => void;
 };
 
 /**
@@ -744,18 +748,21 @@ export function MovePad({
         onClick={NOOP}
       />
 
-      {/* Right thumb: A at rest, B up-left, 4-way NAV above for menus. */}
+      {/* Right thumb: A at rest, B beside/above it, 4-way NAV for menus. */}
       <NavPad node={byId.nav} u={u} btn={btn} />
       <PadKey node={byId.b} label="B" u={u} color={t.red} fontSize={4.4 * u} {...btn('b')} />
       <PadKey node={byId.a} label="A" u={u} color={t.green} fontSize={4.4 * u} {...btn('a')} />
 
-      {/* Chrome: same row, same positions as the gamepad layout, so the toggle
-          never jumps under the thumb that pressed it. */}
-      <ChromeButton
-        node={byId.variant} u={u} text="🎮 PAD"
-        onPress={onVariant}
-        accessibilityLabel="Switch to the full controller"
-      />
+      {/* Chrome: in landscape, same row and positions as the gamepad layout so
+          the toggle never jumps under the thumb that pressed it. The vertical
+          table has no variant node — rotating is the path between layouts. */}
+      {byId.variant && onVariant ? (
+        <ChromeButton
+          node={byId.variant} u={u} text="🎮 PAD"
+          onPress={onVariant}
+          accessibilityLabel="Switch to the full controller"
+        />
+      ) : null}
       <ChromeButton
         node={byId.lock} u={u}
         text={locked ? '🔒 LOCKED' : '🔓 AUTO'}
@@ -780,8 +787,18 @@ const NOOP = () => {};
  * meets the 44dp touch floor. Refusing is the honest answer — a cramped
  * controller that half-works is worse than being told to turn the phone back.
  */
-export function LandscapePadTooSmall({ reason, onExit }: { reason: string; onExit: () => void }) {
+export function LandscapePadTooSmall({
+  reason, onExit, orientation = 'landscape',
+}: {
+  reason: string;
+  onExit: () => void;
+  /** Which way the phone is being held. The card used to assume landscape —
+      it is now reachable from PORTRAIT movement mode, where "turn the phone
+      back to portrait" is advice you have already taken. */
+  orientation?: 'landscape' | 'portrait';
+}) {
   const t = useTheme();
+  const portrait = orientation === 'portrait';
   return (
     <View style={[StyleSheet.absoluteFill, { alignItems: 'center', justifyContent: 'center', padding: 24 }]}>
       <Text style={{ color: t.text, fontFamily: mono, fontSize: 15, textAlign: 'center' }}>
@@ -790,10 +807,14 @@ export function LandscapePadTooSmall({ reason, onExit }: { reason: string; onExi
           : 'This screen is too short for the controller.'}
       </Text>
       <Text style={{ color: t.textFaint, fontSize: 13, textAlign: 'center', marginTop: 8 }}>
-        Turn the phone back to portrait to keep playing.
+        {portrait
+          ? 'Try turning the phone sideways, or leave the controller.'
+          : 'Turn the phone back to portrait to keep playing.'}
       </Text>
       <Pressable onPress={onExit} style={{ marginTop: 16, padding: 12 }}>
-        <Text style={{ color: t.blue, fontFamily: mono, fontSize: 13 }}>✕ BACK TO PORTRAIT</Text>
+        <Text style={{ color: t.blue, fontFamily: mono, fontSize: 13 }}>
+          {portrait ? '✕ LEAVE THE CONTROLLER' : '✕ BACK TO PORTRAIT'}
+        </Text>
       </Pressable>
     </View>
   );

--- a/app/hooks/useLockOrientation.ts
+++ b/app/hooks/useLockOrientation.ts
@@ -23,7 +23,9 @@ export type OrientationPolicy =
   /** Let the device decide — the Pad's gamepad mode follows the phone. */
   | 'allow-landscape'
   /** Pinned sideways: the user asked for it with the LOCK button. */
-  | 'landscape-locked';
+  | 'landscape-locked'
+  /** Pinned upright — movement mode's LOCK while held vertically. */
+  | 'portrait-locked';
 
 export function useLockOrientation(policy: OrientationPolicy): void {
   useFocusEffect(
@@ -36,6 +38,13 @@ export function useLockOrientation(policy: OrientationPolicy): void {
             // DEFAULT policy = all orientations (minus upside-down on iOS),
             // so the device's own rotation drives the Pad layout.
             await ScreenOrientation.unlockAsync();
+          } else if (policy === 'portrait-locked') {
+            // The mirror of landscape-locked, for the vertical movement
+            // layout. PORTRAIT_UP (not PORTRAIT): upside-down portrait is
+            // nothing anyone locks into on purpose, and iOS refuses it anyway.
+            await ScreenOrientation.lockAsync(
+              ScreenOrientation.OrientationLock.PORTRAIT_UP,
+            );
           } else if (policy === 'landscape-locked') {
             // LANDSCAPE, not LANDSCAPE_LEFT: both directions stay legal, so the
             // lock never fights the user's grip or which side they turned the

--- a/app/lib/__tests__/padLayout.test.ts
+++ b/app/lib/__tests__/padLayout.test.ts
@@ -35,6 +35,7 @@ import {
   moveLayout,
   NAV,
   navZone,
+  verticalMoveLayout,
   MIN_SHORT_AXIS,
   MIN_TOUCH,
   dpadZone,
@@ -565,6 +566,114 @@ test('REVIEW: expansion is capped — no node grows more than EXPAND_CAP_U per s
         assert.ok(n.hit.x + n.hit.w - (n.rect.x + n.rect.w) <= cap, `${name}/${c.label}: ${n.id} right growth`);
         assert.ok(n.rect.y - n.hit.y <= cap, `${name}/${c.label}: ${n.id} top growth`);
         assert.ok(n.hit.y + n.hit.h - (n.rect.y + n.rect.h) <= cap, `${name}/${c.label}: ${n.id} bottom growth`);
+      }
+    }
+  }
+});
+
+// ---------- Vertical movement mode: portrait axes, same properties ----------
+
+/** Portrait versions of the device table: w/h swapped, notch on TOP (portrait
+ *  is the one orientation where insets.top is the cutout), home bar bottom. */
+function portraitCases(): Case[] {
+  const out: Case[] = [];
+  for (const d of DEVICES) {
+    out.push({
+      label: `${d.name} (portrait)`,
+      win: { width: d.h, height: d.w },
+      insets: { top: d.side, right: 0, bottom: d.bottom, left: 0 },
+      synthetic: d.synthetic ?? false,
+    });
+  }
+  return out;
+}
+
+test('VERTICAL: every property holds on every portrait device', () => {
+  for (const c of portraitCases()) {
+    const l = verticalMoveLayout(c.win, c.insets);
+    // The landscape floor devices are portrait-refusals here only if their
+    // WIDTH (portrait short axis) is under 326 — the S21 (360) passes.
+    if (!l.ok) {
+      assert.ok(c.win.width - c.insets.left - c.insets.right < 326,
+        `${c.label}: refused but wide enough (${c.win.width})`);
+      continue;
+    }
+    for (const n of l.nodes) {
+      assert.ok(contains(l.play, n.rect), `${c.label}: ${n.id} escapes play`);
+      assert.ok(contains(l.play, n.hit), `${c.label}: ${n.id} hit escapes play`);
+      const min = Math.min(n.hit.w, n.hit.h);
+      assert.ok(min >= MIN_TOUCH - 1e-6, `${c.label}: ${n.id} is ${min.toFixed(1)}dp`);
+      if (n.shape === 'circle') assert.equal(n.rect.w, n.rect.h, `${c.label}: ${n.id} ellipse`);
+    }
+    for (let i = 0; i < l.nodes.length; i += 1) {
+      for (let j = i + 1; j < l.nodes.length; j += 1) {
+        assert.ok(!rectsIntersect(l.nodes[i].hit, l.nodes[j].hit),
+          `${c.label}: ${l.nodes[i].id} and ${l.nodes[j].id} share a touch`);
+      }
+    }
+    for (const n of l.nodes) {
+      if (n.layer === 9) continue;
+      const gap = rectGap(l.byId.exit.hit, n.hit);
+      assert.ok(gap >= EXIT_MOAT_U * l.u - 1e-6,
+        `${c.label}: EXIT only ${(gap / l.u).toFixed(1)}U from ${n.id}`);
+    }
+    // NAV sector still the binding angular target.
+    assert.ok(NAV.thicknessU * l.u >= MIN_TOUCH - 1e-6, `${c.label}: NAV sector too thin`);
+    // Expansion cap holds here too.
+    for (const n of l.nodes) {
+      const cap: number = EXPAND_CAP_U * l.u + 1e-6;
+      assert.ok(n.rect.x - n.hit.x <= cap && n.rect.y - n.hit.y <= cap,
+        `${c.label}: ${n.id} over-expanded`);
+    }
+  }
+});
+
+test('VERTICAL: floors bind on the right axes, both directions', () => {
+  const no = { top: 0, right: 0, bottom: 0, left: 0 };
+  // Short axis is WIDTH in portrait.
+  assert.equal(verticalMoveLayout({ width: MIN_SHORT_AXIS - 1, height: 800 }, no).ok, false);
+  assert.equal(verticalMoveLayout({ width: MIN_SHORT_AXIS, height: 800 }, no).ok, true);
+  // Long axis is HEIGHT: refuse a squat window, accept a real phone.
+  const u = MIN_SHORT_AXIS / 100;
+  assert.equal(verticalMoveLayout({ width: MIN_SHORT_AXIS, height: Math.floor(149 * u) }, no).ok, false);
+  assert.equal(verticalMoveLayout({ width: 393, height: 852 }, no).ok, true, 'a normal phone portrait must render');
+});
+
+test('VERTICAL: the zone is the point — over a third of the screen is movement surface', () => {
+  const l = verticalMoveLayout({ width: 393, height: 852 }, { top: 59, right: 0, bottom: 34, left: 0 });
+  assert.ok(l.ok);
+  if (l.ok) {
+    const m = l.byId.move;
+    const share = (m.hit.w * m.hit.h) / (l.play.w * l.play.h);
+    assert.ok(share >= 0.24, `MOVE covers only ${(share * 100).toFixed(0)}% of a phone portrait play area`);
+  }
+});
+
+test('VERTICAL: the table has no variant node — rotation is the path between layouts', () => {
+  const l = verticalMoveLayout({ width: 393, height: 852 }, { top: 0, right: 0, bottom: 0, left: 0 });
+  assert.ok(l.ok);
+  if (l.ok) {
+    assert.deepEqual(
+      l.nodes.map((n) => n.id).sort(),
+      ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start'],
+    );
+  }
+});
+
+test('VERTICAL: capped-u portrait sweep keeps the moat (tablets held upright)', () => {
+  // The vertical mirror of the landscape capped-u band: portrait width > 430
+  // caps u while the height ratio shrinks toward the floor.
+  for (let w = 430; w <= 840; w += 34) {
+    const u = Math.min(w, 430) / 100;
+    for (let hu = 150; hu <= 160; hu += 2) {
+      const h = Math.ceil(hu * u);
+      const l = verticalMoveLayout({ width: w, height: h }, { top: 0, right: 0, bottom: 0, left: 0 });
+      if (!l.ok) continue;
+      for (const n of l.nodes) {
+        if (n.layer === 9) continue;
+        const gap = rectGap(l.byId.exit.hit, n.hit);
+        assert.ok(gap >= EXIT_MOAT_U * l.u - 1e-6,
+          `@ ${w}x${h}: EXIT only ${(gap / l.u).toFixed(2)}U from ${n.id}`);
       }
     }
   }

--- a/app/lib/__tests__/padSurface.test.ts
+++ b/app/lib/__tests__/padSurface.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Surface-change detection — lib/padSurface.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * WHY THIS EXISTS: this predicate is the ONLY thing that releases a held
+ * input when the pad's components are swapped or removed under a finger.
+ * React fires no responder-terminate and no onPressOut on unmount, and the
+ * agent latches the last frame it received on a healthy socket — so a missed
+ * transition here means the game keeps walking with nobody touching the
+ * screen. Two of these cases were shipped bugs found in review, one per
+ * release; both are pinned below.
+ *
+ * This is the safety-critical input path (CLAUDE.md §4).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { surfaceChanged, type PadSurface } from '../padSurface.ts';
+
+const S = (o: Partial<PadSurface> = {}): PadSurface =>
+  ({ mounted: true, mode: 'move', landscape: false, ...o });
+
+test('an unchanged surface releases nothing', () => {
+  // The predicate runs every render; firing on identity would spam the wire.
+  assert.equal(surfaceChanged(S(), S()), false);
+});
+
+test('leaving the pad releases — EXIT, blur, or a window below the floors', () => {
+  assert.equal(surfaceChanged(S({ mounted: true }), S({ mounted: false })), true);
+  assert.equal(surfaceChanged(S({ mounted: false }), S({ mounted: true })), true);
+});
+
+test('a mode switch releases — different components entirely', () => {
+  assert.equal(surfaceChanged(S({ mode: 'move' }), S({ mode: 'gamepad' })), true);
+  assert.equal(surfaceChanged(S({ mode: 'move' }), S({ mode: 'swipe' })), true);
+});
+
+test('REGRESSION: rotating INSIDE move mode releases', () => {
+  // Found in the vertical-mode review. Rotation swaps the vertical table for
+  // the spread one — every PanResponder is remounted — while `mounted` and
+  // `mode` both stay exactly the same. A tuple of those two alone misses it,
+  // and a stick held through the rotation stays pinned on the agent.
+  assert.equal(
+    surfaceChanged(S({ mode: 'move', landscape: false }), S({ mode: 'move', landscape: true })),
+    true,
+  );
+});
+
+test('REGRESSION: a window shrinking below the floors releases', () => {
+  // Found in the movement-mode review. Stage Manager / Android freeform can
+  // shrink a still-landscape window under the layout floors, swapping the pad
+  // for the too-small card. `mounted` folds landGeom.ok in precisely so this
+  // is not invisible to the guard.
+  assert.equal(
+    surfaceChanged(S({ mounted: true, landscape: true }), S({ mounted: false, landscape: true })),
+    true,
+  );
+});
+
+test('CONTROL — the predicate can return false, so the tests above are not vacuous', () => {
+  // If it always returned true every assertion here would pass while proving
+  // nothing. Vary a field the signature deliberately does NOT carry.
+  const a = { ...S(), extra: 1 } as PadSurface;
+  const b = { ...S(), extra: 2 } as PadSurface;
+  assert.equal(surfaceChanged(a, b), false);
+});

--- a/app/lib/padLayout.ts
+++ b/app/lib/padLayout.ts
@@ -315,6 +315,41 @@ const MOVE_TABLE: Spec[] = [
 ];
 
 /**
+ * VERTICAL MOVEMENT MODE — the third table (spec: project_vertical-move-mode.md).
+ *
+ * One-handed, portrait, immersive: the phone in one hand on the couch arm, the
+ * whole interaction is one thumb. Chrome row on top (LOCK/EXIT left-anchored,
+ * START in the far right corner — the moat maths cannot afford both a centred
+ * exit pair AND a right-anchored START inside a 100U-wide row), a right-biased
+ * A/B + NAV band in the thumb's stretch zone, and the bottom half of the
+ * screen is the movement zone.
+ *
+ * IN PORTRAIT, U IS 1% OF THE USABLE WIDTH — the short axis flips. buildLayout
+ * takes the orientation so the floors bind on the right dimensions; everything
+ * else (expansion, moat, 44dp rules) is axis-agnostic and carries unchanged.
+ */
+const VERTICAL_MOVE_TABLE: Spec[] = [
+  // Chrome, LEFT-anchored: EXIT's moat to START (right corner) is what the
+  // 100U row can actually afford. Same adjacency (LOCK then EXIT, 18U pitch)
+  // as the landscape layouts, so the pair still reads as one unit.
+  { id: 'lock', w: 15, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'exit', w: 15, h: 14, cx: { from: 'left', at: 30 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'start', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 10 }, layer: 5 },
+
+  // The thumb band: NAV against the right edge (right-thumb bias), A and B
+  // stacked inboard of it. A is lowest = nearest the thumb's rest.
+  { id: 'nav', w: 33, h: 33, cx: { from: 'right', at: 19 }, cy: { from: 'bottom', at: 69.5 }, layer: 6 },
+  { id: 'b', w: 15, h: 15, cx: { from: 'right', at: 48 }, cy: { from: 'bottom', at: 79 }, layer: 1, shape: 'circle' },
+  { id: 'a', w: 15, h: 15, cx: { from: 'right', at: 48 }, cy: { from: 'bottom', at: 60 }, layer: 1, shape: 'circle' },
+
+  // The movement zone: bottom band, floating origin, left stick. CENTRE-
+  // anchored, not left: on a capped-u tablet the play rect is far wider than
+  // 100U, and a left-anchored fixed-width band leaves a dead strip under the
+  // right thumb — the one this table is biased toward.
+  { id: 'move', w: 94, h: 47, cx: { from: 'centre', at: 0 }, cy: { from: 'bottom', at: 26.5 }, layer: 7 },
+];
+
+/**
  * The 4-way NAV cluster's geometry. Same angular hit test as the d-pad but no
  * centre disc: menus want pure directions, and A is a separate physical
  * button an inch away. A small dead centre returns null — releasing rather
@@ -374,7 +409,29 @@ export function moveLayout(win: Size, insets: Insets): PadLayout {
   return buildLayout(MOVE_TABLE, win, insets);
 }
 
-function buildLayout(table: Spec[], win: Size, insets: Insets): PadLayout {
+/**
+ * Vertical movement mode: portrait, one-handed. The short axis is the WIDTH;
+ * every rule (U, floors, 44dp, moat, expansion cap) binds exactly as in
+ * landscape with the axes swapped.
+ */
+export function verticalMoveLayout(win: Size, insets: Insets): PadLayout {
+  return buildLayout(VERTICAL_MOVE_TABLE, win, insets, 'portrait');
+}
+
+/**
+ * The long-axis floor for the VERTICAL table, in U of width. The content
+ * spans the chrome row (17U) plus the thumb band (nav top at bottom-86U), so
+ * anything under 150U has the bands colliding; every phone is >= ~195U tall
+ * in portrait, so this refuses only split-screen slivers.
+ */
+export const VMIN_LONG_AXIS_U = 150;
+
+function buildLayout(
+  table: Spec[],
+  win: Size,
+  insets: Insets,
+  orientation: 'landscape' | 'portrait' = 'landscape',
+): PadLayout {
   const play: Rect = {
     x: insets.left,
     y: insets.top,
@@ -383,14 +440,20 @@ function buildLayout(table: Spec[], win: Size, insets: Insets): PadLayout {
   };
 
   // Degrade closed, both axes. A cramped controller that half-works is worse
-  // than an honest "turn the phone back".
-  if (play.h < MIN_SHORT_AXIS) return { ok: false, reason: 'too-short' };
+  // than an honest "turn the phone back". In portrait the SHORT axis is the
+  // width and the LONG axis is the height; every rule binds the same way.
+  const short = orientation === 'landscape' ? play.h : play.w;
+  const long = orientation === 'landscape' ? play.w : play.h;
+  if (short < MIN_SHORT_AXIS)
+    return { ok: false, reason: orientation === 'landscape' ? 'too-short' : 'too-narrow' };
 
   // U caps at 4.3 so a tablet gets a BIGGER EMPTY MIDDLE rather than
   // comic-book buttons — the clusters stay thumb-sized and move apart.
-  const u = Math.min(play.h, 430) / 100;
+  const u = Math.min(short, 430) / 100;
 
-  if (play.w / u < MIN_LONG_AXIS_U) return { ok: false, reason: 'too-narrow' };
+  const longFloor = orientation === 'landscape' ? MIN_LONG_AXIS_U : VMIN_LONG_AXIS_U;
+  if (long / u < longFloor)
+    return { ok: false, reason: orientation === 'landscape' ? 'too-narrow' : 'too-short' };
 
   const centreX = play.x + play.w / 2;
 

--- a/app/lib/padSurface.ts
+++ b/app/lib/padSurface.ts
@@ -1,0 +1,32 @@
+/**
+ * When does the pad's touch surface CHANGE UNDER THE FINGERS?
+ *
+ * Pure, so the safety-critical answer is testable without a renderer.
+ *
+ * Every immersive pad surface (both movement tables, the landscape
+ * controller) is built from PanResponders and Pressables whose releases live
+ * in their own callbacks. React fires NEITHER on unmount — no
+ * onPanResponderTerminate, no onPressOut — so any transition that swaps or
+ * removes those components while a finger is down leaves the agent holding
+ * the last frame: a stick axis pinned, a button latched, the character
+ * walking with nobody touching the screen. The socket stays healthy and the
+ * agent zeroes a pad only on demote/teardown, so nothing self-heals.
+ *
+ * The screen therefore calls `client.releaseAll()` whenever this signature
+ * changes. Each field is here because a real transition changes ONLY that one:
+ *
+ *  - `mounted`  the pad is on screen at all (immersive AND focused AND the
+ *               layout fits). Covers EXIT, blur, and a window shrinking below
+ *               the floors while still landscape (found in review).
+ *  - `mode`     PAD <-> MOVE <-> SWIPE: different components entirely.
+ *  - `landscape` inside MOVE, rotation swaps the vertical table for the
+ *               spread one — every surface remounts while `mounted` and
+ *               `mode` both stay put.
+ */
+export type PadSurface = { mounted: boolean; mode: string; landscape: boolean };
+
+export function surfaceChanged(prev: PadSurface, next: PadSurface): boolean {
+  return prev.mounted !== next.mounted
+    || prev.mode !== next.mode
+    || prev.landscape !== next.landscape;
+}

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -168,12 +168,6 @@ export type Prefs = {
   padKeyboardBar: boolean;
   /** Gesture hint text on the swipe/trackpad surfaces. */
   padHints: boolean;
-  /** Landscape full-screen layout: the full controller, or the movement mode
-   *  (one big left-thumb zone + a small menu cluster) for games that are
-   *  mostly continuous movement. Toggled from the pad's own chrome row; a
-   *  pref so the choice survives sessions — someone playing Vampire Survivors
-   *  nightly should not re-toggle every evening. */
-  landscapePadVariant: 'pad' | 'move';
   /** Collapse the pill + mode tabs + button/keyboard rows so the trackpad
    *  surface fills the pane for edge-to-edge scrolling. Trackpad mode only;
    *  a floating chip restores the chrome. */
@@ -299,7 +293,6 @@ export const DEFAULTS: Prefs = {
   padWinShortcuts: true,
   padKeyboardBar: true,
   padHints: true,
-  landscapePadVariant: 'pad',
   padTrackpadLarge: false,
   padLargeToggle: true,
   askToSwitchControl: true,
@@ -417,7 +410,6 @@ function normalize(raw: unknown): Prefs {
     padWinShortcuts: bool(o.padWinShortcuts, DEFAULTS.padWinShortcuts),
     padKeyboardBar: bool(o.padKeyboardBar, DEFAULTS.padKeyboardBar),
     padHints: bool(o.padHints, DEFAULTS.padHints),
-    landscapePadVariant: o.landscapePadVariant === 'move' ? 'move' : 'pad',
     padTrackpadLarge: bool(o.padTrackpadLarge, DEFAULTS.padTrackpadLarge),
     padLargeToggle: bool(o.padLargeToggle, DEFAULTS.padLargeToggle),
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -16,7 +16,7 @@ import type { BoxCaps } from './api';
  * menus (agent >= 2.9.31). Pad filters it out otherwise rather than offering a
  * mode that would open an empty panel.
  */
-export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus' | 'tvnav';
+export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus' | 'tvnav' | 'move';
 
 /**
  * A single paired box (Bazzite media center, Steam Deck, ...). The app manages
@@ -197,6 +197,9 @@ function normalizePadMode(v: unknown): PadMode {
   // streaming apps where arrow keys only scroll. Accepted here so a box saved
   // on it round-trips losslessly, same as 'menus'.
   if (v === 'tvnav') return 'tvnav';
+  // Movement mode (Vampire-Survivors-likes): a real mode since 2.9.39, so a
+  // box saved on it round-trips losslessly like the others.
+  if (v === 'move') return 'move';
   return 'swipe';
 }
 


### PR DESCRIPTION
Owner ask: the movement layout, but portrait and one-handed, entered by a button beside SWIPE, immersive with the same LOCK/EXIT chrome — and (second ask) **the segment only shows while a game is actually running**.

- `move` is now a real `PadMode`, persisted per box; `landscapePadVariant` retired.
- Orientation picks the table inside the mode: portrait = new vertical one-handed layout, landscape = the shipped spread one. `portrait-locked` added; EXIT returns to the previous mode.
- `padLayout` gains a portrait axis (U = 1% of width); the whole property suite runs over the third table, notch-on-top, both floor directions, plus a capped-u tablet moat sweep.

## Review found six, all fixed

The **high** one would have shipped a brick: immersive is derived in a screen that stays mounted, and it was only ever safe because every immersive state required landscape (leaving the tab rotated the window and self-cleared the flag). Portrait MOVE removed that, so a background caps bounce or the tour's cold-start `replace` could strand the app with no tab bar and — with `gestureEnabled: !immersive` — no way back on iOS. Immersive now follows focus.

Also: stale `exited` leaking into move→gamepad (silently wrong screen on iPad), the refusal card telling portrait users to turn the phone to portrait, a dead thumb strip on capped-u tablets, and the release-on-surface-change rule having no test — now pure in `lib/padSurface.ts` with regressions for both transitions past reviews caught.

401/401, tsc clean. **NOT verified:** portrait wire-proof (harness pane stopped accepting synthetic drags; identical paths wire-proven in landscape last release) and device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)