### PR TITLE
release: 2.9.42 fixed backdrop + reconcile vc 84 / iOS 149

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "148",
+      "buildNumber": "149",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 83
+      "versionCode": 84
     },
     "web": {
       "bundler": "metro",

--- a/app/components/GameBackdrop.tsx
+++ b/app/components/GameBackdrop.tsx
@@ -18,7 +18,7 @@
  *
  * Nothing here is on the input path; it is pure decoration under the controls.
  */
-import { ImageBackground, StyleSheet, View, type ImageSourcePropType } from 'react-native';
+import { Image, StyleSheet, View, type ImageSourcePropType } from 'react-native';
 
 import { backdropAssets } from '@/lib/gameThemeAssets';
 import type { Backdrop } from '@/lib/gameTheme';
@@ -58,16 +58,26 @@ export function GameBackdrop({
   const assets = backdropAssets(backdrop.key);
 
   // ART path.
+  //
+  // A bare <Image> at absoluteFill + cover, NOT <ImageBackground>. ImageBackground
+  // sizes its inner image from an onLayout MEASUREMENT of its container, then
+  // stamps that as a numeric width/height. On native (iOS), the immersive/rotation
+  // transition measured the container once at a non-final size and never
+  // re-measured, so the art filled only a top band with BASE showing below —
+  // invisible in the web harness, where ImageBackground is a CSS `cover` div that
+  // always fills. A bare Image at absoluteFill covers the parent directly at
+  // layout time with no measurement step. The Scrim is a following sibling, so it
+  // still sits on top. (Same pattern the launch-tile art uses, device-proven.)
   if (assets) {
     const source = landscape ? assets.landscape : assets.portrait;
     return (
       <View style={[StyleSheet.absoluteFill, { backgroundColor: BASE }]} pointerEvents="none">
-        <ImageBackground
+        <Image
           source={source as ImageSourcePropType}
-          style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}
-          resizeMode="cover">
-          <Scrim />
-        </ImageBackground>
+          style={StyleSheet.absoluteFill}
+          resizeMode="cover"
+        />
+        <Scrim />
       </View>
     );
   }


### PR DESCRIPTION
Two things for the 2.9.42 rebuild:

1. **fix(app): themed backdrop fills the screen on native.** `ImageBackground` collapsed the art to its intrinsic aspect (a top band, BASE navy below) on device — invisible in the web harness. Root cause read straight from RN's `ImageBackground.js` (it re-applies width/height from the container style, and `absoluteFill` has none). Swapped to a bare `<Image absoluteFill cover>`, the device-proven launch-tile pattern.
2. **release: reconcile to vc 84 / iOS build 149** — autoIncrement at the first 2.9.42 build kicks. Committing these so the rebuild autoIncrements to 150 / vc 85, above the already-uploaded (broken) 149 / 84 so the stores accept them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)