### PR TITLE
release: 2.9.39 (vc 79 / iOS 142) + agent 2.9.72

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.38",
+    "version": "2.9.39",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "141",
+      "buildNumber": "142",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 78
+      "versionCode": 79
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,8 +1,9 @@
-Two ways to play, sideways. Turn the phone on the Pad tab and the controller fills the screen — every stick, button and d-pad spread out like the real thing, with an orientation lock for long sessions. And for games that are mostly about moving — Vampire Survivors and friends — tap ⊕ MOVE for the new Movement mode: one huge thumb zone that works like a left stick, plus just A, B, a menu pad and pause. Nothing to mis-press, nothing in the way.
+Play one-handed. While a game is running, a new MOVE button appears on the Pad tab: tap it and the phone becomes a full-screen movement controller you can hold in one hand — a big steering zone under your thumb, A and B, a menu pad, and pause. Nothing else to mis-press. Turn the phone sideways and it spreads into the wide version; the lock keeps it whichever way you like it.
+
+Built for games that are mostly steering — Vampire Survivors and its kind.
 
 Also in this release:
 • Fixed: on iOS, dragging a stick could swipe you out of the controller
+• The full-screen sideways controller, with every stick and button spread out
 • Use Couchside as a plain TV remote for Roku and Google TV — no PC required
-• Bookmark games (hold a tile) and save your favorite filters as presets
-• See each game's install size, and get a heads-up when a download finishes
-• A guided setup walkthrough — existing users can replay it from Setup
+• Bookmark games, save filter presets, and see each game's install size

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,5 +1,5 @@
-New: Movement mode. Tap ⊕ MOVE on the sideways controller for a huge movement zone plus just the buttons you need — made for games like Vampire Survivors where you mostly steer.
+New: a one-handed MOVE mode. While a game is running, tap MOVE on the Pad tab for a full-screen movement layout you can play with one thumb — big steering zone, just the buttons you need, and a lock so it stays put. Turn the phone sideways for the wide version.
 
-The full-screen controller also arrives in this update: turn the phone sideways on the Pad tab and every stick and button spreads out edge-to-edge, with an orientation lock.
+Made for games like Vampire Survivors where you mostly steer.
 
-Plus: TV remote mode (Roku/Google TV), game bookmarks and filter presets, install sizes, download alerts, and many fixes.
+Also: a fix for iOS where dragging a stick could swipe you out of the controller, plus the full-screen sideways controller from the last update.


### PR DESCRIPTION
Version bump + store notes for the release carrying vertical one-handed MOVE (#379). Signed agent 2.9.72 rides on the same tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)