### PR TITLE
release: reconcile to iOS 150 / vc 89 (2.9.42 backdrop-fix rebuild)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "148",
+      "buildNumber": "149",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 83
+      "versionCode": 84
     },
     "web": {
       "bundler": "metro",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "149",
+      "buildNumber": "150",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 84
+      "versionCode": 89
     },
     "web": {
       "bundler": "metro",

--- a/app/components/GameBackdrop.tsx
+++ b/app/components/GameBackdrop.tsx
@@ -18,7 +18,7 @@
  *
  * Nothing here is on the input path; it is pure decoration under the controls.
  */
-import { ImageBackground, StyleSheet, View, type ImageSourcePropType } from 'react-native';
+import { Image, StyleSheet, View, type ImageSourcePropType } from 'react-native';
 
 import { backdropAssets } from '@/lib/gameThemeAssets';
 import type { Backdrop } from '@/lib/gameTheme';
@@ -58,16 +58,26 @@ export function GameBackdrop({
   const assets = backdropAssets(backdrop.key);
 
   // ART path.
+  //
+  // A bare <Image> at absoluteFill + cover, NOT <ImageBackground>. ImageBackground
+  // sizes its inner image from an onLayout MEASUREMENT of its container, then
+  // stamps that as a numeric width/height. On native (iOS), the immersive/rotation
+  // transition measured the container once at a non-final size and never
+  // re-measured, so the art filled only a top band with BASE showing below —
+  // invisible in the web harness, where ImageBackground is a CSS `cover` div that
+  // always fills. A bare Image at absoluteFill covers the parent directly at
+  // layout time with no measurement step. The Scrim is a following sibling, so it
+  // still sits on top. (Same pattern the launch-tile art uses, device-proven.)
   if (assets) {
     const source = landscape ? assets.landscape : assets.portrait;
     return (
       <View style={[StyleSheet.absoluteFill, { backgroundColor: BASE }]} pointerEvents="none">
-        <ImageBackground
+        <Image
           source={source as ImageSourcePropType}
-          style={[StyleSheet.absoluteFill, { pointerEvents: 'none' }]}
-          resizeMode="cover">
-          <Scrim />
-        </ImageBackground>
+          style={StyleSheet.absoluteFill}
+          resizeMode="cover"
+        />
+        <Scrim />
       </View>
     );
   }


### PR DESCRIPTION
The first 2.9.42 (iOS 149 / vc 84) carried a native-only themed-backdrop bug (ImageBackground collapsed the art to a top band; fine in the web harness, broken on device). Pulled iOS from review, halted Play at 80%, fixed (bare `<Image>`, PR #393), and rebuilt on cloud: **iOS build 150** in App Store review, **Android vc 89** rolling out at 80%. This records the actually-shipped build numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)