### PR TITLE
release: 2.9.42 (vc 83 / iOS 148) — theme library

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.41",
+    "version": "2.9.42",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "147",
+      "buildNumber": "148",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 82
+      "versionCode": 83
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,3 +1,3 @@
-More controller themes. The theme picker (Setup) gains Bonk — bright and playful, for colorful games like Megabonk — alongside Dark Gothic. Auto now matches both Vampire Survivors and Megabonk to the right look, or pick a theme to apply it always.
+35 controller themes. The theme picker (Setup) now offers a big library — Dark Gothic, Bonk, Cyberpunk Rain, Toxic Slime Lab, Coral Reef, Arcane Observatory and many more — each with its own full-screen backdrop behind the buttons.
 
-Each theme styles the full-screen controller (MOVE and landscape pad): a game-styled backdrop behind the buttons, with the controls kept fully readable.
+New: switch themes on the fly. A palette button right inside the full-screen MOVE controller opens a theme menu, so you can re-skin without leaving play. Auto still matches Vampire Survivors and Megabonk to a fitting look.

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,5 +1,3 @@
-New: a one-handed MOVE mode. While a game is running, tap MOVE on the Pad tab for a full-screen movement layout you can play with one thumb — big steering zone, just the buttons you need, and a lock so it stays put. Turn the phone sideways for the wide version.
+35 controller themes. The Setup theme picker now offers a big library — Dark Gothic, Bonk, Cyberpunk Rain, Toxic Slime Lab and many more — each with its own full-screen backdrop behind the buttons.
 
-Made for games like Vampire Survivors where you mostly steer.
-
-Also: a fix for iOS where dragging a stick could swipe you out of the controller, plus the full-screen sideways controller from the last update.
+New: a palette button inside the full-screen MOVE controller switches themes on the fly, no trip to Setup. Auto matches Vampire Survivors and Megabonk to a fitting look. Plus the one-handed MOVE mode and fixes.


### PR DESCRIPTION
35 controller themes + the on-the-fly switcher. Full chain: App Store review + Play at 80%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)