### PR TITLE
chore(app): 2.9.43 build 155

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.42",
+    "version": "2.9.43",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "150",
+      "buildNumber": "155",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Version bump for the TestFlight build carrying the Utilities feature (Stage 1 detection + Stage 2 OpenPuck flash / honest CEC) plus the install-owned-games card + filters. iOS build 155 uploaded to TestFlight (2.9.43). Agent side shipped as 2.9.75 on v2.9.39.

🤖 Generated with [Claude Code](https://claude.com/claude-code)