### PR TITLE
release: 2.9.41 (build 146) — Bonk theme

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.40",
+    "version": "2.9.41",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "145",
+      "buildNumber": "146",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 81
+      "versionCode": 82
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,3 @@
-Dress the controller for the game. A new Controller theme picker (Setup) styles the full-screen controller: choose Auto to match the game running on your box, pick Dark Gothic for a candlelit-hall backdrop with gold accents, or turn it Off. More themes arrive with updates.
+More controller themes. The theme picker (Setup) gains Bonk — bright and playful, for colorful games like Megabonk — alongside Dark Gothic. Auto now matches both Vampire Survivors and Megabonk to the right look, or pick a theme to apply it always.
 
-The theme applies to the MOVE and landscape pad — a game-styled backdrop behind the buttons, with the controls kept fully readable.
-
-Also in this release: the one-handed MOVE mode from the last update, and fixes.
+Each theme styles the full-screen controller (MOVE and landscape pad): a game-styled backdrop behind the buttons, with the controls kept fully readable.


### PR DESCRIPTION
Version bump + iOS notes for the Bonk theme + Megabonk auto-mapping. TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)