### PR TITLE
In-controller theme switcher (on-the-fly)

### DIFF
--- a/app/components/LandscapePad.tsx
+++ b/app/components/LandscapePad.tsx
@@ -36,6 +36,7 @@ import type { ButtonKey, StickKey, TriggerKey } from '@/lib/gamepad';
 import { mono, type Palette } from '@/lib/theme';
 import { useControllerTheme } from '@/hooks/useControllerTheme';
 import { GameBackdrop } from '@/components/GameBackdrop';
+import { ThemeSwitcher } from '@/components/ThemeSwitcher';
 
 /** Movement under this is still a tap (matches the swipe surface's rule). */
 const TAP_SLOP = 12;
@@ -789,6 +790,9 @@ export function MovePad({
         accessibilityLabel="Exit full-screen controller"
       />
       <PadKey node={byId.start} label="START" u={u} fontSize={2.8 * u} {...btn('start')} />
+      {/* In-view theme switcher — re-skin the controller on the fly. Rendered
+          LAST so its dropdown overlays every control. */}
+      <ThemeSwitcher node={byId.theme} play={layout.play} u={u} t={t} />
     </View>
   );
 }

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -1,0 +1,162 @@
+/**
+ * In-controller theme switcher: a chrome button in the immersive MOVE view that
+ * opens a dropdown of every theme, so the controller can be re-skinned on the
+ * fly without leaving play.
+ *
+ * The TRIGGER is a layout node ('theme', layer 9) placed by lib/padLayout.ts —
+ * so it is collision- and moat-checked like LOCK/EXIT. The DROPDOWN is an
+ * overlay: it captures touches (a scrim behind it closes on outside-tap) and
+ * lists lib/gameTheme's THEME_PICKER, writing the `controllerTheme` pref on
+ * select. Because the pref drives useControllerTheme, the whole controller
+ * re-skins the instant a row is tapped — including this component's own colours.
+ *
+ * NOTHING here is on the gamepad input path. The trigger and the dropdown are
+ * ordinary Pressables; while the dropdown is open its scrim sits above the game
+ * controls, so a stray drag closes the menu instead of moving the character —
+ * which is the safe failure, not a latched axis.
+ */
+import { useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { hapticSelection as haptic } from '@/lib/haptics';
+import { THEME_PICKER, type ControllerThemePref } from '@/lib/gameTheme';
+import { setPref, usePref } from '@/lib/prefs';
+import type { PadNode, Rect } from '@/lib/padLayout';
+import type { ThemedPalette } from '@/lib/gameTheme';
+
+const abs = (r: Rect) => ({
+  position: 'absolute' as const,
+  left: r.x,
+  top: r.y,
+  width: r.w,
+  height: r.h,
+});
+const inner = (n: PadNode) => ({
+  position: 'absolute' as const,
+  left: n.rect.x - n.hit.x,
+  top: n.rect.y - n.hit.y,
+  width: n.rect.w,
+  height: n.rect.h,
+});
+
+export function ThemeSwitcher({
+  node, play, u, t,
+}: {
+  /** The 'theme' chrome node from the layout. */
+  node: PadNode;
+  /** The play rect, for sizing/placing the dropdown. */
+  play: Rect;
+  u: number;
+  /** The live controller palette (so the switcher re-skins with everything). */
+  t: ThemedPalette;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = usePref('controllerTheme');
+
+  const pick = (value: ControllerThemePref) => {
+    haptic();
+    void setPref('controllerTheme', value);
+    setOpen(false);
+  };
+
+  // Dropdown geometry: a panel just below the trigger, left-aligned to it,
+  // clamped inside the play rect. Sized in U so it matches the controls.
+  const rowH = 13 * u;
+  const panelW = Math.min(40 * u, play.w - 8 * u);
+  const panelX = Math.min(node.rect.x, play.x + play.w - panelW - 4 * u);
+  const panelY = node.rect.y + node.rect.h + 3 * u;
+  const panelH = Math.min(THEME_PICKER.length * rowH + 4 * u, play.h - panelY - 4 * u);
+
+  return (
+    <>
+      {/* Trigger */}
+      <Pressable
+        style={abs(node.hit)}
+        onPress={() => {
+          haptic();
+          setOpen((v) => !v);
+        }}
+        accessibilityRole="button"
+        accessibilityLabel="Switch controller theme"
+        accessibilityState={{ expanded: open }}>
+        <View
+          style={[
+            inner(node),
+            {
+              borderRadius: 2.5 * u,
+              borderWidth: 1,
+              borderColor: open ? t.blue : t.cardBorder,
+              backgroundColor: t.card,
+              alignItems: 'center',
+              justifyContent: 'center',
+            },
+          ]}>
+          <Text style={{ color: open ? t.blue : t.textFaint, fontSize: 4 * u }}>🎨</Text>
+        </View>
+      </Pressable>
+
+      {/* Dropdown overlay */}
+      {open ? (
+        <>
+          {/* Full-screen scrim: outside-tap closes. Sits above the controls so a
+              stray touch dismisses the menu rather than driving the game. */}
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={() => setOpen(false)}
+            accessibilityLabel="Close theme menu"
+          />
+          <View
+            style={{
+              position: 'absolute',
+              left: panelX,
+              top: panelY,
+              width: panelW,
+              maxHeight: panelH,
+              backgroundColor: t.card,
+              borderColor: t.cardBorder,
+              borderWidth: 1,
+              borderRadius: 3 * u,
+              overflow: 'hidden',
+            }}>
+            <ScrollView>
+              {THEME_PICKER.map((opt) => {
+                const active = opt.value === current;
+                return (
+                  <Pressable
+                    key={opt.value}
+                    onPress={() => pick(opt.value)}
+                    accessibilityRole="menuitem"
+                    accessibilityState={{ selected: active }}
+                    accessibilityLabel={opt.label}
+                    style={({ pressed }) => [
+                      {
+                        height: rowH,
+                        paddingHorizontal: 4 * u,
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        backgroundColor: pressed || active ? t.cardBorder : 'transparent',
+                      },
+                    ]}>
+                    <Text
+                      style={{
+                        color: active ? t.blue : t.text,
+                        fontSize: 3.6 * u,
+                        fontWeight: active ? '700' : '400',
+                      }}
+                      numberOfLines={1}>
+                      {opt.label}
+                    </Text>
+                    {active ? (
+                      <Text style={{ color: t.blue, fontSize: 3.6 * u }}>●</Text>
+                    ) : null}
+                  </Pressable>
+                );
+              })}
+            </ScrollView>
+          </View>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/app/components/ThemeSwitcher.tsx
+++ b/app/components/ThemeSwitcher.tsx
@@ -15,8 +15,8 @@
  * controls, so a stray drag closes the menu instead of moving the character —
  * which is the safe failure, not a latched axis.
  */
-import { useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useMemo, useState } from 'react';
+import { PanResponder, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
 import { hapticSelection as haptic } from '@/lib/haptics';
 import { THEME_PICKER, type ControllerThemePref } from '@/lib/gameTheme';
@@ -52,6 +52,27 @@ export function ThemeSwitcher({
 }) {
   const [open, setOpen] = useState(false);
   const current = usePref('controllerTheme');
+
+  // The scrim must be a MODAL BARRIER, not just a tap target. A plain
+  // Pressable's onPress fires only on a quick tap, so a DRAG that started on
+  // the scrim would slip past it — and the movement zone's PanResponder claims
+  // on MOVE (onMoveShouldSetPanResponder: true), so that drag could steer the
+  // character while the menu is open. This responder claims the touch on
+  // START, before the stick can, and closes the menu on release. Rendered
+  // above the controls (see JSX), so it wins the negotiation for any touch
+  // that lands outside the panel.
+  const scrim = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        // Hold the touch: nothing below may steal a drag that began on the scrim.
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderRelease: () => setOpen(false),
+        onPanResponderTerminate: () => setOpen(false),
+      }),
+    [],
+  );
 
   const pick = (value: ControllerThemePref) => {
     haptic();
@@ -98,11 +119,12 @@ export function ThemeSwitcher({
       {/* Dropdown overlay */}
       {open ? (
         <>
-          {/* Full-screen scrim: outside-tap closes. Sits above the controls so a
-              stray touch dismisses the menu rather than driving the game. */}
-          <Pressable
+          {/* Full-screen modal scrim: any touch (tap OR drag) closes the menu
+              and is consumed here, so a stray drag can never reach the movement
+              zone below while the dropdown is open. */}
+          <View
             style={StyleSheet.absoluteFill}
-            onPress={() => setOpen(false)}
+            {...scrim.panHandlers}
             accessibilityLabel="Close theme menu"
           />
           <View

--- a/app/lib/__tests__/padLayout.test.ts
+++ b/app/lib/__tests__/padLayout.test.ts
@@ -478,7 +478,7 @@ test('MOVE: the move table contains exactly what the mode needs, nothing else', 
   const l = ok(moveLayout({ width: 852, height: 393 }, { top: 0, right: 0, bottom: 21, left: 59 }));
   assert.deepEqual(
     l.nodes.map((n) => n.id).sort(),
-    ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start', 'variant'],
+    ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start', 'theme', 'variant'],
   );
 });
 
@@ -655,7 +655,7 @@ test('VERTICAL: the table has no variant node — rotation is the path between l
   if (l.ok) {
     assert.deepEqual(
       l.nodes.map((n) => n.id).sort(),
-      ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start'],
+      ['a', 'b', 'exit', 'lock', 'move', 'nav', 'start', 'theme'],
     );
   }
 });

--- a/app/lib/padLayout.ts
+++ b/app/lib/padLayout.ts
@@ -52,7 +52,7 @@ export type PadNodeId =
   // Movement mode (moveLayout): the big left-thumb zone, the 4-way menu
   // cluster, and the PAD/MOVE toggle that lives in the chrome row of BOTH
   // layouts.
-  | 'move' | 'nav' | 'variant';
+  | 'move' | 'nav' | 'variant' | 'theme';
 
 export type PadNode = {
   id: PadNodeId;
@@ -296,6 +296,7 @@ const MOVE_TABLE: Spec[] = [
   // under the thumb that just pressed it. START joins the row (pause is
   // deliberate, out-of-the-way) — its main-table slot at row 2 doesn't exist
   // here.
+  { id: 'theme', w: 15, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'variant', w: 15, h: 14, cx: { from: 'centre', at: -29 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'lock', w: 15, h: 14, cx: { from: 'centre', at: -11 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'exit', w: 15, h: 14, cx: { from: 'centre', at: 7 }, cy: { from: 'top', at: 10 }, layer: 9 },
@@ -334,6 +335,7 @@ const VERTICAL_MOVE_TABLE: Spec[] = [
   // as the landscape layouts, so the pair still reads as one unit.
   { id: 'lock', w: 15, h: 14, cx: { from: 'left', at: 12 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'exit', w: 15, h: 14, cx: { from: 'left', at: 30 }, cy: { from: 'top', at: 10 }, layer: 9 },
+  { id: 'theme', w: 15, h: 14, cx: { from: 'centre', at: 0 }, cy: { from: 'top', at: 10 }, layer: 9 },
   { id: 'start', w: 18, h: 14, cx: { from: 'right', at: 12 }, cy: { from: 'top', at: 10 }, layer: 5 },
 
   // The thumb band: NAV against the right edge (right-thumb bias), A and B


### PR DESCRIPTION
A 🎨 button in the MOVE controller opens a dropdown of all themes; tap one and the controller re-skins live (accent + tints + backdrop), no Setup trip, no reload. Trigger is a geometry-checked chrome node; dropdown scrim closes on stray drag (safe failure). 420 tests, harness-verified the live swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)