### PR TITLE
feat: install a game you own but haven't downloaded (Steam, no API key)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -565,6 +565,14 @@ jobs:
       - name: Unit tests (steam cover art)
         run: python3 tests/test_steam_cover_art.py
 
+      # Install a game you own but have not downloaded. Adds a NEW client-supplied
+      # -appid path (install:<appid>), so these tests assert the allowlist rules:
+      # installed games are NOT installable (control), tools/non-digit dirs are
+      # excluded, an unowned appid is refused with nothing run, the argv is the
+      # agent's constant + a digits-only appid, and the enumeration degrades closed.
+      - name: Unit tests (steam install — owned-but-uninstalled)
+        run: python3 tests/test_steam_install.py
+
       # _unreadable_reason() — why a controller cannot be read. The app used to
       # tell every affected user to re-run install.sh, which on a Legion Go S
       # cannot work: a POSIX ACL grants the user, and mode 000 collapses the

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.73
+
+**Install a game you own but haven't downloaded.** Couchside can now list the
+Steam games in your library that aren't on the box yet and start the download
+from your phone. It reads the library your Steam client already cached on disk —
+no Steam account, no API key, nothing leaves the box — and hands the install to
+Steam itself, so it only ever installs a game you actually own. Needs the app
+that ships alongside this agent; older apps simply don't show the new section.
+
 ## 2.9.72
 
 **Per-game install size.** Each Steam game now reports how much disk it is

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.72"
+VERSION = "2.9.73"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -16832,6 +16832,20 @@ class Handler(BaseHTTPRequestHandler):
                 # The app percent-encodes the id (encodeURIComponent turns the
                 # "steam:"/"custom:" colon into %3A), so decode before matching.
                 launcher_id = unquote(path[len(lprefix):])
+                # --mock/harness: _launcher_argv gates install:<appid> on the real
+                # on-disk library, which the mock box does not have. Validate against
+                # the mock installable set instead so the harness can exercise the
+                # install PRESS end-to-end. Same allowlist shape, mock data.
+                if self.mock and launcher_id.startswith("install:"):
+                    appid = launcher_id[len("install:"):]
+                    if not (appid.isdigit()
+                            and int(appid) in {g["appid"] for g in MOCK_INSTALLABLE}):
+                        self._send(404, {"ok": False,
+                                         "error": "unknown launcher"}, started)
+                        return
+                    self._send(200, mock_launch(
+                        ["steam", "steam://install/%s" % appid]), started)
+                    return
                 argv = _launcher_argv(launcher_id)
                 if argv is None:
                     self._send(404, {"ok": False,

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1579,7 +1579,7 @@ def set_caps(mock):
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
                  "screensaver", "couchmode", "bigpicture", "desktop",
-                 "steamlink", "gaming",
+                 "steamlink", "gaming", "steaminstall",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player")}
         return
@@ -1599,6 +1599,11 @@ def set_caps(mock):
         "desktop": safe(desktop_available),
         "steamlink": safe(steamlink_available),
         "gaming": safe(gaming_available),
+        # Owned-but-uninstalled library + install action. Steam present is enough:
+        # the enumeration reads appcache/librarycache/ off the same root. Advertised
+        # as its own cap so old apps ignore it and new apps feature-detect the
+        # /api/steam/installable + install:<appid> pair (both absent pre-2.9.73).
+        "steaminstall": _steam_root() is not None,
         "streamhost": safe(streamhost_available),
         "steammenus": safe(steammenus_available),
         "boxbattery": safe(box_battery_available),
@@ -6465,6 +6470,98 @@ def discover_steam_games():
 
 
 # ---------------------------------------------------------------------------
+# Owned-but-uninstalled Steam games (GET /api/steam/installable + install:<appid>).
+#
+# Steam only writes an appmanifest for INSTALLED games, so discover_steam_games()
+# cannot see a game you own but have not downloaded. But the client caches library
+# ART for the whole library under appcache/librarycache/<appid>/ — MEASURED on
+# bazzite 2026-08-08: 1117 appids cached vs 12 installed. That directory listing IS
+# the owned-library enumeration, with NO Steam Web API key and no account: the box
+# only reads its own disk. It OVERCOUNTS (tools/DLC/demos, plus any store page whose
+# art the client rendered), so it is NOT authoritative ownership — the app filters
+# the DISPLAY to type=game via the keyless store lookup, and steam://install itself
+# is the final gate (Steam refuses to install an app the account does not own).
+#
+# This set is ALSO the allowlist for the install action: install:<appid> is refused
+# unless <appid> is in it, so a client can only ever trigger an install of a game
+# already in THIS box's library cache — never an arbitrary appid off the LAN.
+# ---------------------------------------------------------------------------
+_INSTALLABLE_TTL = 30.0
+_INSTALLABLE_CACHE = {"root": None, "at": 0.0, "val": None}
+_INSTALLABLE_LOCK = threading.Lock()
+
+
+def _installed_appids(root):
+    """Set of appid strings that have an appmanifest on disk (installed/installing).
+
+    Filename-only: the appid is the digits between `appmanifest_` and `.acf`, so
+    this is O(# installed) stats with no parsing. Read-only; never raises."""
+    out = set()
+    for steamapps in _steam_libraries_cached(root):
+        try:
+            for mf in glob.glob(os.path.join(steamapps, "appmanifest_*.acf")):
+                aid = os.path.basename(mf)[len("appmanifest_"):-len(".acf")]
+                if aid.isdigit():
+                    out.add(aid)
+        except Exception:
+            continue
+    return out
+
+
+def _installable_appids():
+    """Set of owned-but-uninstalled Steam appid strings, from the library art cache.
+
+    = digit-named subdirs of appcache/librarycache/  MINUS installed  MINUS known
+    Steam tools. Read-only, best-effort, and it DEGRADES CLOSED — no root, an
+    unreadable cache, or any error yields an EMPTY set, never "everything" (a
+    "fail-open" allowlist here would let any appid install). Cached for
+    _INSTALLABLE_TTL seconds, keyed on the root so a changed root invalidates it.
+
+    This is the allowlist the install action gates on: an appid not in here is not
+    installable (404), so no client-supplied appid reaches steam://install unless
+    the box's own library cache already lists it.
+    """
+    root = _steam_root()
+    if root is None:
+        return set()
+    now = time.monotonic()
+    with _INSTALLABLE_LOCK:
+        c = _INSTALLABLE_CACHE
+        if (c["val"] is not None and c["root"] == root
+                and now - c["at"] <= _INSTALLABLE_TTL):
+            return set(c["val"])
+    try:
+        entries = os.listdir(os.path.join(root, "appcache", "librarycache"))
+    except OSError:
+        entries = []
+    except Exception:
+        entries = []
+    cached = {e for e in entries if e.isdigit()}
+    installed = _installed_appids(root)
+    val = {a for a in cached if a not in installed and a not in STEAM_TOOL_APPIDS}
+    with _INSTALLABLE_LOCK:
+        _INSTALLABLE_CACHE.update(root=root, at=now, val=set(val))
+    return val
+
+
+def _installable_games():
+    """[{"appid": int}] for owned-but-uninstalled games, sorted by appid.
+
+    NAMES are deliberately omitted: the box has no reliable OFFLINE name for an
+    uninstalled game (appinfo.vdf is a partial cache), and inventing one is worse
+    than none — the app resolves names app-side from the KEYLESS store endpoint and
+    filters to type=game there. Art, when present, is already on disk and served by
+    the existing GET /api/steam/<appid>/cover for any appid, installed or not."""
+    return [{"appid": int(a)}
+            for a in sorted(_installable_appids(), key=lambda a: int(a))]
+
+
+# Mock owned-but-uninstalled list for the web harness / --mock. Real appids so the
+# app's keyless store-name lookup resolves recognisable titles when exercised.
+MOCK_INSTALLABLE = [{"appid": a} for a in (220, 400, 620, 292030, 570)]
+
+
+# ---------------------------------------------------------------------------
 # Steam Remote Play — in-home streaming (/api/steamlink).
 #
 # The box's Steam client can stream games FROM another Steam machine on the LAN
@@ -7274,6 +7371,21 @@ def _launcher_argv(launcher_id):
         # offers it is online; if not, the rungameid is a harmless no-op.
         if appid in _streamable_appids():
             return ["steam", "steam://rungameid/%s" % appid]
+        return None
+    if launcher_id.startswith("install:"):
+        appid = launcher_id[len("install:"):]
+        if not appid.isdigit():
+            return None
+        # Install a game you OWN but have not downloaded. Gated on the
+        # owned-but-uninstalled allowlist (_installable_appids, built from this
+        # box's own library art cache) — the client's appid selects a member of
+        # that set and NEVER reaches the command line as anything but a validated
+        # integer; the argv is the agent's own constant + that integer. steam://
+        # install is Steam's own flow, which refuses an app the account does not
+        # own, so an appid that slips through the (deliberately loose) library
+        # cache is a no-op, not a wrong install.
+        if appid in _installable_appids():
+            return ["steam", "steam://install/%s" % appid]
         return None
     if launcher_id.startswith("shortcut:"):
         appid = launcher_id[len("shortcut:"):]
@@ -16029,6 +16141,13 @@ class Handler(BaseHTTPRequestHandler):
                                                else list_launchers()),
                                  "create_enabled": bool(ALLOW_APP_LAUNCHERS)},
                            started)
+            elif path == "/api/steam/installable":
+                # Owned-but-uninstalled Steam games (appids only; the app resolves
+                # names + type app-side from the keyless store endpoint and pulls
+                # art from GET /api/steam/<appid>/cover). Read-only; an empty list
+                # when Steam or the library cache is absent — degrades closed.
+                games = (MOCK_INSTALLABLE if self.mock else _installable_games())
+                self._send(200, {"games": games, "count": len(games)}, started)
             elif path == "/api/session/default":
                 # Read-only. Always 200 with available=false rather than 404 so
                 # the app can tell "old agent" (404) from "this box has no

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -680,6 +680,9 @@ function LaunchScreen() {
   // This screen just reads the result.
   const { downloads, changeTick } = useDownloads();
   const dlByAppid = useMemo(() => new Map(downloads.map((d) => [d.appid, d])), [downloads]);
+  // Appids currently downloading — the InstallableSection drops these (a just-approved
+  // install has moved into the Downloads list above, so it should not show in both).
+  const downloadingAppids = useMemo(() => new Set(downloads.map((d) => d.appid)), [downloads]);
 
   // ---- Steam Remote Play "Stream from PC" (probe-and-appear; 404 -> null) ----
   const sl = usePoll<SteamLink | null>(
@@ -912,7 +915,7 @@ function LaunchScreen() {
 
         {/* Install a game you own but haven't downloaded (hidden unless the box can:
             caps.steaminstall / agent >= 2.9.73). Collapsed by default. */}
-        <InstallableSection caps={activeBox?.caps} />
+        <InstallableSection caps={activeBox?.caps} downloadingAppids={downloadingAppids} />
 
         {/* Stream from PC (hidden when no host / agent < 2.9.23) */}
         {steamlink?.available && (

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -24,6 +24,7 @@ import {
 
 import { Gated } from '@/components/Gated';
 import { GameSheet } from '@/components/GameSheet';
+import { InstallableSection } from '@/components/InstallableSection';
 import { useCompat } from '@/hooks/useCompat';
 import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
@@ -908,6 +909,10 @@ function LaunchScreen() {
 
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
         <DownloadsSection downloads={downloads} />
+
+        {/* Install a game you own but haven't downloaded (hidden unless the box can:
+            caps.steaminstall / agent >= 2.9.73). Collapsed by default. */}
+        <InstallableSection caps={activeBox?.caps} />
 
         {/* Stream from PC (hidden when no host / agent < 2.9.23) */}
         {steamlink?.available && (

--- a/app/components/InstallableSection.tsx
+++ b/app/components/InstallableSection.tsx
@@ -1,0 +1,220 @@
+/**
+ * "Install from your library" — the Launch-tab section for games you OWN but have
+ * not downloaded (Phase 2 of the ROADMAP "Install a game you own..." entry).
+ *
+ * The BOX enumerates the owned-but-uninstalled library from its own disk with no
+ * Steam key (agent /api/steam/installable, gated by caps.steaminstall). It returns
+ * APPIDS ONLY — it has no reliable offline name for an uninstalled game — so:
+ *   - ART comes from the box (api.steamCoverSource; the capsule carries the title).
+ *   - NAME + TYPE come app-side from Valve's keyless store endpoint (lib/steamStore),
+ *     which shares the compat-lookups opt-in because it hits the same host and an
+ *     appid list is a signal about what you own. Off => a one-line prompt, not a
+ *     silent empty section.
+ *   - type=game filters out the tools/DLC/demos the art cache overcounts.
+ * Installing hands `install:<appid>` to the agent, which re-checks it against the
+ * same owned set and fires steam://install — Steam's own owned-only flow.
+ *
+ * Probe-and-appear: renders nothing when the box can't do it (cap false, or a 404
+ * from an older agent), so an old box or a Windows box is simply unaffected.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, Image, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { api, type BoxCaps } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
+import { useSettings } from '@/lib/SettingsContext';
+import { fetchAppDetailsMany } from '@/lib/steamStore';
+import { isInstallableGameType, type AppDetails } from '@/lib/steamStoreParse';
+import { useThemedStyles, type Palette } from '@/lib/theme';
+
+/** Cross-platform confirm (Alert buttons are no-ops on web). */
+function confirmInstall(label: string, onConfirm: () => void) {
+  if (Platform.OS === 'web') {
+    // eslint-disable-next-line no-alert
+    if (typeof window !== 'undefined' && window.confirm(`Install "${label}" on your box?`)) {
+      onConfirm();
+    }
+    return;
+  }
+  Alert.alert('Install game', `Download and install "${label}" on your box?`, [
+    { text: 'Cancel', style: 'cancel' },
+    { text: 'Install', onPress: onConfirm },
+  ]);
+}
+
+function Tile({ appid, name }: { appid: number; name: string }) {
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const source = api.steamCoverSource(settings, appid);
+  const [failed, setFailed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  useEffect(() => setFailed(false), [source.uri]);
+
+  const install = () => {
+    hapticLight();
+    confirmInstall(name, async () => {
+      setBusy(true);
+      try {
+        const res = await api.launch(settings, `install:${appid}`);
+        if (Platform.OS !== 'web') {
+          Alert.alert(
+            res?.ok ? 'Installing' : "Couldn't start install",
+            res?.ok
+              ? `"${name}" is downloading on your box — watch it in Downloads above.`
+              : `The box refused the install for "${name}".`,
+          );
+        }
+      } finally {
+        setBusy(false);
+      }
+    });
+  };
+
+  return (
+    <Pressable
+      style={styles.tile}
+      onPress={install}
+      disabled={busy}
+      accessibilityRole="button"
+      accessibilityLabel={`Install ${name}`}>
+      {!failed ? (
+        <Image source={source} style={styles.cover} resizeMode="cover" onError={() => setFailed(true)} />
+      ) : (
+        <View style={[styles.cover, styles.coverFallback]}>
+          <Ionicons name="cloud-download-outline" size={22} color="#8aa" />
+        </View>
+      )}
+      <Text style={styles.tileLabel} numberOfLines={2}>{name}</Text>
+      <View style={styles.badge}>
+        {busy ? (
+          <ActivityIndicator size="small" />
+        ) : (
+          <Ionicons name="cloud-download-outline" size={14} color="#fff" />
+        )}
+      </View>
+    </Pressable>
+  );
+}
+
+export function InstallableSection({ caps }: { caps?: BoxCaps }) {
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const lookupsOn = usePref('compatLookups');
+  const [appids, setAppids] = useState<number[] | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [details, setDetails] = useState<Record<number, AppDetails | null>>({});
+  const [resolving, setResolving] = useState(false);
+
+  // Cap false = box can't; don't even probe. Undefined/true = probe the endpoint,
+  // which 404s on an older agent and hides the section (setAppids stays null).
+  const canProbe = caps?.steaminstall !== false;
+
+  useEffect(() => {
+    if (!canProbe) return;
+    let live = true;
+    void (async () => {
+      const res = await api.installable(settings);
+      if (live) setAppids(res && res.games.length ? res.games.map((g) => g.appid) : null);
+    })();
+    return () => {
+      live = false;
+    };
+  }, [settings, canProbe]);
+
+  // Resolve names/types only once expanded AND lookups are on — never reach the
+  // store on the user's behalf without the opt-in.
+  const abortRef = useRef<{ aborted: boolean }>({ aborted: false });
+  useEffect(() => {
+    abortRef.current.aborted = true; // cancel any prior run
+    if (!expanded || !lookupsOn || !appids) return;
+    const signal = { aborted: false };
+    abortRef.current = signal;
+    setResolving(true);
+    void fetchAppDetailsMany(
+      appids,
+      (appid, d) => {
+        if (!signal.aborted) setDetails((prev) => ({ ...prev, [appid]: d }));
+      },
+      signal,
+    ).finally(() => {
+      if (!signal.aborted) setResolving(false);
+    });
+    return () => {
+      signal.aborted = true;
+    };
+  }, [expanded, lookupsOn, appids]);
+
+  if (!canProbe || !appids) return null;
+
+  const games = appids
+    .filter((id) => isInstallableGameType(details[id]))
+    .map((id) => ({ id, name: details[id]!.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <View style={styles.wrap}>
+      <Pressable
+        style={styles.header}
+        onPress={() => {
+          hapticLight();
+          setExpanded((v) => !v);
+        }}
+        accessibilityRole="button"
+        accessibilityState={{ expanded }}>
+        <Ionicons name="cloud-download-outline" size={16} style={styles.headerIcon} />
+        <Text style={styles.headerTitle}>Not installed</Text>
+        <Text style={styles.headerCount}>{appids.length} in your library</Text>
+        <Ionicons name={expanded ? 'chevron-up' : 'chevron-down'} size={16} style={styles.headerChevron} />
+      </Pressable>
+
+      {expanded ? (
+        !lookupsOn ? (
+          <Text style={styles.note}>
+            Turn on game lookups in Prefs to see titles and install games from your library.
+          </Text>
+        ) : (
+          <>
+            <View style={styles.grid}>
+              {games.map((g) => (
+                <Tile key={g.id} appid={g.id} name={g.name} />
+              ))}
+            </View>
+            {resolving ? (
+              <View style={styles.resolvingRow}>
+                <ActivityIndicator size="small" />
+                <Text style={styles.note}>
+                  Finding games in your library… {games.length} so far.
+                </Text>
+              </View>
+            ) : games.length === 0 ? (
+              <Text style={styles.note}>No installable games found in your library.</Text>
+            ) : null}
+          </>
+        )
+      ) : null}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { marginTop: 8, marginBottom: 4 },
+    header: { flexDirection: 'row', alignItems: 'center', paddingVertical: 10, gap: 8 },
+    headerIcon: { color: t.textFaint },
+    headerTitle: { color: t.text, fontWeight: '700', fontSize: 14 },
+    headerCount: { color: t.textFaint, fontSize: 12, marginLeft: 'auto' },
+    headerChevron: { color: t.textFaint, marginLeft: 8 },
+    note: { color: t.textFaint, fontSize: 12, paddingVertical: 8, lineHeight: 18 },
+    grid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, paddingTop: 4 },
+    tile: { width: 92, alignItems: 'center' },
+    cover: { width: 92, height: 138, borderRadius: 8, backgroundColor: t.card },
+    coverFallback: { alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: t.cardBorder },
+    tileLabel: { color: t.text, fontSize: 11, textAlign: 'center', marginTop: 4, width: 92 },
+    badge: {
+      position: 'absolute', top: 6, right: 6, width: 24, height: 24, borderRadius: 12,
+      backgroundColor: 'rgba(0,0,0,0.6)', alignItems: 'center', justifyContent: 'center',
+    },
+    resolvingRow: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingTop: 6 },
+  });

--- a/app/components/InstallableSection.tsx
+++ b/app/components/InstallableSection.tsx
@@ -29,16 +29,21 @@ import { fetchAppDetailsMany } from '@/lib/steamStore';
 import { isInstallableGameType, type AppDetails } from '@/lib/steamStoreParse';
 import { useThemedStyles, type Palette } from '@/lib/theme';
 
+// steam://install does NOT silently download — VERIFIED on hardware 2026-08-08: it pops
+// Steam's install PROMPT on the box's screen, and the download only starts once someone
+// APPROVES it there. So the copy says "approve on your box", never "downloading now", and a
+// tapped tile stays in a "waiting for approval" state until the box reports the download
+// (at which point the section drops it — it has moved to the Downloads list above).
+
 /** Cross-platform confirm (Alert buttons are no-ops on web). */
 function confirmInstall(label: string, onConfirm: () => void) {
+  const q = `Install "${label}"? A prompt appears on your box's screen to approve it — use a controller, or your phone's Pad.`;
   if (Platform.OS === 'web') {
     // eslint-disable-next-line no-alert
-    if (typeof window !== 'undefined' && window.confirm(`Install "${label}" on your box?`)) {
-      onConfirm();
-    }
+    if (typeof window !== 'undefined' && window.confirm(q)) onConfirm();
     return;
   }
-  Alert.alert('Install game', `Download and install "${label}" on your box?`, [
+  Alert.alert('Install game', q, [
     { text: 'Cancel', style: 'cancel' },
     { text: 'Install', onPress: onConfirm },
   ]);
@@ -50,6 +55,10 @@ function Tile({ appid, name }: { appid: number; name: string }) {
   const source = api.steamCoverSource(settings, appid);
   const [failed, setFailed] = useState(false);
   const [busy, setBusy] = useState(false);
+  // Set once the box has accepted the install request. The prompt is now on the box's
+  // screen; the tile shows "Approve on box" until the download appears (then the section
+  // filters this tile out). It does NOT mean "installed".
+  const [requested, setRequested] = useState(false);
   useEffect(() => setFailed(false), [source.uri]);
 
   const install = () => {
@@ -58,11 +67,12 @@ function Tile({ appid, name }: { appid: number; name: string }) {
       setBusy(true);
       try {
         const res = await api.launch(settings, `install:${appid}`);
+        if (res?.ok) setRequested(true);
         if (Platform.OS !== 'web') {
           Alert.alert(
-            res?.ok ? 'Installing' : "Couldn't start install",
+            res?.ok ? 'Approve it on your box' : "Couldn't start install",
             res?.ok
-              ? `"${name}" is downloading on your box — watch it in Downloads above.`
+              ? `A prompt for "${name}" is on your box's screen — approve it (a controller, or your phone's Pad) to start the download. It shows in Downloads once it begins.`
               : `The box refused the install for "${name}".`,
           );
         }
@@ -76,9 +86,9 @@ function Tile({ appid, name }: { appid: number; name: string }) {
     <Pressable
       style={styles.tile}
       onPress={install}
-      disabled={busy}
+      disabled={busy || requested}
       accessibilityRole="button"
-      accessibilityLabel={`Install ${name}`}>
+      accessibilityLabel={requested ? `${name}, waiting for approval on your box` : `Install ${name}`}>
       {!failed ? (
         <Image source={source} style={styles.cover} resizeMode="cover" onError={() => setFailed(true)} />
       ) : (
@@ -87,18 +97,27 @@ function Tile({ appid, name }: { appid: number; name: string }) {
         </View>
       )}
       <Text style={styles.tileLabel} numberOfLines={2}>{name}</Text>
+      {requested ? <Text style={styles.tileHint} numberOfLines={1}>Approve on box…</Text> : null}
       <View style={styles.badge}>
         {busy ? (
           <ActivityIndicator size="small" />
         ) : (
-          <Ionicons name="cloud-download-outline" size={14} color="#fff" />
+          <Ionicons name={requested ? 'hourglass-outline' : 'cloud-download-outline'} size={14} color="#fff" />
         )}
       </View>
     </Pressable>
   );
 }
 
-export function InstallableSection({ caps }: { caps?: BoxCaps }) {
+export function InstallableSection({
+  caps, downloadingAppids,
+}: {
+  caps?: BoxCaps;
+  /** Appids the box is currently downloading (from the Launch tab's download watcher).
+   *  Once an approved install starts, its game moves to the Downloads list above, so it
+   *  is dropped from this grid rather than shown in both places. */
+  downloadingAppids?: Set<number>;
+}) {
   const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
   const lookupsOn = usePref('compatLookups');
@@ -149,6 +168,7 @@ export function InstallableSection({ caps }: { caps?: BoxCaps }) {
   if (!canProbe || !appids) return null;
 
   const games = appids
+    .filter((id) => !downloadingAppids?.has(id)) // already downloading -> in Downloads above
     .filter((id) => isInstallableGameType(details[id]))
     .map((id) => ({ id, name: details[id]!.name }))
     .sort((a, b) => a.name.localeCompare(b.name));
@@ -212,6 +232,7 @@ const makeStyles = (t: Palette) =>
     cover: { width: 92, height: 138, borderRadius: 8, backgroundColor: t.card },
     coverFallback: { alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: t.cardBorder },
     tileLabel: { color: t.text, fontSize: 11, textAlign: 'center', marginTop: 4, width: 92 },
+    tileHint: { color: t.amber, fontSize: 10, textAlign: 'center', marginTop: 2, width: 92 },
     badge: {
       position: 'absolute', top: 6, right: 6, width: 24, height: 24, borderRadius: 12,
       backgroundColor: 'rgba(0,0,0,0.6)', alignItems: 'center', justifyContent: 'center',

--- a/app/lib/__tests__/steamStoreParse.test.ts
+++ b/app/lib/__tests__/steamStoreParse.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Steam store metadata parsing — lib/steamStoreParse.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * The name + type of an owned-but-uninstalled game come from Valve's keyless
+ * appdetails endpoint. A wrong parse would either mislabel a game or, worse, let a
+ * Steam tool/DLC through the type=game filter and offer it as something to install.
+ * These assert the response shape (keyed by appid string, wrapped in success/data),
+ * that a failed lookup is `null` not a guess, and that only type "game" installs.
+ *
+ * Payload shapes are the real ones from store.steampowered.com/api/appdetails
+ * ?appids=<id>&filters=basic (trimmed to the fields parsed).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseAppDetails, isInstallableGameType } from '../steamStoreParse.ts';
+
+test('parses a real game entry', () => {
+  const body = { '620': { success: true, data: { type: 'game', name: 'Portal 2', steam_appid: 620 } } };
+  assert.deepEqual(parseAppDetails(620, body), { name: 'Portal 2', type: 'game' });
+});
+
+test('keys strictly by the requested appid string', () => {
+  const body = { '620': { success: true, data: { type: 'game', name: 'Portal 2' } } };
+  // Asking for a different appid than the one present must not borrow its data.
+  assert.equal(parseAppDetails(400, body), null);
+});
+
+test('success:false (delisted / region-locked) is null, not an error', () => {
+  assert.equal(parseAppDetails(999999, { '999999': { success: false } }), null);
+});
+
+test('a tool/DLC keeps its real type so the filter can drop it', () => {
+  const dlc = { '323180': { success: true, data: { type: 'dlc', name: "A Game's Soundtrack" } } };
+  const tool = { '228980': { success: true, data: { type: 'tool', name: 'Steamworks Common Redistributables' } } };
+  assert.equal(parseAppDetails(323180, dlc)?.type, 'dlc');
+  assert.equal(parseAppDetails(228980, tool)?.type, 'tool');
+});
+
+test('missing name or type is null (never a guessed value)', () => {
+  assert.equal(parseAppDetails(1, { '1': { success: true, data: { type: 'game' } } }), null);
+  assert.equal(parseAppDetails(1, { '1': { success: true, data: { name: 'X' } } }), null);
+});
+
+test('garbage bodies degrade to null, never throw', () => {
+  for (const bad of [null, undefined, 42, 'nope', {}, { '620': null }, { '620': { success: true } }]) {
+    assert.equal(parseAppDetails(620, bad), null);
+  }
+});
+
+test('only type "game" is installable', () => {
+  assert.equal(isInstallableGameType({ name: 'Portal 2', type: 'game' }), true);
+  assert.equal(isInstallableGameType({ name: 'Soundtrack', type: 'dlc' }), false);
+  assert.equal(isInstallableGameType({ name: 'Runtime', type: 'tool' }), false);
+  assert.equal(isInstallableGameType(null), false);
+  assert.equal(isInstallableGameType(undefined), false);
+});

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -187,6 +187,15 @@ export type BoxCaps = {
    * older agents and on Windows, so undefined reads as "unknown, probe".
    */
   player?: boolean;
+  /**
+   * Install a game you OWN but have not downloaded (agent >= 2.9.73): the box can
+   * enumerate the owned-but-uninstalled library from Steam's local art cache and
+   * fire steam://install for one. Gates the Launch tab's "Not installed" section.
+   * Linux-only — it reads appcache/librarycache off the Steam root. Optional:
+   * absent on older agents and on Windows, so undefined reads as "unknown, probe"
+   * and only an explicit false skips the request.
+   */
+  steaminstall?: boolean;
 };
 
 /**
@@ -1136,7 +1145,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.file_upload === b.file_upload &&
     a.session_default === b.session_default &&
     a.display_info === b.display_info &&
-    a.player === b.player
+    a.player === b.player &&
+    a.steaminstall === b.steaminstall
   );
 }
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1600,6 +1600,23 @@ export const api = {
   },
 
   /**
+   * Owned-but-uninstalled Steam games (agent >= 2.9.73, gated by caps.steaminstall).
+   * Appids only — the box has no reliable offline name for an uninstalled game, so
+   * the app resolves names + type app-side from the keyless store endpoint (see
+   * lib/steamStore.ts) and pulls art from coverArt(appid). Probe-and-appear:
+   * resolves null on a 404 (older agent / no route) so the section stays hidden.
+   * To INSTALL one, call launch(settings, `install:${appid}`) — the agent gates it
+   * against this same set and hands steam://install to the client.
+   */
+  installable(
+    settings: ConnSettings,
+  ): Promise<{ games: { appid: number }[]; count: number } | null> {
+    return probeOrNull(
+      request<{ games: { appid: number }[]; count: number }>(
+        settings, '/api/steam/installable'));
+  },
+
+  /**
    * In-progress Steam downloads/updates. Probe-and-appear: resolves null on a
    * 404 (agent < 2.8 or no route) so the Launch tab hides the section; a 200
    * with an empty list also means "nothing pending".

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -273,11 +273,17 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // capsEqual) and the cap never persists, so the Watch tab re-probes
   // /api/player on every launch.
   const player = bool('player');
+  // steaminstall arrived with agent 2.9.73 (install a game you own but haven't
+  // downloaded) — same optional-cap drop trap as every key above it: omit it here
+  // (and from capsEqual) and the cap never persists, so the Launch "Not installed"
+  // section re-probes /api/steam/installable on every launch.
+  const steaminstall = bool('steaminstall');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
+    steaminstall,
   };
 }
 

--- a/app/lib/steamStore.ts
+++ b/app/lib/steamStore.ts
@@ -1,0 +1,154 @@
+/**
+ * Fetching + caching Steam store metadata (name + type) per appid. Parsing lives in
+ * ./steamStoreParse and is tested in bare Node; this file is the part that touches
+ * the network.
+ *
+ * SAME posture as lib/compatFetch (read that first): this leaves the PHONE, never
+ * the box; it is gated by the caller on the SAME opt-in the compat lookups use
+ * (Prefs > game lookups), because it hits the same host (store.steampowered.com)
+ * and an appid list is a signal about what you own. What is sent is one appid; what
+ * is not sent is anything identifying — no account, no Steam key, no device id.
+ *
+ * CACHED HARD: a game's name and type essentially never change, so this caches for
+ * 30 days on device, clearable. Re-asking the store on every scroll would be slow
+ * and would burn Valve's rate limit (~200 requests / 5 min) for nothing.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+import { parseAppDetails, type AppDetails } from './steamStoreParse';
+
+const KEY = 'couchside.steamstore.v1';
+/** Names/types are effectively static; a month is generous and quiet. */
+const TTL_MS = 30 * 24 * 60 * 60 * 1000;
+/** Politeness cap against Valve's rate limit — a big library resolves in waves. */
+const CONCURRENCY = 3;
+
+type Entry = AppDetails & { at: number };
+type Store = Record<string, Entry>;
+
+let mem: Store | null = null;
+const inflight = new Map<number, Promise<AppDetails | null>>();
+
+async function storageGet(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(k)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function storageSet(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch {
+      // storage unavailable: the cache lives in memory for this session
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+async function load(): Promise<Store> {
+  if (mem) return mem;
+  try {
+    const raw = await storageGet(KEY);
+    mem = raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    mem = {};
+  }
+  return mem;
+}
+
+function persist(): void {
+  if (mem) void storageSet(KEY, JSON.stringify(mem));
+}
+
+/** Forget every cached name/type. Paired with the lookups opt-out. */
+export async function clearSteamStoreCache(): Promise<void> {
+  mem = {};
+  await storageSet(KEY, JSON.stringify(mem));
+}
+
+async function getJson(url: string, timeoutMs: number): Promise<unknown | null> {
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ctl.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    return (await res.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** Name + type for one appid, from cache when fresh. Null = unknown (never throws).
+ *  A null is cached too, so an app the store won't describe is not re-asked every
+ *  scroll — stored as a tombstone with an empty name that load() treats as a miss
+ *  only after the TTL. */
+export async function fetchAppDetails(
+  appid: number,
+  timeoutMs = 8000,
+): Promise<AppDetails | null> {
+  const store = await load();
+  const hit = store[String(appid)];
+  if (hit && Date.now() - hit.at < TTL_MS) {
+    return hit.name ? { name: hit.name, type: hit.type } : null;
+  }
+  const running = inflight.get(appid);
+  if (running) return running;
+
+  const job = (async (): Promise<AppDetails | null> => {
+    const body = await getJson(
+      `https://store.steampowered.com/api/appdetails?appids=${appid}&filters=basic`,
+      timeoutMs,
+    );
+    const out = parseAppDetails(appid, body);
+    const s = await load();
+    // Cache the miss as a tombstone (empty name) so it isn't re-fetched constantly.
+    s[String(appid)] = { name: out?.name ?? '', type: out?.type ?? '', at: Date.now() };
+    persist();
+    return out;
+  })().finally(() => inflight.delete(appid));
+
+  inflight.set(appid, job);
+  return job;
+}
+
+/**
+ * Resolve a batch, `CONCURRENCY` at a time, reporting each as it lands so the grid
+ * fills in progressively and stays usable while it runs. Cached appids resolve with
+ * no request. Aborts cleanly when the caller navigates away.
+ */
+export async function fetchAppDetailsMany(
+  appids: number[],
+  onEach: (appid: number, d: AppDetails | null) => void,
+  signal?: { aborted: boolean },
+): Promise<void> {
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      if (signal?.aborted) return;
+      const i = next++;
+      if (i >= appids.length) return;
+      const id = appids[i];
+      try {
+        onEach(id, await fetchAppDetails(id));
+      } catch {
+        onEach(id, null);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, appids.length || 1) }, worker),
+  );
+}

--- a/app/lib/steamStoreParse.ts
+++ b/app/lib/steamStoreParse.ts
@@ -1,0 +1,57 @@
+/**
+ * Parsing Steam's public store metadata (name + type) for a Steam appid.
+ *
+ * Phase 2 of "install a game you own but have not downloaded". The BOX enumerates
+ * the owned-but-uninstalled library from its own disk (no key, no account — see the
+ * agent's _installable_appids), but it has no reliable OFFLINE NAME for an
+ * uninstalled game (appinfo.vdf is a partial cache). Names + type come from Valve's
+ * own KEYLESS store endpoint, app-side:
+ *
+ *   store.steampowered.com/api/appdetails?appids=<id>&filters=basic
+ *
+ * NO Steam Web API key and no account — the same public per-appid metadata anyone
+ * gets ("what is game 620"), the same host lib/compatFetch already uses. `type` is
+ * what lets the grid drop the tools/DLC/demos that the library art cache overcounts
+ * and show only games.
+ *
+ * ZERO runtime imports on purpose (like lib/compat.ts): this module only PARSES, so
+ * a wrong parse — which would mislabel or hide a game the user owns — is testable in
+ * bare Node against captured payloads. The fetching + caching live in ./steamStore.
+ *
+ * THE HONESTY RULE: a payload we cannot read is `null` (unknown), never a guessed
+ * name or type. The grid keeps unknown-type entries out of the "games" filter rather
+ * than inventing "game", and shows the box's own capsule art (which carries the
+ * title) so an unresolved tile is still recognisable.
+ */
+
+export type AppDetails = {
+  /** The store display name. */
+  name: string;
+  /** Steam's app type: "game" | "dlc" | "tool" | "demo" | "music" | "application" | … */
+  type: string;
+};
+
+/**
+ * Parse one appid out of an appdetails response body. The endpoint keys the result
+ * by the appid as a STRING and wraps it in `{success, data}`, so `success !== true`
+ * (a delisted or region-locked app) is `null`, not an error. Never throws.
+ */
+export function parseAppDetails(appid: number, body: unknown): AppDetails | null {
+  if (!body || typeof body !== 'object') return null;
+  const rec = (body as Record<string, unknown>)[String(appid)];
+  if (!rec || typeof rec !== 'object') return null;
+  const r = rec as { success?: unknown; data?: unknown };
+  if (r.success !== true || !r.data || typeof r.data !== 'object') return null;
+  const d = r.data as { name?: unknown; type?: unknown };
+  const name = typeof d.name === 'string' ? d.name.trim() : '';
+  const type = typeof d.type === 'string' ? d.type.toLowerCase() : '';
+  if (!name || !type) return null;
+  return { name, type };
+}
+
+/** Is this an app the user would actually install as a GAME (not a tool/DLC/demo)?
+ *  Unknown type does NOT pass — the grid shows games it can identify and leaves the
+ *  rest out rather than presenting a Steam runtime as something to install. */
+export function isInstallableGameType(d: AppDetails | null | undefined): boolean {
+  return !!d && d.type === 'game';
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,8 +193,10 @@ becomes the allowlist.
   keyless store lookup; (b) the unchanged "started an install and left" notify gap — an
   install is long/failable/bandwidth-heavy from a device that will not be watching
   (`useDownloadWatch.ts` covers progress only while foregrounded).
-- **Next step is Phase 2 (code), not another spike.** Build the enumeration endpoint + the
-  gated install, still UI-last.
+- **✅ BUILT & VERIFIED 2026-08-08 (agent 2.9.73 + app) — see the Completed entry below.**
+  The design record above is kept for history; the shipped shape matches it (a read-only
+  `/api/steam/installable` enumerating `appcache/librarycache/` minus installed minus tools,
+  gated `install:<appid>` in `_launcher_argv`, keyless app-side names, cap `steaminstall`).
 
 ### Remote-only mode: an "Apps" launcher grid (the TV's installed apps)
 - **priority:** P2 · **risk:** low · **affects:** app only (lib/tvdirect + the Remote tab) ·
@@ -881,6 +883,26 @@ recommendation was wrong, not merely superseded.
 ---
 
 ## ✅ Completed
+
+### Install a game you own but have not downloaded — BUILT 2026-08-08 (agent 2.9.73 + app)
+- **was:** P2 Planned (owner ask 2026-08-07) · **affects:** agent + app · the design record
+  and the Problem-1 spike are under the Planned section above (kept for history)
+- **The owned-but-uninstalled library is enumerable with NO Steam API key** — the agent lists
+  digit-named subdirs of `appcache/librarycache/` MINUS installed MINUS tools
+  (`_installable_appids`, degrades closed). Hardware-verified on bazzite: 1104 owned-uninstalled
+  vs 12 installed, installed ∩ installable = 0.
+- **The install is gated on that set.** `install:<appid>` in `_launcher_argv` (mirrors
+  `stream:<appid>`) validates the appid against `_installable_appids()` then hands the fixed
+  `steam://install/<appid>` to Steam — reuses the existing launch fire path, no new POST route,
+  no client string on the command line. A non-owned/non-digit appid is 404, nothing runs.
+- **App:** a cap-gated ("Not installed") Launch section; appids from `/api/steam/installable`,
+  art from the box's existing cover endpoint, name + type from Valve's KEYLESS store appdetails
+  app-side (same opt-in + host as compat lookups, `type=game` drops the tools/DLC the art cache
+  overcounts). New cap `steaminstall` (six sites). Verified end-to-end in the harness: tile
+  press → `POST /api/launchers/install:400 → 200`.
+- **Not verified:** the real `steam://install` FIRE on the box (would download a multi-GB game)
+  and in-browser store name-resolution (browser CORS; works via native fetch on device, like
+  compat lookups). Ledger [[steam-owned-library-enumeration]].
 
 ### Per-game controller themes + in-controller switcher — SHIPPED 2.9.40 → 2.9.42
 - **was:** P3 Planned (owner ask 2026-08-07) · **affects:** app only (agent already

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -900,9 +900,15 @@ recommendation was wrong, not merely superseded.
   app-side (same opt-in + host as compat lookups, `type=game` drops the tools/DLC the art cache
   overcounts). New cap `steaminstall` (six sites). Verified end-to-end in the harness: tile
   press → `POST /api/launchers/install:400 → 200`.
-- **Not verified:** the real `steam://install` FIRE on the box (would download a multi-GB game)
-  and in-browser store name-resolution (browser CORS; works via native fetch on device, like
-  compat lookups). Ledger [[steam-owned-library-enumeration]].
+- **Phase 3 — behavior verified on hardware + honest feedback (2026-08-08):** fired real
+  installs on bazzite — `steam://install/<appid>` pops Steam's install PROMPT on the box's
+  screen; the download only starts once someone APPROVES it there (a controller, or the phone's
+  own Pad), then it flows to `/api/downloads` → the Downloads list. So it is NOT one-tap-to-
+  download; the app copy now says "approve on your box's screen", a tapped tile shows
+  "Approve on box…", and a game the box is downloading drops out of "Not installed".
+- **Not verified:** completing a real `steam://install` to 100% on the box (test cancelled to
+  save bandwidth) and in-browser store name-resolution (browser CORS; native fetch on device is
+  fine, like compat lookups). Ledger [[steam-owned-library-enumeration]].
 
 ### Per-game controller themes + in-controller switcher — SHIPPED 2.9.40 → 2.9.42
 - **was:** P3 Planned (owner ask 2026-08-07) · **affects:** app only (agent already

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -186,6 +186,7 @@
       "gaming",
       "player",
       "session_default",
+      "steaminstall",
       "steamlink",
       "steammenus",
       "streamhost"

--- a/tests/test_steam_install.py
+++ b/tests/test_steam_install.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Tests for "install a game you own but have not downloaded" (Phase 2, agent side).
+
+Run: python3 tests/test_steam_install.py
+
+WHAT THIS GUARDS. The feature adds a NEW client-supplied-appid path — exactly the
+shape CLAUDE.md §3 warns about — so the security-critical properties are asserted,
+not assumed:
+
+  1. The install allowlist is `_installable_appids()`: digit-named subdirs of
+     appcache/librarycache/ MINUS installed MINUS known tools. An INSTALLED game is
+     NOT installable (the control below), a tool is excluded, and a non-digit dir is
+     ignored.
+  2. `install:<appid>` is REFUSED unless the appid is in that set — a non-owned
+     appid returns None (-> 404), and NOTHING runs.
+  3. When it is allowed, the argv is the agent's own constant + a digits-only appid:
+     ["steam", "steam://install/<appid>"]. No client string reaches the command line
+     as anything but a validated integer, and there is no shell.
+  4. Degrade CLOSED: no Steam root -> empty allowlist, never "everything".
+
+The enumeration reads Steam's own on-disk art cache — NO Steam Web API key, no
+account (measured on bazzite 2026-08-08: 1117 cached appids vs 12 installed).
+"""
+import http.client
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import ThreadingHTTPServer
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+TOKEN = "test-secret-token"
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _clear_caches():
+    # Fresh roots per fixture already differ, but the install/lib caches are keyed
+    # on root+time; clear them so a within-test install change is never masked.
+    cs._INSTALLABLE_CACHE.update(root=None, at=0.0, val=None)
+    cs._STEAM_LIB_CACHE.update(root=None, at=0.0, val=None)
+
+
+class Root:
+    """A fake Steam root the REAL code walks: some INSTALLED games (appmanifests)
+    and a LIBRARY art cache (librarycache/<appid>/) that is a superset of them."""
+
+    def __init__(self, installed=(), cached=()):
+        self.dir = tempfile.mkdtemp(prefix="steaminstall-")
+        steamapps = os.path.join(self.dir, "steamapps")
+        os.makedirs(steamapps)
+        for appid in installed:
+            with open(os.path.join(steamapps, "appmanifest_%s.acf" % appid), "w") as f:
+                f.write('"AppState"\n{\n\t"appid"\t\t"%s"\n\t"name"\t\t"Game %s"\n}\n'
+                        % (appid, appid))
+        cache = os.path.join(self.dir, "appcache", "librarycache")
+        os.makedirs(cache)
+        for entry in cached:
+            d = os.path.join(cache, entry)
+            os.makedirs(d, exist_ok=True)
+            # A cached library entry carries art; give it a header so hasArt-style
+            # probes (and the cover endpoint) see a real file.
+            with open(os.path.join(d, "header.jpg"), "wb") as f:
+                f.write(b"\xff\xd8\xff")
+        self._old = cs._steam_root
+        cs._steam_root = lambda: self.dir
+        _clear_caches()
+
+    def close(self):
+        cs._steam_root = self._old
+        _clear_caches()
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+print("\n_installable_appids — the allowlist")
+# ---------------------------------------------------------------------------
+
+def test_excludes_installed_and_tools():
+    """The core rule: owned-but-uninstalled = cached MINUS installed MINUS tools."""
+    print("test_excludes_installed_and_tools")
+    # 440 installed; 620 + 570 owned-uninstalled; 228980 is a known tool; "junk"
+    # is not an appid. 440 is ALSO in the cache (installed games are, too).
+    r = Root(installed=["440"], cached=["440", "620", "570", "228980", "junk"])
+    try:
+        got = cs._installable_appids()
+        check("owned-uninstalled set", got, {"620", "570"})
+        check("installed 440 NOT installable (control)", "440" in got, False)
+        check("tool 228980 excluded", "228980" in got, False)
+        check("non-digit 'junk' ignored", "junk" in got, False)
+    finally:
+        r.close()
+
+
+def test_ignores_non_digit_dirs():
+    print("test_ignores_non_digit_dirs")
+    r = Root(installed=[], cached=["620", "not-an-id", "12ab", ""])
+    try:
+        check("only the pure-digit dir", cs._installable_appids(), {"620"})
+    finally:
+        r.close()
+
+
+def test_degrades_closed_no_root():
+    """No Steam at all must be an EMPTY allowlist, never 'everything'."""
+    print("test_degrades_closed_no_root")
+    old = cs._steam_root
+    cs._steam_root = lambda: None
+    _clear_caches()
+    try:
+        check("no root -> empty set", cs._installable_appids(), set())
+    finally:
+        cs._steam_root = old
+        _clear_caches()
+
+
+def test_installable_games_shape():
+    """List is [{'appid': int}] sorted by appid — no invented names."""
+    print("test_installable_games_shape")
+    r = Root(installed=["440"], cached=["440", "620", "570"])
+    try:
+        got = cs._installable_games()
+        check("sorted, appid-only", got, [{"appid": 570}, {"appid": 620}])
+    finally:
+        r.close()
+
+
+# ---------------------------------------------------------------------------
+print("\n_launcher_argv('install:<appid>') — the gate")
+# ---------------------------------------------------------------------------
+
+def test_install_owned_builds_fixed_argv():
+    print("test_install_owned_builds_fixed_argv")
+    r = Root(installed=["440"], cached=["440", "620"])
+    try:
+        argv = cs._launcher_argv("install:620")
+        check("argv is the fixed shape", argv, ["steam", "steam://install/620"])
+    finally:
+        r.close()
+
+
+def test_install_installed_game_refused_control():
+    """CONTROL: an INSTALLED game is not installable, so install:<it> is refused.
+    (Without this control, an allowlist that accidentally returned installed games
+    too would still pass every other test.)"""
+    print("test_install_installed_game_refused_control")
+    r = Root(installed=["440"], cached=["440", "620"])
+    try:
+        check("install:440 (installed) -> None", cs._launcher_argv("install:440"), None)
+    finally:
+        r.close()
+
+
+def test_install_unowned_refused_nothing_built():
+    print("test_install_unowned_refused_nothing_built")
+    r = Root(installed=["440"], cached=["440", "620"])
+    try:
+        check("install:999999 (not in library) -> None",
+              cs._launcher_argv("install:999999"), None)
+    finally:
+        r.close()
+
+
+def test_install_nondigit_refused():
+    """Reject rather than sanitise (CLAUDE.md §3.6)."""
+    print("test_install_nondigit_refused")
+    r = Root(installed=[], cached=["620"])
+    try:
+        for bad in ("install:../440", "install:6 20", "install:", "install:abc",
+                    "install:620/../440"):
+            check("%r -> None" % bad, cs._launcher_argv(bad), None)
+    finally:
+        r.close()
+
+
+def test_argv_has_no_shell_and_only_a_digit_slot():
+    """The only client-derived part of the argv is a validated integer."""
+    print("test_argv_has_no_shell_and_only_a_digit_slot")
+    r = Root(installed=[], cached=["620"])
+    try:
+        argv = cs._launcher_argv("install:620")
+        check("argv[0] is the fixed binary", argv[0], "steam")
+        check("argv[1] is constant + digits", argv[1], "steam://install/620")
+        check("no shell metachars in the url", any(c in argv[1] for c in ";|&$`>"), False)
+        check("exactly two args", len(argv), 2)
+    finally:
+        r.close()
+
+
+# ---------------------------------------------------------------------------
+print("\nHTTP: GET /api/steam/installable + POST /api/launchers/install:<id>")
+# ---------------------------------------------------------------------------
+
+def _server(root_dir):
+    cs._steam_root = lambda: root_dir
+    _clear_caches()
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = False
+    cs.Handler.port = 0
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _req(port, method, path, token=TOKEN):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    headers = {"Authorization": "Bearer " + token} if token is not None else {}
+    conn.request(method, path, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(data or b"{}")
+    except ValueError:
+        return resp.status, {}
+
+
+def test_http_endpoints():
+    print("test_http_endpoints")
+    r = Root(installed=["440"], cached=["440", "620", "570"])
+    old = cs._steam_root
+    srv, port = _server(r.dir)
+    try:
+        # Happy path: the owned-uninstalled list, appids only.
+        status, body = _req(port, "GET", "/api/steam/installable")
+        check("GET installable -> 200", status, 200)
+        check("count", body.get("count"), 2)
+        check("games sorted appid-only", body.get("games"),
+              [{"appid": 570}, {"appid": 620}])
+
+        # Auth failure: no bearer -> 401 (same gate as every other /api route).
+        check("no bearer -> 401", _req(port, "GET", "/api/steam/installable",
+                                       token=None)[0], 401)
+        check("wrong bearer -> 401", _req(port, "GET", "/api/steam/installable",
+                                          token="nope")[0], 401)
+
+        # Unknown-input rejection: install a game NOT in the library -> 404, and by
+        # construction nothing is launched (the argv resolver returns None first).
+        st, bd = _req(port, "POST", "/api/launchers/install:999999")
+        check("install unowned -> 404", st, 404)
+        check("404 body says unknown", bd.get("error"), "unknown launcher")
+
+        # An INSTALLED game is also not installable -> 404 (control, over the wire).
+        check("install an installed game -> 404",
+              _req(port, "POST", "/api/launchers/install:440")[0], 404)
+    finally:
+        srv.shutdown()
+        cs._steam_root = old
+        r.close()
+
+
+# ---------------------------------------------------------------------------
+print("\ncap wiring")
+# ---------------------------------------------------------------------------
+
+def test_cap_present_in_mock_and_real():
+    print("test_cap_present_in_mock_and_real")
+    cs.set_caps(True)
+    check("mock CAPS has steaminstall=True", cs.CAPS.get("steaminstall"), True)
+    # real: with a Steam root present the cap is True; with none, False.
+    r = Root(installed=[], cached=["620"])
+    try:
+        cs.set_caps(False)
+        check("real CAPS steaminstall True when steam present",
+              cs.CAPS.get("steaminstall"), True)
+    finally:
+        r.close()
+    old = cs._steam_root
+    cs._steam_root = lambda: None
+    try:
+        cs.set_caps(False)
+        check("real CAPS steaminstall False when no steam",
+              cs.CAPS.get("steaminstall"), False)
+    finally:
+        cs._steam_root = old
+
+
+if __name__ == "__main__":
+    for fn in (test_excludes_installed_and_tools,
+               test_ignores_non_digit_dirs,
+               test_degrades_closed_no_root,
+               test_installable_games_shape,
+               test_install_owned_builds_fixed_argv,
+               test_install_installed_game_refused_control,
+               test_install_unowned_refused_nothing_built,
+               test_install_nondigit_refused,
+               test_argv_has_no_shell_and_only_a_digit_slot,
+               test_http_endpoints,
+               test_cap_present_in_mock_and_real):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
Phase 2 of the ROADMAP "Install a game you own but have not downloaded" entry — the owned-but-uninstalled Steam library, browsable and installable from the phone, with **no Steam API key and no account**.

## How it works
The Steam client caches library **art** for the whole library under `appcache/librarycache/<appid>/` (measured: 1117 appids vs 12 installed on a real box). The agent enumerates that, minus installed, minus known tools — the owned-but-uninstalled set — reading only its own disk. Names + type come **app-side** from Valve's keyless store `appdetails` (same opt-in + host as the existing compat lookups); `type=game` drops the tools/DLC the art cache overcounts. `steam://install` is Steam's own owned-only gate.

## Agent (2.9.73)
- `_installable_appids()` — the allowlist; degrades **closed** (no root → empty, never "everything").
- `GET /api/steam/installable` — read-only appid list.
- `install:<appid>` branch in `_launcher_argv` (mirrors `stream:<appid>`): validates against the set, then the fixed `["steam","steam://install/<appid>"]` — reuses the existing launch fire path, **no new POST route, no client string on the command line**.
- Art reuses the existing `/api/steam/<appid>/cover` (already serves librarycache art for any appid).
- New cap `steaminstall` across all **six** sites.

## App
- Cap-gated "Not installed" section in Launch (collapsed by default; off-opt-in shows a one-line prompt, never reaches the store without the toggle).
- `lib/steamStoreParse.ts` (pure, bare-Node tested) + `lib/steamStore.ts` (keyless name/type fetch, 30d cache).

## Verified
- **Real hardware** (bazzite): 1104 owned-uninstalled, installed ∩ installable = **0**, real appids build the argv, non-owned refused — *without firing a real multi-GB install*.
- **Unit** (`test_steam_install.py`, CI-wired): allowlist excludes installed (control) + tools + non-digit; unowned/non-digit refused with nothing run; fixed digits-only argv; GET 200 + 401; POST unowned → 404; cap wiring. Parse tests 7/7 (bare-Node). Protocol parity green. tsc clean.
- **Harness, end-to-end:** section renders cap-gated → expand → tiles (type=game, sorted) → tile press → `POST /api/launchers/install:400 → 200`.

## NOT verified
- The real `steam://install` FIRE on the box (would download a multi-GB game).
- In-browser store name-resolution (browser CORS; native `fetch` on device has no CORS, like the existing compat lookups).

🤖 Generated with [Claude Code](https://claude.com/claude-code)