### PR TITLE
Megabonk auto-theme (appid 3405340)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "144",
+      "buildNumber": "145",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/lib/__tests__/gameTheme.test.ts
+++ b/app/lib/__tests__/gameTheme.test.ts
@@ -196,6 +196,7 @@ test('resolveTheme: OFF is always null', () => {
 
 test('resolveTheme: AUTO follows the running game', () => {
   assert.equal(resolveTheme('auto', 1794680)?.label, 'Dark Gothic'); // VS -> gothic
+  assert.equal(resolveTheme('auto', 3405340)?.label, 'Dark Gothic'); // Megabonk -> gothic
   assert.equal(resolveTheme('auto', 999999), null); // unmapped game
   assert.equal(resolveTheme('auto', null), null);   // nothing running
 });

--- a/app/lib/gameTheme.ts
+++ b/app/lib/gameTheme.ts
@@ -98,6 +98,11 @@ export const THEMES: Readonly<Record<ThemeKey, GameTheme>> = Object.freeze({
  */
 export const APPID_THEMES: Readonly<Record<number, ThemeKey>> = Object.freeze({
   1794680: 'dark-gothic', // Vampire Survivors — appid from its Steam store URL.
+  // Megabonk — appid from Steam's storefront search API (exact-name match),
+  // confirmed installed on the owner's Steam Deck 2026-08-08. A bullet-heaven /
+  // hack-and-slash, same family as VS, so 'auto' gives it the gothic look for
+  // now; its own art skews colourful and it may earn a dedicated theme later.
+  3405340: 'dark-gothic',
 });
 
 /**


### PR DESCRIPTION
One-line auto-map entry: Megabonk (Steam appid 3405340, confirmed first-party + installed on the Deck) auto-selects Dark Gothic. Its art is more colourful than gothic, so a dedicated theme may follow. 16/16 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)