### PR TITLE
feat: Setup → Utilities menu — detection (Stage 1) + OpenPuck flash & honest CEC (Stage 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,6 +573,15 @@ jobs:
       - name: Unit tests (steam install — owned-but-uninstalled)
         run: python3 tests/test_steam_install.py
 
+      # Setup -> Utilities (Stage 1: read-only detection). A new surface that will
+      # grow state-changing tenants, so the tests pin the §3 properties up front:
+      # the tenant set is FROZEN (built from _UTILITY_IDS, never client input), the
+      # OpenPuck flash target needs a known label AND the UF2 marker (a mislabelled
+      # stick is refused — the control), detection degrades closed, and the route is
+      # behind the bearer gate.
+      - name: Unit tests (utilities detection)
+        run: python3 tests/test_utilities.py
+
       # _unreadable_reason() — why a controller cannot be read. The app used to
       # tell every affected user to re-run install.sh, which on a Legion Go S
       # cannot work: a POSIX ACL grants the user, and mode 000 collapses the

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.74
+
+**Utilities — one-click hardware helpers (new, opt-in).** Setup gains a Utilities
+section that shows what your box can help with: flashing an nRF52840 board into an
+OpenPuck Steam Controller receiver, and turning on HDMI-CEC so the box can power
+your TV and switch inputs over the HDMI cable. This first release only *detects*
+and reports status — it tells you when a board is plugged in and ready, or when a
+CEC adapter is present — with the flashing and enabling actions to follow. It's
+off by default; turn it on under Setup, and older apps don't show it at all.
+
 ## 2.9.73
 
 **Install a game you own but haven't downloaded.** Couchside can now list the

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,18 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.75
+
+**Utilities can now flash an OpenPuck receiver.** The OpenPuck utility gained a
+Flash button: plug an nRF52840 board into the box (in its UF2 bootloader), press
+Flash, and Couchside writes the OpenPuck firmware — the board reboots as a Steam
+Controller 2 wireless receiver. The firmware is fetched and verified by the
+installer, so flashing works with the box offline; the bootloader is kept, so you
+can re-flash any time. HDMI-CEC detection is now honest about whether the box can
+actually open the CEC device (so a permissions fix shows up), and the installer
+adds a udev rule that grants that access. Needs the app that ships alongside this
+agent.
+
 ## 2.9.74
 
 **Utilities — one-click hardware helpers (new, opt-in).** Setup gains a Utilities

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -14,6 +14,7 @@ defaults.
 import argparse
 import base64
 import calendar
+import errno
 import glob
 import hashlib
 import hmac
@@ -45,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.74"
+VERSION = "2.9.75"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -7750,6 +7751,19 @@ def cec_available():
 # ---------------------------------------------------------------------------
 _UTILITY_IDS = frozenset({"openpuck", "cec"})
 
+# The state-CHANGING subset of _UTILITY_IDS, used by POST /api/utilities/<id>/run.
+# 'cec' is deliberately absent: enabling CEC is an install-time udev regroup of the
+# device into the `input` group (the agent already holds it) — NOT something the
+# daemon can do to itself at runtime (a running process cannot gain a supplementary
+# group, and the agent cannot edit its own unit). So there is no cec RUN action.
+_UTILITY_RUN_IDS = frozenset({"openpuck"})
+
+# install.sh fetches the pinned OpenPuck release .uf2 (sha256-verified, the same
+# gate as the agent asset) and drops it HERE. The flash op reads this fixed,
+# agent-owned path, selected only by the allowlisted 'openpuck' id — the client
+# never supplies a path or the firmware bytes. Absent -> the flash degrades closed.
+_OPENPUCK_FIRMWARE = "/etc/couchside/openpuck/firmware.uf2"
+
 # The nRF52840 nice!nano presents its UF2 bootloader as a mass-storage volume with
 # one of these labels + an INFO_UF2.TXT marker. That mount is the drag-drop flash
 # target; its presence is how we know a board is plugged in AND in DFU mode.
@@ -7833,16 +7847,49 @@ def _cec_devices_exist():
         return False
 
 
-def _cec_util_state():
-    """'enabled' (the agent can drive CEC now), 'needs_enable' (a /dev/cec adapter
-    exists but the agent can't use it yet) or 'no_adapter'. Read-only."""
+def _cec_dev_openable(dev):
+    """True if the agent can open a specific CEC node for read+write — exactly what
+    the install-time udev regroup-to-`input` rule grants (the agent already holds
+    the `input` group). Read-only; never raises."""
     try:
-        if cec_available():
-            return "enabled"
-        if _cec_devices_exist():
-            return "needs_enable"
+        return bool(dev) and os.access(dev, os.R_OK | os.W_OK)
     except Exception:
-        pass
+        return False
+
+
+def _cec_util_state():
+    """Honest three-way state for the Setup->Utilities row. READ-ONLY.
+
+      'enabled'      -- the agent can drive the TV over CEC via a live backend: the
+                        kernel (cec-ctl) on a /dev/cecN it can OPEN, or a libcec
+                        USB-serial dongle (cec-client, on its own /dev/ttyACM*).
+      'needs_enable' -- a kernel /dev/cec[0-9] node exists but the agent can't open
+                        it (the group/permission gap the install-time udev
+                        regroup-to-`input` rule fixes), or a node exists with no
+                        live backend yet (e.g. the HDMI port is off; self-heals).
+      'no_adapter'   -- no CEC hardware at all.
+
+    Gating the KERNEL path's 'enabled' on real openability (os.access on the node)
+    is the §11 fix: cec_current() reports a kernel descriptor from sysfs WITHOUT
+    ever opening /dev/cecN, so a node the agent cannot open would otherwise read as
+    a false 'enabled' that only failed later in real_cec(). The libcec/dongle
+    backend is decoupled from /dev/cecN (it drives its own serial device) and is
+    genuinely usable whenever it is live, so it is NOT subject to that gate.
+    Degrades closed: any probe failure yields a non-'enabled' state."""
+    try:
+        cec = cec_current()
+    except Exception:
+        cec = None
+    if cec is not None:
+        # The kernel backend must ALSO be openable by the agent; the libcec dongle
+        # needs no /dev/cecN access, so a live descriptor there is 'enabled' as-is.
+        if cec.get("tool") == "cec-ctl" and not _cec_dev_openable(cec.get("device")):
+            return "needs_enable"
+        return "enabled"
+    # No live backend. A kernel node that merely lacks access (or whose HDMI port
+    # is off) is a fixable/transient 'needs_enable'; else there is no adapter.
+    if _cec_devices_exist():
+        return "needs_enable"
     return "no_adapter"
 
 
@@ -7857,6 +7904,86 @@ def utilities_state(mock):
     for uid in ("openpuck", "cec"):
         out.append({"id": uid, "state": states[uid], **_UTILITY_META[uid]})
     return out
+
+
+def _is_uf2(path):
+    """True if `path` looks like a real UF2 image: non-empty, a whole number of
+    512-byte blocks, and the first block carries the UF2 magic (first word
+    0x0A324655 'UF2\\n', second word 0x9E5D5157). This guards against 'flashing' a
+    truncated / zeroed / non-UF2 file — a bootloader silently IGNORES such an image
+    and never reboots, so the copy would complete with no error and we'd falsely
+    report success. Read-only; never raises."""
+    try:
+        size = os.path.getsize(path)
+        if size == 0 or size % 512 != 0:
+            return False
+        with open(path, "rb") as f:
+            head = f.read(8)
+        if len(head) < 8:
+            return False
+        w0, w1 = struct.unpack("<II", head)
+        return w0 == 0x0A324655 and w1 == 0x9E5D5157
+    except OSError:
+        return False
+
+
+def real_openpuck_flash():
+    """Flash the pinned OpenPuck firmware onto a plugged-in nRF52840 board that is
+    in its UF2 bootloader. Returns the standard ActionResult (ok/exit_code/stdout/
+    stderr/duration_ms).
+
+    §3-safe: the flash TARGET is _openpuck_bootloader_mount() (a label + UF2-marker
+    match, never client input), and the firmware is the agent-owned fixed-path
+    asset _OPENPUCK_FIRMWARE selected only by the 'openpuck' id — the client
+    supplies neither a path nor the bytes. The copy is shutil.copyfile into the
+    desktop user's own automount, so no sudo and no shell.
+
+    The board reboots the instant the UF2 lands and yanks its USB mass-storage
+    mid-write, so the copy errors (ENXIO/EIO) even on a SUCCESSFUL flash; that
+    specific errno is treated as success (both directions are tested)."""
+    start = time.monotonic()
+
+    def _done(ok, exit_code, stdout, stderr):
+        return {"ok": ok, "exit_code": exit_code, "stdout": stdout,
+                "stderr": stderr,
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+
+    mount = _openpuck_bootloader_mount()
+    if mount is None:
+        # Degrade closed: no board in DFU -> nothing to flash, no guessed path.
+        return _done(False, -1, "",
+                     "No board in DFU mode. Plug in an nRF52840 board (or "
+                     "double-tap its reset button) and try again.")
+    fw = _OPENPUCK_FIRMWARE
+    if not os.path.isfile(fw):
+        return _done(False, -1, "",
+                     "OpenPuck firmware is not installed on this box. Re-run the "
+                     "Couchside installer to fetch it.")
+    if not _is_uf2(fw):
+        # Degrade CLOSED: a bootloader silently ignores a truncated/garbage image
+        # and never reboots, so copying it would report a no-op flash as success.
+        return _done(False, -1, "",
+                     "OpenPuck firmware looks corrupt (not a valid UF2). Re-run "
+                     "the Couchside installer to reinstall it.")
+    dst = os.path.join(mount, os.path.basename(fw))
+    ok_msg = "Flashed. The board is rebooting as a Steam Controller Puck."
+    try:
+        shutil.copyfile(fw, dst)
+    except OSError as e:
+        if e.errno in (errno.ENXIO, errno.EIO):
+            # Expected: the board rebooted and pulled its drive mid-write. Success.
+            return _done(True, 0, ok_msg, "")
+        return _done(False, e.errno or -1, "", "Flash failed: %s" % e)
+    # Some kernels finish the copy before the board yanks the drive. Also success.
+    return _done(True, 0, ok_msg, "")
+
+
+def mock_openpuck_flash():
+    """--mock/harness: exercise the flash PRESS end-to-end without a real board."""
+    return {"ok": True, "exit_code": 0,
+            "stdout": "Flashed (mock). The board is rebooting as a Steam "
+                      "Controller Puck.",
+            "stderr": "", "duration_ms": 3}
 
 
 def _cec_argv(cec, op):
@@ -16984,6 +17111,31 @@ class Handler(BaseHTTPRequestHandler):
                     return
                 result = mock_launch(argv) if self.mock else real_launch(argv)
                 self._send(200, result, started)
+                return
+
+            # POST /api/utilities/<id>/run: run a Utilities tenant's state-changing
+            # action (Stage 2). The id is LOOKED UP in the frozen sets, never
+            # interpolated and never a command. Only 'openpuck' (flash a board) is
+            # runnable; 'cec' is detect-only (its enable is an install-time udev
+            # rule, not a daemon action) so it 404s with a distinct reason.
+            uprefix = "/api/utilities/"
+            if path.startswith(uprefix) and path.endswith("/run"):
+                uid = unquote(path[len(uprefix):-len("/run")])
+                if uid not in _UTILITY_IDS:
+                    self._send(404, {"ok": False,
+                                     "error": "unknown utility"}, started)
+                    return
+                if uid not in _UTILITY_RUN_IDS:
+                    self._send(404, {"ok": False,
+                                     "error": "utility has no run action"}, started)
+                    return
+                if uid == "openpuck":
+                    result = (mock_openpuck_flash() if self.mock
+                              else real_openpuck_flash())
+                    self._send(200, result, started)
+                    return
+                # Defensive: a run id in the frozen set with no dispatch branch.
+                self._send(404, {"ok": False, "error": "unknown utility"}, started)
                 return
 
             # POST /api/tv/volume: absolute volume {"level": 0-100, "target":

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -45,7 +45,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.73"
+VERSION = "2.9.74"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1579,7 +1579,7 @@ def set_caps(mock):
         CAPS = {k: True for k in
                 ("gamepad", "steam", "media", "tv", "screen", "power_schedule",
                  "screensaver", "couchmode", "bigpicture", "desktop",
-                 "steamlink", "gaming", "steaminstall",
+                 "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player")}
         return
@@ -1604,6 +1604,10 @@ def set_caps(mock):
         # as its own cap so old apps ignore it and new apps feature-detect the
         # /api/steam/installable + install:<appid> pair (both absent pre-2.9.73).
         "steaminstall": _steam_root() is not None,
+        # Setup -> Utilities endpoint present (per-utility availability is in the
+        # state, not the cap). The app also gates the section behind an OPT-IN pref,
+        # so a firmware-flashing surface is never shown unless the user turns it on.
+        "utilities": True,
         "streamhost": safe(streamhost_available),
         "steammenus": safe(steammenus_available),
         "boxbattery": safe(box_battery_available),
@@ -7732,6 +7736,127 @@ def cec_current():
 
 def cec_available():
     return cec_current() is not None
+
+
+# ---------------------------------------------------------------------------
+# Utilities — one-click hardware/setup helpers (app: Setup → Utilities, OPT-IN).
+#
+# Each utility is a FIXED, allowlisted operation (CLAUDE.md §3): a client selects
+# WHICH utility runs by id (looked up in _UTILITY_IDS, never interpolated); it never
+# supplies a command, a device, or firmware. Everything here is READ-ONLY DETECTION —
+# the state-changing RUN handlers (flash / enable) are a separate step, gated on the
+# same frozen id set. Launch tenants: 'openpuck' (flash an nRF52840 nice!nano into a
+# Steam Controller 2 wireless receiver) and 'cec' (enable box->TV HDMI-CEC control).
+# ---------------------------------------------------------------------------
+_UTILITY_IDS = frozenset({"openpuck", "cec"})
+
+# The nRF52840 nice!nano presents its UF2 bootloader as a mass-storage volume with
+# one of these labels + an INFO_UF2.TXT marker. That mount is the drag-drop flash
+# target; its presence is how we know a board is plugged in AND in DFU mode.
+_UF2_BOOTLOADER_LABELS = ("NICENANO", "NRF52BOOT", "FTHR840BOOT")
+# A flashed board re-enumerates as Valve's Steam Controller Puck.
+_OPENPUCK_USB = ("28de", "1304")
+# udisks automount roots for the desktop user the agent runs as. A constant so a
+# test can point detection at a fixture tree.
+_MEDIA_ROOTS = ("/run/media", "/media")
+
+_UTILITY_META = {
+    "openpuck": {
+        "label": "OpenPuck receiver",
+        "description": "Flash a plugged-in nRF52840 board into a Steam Controller 2 "
+                       "wireless receiver.",
+    },
+    "cec": {
+        "label": "TV control over HDMI-CEC",
+        "description": "Let the box power your TV and switch inputs over the HDMI "
+                       "cable — no extra hardware.",
+    },
+}
+
+
+def _openpuck_bootloader_mount():
+    """Path to a mounted nRF52840 UF2 bootloader volume (INFO_UF2.TXT present), or
+    None. Read-only; never raises. This is the flash TARGET, matched by a known
+    label + the UF2 marker file, never a client-supplied path."""
+    for root in _MEDIA_ROOTS:
+        try:
+            users = os.listdir(root)
+        except OSError:
+            continue
+        for user in users:
+            d = os.path.join(root, user)
+            try:
+                vols = os.listdir(d)
+            except OSError:
+                continue
+            for vol in vols:
+                if vol.upper() in _UF2_BOOTLOADER_LABELS:
+                    p = os.path.join(d, vol)
+                    try:
+                        if os.path.isfile(os.path.join(p, "INFO_UF2.TXT")):
+                            return p
+                    except OSError:
+                        continue
+    return None
+
+
+def _usb_present(vid, pid):
+    """True if a USB device with idVendor:idProduct is enumerated. Read-only."""
+    try:
+        names = os.listdir(_USB_DEVICES_DIR)
+    except OSError:
+        return False
+    for name in names:
+        if ":" in name:
+            continue  # interface node
+        base = os.path.join(_USB_DEVICES_DIR, name)
+        if ((_usb_read(os.path.join(base, "idVendor")) or "").lower() == vid
+                and (_usb_read(os.path.join(base, "idProduct")) or "").lower() == pid):
+            return True
+    return False
+
+
+def _openpuck_state():
+    """'board_ready' (a bootloader mount is present -> ready to flash), 'puck_present'
+    (a flashed / real Valve puck is enumerated) or 'no_board'. Read-only."""
+    if _openpuck_bootloader_mount():
+        return "board_ready"
+    if _usb_present(*_OPENPUCK_USB):
+        return "puck_present"
+    return "no_board"
+
+
+def _cec_devices_exist():
+    try:
+        return bool(glob.glob("/dev/cec[0-9]"))
+    except Exception:
+        return False
+
+
+def _cec_util_state():
+    """'enabled' (the agent can drive CEC now), 'needs_enable' (a /dev/cec adapter
+    exists but the agent can't use it yet) or 'no_adapter'. Read-only."""
+    try:
+        if cec_available():
+            return "enabled"
+        if _cec_devices_exist():
+            return "needs_enable"
+    except Exception:
+        pass
+    return "no_adapter"
+
+
+def utilities_state(mock):
+    """The Setup->Utilities list: each supported utility + its live state. READ-ONLY.
+    In --mock both appear in a ready-ish state so the harness renders them."""
+    if mock:
+        states = {"openpuck": "board_ready", "cec": "needs_enable"}
+    else:
+        states = {"openpuck": _openpuck_state(), "cec": _cec_util_state()}
+    out = []
+    for uid in ("openpuck", "cec"):
+        out.append({"id": uid, "state": states[uid], **_UTILITY_META[uid]})
+    return out
 
 
 def _cec_argv(cec, op):
@@ -16148,6 +16273,12 @@ class Handler(BaseHTTPRequestHandler):
                 # when Steam or the library cache is absent — degrades closed.
                 games = (MOCK_INSTALLABLE if self.mock else _installable_games())
                 self._send(200, {"games": games, "count": len(games)}, started)
+            elif path == "/api/utilities":
+                # Setup -> Utilities: each supported utility + its live state
+                # (openpuck: board_ready/puck_present/no_board; cec: enabled/
+                # needs_enable/no_adapter). Read-only; the app gates the whole
+                # section behind an opt-in pref.
+                self._send(200, {"utilities": utilities_state(self.mock)}, started)
             elif path == "/api/session/default":
                 # Read-only. Always 200 with available=false rather than 404 so
                 # the app can tell "old agent" (404) from "this box has no

--- a/agent/openpuck/OPENPUCK-NOTICE.txt
+++ b/agent/openpuck/OPENPUCK-NOTICE.txt
@@ -1,0 +1,25 @@
+OpenPuck firmware — attribution and source offer
+=================================================
+
+Couchside's "OpenPuck receiver" utility flashes the OpenPuck firmware onto a
+plugged-in nRF52840 board. That firmware is a separate work, NOT part of
+Couchside:
+
+  Project:  OpenPuck — https://github.com/safijari/openpuck
+  Author:   safijari
+  License:  GNU Affero General Public License v3.0 (AGPL-3.0)
+
+Couchside redistributes an UNMODIFIED OpenPuck release binary
+(OpenPuck-0.9.31-standard.uf2) purely as a convenience so the flash works with
+the box offline. Couchside itself (this agent) is licensed separately and does
+NOT incorporate OpenPuck's code.
+
+Corresponding source for the exact firmware version distributed here is
+available from the upstream release it was fetched from:
+
+  https://github.com/safijari/openpuck/releases/tag/0.9.31
+
+The AGPL-3.0 license text is published with the OpenPuck project at the URL
+above. This notice satisfies the redistribution requirement to convey the
+license and offer the corresponding source; it does not modify the terms under
+which OpenPuck is licensed.

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -29,6 +29,7 @@ import { BoxScanPair } from '@/components/BoxScanPair';
 import { DirectTvSetup } from '@/components/DirectTvSetup';
 import { BoxScanQr } from '@/components/BoxScanQr';
 import { SetupProgress, SETUP_GUIDE_URL } from '@/components/SetupProgress';
+import { UtilitiesSection } from '@/components/UtilitiesSection';
 import { buildPairLink } from '@/lib/pairLink';
 import { GuideHoldSetup } from '@/components/GuideHoldSetup';
 import { SmartTvSetup } from '@/components/SmartTvSetup';
@@ -823,6 +824,7 @@ function SetupBody() {
   } = useBoxes();
 
   const status = useBoxOnlineStatus(boxes, { active: true, intervalMs: 10000 });
+  const activeBox = boxes.find((b) => b.id === activeBoxId);
   const hapticsOn = useHapticsEnabled();
   const keepAwakeOn = useKeepAwakeEnabled();
   const keepAwakeTimeout = useKeepAwakeTimeoutMin();
@@ -838,6 +840,7 @@ function SetupBody() {
   const confirmSuspend = usePref('confirmSuspend');
   const streakCelebrations = usePref('streakCelebrations');
   const compatLookups = usePref('compatLookups');
+  const utilitiesEnabled = usePref('utilitiesEnabled');
   const featureTour = usePref('featureTour');
   const remoteOnlyOn = usePref('remoteOnlyMode');
   // DETECT, DO NOT PRESUME. This used to spring open for anyone with no box —
@@ -1447,6 +1450,20 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+              <TogglePref
+                label="Utilities (advanced)"
+                sub="One-click hardware helpers on your box — flash an OpenPuck Steam Controller receiver, turn on HDMI-CEC TV control. OFF by default: these run firmware flashes and system changes on the box, so you turn them on deliberately. On to see what your box supports."
+                value={utilitiesEnabled}
+                onValueChange={(v) => {
+                  void setPref('utilitiesEnabled', v);
+                  hapticSelection();
+                }}
+              />
+              {/* The Utilities list itself — only when opted in, and hidden while
+                  searching prefs (it is a section, not a filtered pref row). */}
+              {utilitiesEnabled && !prefQuery ? (
+                <UtilitiesSection caps={activeBox?.caps} />
+              ) : null}
               {/* A BUTTON, not a toggle — for the same reason as the welcome
                   flow below, which this now matches.
 

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -3,16 +3,18 @@
  * `utilitiesEnabled` pref AND caps.utilities). Reads GET /api/utilities and shows
  * each supported utility with its live state.
  *
- * STAGE 1 is READ-ONLY: it surfaces what the box detects (a puck connected, a board
- * ready to flash, CEC on/available). The state-changing actions (flash the board /
- * enable CEC) are a deliberate next step — a firmware flash and a system change are
- * not things to wire up on the way past, and the copy here says what's next rather
- * than offering a control that isn't wired.
+ * STAGE 2: OpenPuck can now be FLASHED. When a board is in its UF2 bootloader
+ * (state `board_ready`), a Flash button POSTs /api/utilities/openpuck/run; the
+ * agent copies the pinned firmware onto the board, which reboots as a Steam
+ * Controller Puck — the list then re-polls and the row flips to `puck_present`.
+ * CEC stays display-only: enabling it is an install-time udev step, not a daemon
+ * action, so there is deliberately no button that would lie about flipping it.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useEffect, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { hapticLight, hapticSuccess, hapticWarning } from '@/lib/haptics';
 import { api, type BoxCaps, type Utility } from '@/lib/api';
 import { useSettings } from '@/lib/SettingsContext';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -20,13 +22,13 @@ import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 /** (statusLine, iconName, tone) for a utility's state. tone: 'good' | 'action' | 'idle'. */
 function present(u: Utility): { line: string; icon: string; tone: 'good' | 'action' | 'idle' } {
   if (u.id === 'openpuck') {
-    if (u.state === 'board_ready') return { line: 'Board connected — ready to flash (next update).', icon: 'hardware-chip-outline', tone: 'action' };
+    if (u.state === 'board_ready') return { line: 'Board connected — ready to flash.', icon: 'hardware-chip-outline', tone: 'action' };
     if (u.state === 'puck_present') return { line: 'A Steam Controller Puck is connected.', icon: 'checkmark-circle', tone: 'good' };
     return { line: 'Plug an nRF52840 board into the box to flash one.', icon: 'hardware-chip-outline', tone: 'idle' };
   }
   if (u.id === 'cec') {
     if (u.state === 'enabled') return { line: 'On — the box can control your TV over HDMI.', icon: 'checkmark-circle', tone: 'good' };
-    if (u.state === 'needs_enable') return { line: 'Adapter found — enable coming (next update).', icon: 'tv-outline', tone: 'action' };
+    if (u.state === 'needs_enable') return { line: 'Adapter found — re-run the installer to enable it.', icon: 'tv-outline', tone: 'action' };
     return { line: 'No HDMI-CEC adapter found on this box.', icon: 'tv-outline', tone: 'idle' };
   }
   return { line: u.state, icon: 'construct-outline', tone: 'idle' };
@@ -37,18 +39,64 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
   const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
   const [utils, setUtils] = useState<Utility[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null); // utility id being run
+  const [note, setNote] = useState<Record<string, { ok: boolean; msg: string }>>({});
+  const live = useRef(true);
 
   const canProbe = caps?.utilities !== false;
 
+  const refresh = useCallback(async () => {
+    const res = await api.utilities(settings);
+    if (live.current) setUtils(res ? res.utilities : null);
+  }, [settings]);
+
   useEffect(() => {
+    live.current = true;
     if (!canProbe) { setUtils(null); return; }
-    let live = true;
-    void (async () => {
-      const res = await api.utilities(settings);
-      if (live) setUtils(res ? res.utilities : null);
-    })();
-    return () => { live = false; };
-  }, [settings, canProbe]);
+    void refresh();
+    return () => { live.current = false; };
+  }, [refresh, canProbe]);
+
+  const flashOpenpuck = useCallback(() => {
+    const doFlash = async () => {
+      hapticLight();
+      setBusy('openpuck');
+      setNote((n) => { const c = { ...n }; delete c.openpuck; return c; });
+      try {
+        const r = await api.runUtility(settings, 'openpuck');
+        if (!live.current) return;
+        const msg = r.ok
+          ? (r.stdout || 'Flashed. The board is rebooting as a Steam Controller Puck.')
+          : (r.stderr || 'Flash failed.');
+        setNote((n) => ({ ...n, openpuck: { ok: r.ok, msg } }));
+        if (r.ok) hapticSuccess(); else hapticWarning();
+        // The board re-enumerates as a puck a few seconds after flashing; re-poll
+        // so the row flips board_ready -> puck_present.
+        setTimeout(() => { void refresh(); }, 4000);
+      } catch {
+        if (live.current) {
+          setNote((n) => ({ ...n, openpuck: { ok: false, msg: 'Could not reach the box.' } }));
+          hapticWarning();
+        }
+      } finally {
+        if (live.current) setBusy(null);
+      }
+    };
+    // A firmware write is a real action — confirm first, even though the
+    // bootloader stays intact and it's re-flashable.
+    const q = 'Flash the OpenPuck firmware to the plugged-in board? It reboots as '
+      + 'a Steam Controller Puck when done. The bootloader is kept, so you can '
+      + 're-flash any time.';
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (typeof window !== 'undefined' && window.confirm(q)) void doFlash();
+      return;
+    }
+    Alert.alert('Flash OpenPuck receiver?', q, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Flash', onPress: () => { void doFlash(); } },
+    ]);
+  }, [settings, refresh]);
 
   // Nothing to show if the box lacks the endpoint (old agent / Windows).
   if (!canProbe || !utils || utils.length === 0) return null;
@@ -59,6 +107,9 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
       {utils.map((u) => {
         const p = present(u);
         const color = p.tone === 'good' ? t.green : p.tone === 'action' ? t.blue : t.textFaint;
+        const canFlash = u.id === 'openpuck' && u.state === 'board_ready';
+        const running = busy === u.id;
+        const n = note[u.id];
         return (
           <View key={u.id} style={styles.row}>
             <Ionicons name={p.icon as never} size={20} color={color} style={styles.icon} />
@@ -66,6 +117,30 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
               <Text style={styles.label}>{u.label}</Text>
               <Text style={styles.sub}>{u.description}</Text>
               <Text style={[styles.status, { color }]}>{p.line}</Text>
+              {canFlash ? (
+                <Pressable
+                  onPress={flashOpenpuck}
+                  disabled={running}
+                  style={({ pressed }) => [
+                    styles.btn,
+                    { borderColor: t.blue, opacity: running ? 0.6 : pressed ? 0.8 : 1 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityLabel="Flash OpenPuck receiver"
+                >
+                  {running ? (
+                    <ActivityIndicator size="small" color={t.blue} />
+                  ) : (
+                    <Ionicons name="flash-outline" size={16} color={t.blue} />
+                  )}
+                  <Text style={[styles.btnText, { color: t.blue }]}>
+                    {running ? 'Flashing…' : 'Flash receiver'}
+                  </Text>
+                </Pressable>
+              ) : null}
+              {n ? (
+                <Text style={[styles.note, { color: n.ok ? t.green : t.red }]}>{n.msg}</Text>
+              ) : null}
             </View>
           </View>
         );
@@ -88,4 +163,11 @@ const makeStyles = (t: Palette) =>
     label: { color: t.text, fontWeight: '700', fontSize: 14 },
     sub: { color: t.textFaint, fontSize: 12, marginTop: 2, lineHeight: 17 },
     status: { fontSize: 12, marginTop: 6, fontWeight: '600' },
+    btn: {
+      flexDirection: 'row', alignItems: 'center', gap: 8, alignSelf: 'flex-start',
+      marginTop: 10, paddingVertical: 8, paddingHorizontal: 14,
+      borderWidth: 1, borderRadius: 10,
+    },
+    btnText: { fontSize: 13, fontWeight: '700' },
+    note: { fontSize: 12, marginTop: 8, fontWeight: '600', lineHeight: 17 },
   });

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -1,0 +1,91 @@
+/**
+ * Setup → Utilities — one-click hardware/setup helpers (OPT-IN: gated on the
+ * `utilitiesEnabled` pref AND caps.utilities). Reads GET /api/utilities and shows
+ * each supported utility with its live state.
+ *
+ * STAGE 1 is READ-ONLY: it surfaces what the box detects (a puck connected, a board
+ * ready to flash, CEC on/available). The state-changing actions (flash the board /
+ * enable CEC) are a deliberate next step — a firmware flash and a system change are
+ * not things to wire up on the way past, and the copy here says what's next rather
+ * than offering a control that isn't wired.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useEffect, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+import { api, type BoxCaps, type Utility } from '@/lib/api';
+import { useSettings } from '@/lib/SettingsContext';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** (statusLine, iconName, tone) for a utility's state. tone: 'good' | 'action' | 'idle'. */
+function present(u: Utility): { line: string; icon: string; tone: 'good' | 'action' | 'idle' } {
+  if (u.id === 'openpuck') {
+    if (u.state === 'board_ready') return { line: 'Board connected — ready to flash (next update).', icon: 'hardware-chip-outline', tone: 'action' };
+    if (u.state === 'puck_present') return { line: 'A Steam Controller Puck is connected.', icon: 'checkmark-circle', tone: 'good' };
+    return { line: 'Plug an nRF52840 board into the box to flash one.', icon: 'hardware-chip-outline', tone: 'idle' };
+  }
+  if (u.id === 'cec') {
+    if (u.state === 'enabled') return { line: 'On — the box can control your TV over HDMI.', icon: 'checkmark-circle', tone: 'good' };
+    if (u.state === 'needs_enable') return { line: 'Adapter found — enable coming (next update).', icon: 'tv-outline', tone: 'action' };
+    return { line: 'No HDMI-CEC adapter found on this box.', icon: 'tv-outline', tone: 'idle' };
+  }
+  return { line: u.state, icon: 'construct-outline', tone: 'idle' };
+}
+
+export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const [utils, setUtils] = useState<Utility[] | null>(null);
+
+  const canProbe = caps?.utilities !== false;
+
+  useEffect(() => {
+    if (!canProbe) { setUtils(null); return; }
+    let live = true;
+    void (async () => {
+      const res = await api.utilities(settings);
+      if (live) setUtils(res ? res.utilities : null);
+    })();
+    return () => { live = false; };
+  }, [settings, canProbe]);
+
+  // Nothing to show if the box lacks the endpoint (old agent / Windows).
+  if (!canProbe || !utils || utils.length === 0) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.h}>UTILITIES</Text>
+      {utils.map((u) => {
+        const p = present(u);
+        const color = p.tone === 'good' ? t.green : p.tone === 'action' ? t.blue : t.textFaint;
+        return (
+          <View key={u.id} style={styles.row}>
+            <Ionicons name={p.icon as never} size={20} color={color} style={styles.icon} />
+            <View style={styles.body}>
+              <Text style={styles.label}>{u.label}</Text>
+              <Text style={styles.sub}>{u.description}</Text>
+              <Text style={[styles.status, { color }]}>{p.line}</Text>
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { marginTop: 8 },
+    h: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1, marginBottom: 6 },
+    row: {
+      flexDirection: 'row', gap: 12, paddingVertical: 12, paddingHorizontal: 12,
+      backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,
+      marginBottom: 8,
+    },
+    icon: { marginTop: 2 },
+    body: { flex: 1 },
+    label: { color: t.text, fontWeight: '700', fontSize: 14 },
+    sub: { color: t.textFaint, fontSize: 12, marginTop: 2, lineHeight: 17 },
+    status: { fontSize: 12, marginTop: 6, fontWeight: '600' },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -196,7 +196,20 @@ export type BoxCaps = {
    * and only an explicit false skips the request.
    */
   steaminstall?: boolean;
+  /**
+   * Setup → Utilities endpoint present (agent >= 2.9.74): one-click hardware/setup
+   * helpers (flash an OpenPuck receiver, enable HDMI-CEC, …). Linux-only. The app
+   * ALSO gates the section behind an opt-in pref, so a firmware-flashing surface is
+   * never shown unless the user turns it on. Optional: undefined reads as "unknown,
+   * probe"; only explicit false skips it.
+   */
+  utilities?: boolean;
 };
+
+/** One Setup → Utilities helper + its live state, from GET /api/utilities.
+ *  `state` is per-utility (openpuck: 'board_ready' | 'puck_present' | 'no_board';
+ *  cec: 'enabled' | 'needs_enable' | 'no_adapter'). */
+export type Utility = { id: string; state: string; label: string; description: string };
 
 /**
  * Couchside Player state, from GET /api/player.
@@ -1146,7 +1159,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.session_default === b.session_default &&
     a.display_info === b.display_info &&
     a.player === b.player &&
-    a.steaminstall === b.steaminstall
+    a.steaminstall === b.steaminstall &&
+    a.utilities === b.utilities
   );
 }
 
@@ -1614,6 +1628,16 @@ export const api = {
     return probeOrNull(
       request<{ games: { appid: number }[]; count: number }>(
         settings, '/api/steam/installable'));
+  },
+
+  /**
+   * Setup → Utilities: the box's one-click hardware/setup helpers + their live
+   * state (agent >= 2.9.74, cap `utilities`). Read-only probe-and-appear: null on a
+   * 404 hides the section. The app ALSO gates the section behind the opt-in
+   * `utilitiesEnabled` pref, so a firmware-flashing surface never shows unasked.
+   */
+  utilities(settings: ConnSettings): Promise<{ utilities: Utility[] } | null> {
+    return probeOrNull(request<{ utilities: Utility[] }>(settings, '/api/utilities'));
   },
 
   /**

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1641,6 +1641,17 @@ export const api = {
   },
 
   /**
+   * Run a Utilities tenant's state-changing action (agent >= 2.9.75), e.g.
+   * runUtility(settings, 'openpuck') to flash a plugged-in board. The id is
+   * looked up in the agent's frozen run-allowlist; a non-runnable id (e.g. 'cec',
+   * whose enable is an install-time step) 404s. Returns the standard ActionResult.
+   */
+  runUtility(settings: ConnSettings, id: string): Promise<ActionResult> {
+    return request<ActionResult>(
+      settings, `/api/utilities/${encodeURIComponent(id)}/run`, { method: 'POST' });
+  },
+
+  /**
    * In-progress Steam downloads/updates. Probe-and-appear: resolves null on a
    * 404 (agent < 2.8 or no route) so the Launch tab hides the section; a 200
    * with an empty list also means "nothing pending".

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -48,6 +48,11 @@ export type Prefs = {
    *  appids still says something about what you own, so it is a switch the user
    *  throws rather than a default they discover later. */
   compatLookups: boolean;
+  /** Setup → Utilities: one-click hardware/setup helpers (flash an OpenPuck
+   *  receiver, enable HDMI-CEC). OFF by default and opt-in, because these run
+   *  firmware flashes / system changes on the box — a surface the user should
+   *  turn on deliberately, not stumble into. */
+  utilitiesEnabled: boolean;
   /** The one-time spotlight tour, shown after the first box is paired. On by
    *  default; turning it off before it has run means it never runs. */
   featureTour: boolean;
@@ -275,6 +280,7 @@ export const DEFAULTS: Prefs = {
   confirmSuspend: true,
   streakCelebrations: true,
   compatLookups: false,
+  utilitiesEnabled: false,
   featureTour: true,
   remoteOnlyMode: false,
   landingTab: 'index',
@@ -399,6 +405,7 @@ function normalize(raw: unknown): Prefs {
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,
     streakCelebrations: bool(o.streakCelebrations, DEFAULTS.streakCelebrations),
     compatLookups: bool(o.compatLookups, DEFAULTS.compatLookups),
+    utilitiesEnabled: bool(o.utilitiesEnabled, DEFAULTS.utilitiesEnabled),
     featureTour: bool(o.featureTour, DEFAULTS.featureTour),
     remoteOnlyMode: bool(o.remoteOnlyMode, DEFAULTS.remoteOnlyMode),
     landingTab,

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -278,12 +278,16 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // (and from capsEqual) and the cap never persists, so the Launch "Not installed"
   // section re-probes /api/steam/installable on every launch.
   const steaminstall = bool('steaminstall');
+  // utilities arrived with agent 2.9.74 (Setup → Utilities) — same optional-cap drop
+  // trap: omit it here (and from capsEqual) and the cap never persists, so the
+  // Utilities section re-probes on every launch.
+  const utilities = bool('utilities');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
-    steaminstall,
+    steaminstall, utilities,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,30 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Setup → Utilities menu — extensible one-click hardware/setup helpers (owner ask 2026-08-08)
+- **priority:** P2 · **risk:** medium-high (agent runs hardware-touching flashes + signed
+  setups; must stay strictly allowlisted) · **affects:** agent + app · **depends_on:** nothing
+- **Owner:** an extensible Utilities section that grows with the app. **Launch with two
+  tenants: OpenPuck flash + HDMI-CEC.** **Opt-in, off by default.**
+- **STAGE 1 DONE (PR #399, agent 2.9.74).** Read-only DETECTION only: `GET /api/utilities`
+  reports each tenant's live state (OpenPuck board_ready/puck_present/no_board; CEC
+  enabled/needs_enable/no_adapter). New cap `utilities` (six sites); frozen tenant set;
+  OpenPuck target = known bootloader label + `INFO_UF2.TXT` marker; degrade-closed. App:
+  `UtilitiesSection.tsx` gated on `utilitiesEnabled` pref (default false). Harness-verified
+  both states; box detection hardware-checked on bazzite.
+- **STAGE 2 (next):** the state-changing RUN handlers. (A) **board flasher engine** — detect
+  bootloader → PINNED firmware (verify sha256) → write → verify re-enumerate (OpenPuck now;
+  ZMK/QMK/WLED/Pico later); (B) **guided installer engine** — run a signed setup, report state
+  (CEC enable now via video-group grant through the privileged helper;
+  Sunshine/Tailscale/Decky/xone/fwupd/EmuDeck later). **Open decision:** OpenPuck firmware
+  bundle-in-agent vs fetch-pinned (LAN-only posture favors a signed bundle). Needs hardware
+  to verify: a board in DFU + a `needs_enable` box.
+- **Allowlist model (non-negotiable):** a client selects WHICH utility runs; never supplies a
+  command, firmware URL, or device. Firmware = pinned+sha256-verified; target = matched
+  bootloader VID:PID/mount, path-contained, fail-closed.
+- **Full spec + tenant detail: `docs/memory/project_utilities-menu.md`** (+ memory
+  [[openpuck-utilities-idea]]).
+
 ### Feature tour — element spotlights
 - **priority:** P2 · **risk:** low (app-only, additive) · **affects:** app only ·
   **depends_on:** nothing
@@ -129,21 +153,6 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   so a stale frame can't produce a confident wrong click.
 
 ## 📋 Planned
-
-### Setup → Utilities menu — extensible one-click hardware/setup helpers (owner ask 2026-08-08)
-- **priority:** P2 · **risk:** medium-high (agent runs hardware-touching flashes + signed
-  setups; must stay strictly allowlisted) · **affects:** agent + app · **depends_on:** nothing
-- **Owner:** an extensible Utilities section that grows with the app. **Launch with two
-  tenants: OpenPuck flash + HDMI-CEC.**
-- **Two reusable ENGINES** (build once, tenants are manifests): (A) **board flasher** —
-  detect bootloader → PINNED firmware (verify sha256) → write → verify re-enumerate (OpenPuck
-  now; ZMK/QMK/WLED/Pico later); (B) **guided installer** — run a signed setup, report state
-  (Sunshine/Tailscale/Decky/xone/CEC-bridge/fwupd/EmuDeck later).
-- **Allowlist model (non-negotiable):** a client selects WHICH utility runs; never supplies a
-  command, firmware URL, or device. Firmware = pinned+sha256-verified; target = matched
-  bootloader VID:PID/mount, path-contained, fail-closed. New cap `utilities`.
-- **Full spec + tenant detail: `docs/memory/project_utilities-menu.md`** (+ memory
-  [[openpuck-utilities-idea]]). HDMI-CEC scope (box-enable vs Pi-bridge) pending owner confirm.
 
 ### Install a game you own but have not downloaded (owner ask 2026-08-07)
 - **priority:** P2 · **risk:** medium-high (needs a NEW client-supplied-appid path that

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -130,6 +130,21 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### Setup → Utilities menu — extensible one-click hardware/setup helpers (owner ask 2026-08-08)
+- **priority:** P2 · **risk:** medium-high (agent runs hardware-touching flashes + signed
+  setups; must stay strictly allowlisted) · **affects:** agent + app · **depends_on:** nothing
+- **Owner:** an extensible Utilities section that grows with the app. **Launch with two
+  tenants: OpenPuck flash + HDMI-CEC.**
+- **Two reusable ENGINES** (build once, tenants are manifests): (A) **board flasher** —
+  detect bootloader → PINNED firmware (verify sha256) → write → verify re-enumerate (OpenPuck
+  now; ZMK/QMK/WLED/Pico later); (B) **guided installer** — run a signed setup, report state
+  (Sunshine/Tailscale/Decky/xone/CEC-bridge/fwupd/EmuDeck later).
+- **Allowlist model (non-negotiable):** a client selects WHICH utility runs; never supplies a
+  command, firmware URL, or device. Firmware = pinned+sha256-verified; target = matched
+  bootloader VID:PID/mount, path-contained, fail-closed. New cap `utilities`.
+- **Full spec + tenant detail: `docs/memory/project_utilities-menu.md`** (+ memory
+  [[openpuck-utilities-idea]]). HDMI-CEC scope (box-enable vs Pi-bridge) pending owner confirm.
+
 ### Install a game you own but have not downloaded (owner ask 2026-08-07)
 - **priority:** P2 · **risk:** medium-high (needs a NEW client-supplied-appid path that
   the existing installed-game validator cannot gate) · **affects:** agent + app ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,19 +14,23 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   setups; must stay strictly allowlisted) · **affects:** agent + app · **depends_on:** nothing
 - **Owner:** an extensible Utilities section that grows with the app. **Launch with two
   tenants: OpenPuck flash + HDMI-CEC.** **Opt-in, off by default.**
-- **STAGE 1 DONE (PR #399, agent 2.9.74).** Read-only DETECTION only: `GET /api/utilities`
-  reports each tenant's live state (OpenPuck board_ready/puck_present/no_board; CEC
-  enabled/needs_enable/no_adapter). New cap `utilities` (six sites); frozen tenant set;
+- **STAGE 1 DONE (PR #399, agent 2.9.74).** Read-only DETECTION: `GET /api/utilities`
+  reports each tenant's live state. New cap `utilities` (six sites); frozen tenant set;
   OpenPuck target = known bootloader label + `INFO_UF2.TXT` marker; degrade-closed. App:
-  `UtilitiesSection.tsx` gated on `utilitiesEnabled` pref (default false). Harness-verified
-  both states; box detection hardware-checked on bazzite.
-- **STAGE 2 (next):** the state-changing RUN handlers. (A) **board flasher engine** — detect
-  bootloader → PINNED firmware (verify sha256) → write → verify re-enumerate (OpenPuck now;
-  ZMK/QMK/WLED/Pico later); (B) **guided installer engine** — run a signed setup, report state
-  (CEC enable now via video-group grant through the privileged helper;
-  Sunshine/Tailscale/Decky/xone/fwupd/EmuDeck later). **Open decision:** OpenPuck firmware
-  bundle-in-agent vs fetch-pinned (LAN-only posture favors a signed bundle). Needs hardware
-  to verify: a board in DFU + a `needs_enable` box.
+  `UtilitiesSection.tsx` gated on `utilitiesEnabled` pref (default false).
+- **STAGE 2 DONE (PR #399, agent 2.9.75).** OpenPuck FLASH: `POST /api/utilities/openpuck/run`
+  copies the pinned firmware onto a DFU board (id in the frozen `_UTILITY_RUN_IDS`, target
+  from the bootloader-mount match, no-shell copy, ENXIO/EIO = success). Firmware = BUNDLE
+  (owner-chosen): release-agent.sh fetches from safijari/openpuck + pins sha256, install.sh
+  installs it only if it passed the signed SHA256SUMS gate, so flashing works offline; AGPL
+  notice ships alongside. CEC turned out NOT to be a runtime button — instead: honest detector
+  (`enabled` now gated on `os.access` openability, so a permission gap is observable both ways,
+  §11) + an install-time udev regroup-to-`input` rule for /dev/cec* (`cec` is NOT in
+  `_UTILITY_RUN_IDS`; POST cec/run → 404). App Flash button harness-verified end-to-end.
+  **NOT verified on hardware:** a real board in DFU, the udev rule flipping a real
+  `needs_enable` box, and a real release publishing the .uf2 (box was off-subnet).
+- **STAGE 3 (later, backlog):** more tenants on the two engines — board flasher (ZMK/QMK/
+  WLED/Pico), guided installer (Sunshine/Tailscale/Decky/xone/fwupd/EmuDeck).
 - **Allowlist model (non-negotiable):** a client selects WHICH utility runs; never supplies a
   command, firmware URL, or device. Firmware = pinned+sha256-verified; target = matched
   bootloader VID:PID/mount, path-contained, fail-closed.

--- a/docs/memory/project_utilities-menu.md
+++ b/docs/memory/project_utilities-menu.md
@@ -1,0 +1,78 @@
+# Setup → Utilities menu (owner ask 2026-08-08)
+
+> **Status: SPEC, building.** Owner: an extensible Utilities section in Setup that
+> hosts one-click hardware/setup helpers as the app grows. **Launch with two
+> tenants: OpenPuck flash + HDMI-CEC.** Framework first, tenants plug in.
+
+## The insight: two reusable ENGINES, not N one-offs
+
+Most candidate utilities are one of two shapes. Build each engine once; a new
+utility is then a MANIFEST, not new code.
+
+**Engine A — Board flasher** (the OpenPuck pattern):
+detect a plugged board's bootloader → fetch a PINNED firmware (verify sha256) →
+write it (UF2 drag-drop, or esptool) → verify the device re-enumerates.
+Tenants: OpenPuck (nRF52840→SC2 puck), ZMK (same nice!nano board), QMK, WLED
+(ESP→TV bias light), CircuitPython (Pico).
+
+**Engine B — Guided installer**: agent runs a FIXED, signed setup → reports state.
+Tenants: Sunshine (game-stream host), Tailscale (remote access), Decky install/
+repair, xone/xpadneo (Xbox pads), Pi CEC bridge, fwupd (device firmware), EmuDeck.
+
+## Allowlist model — NON-NEGOTIABLE (CLAUDE.md §3)
+
+Every utility is a FIXED operation. A client selects WHICH allowlisted utility runs;
+it never supplies a command, path, firmware URL, or device.
+- Firmware = a pinned asset + pinned sha256 (fetch-and-verify, or bundled+signed).
+  A hash mismatch aborts. No client-supplied firmware/URL ever.
+- Target device = matched by a known bootloader VID:PID / mount label, and the
+  resolved path is verified contained. Never a random USB drive. Fail-closed.
+- Setup scripts (Engine B) = the same signed-release channel the agent assets use.
+- Each utility is its own allowlist entry (id → handler), like ACTIONS / _STEAM_MENU_IDS.
+
+## Agent shape (proposed)
+
+- `GET /api/utilities` — list utilities this box supports + per-utility STATE
+  (e.g. openpuck: `board_present` / `no_board`; cec: `available`/`enabled`).
+  Read-only, probe-and-appear, cap-gated.
+- `POST /api/utilities/<id>/run` — execute the allowlisted utility. `<id>` is looked
+  up in a frozen registry (`_UTILITIES`), never interpolated. Long ops report via the
+  existing progress/notify path where possible.
+- New cap `utilities` (SIX sites). Per-tenant availability is a field in the state,
+  not a separate cap, so the app renders the section from one probe.
+
+## Tenant 1 — OpenPuck (Engine A). Detail: [[openpuck-utilities-idea]] (memory)
+
+- **Detect:** the nRF52840 nice!nano UF2 bootloader mounts as `NICENANO` /
+  `NRF52BOOT` on the box (Linux, same as macOS). Agent watches for that mount /
+  the bootloader USB id.
+- **Flash:** fetch pinned `OpenPuck-<ver>-standard.uf2` from safijari/openpuck
+  (AGPL; verify pinned sha256), `cp` to the mount. The `cp` "Device not configured"
+  NON-ZERO exit **is success** (board reboots on write). Then confirm USB
+  re-enumerates as Valve `0x28DE:0x1304` ("Steam Controller Puck").
+- **Open spike:** does the box automount the bootloader for the agent user (no root
+  cp)? — verify on the box before claiming it works.
+
+## Tenant 2 — HDMI-CEC. SCOPE PENDING owner confirm (box-enable vs Pi bridge)
+
+Couchside already has: box CEC via `SupplementaryGroups=video` ([[cec-video-group-fix]]),
+CEC control code, and a Pi CEC bridge (`install-cec-bridge.sh`, [[bedroom-cec-bridge]]).
+The utility is ONE of:
+  (i) **Enable box CEC** — detect a CEC adapter, apply the video-group grant, verify
+      the box can drive the TV. Box-side, reuses existing code, verifiable.
+  (ii) **Set up a Pi CEC bridge** — for boxes with no CEC: flash/configure a spare Pi.
+       Bigger; needs the Pi.
+
+## Phases
+
+1. **Framework:** cap `utilities`, `GET /api/utilities` (+ state), `POST /run`, app
+   Setup→Utilities section (probe-and-appear list, per-utility state + action).
+2. **OpenPuck tenant** (Engine A core = the board flasher). Fixture-test the flash
+   gate (pinned sha256, matched mount, no injection); hardware-verify on the box.
+3. **HDMI-CEC tenant** (per the confirmed scope).
+4. Later tenants (ZMK/QMK/WLED via the same flasher; Sunshine/Tailscale via Engine B).
+
+## What NOT to do
+- No client-supplied firmware/URL/device/command, ever. Pinned + matched + verified.
+- No flashing a device that isn't the exact matched bootloader. Fail-closed.
+- Don't claim a flasher/CEC works without HARDWARE verification (§11).

--- a/install.sh
+++ b/install.sh
@@ -55,6 +55,15 @@ PLAYER_DEST_NAME="Couchside Player"
 
 SCREENSAVER_DEST_NAME="Couchside Screensaver"
 SCREENSAVER_DEST_LEGACY="couchside-screensaver.sh"
+# OpenPuck firmware .uf2 (nRF52840 nice!nano), an AGPL-3.0 build from
+# safijari/openpuck, republished as a release asset and verified by the SAME
+# SHA256SUMS gate as the agent, then dropped at a fixed path the agent reads to
+# flash a plugged-in board (Setup -> Utilities). Bundling it means flashing works
+# with the box offline. Optional: a release predating it has no such asset and the
+# flash feature stays dark (the agent degrades closed).
+OPENPUCK_FW_NAME="OpenPuck-0.9.31-standard.uf2"
+OPENPUCK_FW_URL="${AGENT_BASE}/${OPENPUCK_FW_NAME}"
+OPENPUCK_FW_DEST="/etc/couchside/openpuck/firmware.uf2"
 # Signature + checksums for the agent files above, published as sibling assets
 # in the SAME release. install.sh verifies the sig (authenticity) + hashes
 # (integrity) before installing any fetched agent file.
@@ -459,7 +468,9 @@ if [ "$UNINSTALL" -eq 1 ]; then
     note "removed the privileged helper (binary, units, socket dir)"
     sudo rm -f /etc/udev/rules.d/99-couchside-uinput.rules \
                /etc/udev/rules.d/99-couchside-rtc.rules \
+               /etc/udev/rules.d/99-couchside-cec.rules \
                /etc/modules-load.d/couchside-uinput.conf
+    sudo rm -rf /etc/couchside/openpuck
     sudo udevadm control --reload-rules 2>/dev/null || true
     note "removed the udev/modules-load drop-ins"
     if [ "$NO_DECKY" -eq 0 ] && sudo test -d "$DECKY_PLUGIN_DIR"; then
@@ -647,6 +658,12 @@ else
         curl -fsSL "$SCREENSAVER_ART_LANDSCAPE_URL" -o "$WORK_DIR/screensaver-landscape.png" 2>/dev/null || true
         curl -fsSL "$SCREENSAVER_ART_LOGO_URL"      -o "$WORK_DIR/screensaver-logo.png"      2>/dev/null || true
     fi
+    # Optional OpenPuck firmware + its AGPL notice: fetched best-effort and
+    # verified by the SHA256SUMS gate below (both are listed there); installed
+    # only if they land AND are in the signed manifest. A release without them
+    # leaves the flash dark.
+    curl -fsSL "$OPENPUCK_FW_URL" -o "$WORK_DIR/$OPENPUCK_FW_NAME" 2>/dev/null || true
+    curl -fsSL "${AGENT_BASE}/OPENPUCK-NOTICE.txt" -o "$WORK_DIR/OPENPUCK-NOTICE.txt" 2>/dev/null || true
 
     # --- Supply-chain gate (FAIL CLOSED): the fetched agent must be SIGNED by
     # the maintainer's offline Ed25519 key AND match its SHA256SUMS before we
@@ -725,6 +742,24 @@ fi
 say "Installing daemon to $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 install -m 0755 "$WORK_DIR/couchsided.py" "$INSTALL_DIR/couchsided.py"
+# OpenPuck firmware (optional): install ONLY the verified release asset. It rode
+# through the SHA256SUMS gate above like every other fetched file, so if it is
+# both present AND listed in the signed manifest it has been hash-verified;
+# anything else is not installed (fail closed, same policy as the helper). Dropped
+# root-owned at the fixed path the agent reads for Setup -> Utilities flashing.
+if [ -f "$WORK_DIR/$OPENPUCK_FW_NAME" ] \
+   && [ -f "$WORK_DIR/SHA256SUMS" ] \
+   && grep -qF " $OPENPUCK_FW_NAME" "$WORK_DIR/SHA256SUMS"; then
+    sudo install -d -m 0755 "$(dirname "$OPENPUCK_FW_DEST")"
+    sudo install -m 0644 -o root -g root "$WORK_DIR/$OPENPUCK_FW_NAME" "$OPENPUCK_FW_DEST"
+    # AGPL-3.0: the notice (attribution + source offer) rides beside the binary.
+    if [ -f "$WORK_DIR/OPENPUCK-NOTICE.txt" ] \
+       && grep -qF ' OPENPUCK-NOTICE.txt' "$WORK_DIR/SHA256SUMS"; then
+        sudo install -m 0644 -o root -g root "$WORK_DIR/OPENPUCK-NOTICE.txt" \
+            "$(dirname "$OPENPUCK_FW_DEST")/OPENPUCK-NOTICE.txt"
+    fi
+    note "installed OpenPuck firmware ($OPENPUCK_FW_NAME)"
+fi
 # The aerial-screensaver player is optional: install only if wanted AND it
 # fetched and parses (bash -n), so a failed/HTML fetch can't land as an
 # executable script. Installed UNDER THE DISPLAY NAME "Couchside Screensaver" —
@@ -1191,10 +1226,20 @@ say "Granting the agent access to /dev/rtc0 (scheduled wake)"
 printf '%s\n' 'KERNEL=="rtc0", SUBSYSTEM=="rtc", GROUP="input", MODE="0660"' \
     | sudo tee /etc/udev/rules.d/99-couchside-rtc.rules >/dev/null
 
+# HDMI-CEC device access (/dev/cec*): so the Utilities "TV control over HDMI-CEC"
+# helper can actually open the node. Same regroup-to-"input" trick as uinput/rtc0
+# (the agent already holds that group) — applied live, so no re-login or service
+# restart. This is why the agent's CEC state gates "enabled" on real openability:
+# before this rule the node is not openable (needs_enable); after it, enabled.
+say "Granting the agent access to /dev/cec* (HDMI-CEC TV control)"
+printf '%s\n' 'KERNEL=="cec[0-9]", SUBSYSTEM=="cec", GROUP="input", MODE="0660"' \
+    | sudo tee /etc/udev/rules.d/99-couchside-cec.rules >/dev/null
+
 # Apply the rules to the already-present nodes so no reboot is needed.
 sudo udevadm control --reload-rules 2>/dev/null || true
 sudo udevadm trigger --name-match=uinput 2>/dev/null || true
 sudo udevadm trigger --subsystem-match=rtc --action=change 2>/dev/null || true
+sudo udevadm trigger --subsystem-match=cec --action=change 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # (f3) Wake-on-LAN: arm the wired NIC so the phone can wake the box from suspend

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -189,7 +189,8 @@
       "steaminstall",
       "steamlink",
       "steammenus",
-      "streamhost"
+      "streamhost",
+      "utilities"
     ]
   },
   "windowsOnlyCapabilities": {

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -128,6 +128,31 @@ printf '%s\n' "$win_ver" > "$tmp/agent-version-win.txt"
 files+=(agent-version-win.txt)
 echo "==> windows agent version: $win_ver"
 
+# OpenPuck firmware (AGPL-3.0, safijari/openpuck), republished as a signed asset
+# so install.sh can drop it on the box — Setup -> Utilities flashing then works
+# with the box offline. Fetched from the UPSTREAM release and PINNED by sha256;
+# the build ABORTS on any mismatch so we never publish a firmware we didn't
+# verify. The AGPL notice (attribution + source offer) rides alongside it.
+openpuck_fw="OpenPuck-0.9.31-standard.uf2"
+openpuck_sha="36ef6127afc46a067b17de4fe6e79f67a5e1eef15845899f1d4c5aaaf25ba844"
+openpuck_url="https://github.com/safijari/openpuck/releases/download/0.9.31/$openpuck_fw"
+echo "==> fetching OpenPuck firmware $openpuck_fw (pinned sha256)"
+curl -fsSL --max-time 60 "$openpuck_url" -o "$tmp/$openpuck_fw" \
+    || { echo "error: could not fetch OpenPuck firmware from upstream" >&2; exit 2; }
+openpuck_got="$( { command -v sha256sum >/dev/null 2>&1 \
+    && sha256sum "$tmp/$openpuck_fw" \
+    || shasum -a 256 "$tmp/$openpuck_fw"; } | cut -d' ' -f1)"
+if [ "$openpuck_got" != "$openpuck_sha" ]; then
+    echo "error: OpenPuck firmware sha256 mismatch (got $openpuck_got, want $openpuck_sha) — not publishing" >&2
+    exit 2
+fi
+echo "==> OpenPuck firmware verified ($openpuck_sha)"
+files+=("$openpuck_fw")
+[ -f "$agent/openpuck/OPENPUCK-NOTICE.txt" ] \
+    || { echo "error: missing agent/openpuck/OPENPUCK-NOTICE.txt" >&2; exit 2; }
+cp "$agent/openpuck/OPENPUCK-NOTICE.txt" "$tmp/OPENPUCK-NOTICE.txt"
+files+=("OPENPUCK-NOTICE.txt")
+
 echo "==> generating SHA256SUMS over ${#files[@]} agent files"
 ( cd "$tmp" && { command -v sha256sum >/dev/null 2>&1 \
     && sha256sum "${files[@]}" \

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -20,10 +20,12 @@ properties CLAUDE.md §3 cares about BEFORE any RUN handler exists:
 These are fixtures, not live hardware; the box-side truth (openpuck=puck_present,
 cec=enabled on bazzite 2026-08-08) was observed separately.
 """
+import errno
 import http.client
 import importlib.util
 import json
 import os
+import struct
 import shutil
 import sys
 import tempfile
@@ -187,23 +189,52 @@ def test_openpuck_state_precedence():
 print("\n_cec_util_state")
 # ---------------------------------------------------------------------------
 
-def test_cec_state_three_ways():
-    print("test_cec_state_three_ways")
-    with Patch(cec_available=lambda: True):
-        check("agent can drive -> enabled", cs._cec_util_state(), "enabled")
-    with Patch(cec_available=lambda: False, _cec_devices_exist=lambda: True):
-        check("adapter but no access -> needs_enable", cs._cec_util_state(), "needs_enable")
-    with Patch(cec_available=lambda: False, _cec_devices_exist=lambda: False):
-        check("no adapter -> no_adapter", cs._cec_util_state(), "no_adapter")
+def _kern(dev="/dev/cec0"):
+    return {"tool": "cec-ctl", "bin": "/usr/bin/cec-ctl", "device": dev}
+
+
+def _dongle():
+    return {"tool": "cec-client", "bin": "/usr/bin/cec-client", "device": None}
+
+
+def test_cec_state_openability_matrix():
+    """'enabled' means the agent can drive the TV via a live backend. For the KERNEL
+    (cec-ctl) backend it is additionally gated on being able to OPEN the node — the
+    §11 fix so a permission gap is observable as 'needs_enable' and flips to
+    'enabled' once the install-time udev regroup grants access. The libcec dongle
+    backend drives its own serial device and is enabled whenever it is live."""
+    print("test_cec_state_openability_matrix")
+    # No live backend, no node -> no hardware.
+    with Patch(cec_current=lambda: None, _cec_devices_exist=lambda: False):
+        check("no backend, no node -> no_adapter", cs._cec_util_state(), "no_adapter")
+    # Kernel backend on a node the agent can open -> enabled.
+    with Patch(cec_current=_kern, _cec_dev_openable=lambda d: True):
+        check("kernel + openable node -> enabled", cs._cec_util_state(), "enabled")
+    # CONTROL for the false-positive: kernel descriptor present (cec_current sees a
+    # connected port from sysfs) but the node is NOT openable. Old code said
+    # 'enabled'; it must be needs_enable.
+    with Patch(cec_current=_kern, _cec_dev_openable=lambda d: False):
+        check("kernel + node not openable -> needs_enable",
+              cs._cec_util_state(), "needs_enable")
+    # REGRESSION GUARD (finding #2/#3): a libcec USB dongle has NO /dev/cecN node,
+    # but CEC genuinely works. Must be 'enabled', not 'no_adapter'.
+    with Patch(cec_current=_dongle, _cec_devices_exist=lambda: False):
+        check("libcec dongle, no node -> enabled", cs._cec_util_state(), "enabled")
+    # No live backend but a kernel node exists (port off / not yet accessible).
+    with Patch(cec_current=lambda: None, _cec_devices_exist=lambda: True):
+        check("no backend but node exists -> needs_enable",
+              cs._cec_util_state(), "needs_enable")
 
 
 def test_cec_state_probe_raises_degrades_closed():
-    """A throwing probe must not read as enabled."""
+    """A throwing backend probe must never read as enabled."""
     print("test_cec_state_probe_raises_degrades_closed")
     def boom():
-        raise RuntimeError("cec-ctl exploded")
-    with Patch(cec_available=boom, _cec_devices_exist=lambda: False):
-        check("probe raises -> no_adapter", cs._cec_util_state(), "no_adapter")
+        raise RuntimeError("cec probe exploded")
+    with Patch(cec_current=boom, _cec_devices_exist=lambda: True):
+        check("probe raises, node exists -> needs_enable", cs._cec_util_state(), "needs_enable")
+    with Patch(cec_current=boom, _cec_devices_exist=lambda: False):
+        check("probe raises, no node -> no_adapter", cs._cec_util_state(), "no_adapter")
 
 
 # ---------------------------------------------------------------------------
@@ -238,7 +269,7 @@ def test_real_state_uses_probes():
     usb = _usb_tree([])
     try:
         with Patch(_MEDIA_ROOTS=(media,), _USB_DEVICES_DIR=usb,
-                   cec_available=lambda: False, _cec_devices_exist=lambda: False):
+                   cec_current=lambda: None, _cec_devices_exist=lambda: False):
             rows = {r["id"]: r["state"] for r in cs.utilities_state(mock=False)}
             check("real openpuck -> no_board", rows["openpuck"], "no_board")
             check("real cec -> no_adapter", rows["cec"], "no_adapter")
@@ -291,6 +322,188 @@ def test_http_endpoint():
 
 
 # ---------------------------------------------------------------------------
+print("\nreal_openpuck_flash — the Stage 2 flash (both success + failure)")
+# ---------------------------------------------------------------------------
+
+def _fw_file():
+    """A minimal but STRUCTURALLY-VALID UF2 file: one 512-byte block carrying the
+    UF2 magic words, so it passes the agent's _is_uf2 sanity check."""
+    fd, p = tempfile.mkstemp(prefix="openpuck-", suffix=".uf2")
+    os.write(fd, struct.pack("<II", 0x0A324655, 0x9E5D5157) + b"\x00" * (512 - 8))
+    os.close(fd)
+    return p
+
+
+class copyfile_raising:
+    """Force cs's shutil.copyfile to raise a chosen OSError, restore after."""
+
+    def __init__(self, err):
+        self._err = err
+
+    def __enter__(self):
+        self._old = cs.shutil.copyfile
+        def boom(*a, **k):
+            raise OSError(self._err, os.strerror(self._err))
+        cs.shutil.copyfile = boom
+
+    def __exit__(self, *a):
+        cs.shutil.copyfile = self._old
+
+
+def test_flash_no_board_degrades_closed():
+    """No board in DFU -> refuse, never a guessed target."""
+    print("test_flash_no_board_degrades_closed")
+    empty = _media_tree({})
+    fw = _fw_file()
+    try:
+        with Patch(_MEDIA_ROOTS=(empty,), _OPENPUCK_FIRMWARE=fw):
+            r = cs.real_openpuck_flash()
+            check("no board -> ok False", r["ok"], False)
+            check("no board -> exit -1", r["exit_code"], -1)
+    finally:
+        shutil.rmtree(empty, ignore_errors=True)
+        os.unlink(fw)
+
+
+def test_flash_missing_firmware_degrades_closed():
+    """A board is ready but the firmware asset was never installed -> refuse."""
+    print("test_flash_missing_firmware_degrades_closed")
+    ready = _media_tree({"NICENANO": True})
+    try:
+        with Patch(_MEDIA_ROOTS=(ready,),
+                   _OPENPUCK_FIRMWARE="/nonexistent-couchside-fw.uf2"):
+            r = cs.real_openpuck_flash()
+            check("no firmware -> ok False", r["ok"], False)
+    finally:
+        shutil.rmtree(ready, ignore_errors=True)
+
+
+def test_flash_rejects_invalid_firmware():
+    """CONTROL for degrade-CLOSED: a present-but-invalid firmware (0 bytes, or the
+    right size but not a UF2) must NOT flash and report success. A bootloader
+    silently ignores such an image and never reboots, so 'copy didn't error' is not
+    proof of a flash (§3.7, §11)."""
+    print("test_flash_rejects_invalid_firmware")
+    ready = _media_tree({"NICENANO": True})
+    fd, empty = tempfile.mkstemp(suffix=".uf2"); os.close(fd)          # 0 bytes
+    fd, garbage = tempfile.mkstemp(suffix=".uf2")                      # 512B, no magic
+    os.write(fd, b"\x00" * 512); os.close(fd)
+    fd, short = tempfile.mkstemp(suffix=".uf2")                        # magic but not a block multiple
+    os.write(fd, struct.pack("<II", 0x0A324655, 0x9E5D5157)); os.close(fd)
+    try:
+        for bad in (empty, garbage, short):
+            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=bad):
+                r = cs.real_openpuck_flash()
+                check("invalid firmware -> ok False", r["ok"], False)
+    finally:
+        shutil.rmtree(ready, ignore_errors=True)
+        for p in (empty, garbage, short):
+            os.unlink(p)
+
+
+def test_flash_clean_copy_is_success():
+    """Board ready + firmware present + copy completes cleanly -> success, and the
+    bytes actually land in the bootloader mount."""
+    print("test_flash_clean_copy_is_success")
+    ready = _media_tree({"NICENANO": True})
+    fw = _fw_file()
+    try:
+        with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+            r = cs.real_openpuck_flash()
+            check("clean copy -> ok True", r["ok"], True)
+            landed = os.path.join(ready, "deck", "NICENANO", os.path.basename(fw))
+            check("firmware copied into the mount", os.path.isfile(landed), True)
+    finally:
+        shutil.rmtree(ready, ignore_errors=True)
+        os.unlink(fw)
+
+
+def test_flash_device_yank_errno_is_success():
+    """THE inverted rule: the board reboots and yanks its drive mid-write, so the
+    copy raises ENXIO/EIO on a SUCCESSFUL flash. Must read as success."""
+    print("test_flash_device_yank_errno_is_success")
+    ready = _media_tree({"NICENANO": True})
+    fw = _fw_file()
+    try:
+        for err in (errno.ENXIO, errno.EIO):
+            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+                with copyfile_raising(err):
+                    r = cs.real_openpuck_flash()
+                    check("errno %d -> ok True" % err, r["ok"], True)
+    finally:
+        shutil.rmtree(ready, ignore_errors=True)
+        os.unlink(fw)
+
+
+def test_flash_other_errno_is_failure():
+    """CONTROL for the inverted rule: an unrelated OSError (EPERM/EACCES) is a
+    genuine failure, not success. Without this, 'any error = success' would pass
+    every other test too."""
+    print("test_flash_other_errno_is_failure")
+    ready = _media_tree({"NICENANO": True})
+    fw = _fw_file()
+    try:
+        for err in (errno.EPERM, errno.EACCES, errno.ENOSPC):
+            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+                with copyfile_raising(err):
+                    r = cs.real_openpuck_flash()
+                    check("errno %d -> ok False" % err, r["ok"], False)
+    finally:
+        shutil.rmtree(ready, ignore_errors=True)
+        os.unlink(fw)
+
+
+def test_flash_target_is_not_client_supplied():
+    """§3: real_openpuck_flash takes NO arguments — the target comes from
+    _openpuck_bootloader_mount() and the firmware from the fixed agent-owned
+    constant. The client can influence neither."""
+    print("test_flash_target_is_not_client_supplied")
+    import inspect
+    sig = inspect.signature(cs.real_openpuck_flash)
+    check("flash takes no client params", len(sig.parameters), 0)
+
+
+# ---------------------------------------------------------------------------
+print("\nHTTP: POST /api/utilities/<id>/run")
+# ---------------------------------------------------------------------------
+
+def test_http_run_endpoint():
+    print("test_http_run_endpoint")
+    srv, port = _server()  # mock=True -> mock_openpuck_flash
+    try:
+        # Happy path: flash the board (mock).
+        st, bd = _req(port, "POST", "/api/utilities/openpuck/run")
+        check("POST openpuck/run -> 200", st, 200)
+        check("mock flash -> ok True", bd.get("ok"), True)
+
+        # Auth gate.
+        check("no bearer -> 401",
+              _req(port, "POST", "/api/utilities/openpuck/run", token=None)[0], 401)
+        check("wrong bearer -> 401",
+              _req(port, "POST", "/api/utilities/openpuck/run", token="nope")[0], 401)
+
+        # cec is DETECTABLE but not runnable -> distinct 404, nothing runs.
+        st, bd = _req(port, "POST", "/api/utilities/cec/run")
+        check("cec/run -> 404", st, 404)
+        check("cec/run says no run action", bd.get("error"), "utility has no run action")
+
+        # Unknown utility id -> 404, nothing runs (reject not sanitise).
+        st, bd = _req(port, "POST", "/api/utilities/bogus/run")
+        check("bogus/run -> 404", st, 404)
+        check("bogus/run unknown utility", bd.get("error"), "unknown utility")
+
+        # Path-shaped / injection-shaped ids are just unknown ids -> 404.
+        for bad in ("/api/utilities/..%2Frun/run", "/api/utilities/openpuck%20/run"):
+            check("%s -> 404" % bad, _req(port, "POST", bad)[0], 404)
+
+        # No /run suffix is not a run route at all (falls through to a 404).
+        check("openpuck without /run -> 404",
+              _req(port, "POST", "/api/utilities/openpuck")[0], 404)
+    finally:
+        srv.shutdown()
+
+
+# ---------------------------------------------------------------------------
 print("\ncap wiring")
 # ---------------------------------------------------------------------------
 
@@ -310,12 +523,20 @@ if __name__ == "__main__":
                test_usb_present_matches_vid_pid,
                test_usb_present_missing_dir_degrades_closed,
                test_openpuck_state_precedence,
-               test_cec_state_three_ways,
+               test_cec_state_openability_matrix,
                test_cec_state_probe_raises_degrades_closed,
                test_state_iterates_frozen_id_set,
                test_mock_state_is_renderable,
                test_real_state_uses_probes,
                test_http_endpoint,
+               test_flash_no_board_degrades_closed,
+               test_flash_missing_firmware_degrades_closed,
+               test_flash_rejects_invalid_firmware,
+               test_flash_clean_copy_is_success,
+               test_flash_device_yank_errno_is_success,
+               test_flash_other_errno_is_failure,
+               test_flash_target_is_not_client_supplied,
+               test_http_run_endpoint,
                test_cap_present_in_mock_and_real):
         fn()
     if FAILURES:

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Tests for Setup -> Utilities (Stage 1: read-only detection, agent side).
+
+Run: python3 tests/test_utilities.py
+
+WHAT THIS GUARDS. Utilities is a NEW surface that will grow state-changing tenants
+(flash a board, enable CEC). Stage 1 ships only DETECTION, and this file pins the
+properties CLAUDE.md §3 cares about BEFORE any RUN handler exists:
+
+  1. The tenant set is a FROZEN id list (`_UTILITY_IDS`); the state is built by
+     iterating that list and looking each id up in `_UTILITY_META` — a client never
+     names a utility, supplies a device, or supplies firmware.
+  2. Detection is READ-ONLY and degrades CLOSED: an unreadable /sys, /run/media, or a
+     missing /dev/cec is 'no_board' / 'no_adapter', never a ready/enabled state.
+  3. The OpenPuck flash TARGET is matched by a known bootloader label + the UF2 marker
+     file (INFO_UF2.TXT) — a volume with the right label but no marker is NOT ready
+     (the control), so we never point a future flash at the wrong mount.
+  4. GET /api/utilities is behind the bearer gate like every other /api route.
+
+These are fixtures, not live hardware; the box-side truth (openpuck=puck_present,
+cec=enabled on bazzite 2026-08-08) was observed separately.
+"""
+import http.client
+import importlib.util
+import json
+import os
+import shutil
+import sys
+import tempfile
+import threading
+from http.server import ThreadingHTTPServer
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+TOKEN = "test-secret-token"
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+class Patch:
+    """Swap module attributes for the duration of a `with`, restore after."""
+
+    def __init__(self, **kw):
+        self._kw = kw
+        self._old = {}
+
+    def __enter__(self):
+        for k, v in self._kw.items():
+            self._old[k] = getattr(cs, k)
+            setattr(cs, k, v)
+        return self
+
+    def __exit__(self, *a):
+        for k, v in self._old.items():
+            setattr(cs, k, v)
+
+
+def _media_tree(volumes):
+    """Build a fake udisks automount root: {volume_label: has_marker_bool}.
+    Returns a dir usable as a single entry of _MEDIA_ROOTS (root/<user>/<vol>)."""
+    root = tempfile.mkdtemp(prefix="util-media-")
+    user = os.path.join(root, "deck")
+    os.makedirs(user)
+    for label, has_marker in volumes.items():
+        vol = os.path.join(user, label)
+        os.makedirs(vol)
+        if has_marker:
+            with open(os.path.join(vol, "INFO_UF2.TXT"), "w") as f:
+                f.write("UF2 Bootloader\nModel: nice!nano\n")
+    return root
+
+
+def _usb_tree(devices):
+    """Build a fake /sys/bus/usb/devices: list of (vid, pid). Names are dev1.. and
+    an interface node (with ':') is added to prove it is skipped."""
+    root = tempfile.mkdtemp(prefix="util-usb-")
+    for i, (vid, pid) in enumerate(devices):
+        d = os.path.join(root, "dev%d" % i)
+        os.makedirs(d)
+        with open(os.path.join(d, "idVendor"), "w") as f:
+            f.write(vid + "\n")
+        with open(os.path.join(d, "idProduct"), "w") as f:
+            f.write(pid + "\n")
+    # An interface node — has ':' in the name, must be ignored, no id files.
+    os.makedirs(os.path.join(root, "1-1:1.0"))
+    return root
+
+
+# ---------------------------------------------------------------------------
+print("\n_openpuck_bootloader_mount — the flash target")
+# ---------------------------------------------------------------------------
+
+def test_bootloader_mount_needs_label_and_marker():
+    print("test_bootloader_mount_needs_label_and_marker")
+    r = _media_tree({"NICENANO": True})
+    try:
+        with Patch(_MEDIA_ROOTS=(r,)):
+            got = cs._openpuck_bootloader_mount()
+            check("labelled + marker -> path", got and got.endswith("NICENANO"), True)
+    finally:
+        shutil.rmtree(r, ignore_errors=True)
+
+
+def test_bootloader_label_without_marker_refused():
+    """CONTROL: a volume with the bootloader label but NO INFO_UF2.TXT is not a
+    ready board — a random USB stick someone named NICENANO must not be a flash
+    target."""
+    print("test_bootloader_label_without_marker_refused")
+    r = _media_tree({"NICENANO": False})
+    try:
+        with Patch(_MEDIA_ROOTS=(r,)):
+            check("label but no marker -> None", cs._openpuck_bootloader_mount(), None)
+    finally:
+        shutil.rmtree(r, ignore_errors=True)
+
+
+def test_bootloader_wrong_label_refused():
+    print("test_bootloader_wrong_label_refused")
+    r = _media_tree({"MYUSB": True, "STEAMSD": True})
+    try:
+        with Patch(_MEDIA_ROOTS=(r,)):
+            check("non-bootloader labels -> None", cs._openpuck_bootloader_mount(), None)
+    finally:
+        shutil.rmtree(r, ignore_errors=True)
+
+
+def test_bootloader_missing_root_degrades_closed():
+    print("test_bootloader_missing_root_degrades_closed")
+    with Patch(_MEDIA_ROOTS=("/nonexistent-couchside-xyz",)):
+        check("unreadable roots -> None", cs._openpuck_bootloader_mount(), None)
+
+
+# ---------------------------------------------------------------------------
+print("\n_usb_present + _openpuck_state")
+# ---------------------------------------------------------------------------
+
+def test_usb_present_matches_vid_pid():
+    print("test_usb_present_matches_vid_pid")
+    r = _usb_tree([("28de", "1304"), ("1234", "5678")])
+    try:
+        with Patch(_USB_DEVICES_DIR=r):
+            check("puck vid:pid present", cs._usb_present("28de", "1304"), True)
+            check("absent vid:pid (control)", cs._usb_present("dead", "beef"), False)
+    finally:
+        shutil.rmtree(r, ignore_errors=True)
+
+
+def test_usb_present_missing_dir_degrades_closed():
+    print("test_usb_present_missing_dir_degrades_closed")
+    with Patch(_USB_DEVICES_DIR="/nonexistent-couchside-xyz"):
+        check("no sysfs -> False", cs._usb_present("28de", "1304"), False)
+
+
+def test_openpuck_state_precedence():
+    """board_ready (a bootloader mount) beats puck_present beats no_board."""
+    print("test_openpuck_state_precedence")
+    media_ready = _media_tree({"NICENANO": True})
+    media_empty = _media_tree({})
+    usb_puck = _usb_tree([("28de", "1304")])
+    usb_none = _usb_tree([("1234", "5678")])
+    try:
+        # A board in DFU takes priority even if a puck is also enumerated.
+        with Patch(_MEDIA_ROOTS=(media_ready,), _USB_DEVICES_DIR=usb_puck):
+            check("dfu board -> board_ready", cs._openpuck_state(), "board_ready")
+        with Patch(_MEDIA_ROOTS=(media_empty,), _USB_DEVICES_DIR=usb_puck):
+            check("flashed puck -> puck_present", cs._openpuck_state(), "puck_present")
+        with Patch(_MEDIA_ROOTS=(media_empty,), _USB_DEVICES_DIR=usb_none):
+            check("nothing -> no_board", cs._openpuck_state(), "no_board")
+    finally:
+        for d in (media_ready, media_empty, usb_puck, usb_none):
+            shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+print("\n_cec_util_state")
+# ---------------------------------------------------------------------------
+
+def test_cec_state_three_ways():
+    print("test_cec_state_three_ways")
+    with Patch(cec_available=lambda: True):
+        check("agent can drive -> enabled", cs._cec_util_state(), "enabled")
+    with Patch(cec_available=lambda: False, _cec_devices_exist=lambda: True):
+        check("adapter but no access -> needs_enable", cs._cec_util_state(), "needs_enable")
+    with Patch(cec_available=lambda: False, _cec_devices_exist=lambda: False):
+        check("no adapter -> no_adapter", cs._cec_util_state(), "no_adapter")
+
+
+def test_cec_state_probe_raises_degrades_closed():
+    """A throwing probe must not read as enabled."""
+    print("test_cec_state_probe_raises_degrades_closed")
+    def boom():
+        raise RuntimeError("cec-ctl exploded")
+    with Patch(cec_available=boom, _cec_devices_exist=lambda: False):
+        check("probe raises -> no_adapter", cs._cec_util_state(), "no_adapter")
+
+
+# ---------------------------------------------------------------------------
+print("\nutilities_state — the list shape + frozen tenant set")
+# ---------------------------------------------------------------------------
+
+def test_state_iterates_frozen_id_set():
+    """Every row's id is in the frozen tenant set, and each carries meta. A client
+    can never introduce a row — the list is built from _UTILITY_IDS, not input."""
+    print("test_state_iterates_frozen_id_set")
+    rows = cs.utilities_state(mock=True)
+    ids = [r["id"] for r in rows]
+    check("ids are exactly the frozen tenants", set(ids), set(cs._UTILITY_IDS))
+    check("openpuck + cec, in order", ids, ["openpuck", "cec"])
+    for r in rows:
+        check("row %s has label" % r["id"], bool(r.get("label")), True)
+        check("row %s has description" % r["id"], bool(r.get("description")), True)
+        check("row %s has a state" % r["id"], bool(r.get("state")), True)
+
+
+def test_mock_state_is_renderable():
+    print("test_mock_state_is_renderable")
+    rows = {r["id"]: r["state"] for r in cs.utilities_state(mock=True)}
+    check("mock openpuck board_ready", rows["openpuck"], "board_ready")
+    check("mock cec needs_enable", rows["cec"], "needs_enable")
+
+
+def test_real_state_uses_probes():
+    """Real (non-mock) state comes from the detectors, not the mock literals."""
+    print("test_real_state_uses_probes")
+    media = _media_tree({})
+    usb = _usb_tree([])
+    try:
+        with Patch(_MEDIA_ROOTS=(media,), _USB_DEVICES_DIR=usb,
+                   cec_available=lambda: False, _cec_devices_exist=lambda: False):
+            rows = {r["id"]: r["state"] for r in cs.utilities_state(mock=False)}
+            check("real openpuck -> no_board", rows["openpuck"], "no_board")
+            check("real cec -> no_adapter", rows["cec"], "no_adapter")
+    finally:
+        shutil.rmtree(media, ignore_errors=True)
+        shutil.rmtree(usb, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+print("\nHTTP: GET /api/utilities")
+# ---------------------------------------------------------------------------
+
+def _server():
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True  # deterministic body; detection is unit-tested above
+    cs.Handler.port = 0
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _req(port, method, path, token=TOKEN):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    headers = {"Authorization": "Bearer " + token} if token is not None else {}
+    conn.request(method, path, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(data or b"{}")
+    except ValueError:
+        return resp.status, {}
+
+
+def test_http_endpoint():
+    print("test_http_endpoint")
+    srv, port = _server()
+    try:
+        status, body = _req(port, "GET", "/api/utilities")
+        check("GET utilities -> 200", status, 200)
+        ids = [u["id"] for u in body.get("utilities", [])]
+        check("body lists the tenants", ids, ["openpuck", "cec"])
+
+        # Auth gate: same as every other /api route.
+        check("no bearer -> 401", _req(port, "GET", "/api/utilities", token=None)[0], 401)
+        check("wrong bearer -> 401", _req(port, "GET", "/api/utilities", token="nope")[0], 401)
+    finally:
+        srv.shutdown()
+
+
+# ---------------------------------------------------------------------------
+print("\ncap wiring")
+# ---------------------------------------------------------------------------
+
+def test_cap_present_in_mock_and_real():
+    print("test_cap_present_in_mock_and_real")
+    cs.set_caps(True)
+    check("mock CAPS has utilities=True", cs.CAPS.get("utilities"), True)
+    cs.set_caps(False)
+    check("real CAPS has utilities=True", cs.CAPS.get("utilities"), True)
+
+
+if __name__ == "__main__":
+    for fn in (test_bootloader_mount_needs_label_and_marker,
+               test_bootloader_label_without_marker_refused,
+               test_bootloader_wrong_label_refused,
+               test_bootloader_missing_root_degrades_closed,
+               test_usb_present_matches_vid_pid,
+               test_usb_present_missing_dir_degrades_closed,
+               test_openpuck_state_precedence,
+               test_cec_state_three_ways,
+               test_cec_state_probe_raises_degrades_closed,
+               test_state_iterates_frozen_id_set,
+               test_mock_state_is_renderable,
+               test_real_state_uses_probes,
+               test_http_endpoint,
+               test_cap_present_in_mock_and_real):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")


### PR DESCRIPTION
An extensible, **opt-in** Utilities menu under Setup → Prefs. Launch tenants:
**OpenPuck** (flash an nRF52840 board into a Steam Controller 2 receiver) and
**HDMI-CEC** (box drives the TV over HDMI).

## Stage 1 — detection (agent 2.9.74)
`GET /api/utilities` reports each tenant's live state, read-only + bearer-gated;
new `utilities` cap (six sites); frozen tenant set; OpenPuck target matched by a
known bootloader label **and** the `INFO_UF2.TXT` marker; degrade-closed. App
`UtilitiesSection.tsx` gated on the `utilitiesEnabled` pref (default false).

## Stage 2 — OpenPuck flash + honest CEC (agent 2.9.75)

**OpenPuck flash** — `POST /api/utilities/openpuck/run` copies the pinned firmware
onto a plugged-in board in its UF2 bootloader; it reboots as a Steam Controller 2
receiver.
- id looked up in the frozen `_UTILITY_RUN_IDS` (`cec` is detectable-not-runnable →
  404 "utility has no run action"); target from `_openpuck_bootloader_mount()` (None
  → refuse); firmware from the fixed agent-owned path; no-shell `shutil.copyfile`.
- The board yanks its USB drive mid-write, so `OSError` ENXIO/EIO = **success**
  (EPERM/EACCES/ENOSPC = failure).
- Firmware is validated as a real UF2 (size + magic) **before** copy, so a
  truncated/zeroed image degrades closed instead of a false "Flashed".

**Firmware = bundle** (owner-chosen, offline-capable): `release-agent.sh` fetches
the .uf2 from safijari/openpuck, verifies a **pinned sha256**, republishes it as a
signed asset + AGPL notice; `install.sh` installs it only if present **and** listed
in the signed SHA256SUMS (fail closed).

**CEC — honest detection, not a runtime button.** A runtime "enable" can't flip the
state (recon-proven): `needs_enable` is a catch-all, the fixable case (node not
openable) was invisible to the old detector, and `SupplementaryGroups=video` can't
work at runtime.
- `_cec_util_state` now gates the **kernel** path's `enabled` on real node
  openability (`os.access`), so a permission gap shows as `needs_enable` and flips
  to `enabled` once granted (§11, both directions). The **libcec USB-dongle** backend
  is decoupled from `/dev/cecN` and stays `enabled` when live.
- `install.sh` adds a udev regroup-to-`input` rule for `/dev/cec*` (mirrors
  uinput/rtc0, applied live).

## Allowlist / §3 posture
- Run id looked up in the frozen `_UTILITY_RUN_IDS`; unknown → 404, nothing runs.
- Flash target + firmware are never client-supplied; copy is a no-shell `copyfile`.
- Route behind the `do_POST` bearer gate; installer firmware behind the signed
  SHA256SUMS gate.

## Verified
- Agent unit tests **60/60** (flash success/failure both errno directions,
  invalid-firmware degrade-closed, POST auth/unknown/cec-not-runnable/path-shaped,
  CEC openability matrix incl. the false-positive control **and** the libcec-dongle
  regression guard). protocol-parity + ci-wiring + steam-install + actions-inject +
  tv-identify green. App node tests **430/430**; tsc clean; `bash -n` clean.
- **Web harness (--mock):** pressed **Flash receiver** → confirm → `POST
  /api/utilities/openpuck/run → 200` (network log) → green success note; `POST
  cec/run → 404`; honest CEC copy. Toggle OFF hides the section, ON reveals both
  tenants (both states observed).
- **Adversarial review** found 3 issues (empty-firmware false success; libcec CEC
  regression; missing libcec test) — **all fixed** in this PR.
- **NOT verified on hardware:** a real board in DFU, the udev rule flipping a real
  `needs_enable` box, and a real release publishing the .uf2 (box was off-subnet).
  The flash logic is covered by errno + degrade-closed fixtures instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)