### PR TITLE
feat: whole library instantly — agent-side names from appinfo.vdf (2.9.76, build 157)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.76
+
+**Your whole library, instantly.** The Not-installed page used to fill in game
+names through Steam's rate-limited store API, so a big library appeared a few
+dozen games at a time (an 1101-app library showed 88 after days). The box now
+reads the names Steam already keeps on disk and sends them with the list — every
+game appears immediately, alphabetical and searchable, even with the internet
+down. Genres and release years still fill in gradually for the filters.
+
 ## 2.9.75
 
 **Utilities can now flash an OpenPuck receiver.** The OpenPuck utility gained a

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.75"
+VERSION = "2.9.76"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -6549,21 +6549,172 @@ def _installable_appids():
     return val
 
 
+# ---------------------------------------------------------------------------
+# appinfo.vdf — Steam's own metadata cache: name + type for every owned app.
+#
+# The first cut of the installable list shipped appid-only, on the belief that
+# "appinfo.vdf is a partial cache". MEASURED on real hardware (bazzite,
+# 2026-08-09): it carried a name for 1101/1101 (100%) of the installable set —
+# and the app-side store lookup it deferred to rate-limits at ~200/5min, which on
+# an 1101-app library meant the Not-installed page listed 88 games after days of
+# use. So the agent now parses appinfo.vdf (READ-ONLY, pure stdlib) and ships
+# name+type with the list; the store lookup remains app-side for what appinfo
+# lacks (genres, release year). Additive fields only — old apps ignore them.
+#
+# Format (binary): header magic 0x075644{27,28,29} + universe u32; v29 adds an
+# i64 offset to a string table (keys become u32 indices instead of inline
+# cstrings). Then per app: appid u32, size u32, then `size` bytes = fixed fields
+# (infoState u32, lastUpdated u32, picsToken u64, sha1[20], changeNumber u32,
+# v28+: binarySha1[20]) + a binary-VDF blob. name/type live at
+# appinfo.common.{name,type}. Node types: 0x00 dict, 0x01 str, 0x02 u32,
+# 0x07 u64, 0x08 end-of-dict.
+# ---------------------------------------------------------------------------
+_APPINFO_MAGIC_V29 = 0x07564429
+_APPINFO_MAGIC_V28 = 0x07564428
+_APPINFO_MAGIC_V27 = 0x07564427
+# Parse cache keyed on (path, mtime, size) — the file only changes when Steam
+# updates app metadata, and a full parse of a real 4.2MB file measures ~80ms.
+_APPINFO_CACHE = {"key": None, "val": None}
+
+
+def _appinfo_bvdf(buf, pos, end, strings):
+    """One binary-VDF node table -> dict. Keys: v29 = u32 string-table index;
+    v27/v28 = inline cstring. Raises on malformed input (caller degrades)."""
+    root = {}
+    stack = [root]
+    while pos < end:
+        t = buf[pos]
+        pos += 1
+        if t == 0x08:  # end of current dict
+            stack.pop()
+            if not stack:
+                break
+            continue
+        if strings is not None:
+            (idx,) = struct.unpack_from("<I", buf, pos)
+            pos += 4
+            key = strings[idx]
+        else:
+            zero = buf.index(b"\x00", pos)
+            key = buf[pos:zero].decode("utf-8", "replace")
+            pos = zero + 1
+        if t == 0x00:
+            d = {}
+            stack[-1][key] = d
+            stack.append(d)
+        elif t == 0x01:
+            zero = buf.index(b"\x00", pos)
+            stack[-1][key] = buf[pos:zero].decode("utf-8", "replace")
+            pos = zero + 1
+        elif t == 0x02:
+            (v,) = struct.unpack_from("<I", buf, pos)
+            pos += 4
+            stack[-1][key] = v
+        elif t == 0x07:
+            (v,) = struct.unpack_from("<Q", buf, pos)
+            pos += 8
+            stack[-1][key] = v
+        else:
+            raise ValueError("unknown vdf node type 0x%02X" % t)
+    return root
+
+
+def _appinfo_path():
+    root = _steam_root()
+    if not root:
+        return None
+    p = os.path.join(root, "appcache", "appinfo.vdf")
+    return p if os.path.isfile(p) else None
+
+
+def _appinfo_names():
+    """{appid: {"name": str, "type": str}} parsed from appinfo.vdf. READ-ONLY and
+    degrades CLOSED: any missing file, bad magic, or malformed blob yields {} (or
+    skips just that app) — the list then ships appid-only exactly as before."""
+    path = _appinfo_path()
+    if not path:
+        return {}
+    try:
+        st = os.stat(path)
+        key = (path, st.st_mtime, st.st_size)
+        if _APPINFO_CACHE["key"] == key:
+            return _APPINFO_CACHE["val"]
+        with open(path, "rb") as f:
+            buf = f.read()
+        magic, _universe = struct.unpack_from("<II", buf, 0)
+        if magic not in (_APPINFO_MAGIC_V29, _APPINFO_MAGIC_V28, _APPINFO_MAGIC_V27):
+            return {}
+        pos = 8
+        strings = None
+        data_end = len(buf)
+        if magic == _APPINFO_MAGIC_V29:
+            (table_off,) = struct.unpack_from("<q", buf, pos)
+            pos += 8
+            (count,) = struct.unpack_from("<I", buf, table_off)
+            strings = []
+            p = table_off + 4
+            for _ in range(count):
+                zero = buf.index(b"\x00", p)
+                strings.append(buf[p:zero].decode("utf-8", "replace"))
+                p = zero + 1
+            data_end = table_off
+        out = {}
+        while pos + 8 <= data_end:
+            appid, size = struct.unpack_from("<II", buf, pos)
+            pos += 8
+            if appid == 0:
+                break
+            blob_end = pos + size
+            hdr = 4 + 4 + 8 + 20 + 4  # infoState, lastUpdated, picsToken, sha1, changeNumber
+            if magic in (_APPINFO_MAGIC_V28, _APPINFO_MAGIC_V29):
+                hdr += 20  # binarySha1
+            try:
+                kv = _appinfo_bvdf(buf, pos + hdr, blob_end, strings)
+                common = kv.get("appinfo", {}).get("common", {})
+                name = common.get("name")
+                if isinstance(name, str) and name:
+                    typ = common.get("type")
+                    out[appid] = {"name": name,
+                                  "type": (typ if isinstance(typ, str) else "").lower()}
+            except Exception:
+                pass  # one bad blob must not sink the rest
+            pos = blob_end
+        _APPINFO_CACHE.update(key=key, val=out)
+        return out
+    except Exception:
+        return {}
+
+
 def _installable_games():
-    """[{"appid": int}] for owned-but-uninstalled games, sorted by appid.
+    """[{"appid": int, "name"?: str, "type"?: str}] for owned-but-uninstalled
+    apps, sorted by appid. name/type come OFFLINE from Steam's own appinfo.vdf
+    when it parses (measured 100% coverage on a real 1101-app library); entries
+    it lacks ship appid-only and the app's keyless store lookup covers them.
+    The app filters to type=game — DLC/tools/demos carry librarycache art too,
+    so the raw list overcounts games by ~2.5x. Additive fields only (§4)."""
+    meta = _appinfo_names()
+    out = []
+    for a in sorted(_installable_appids(), key=lambda a: int(a)):
+        g = {"appid": int(a)}
+        m = meta.get(int(a))
+        if m:
+            g["name"] = m["name"]
+            g["type"] = m["type"]
+        out.append(g)
+    return out
 
-    NAMES are deliberately omitted: the box has no reliable OFFLINE name for an
-    uninstalled game (appinfo.vdf is a partial cache), and inventing one is worse
-    than none — the app resolves names app-side from the KEYLESS store endpoint and
-    filters to type=game there. Art, when present, is already on disk and served by
-    the existing GET /api/steam/<appid>/cover for any appid, installed or not."""
-    return [{"appid": int(a)}
-            for a in sorted(_installable_appids(), key=lambda a: int(a))]
 
-
-# Mock owned-but-uninstalled list for the web harness / --mock. Real appids so the
-# app's keyless store-name lookup resolves recognisable titles when exercised.
-MOCK_INSTALLABLE = [{"appid": a} for a in (220, 400, 620, 292030, 570)]
+# Mock owned-but-uninstalled list for the web harness / --mock. Real appids +
+# names/types matching what a real appinfo.vdf would supply, so the app renders
+# titles immediately and its type=game filter is exercised (620 = a non-game
+# control would be wrong here: all five are games).
+MOCK_INSTALLABLE = [
+    {"appid": 220, "name": "Half-Life 2", "type": "game"},
+    {"appid": 400, "name": "Portal", "type": "game"},
+    {"appid": 620, "name": "Portal 2", "type": "game"},
+    {"appid": 292030, "name": "The Witcher 3: Wild Hunt", "type": "game"},
+    {"appid": 570, "name": "Dota 2", "type": "game"},
+]
 
 
 # ---------------------------------------------------------------------------

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "156",
+      "buildNumber": "157",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/installable.tsx
+++ b/app/app/installable.tsx
@@ -133,6 +133,14 @@ export default function InstallablePage() {
   const { width: winW } = useWindowDimensions();
   const [appids, setAppids] = useState<number[] | null>(null);
   const [details, setDetails] = useState<Record<number, AppDetails | null | undefined>>({});
+  // OFFLINE names+types from the agent (>= 2.9.76, parsed from the box's own
+  // appinfo.vdf). Kept SEPARATE from the store `details` map on purpose: the
+  // store index still runs to enrich genres/release-year (agent meta has
+  // neither), and `details[id] ?? agentMeta[id]` means store data wins when it
+  // arrives while the agent name survives a store failure. Before this seed, a
+  // big library filled at the store's ~200/5min rate — an 1101-app library
+  // showed 88 games after days of use.
+  const [agentMeta, setAgentMeta] = useState<Record<number, AppDetails>>({});
   const [compat, setCompat] = useState<Record<number, Compat | undefined>>({});
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<Sort>('az');
@@ -140,12 +148,20 @@ export default function InstallablePage() {
   const [onlyRunsWell, setOnlyRunsWell] = useState(false);
   const [sheet, setSheet] = useState(false);
 
-  // Fetch the appid list once.
+  // Fetch the appid list once. Entries carry name/type on new agents.
   useEffect(() => {
     let live = true;
     void (async () => {
       const res = await api.installable(settings);
-      if (live) setAppids(res ? res.games.map((g) => g.appid) : []);
+      if (!live) return;
+      setAppids(res ? res.games.map((g) => g.appid) : []);
+      if (res) {
+        const seed: Record<number, AppDetails> = {};
+        for (const g of res.games) {
+          if (g.name) seed[g.appid] = { name: g.name, type: g.type ?? '' };
+        }
+        setAgentMeta(seed);
+      }
     })();
     return () => { live = false; };
   }, [settings]);
@@ -176,8 +192,8 @@ export default function InstallablePage() {
   const compatRef = useRef(compat);
   compatRef.current = compat;
   const gameIds = useMemo(
-    () => (appids ?? []).filter((id) => isInstallableGameType(details[id])),
-    [appids, details],
+    () => (appids ?? []).filter((id) => isInstallableGameType(details[id] ?? agentMeta[id])),
+    [appids, details, agentMeta],
   );
   useEffect(() => {
     if (!onlyRunsWell) return;
@@ -219,8 +235,11 @@ export default function InstallablePage() {
 
   const q = query.trim().toLowerCase();
   const data = useMemo(() => {
+    // Store details win (they carry genres/year); the agent's offline name+type
+    // stand in until then — and permanently, if the store never answers.
+    const eff = (id: number) => (details[id] ?? agentMeta[id])!;
     const rows = gameIds.filter((id) => {
-      const d = details[id]!;
+      const d = eff(id);
       if (q && !d.name.toLowerCase().includes(q)) return false;
       if (genres.size && !(d.genres ?? []).some((g) => genres.has(g))) return false;
       if (onlyRunsWell) {
@@ -230,14 +249,14 @@ export default function InstallablePage() {
       return true;
     });
     rows.sort((a, b) => {
-      const da = details[a]!, db = details[b]!;
+      const da = eff(a), db = eff(b);
       if (sort === 'newest') return (db.releaseYear ?? -1) - (da.releaseYear ?? -1)
         || da.name.localeCompare(db.name);
       const c = da.name.localeCompare(db.name);
       return sort === 'za' ? -c : c;
     });
     return rows;
-  }, [gameIds, details, compat, q, genres, onlyRunsWell, sort]);
+  }, [gameIds, details, agentMeta, compat, q, genres, onlyRunsWell, sort]);
 
   const [requested, setRequested] = useState<Set<number>>(new Set());
   const onRequested = useCallback((appid: number) => setRequested((p) => new Set(p).add(appid)), []);
@@ -245,6 +264,7 @@ export default function InstallablePage() {
   const colW = Math.floor((winW - 12) / COLUMNS); // listWrap has paddingHorizontal: 6
   const resolvedCount = appids ? appids.filter((id) => details[id] !== undefined).length : 0;
   const indexing = appids ? resolvedCount < appids.length : false;
+  const seeded = Object.keys(agentMeta).length > 0;
   const activeFilters = genres.size + (onlyRunsWell ? 1 : 0);
   const sortLabel = SORTS.find((s) => s.key === sort)!.label;
 
@@ -256,7 +276,10 @@ export default function InstallablePage() {
           <Ionicons name="chevron-back" size={26} color={t.text} />
         </Pressable>
         <Text style={styles.title}>Not installed</Text>
-        <Text style={styles.count}>{appids ? `${appids.length}` : ''}</Text>
+        {/* Seeded (agent >= 2.9.76): the true GAME count, immediately — the raw
+            appid list overcounts ~2.5x with DLC/tools. Unseeded: the raw count,
+            as before, while the store index discovers which entries are games. */}
+        <Text style={styles.count}>{appids ? `${seeded ? gameIds.length : appids.length}` : ''}</Text>
       </View>
 
       <View style={styles.controls}>
@@ -289,7 +312,11 @@ export default function InstallablePage() {
       </View>
       <Text style={styles.sortLine} numberOfLines={1}>
         {sortLabel}{activeFilters > 0 ? ` · ${activeFilters} filter${activeFilters > 1 ? 's' : ''}` : ''}
-        {indexing ? `  ·  indexing ${resolvedCount}/${appids!.length}…` : ''}
+        {/* Seeded: the LIST is already complete (agent names); the store index only
+            enriches genres/release-year for the filters. Unseeded: it IS the list. */}
+        {indexing ? (seeded
+          ? `  ·  loading genres ${resolvedCount}/${appids!.length}…`
+          : `  ·  indexing ${resolvedCount}/${appids!.length}…`) : ''}
       </Text>
 
       {appids === null ? (
@@ -301,8 +328,8 @@ export default function InstallablePage() {
             keyExtractor={(id) => String(id)}
             numColumns={COLUMNS}
             renderItem={({ item }) => (
-              <Cell appid={item} name={details[item]?.name} requested={requested.has(item)}
-                onRequested={onRequested} colW={colW} />
+              <Cell appid={item} name={(details[item] ?? agentMeta[item])?.name}
+                requested={requested.has(item)} onRequested={onRequested} colW={colW} />
             )}
             onViewableItemsChanged={onViewableItemsChanged}
             viewabilityConfig={{ itemVisiblePercentThreshold: 10 }}
@@ -313,7 +340,7 @@ export default function InstallablePage() {
             keyboardShouldPersistTaps="handled"
             ListEmptyComponent={
               <Text style={styles.empty}>
-                {indexing ? 'Finding games in your library…'
+                {!seeded && indexing ? 'Finding games in your library…'
                   : (q || activeFilters) ? 'No games match.' : 'No games found.'}
               </Text>
             }

--- a/app/components/InstallableSection.tsx
+++ b/app/components/InstallableSection.tsx
@@ -33,7 +33,16 @@ export function InstallableSection({ caps }: { caps?: BoxCaps }) {
     let live = true;
     void (async () => {
       const res = await api.installable(settings);
-      if (live) setCount(res ? res.count : null);
+      if (!live) return;
+      if (!res) { setCount(null); return; }
+      // New agents (>= 2.9.76) type each entry from appinfo.vdf — count actual
+      // GAMES, not the raw librarycache list (which overcounts ~2.5x with
+      // DLC/tools; a real library read "1101" when it has 441 games). Old
+      // agents send untyped entries: keep the raw count, as before.
+      const typed = res.games.filter((g) => g.type !== undefined);
+      setCount(typed.length > 0
+        ? typed.filter((g) => g.type === 'game').length
+        : res.count);
     })();
     return () => { live = false; };
   }, [settings, canProbe]);

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -211,6 +211,11 @@ export type BoxCaps = {
  *  cec: 'enabled' | 'needs_enable' | 'no_adapter'). */
 export type Utility = { id: string; state: string; label: string; description: string };
 
+/** One owned-but-uninstalled entry from GET /api/steam/installable. name/type are
+ *  present when the agent (>= 2.9.76) parsed them offline from appinfo.vdf; type
+ *  is lowercased ('game' | 'dlc' | 'tool' | …) and drives the app's game filter. */
+export type InstallableGame = { appid: number; name?: string; type?: string };
+
 /**
  * Couchside Player state, from GET /api/player.
  *
@@ -1615,18 +1620,22 @@ export const api = {
 
   /**
    * Owned-but-uninstalled Steam games (agent >= 2.9.73, gated by caps.steaminstall).
-   * Appids only — the box has no reliable offline name for an uninstalled game, so
-   * the app resolves names + type app-side from the keyless store endpoint (see
-   * lib/steamStore.ts) and pulls art from coverArt(appid). Probe-and-appear:
-   * resolves null on a 404 (older agent / no route) so the section stays hidden.
-   * To INSTALL one, call launch(settings, `install:${appid}`) — the agent gates it
-   * against this same set and hands steam://install to the client.
+   * Since agent 2.9.76 each entry may carry name + type, parsed OFFLINE from
+   * Steam's own appinfo.vdf on the box (measured 100% coverage of a real 1101-app
+   * library) — the app seeds its details index from these so the whole library
+   * renders instantly instead of trickling through the rate-limited store API
+   * (~200/5min; an 1101-app library showed 88 games after days). The store lookup
+   * remains as enrichment for what appinfo lacks (genres, release year). Older
+   * agents send appids only; the store path still covers those. Art comes from
+   * coverArt(appid). Probe-and-appear: null on 404 hides the section. To INSTALL
+   * one, call launch(settings, `install:${appid}`) — the agent gates it against
+   * this same set and hands steam://install to the client.
    */
   installable(
     settings: ConnSettings,
-  ): Promise<{ games: { appid: number }[]; count: number } | null> {
+  ): Promise<{ games: InstallableGame[]; count: number } | null> {
     return probeOrNull(
-      request<{ games: { appid: number }[]; count: number }>(
+      request<{ games: InstallableGame[]; count: number }>(
         settings, '/api/steam/installable'));
   },
 

--- a/app/lib/steamStoreParse.ts
+++ b/app/lib/steamStoreParse.ts
@@ -4,10 +4,12 @@
  *
  * Phase 2/filters of "install a game you own but haven't downloaded". The BOX
  * enumerates the owned-but-uninstalled library from its own disk (no key, no
- * account — see the agent's _installable_appids), but it has no reliable OFFLINE
- * NAME for an uninstalled game (appinfo.vdf is a partial cache). Name, type,
- * release date and genres all come from Valve's own KEYLESS store endpoint,
- * app-side:
+ * account — see the agent's _installable_appids). Since agent 2.9.76 it ALSO
+ * ships name+type parsed OFFLINE from appinfo.vdf (the earlier "partial cache"
+ * assumption was disproven by measurement: 100% name coverage of a real 1101-app
+ * library) — those seed the page instantly. This module parses what appinfo
+ * cannot supply (genres, release year), plus name/type for OLD agents, from
+ * Valve's own KEYLESS store endpoint, app-side:
  *
  *   store.steampowered.com/api/appdetails?appids=<id>&l=english
  *

--- a/tests/test_steam_install.py
+++ b/tests/test_steam_install.py
@@ -292,6 +292,161 @@ def test_cap_present_in_mock_and_real():
         cs._steam_root = old
 
 
+# ---------------------------------------------------------------------------
+print("\nappinfo.vdf names — offline name+type for the installable list")
+# ---------------------------------------------------------------------------
+# The list used to ship appid-only ("appinfo.vdf is a partial cache" — DISPROVEN
+# by measurement: 100% coverage of a real 1101-app library). These fixtures are
+# SYNTHETIC (the real file is 4.2MB, too big to commit); the parser was also
+# verified against the real bazzite file (1560 apps, controls Portal 2 / Dota 2).
+
+import struct
+
+
+def _bvdf_bytes(d, strtab):
+    """Serialize a dict as binary VDF. strtab None -> v27/28 inline-cstring keys;
+    a list -> v29 (keys appended, encoded as u32 indices)."""
+    out = b""
+    for k, v in d.items():
+        if strtab is None:
+            key = k.encode() + b"\x00"
+        else:
+            if k not in strtab:
+                strtab.append(k)
+            key = struct.pack("<I", strtab.index(k))
+        if isinstance(v, dict):
+            out += b"\x00" + key + _bvdf_bytes(v, strtab) + b"\x08"
+        elif isinstance(v, str):
+            out += b"\x01" + key + v.encode() + b"\x00"
+        else:
+            out += b"\x02" + key + struct.pack("<I", v)
+    return out
+
+
+def _appinfo_file(apps, version=29):
+    """Write a synthetic appinfo.vdf: {appid: {"name":..., "type":...}}."""
+    magic = {27: 0x07564427, 28: 0x07564428, 29: 0x07564429}[version]
+    strtab = [] if version == 29 else None
+    blobs = b""
+    for appid, meta in apps.items():
+        kv = {"appinfo": {"common": dict(meta)}}
+        vdf = _bvdf_bytes(kv, strtab) + b"\x08"
+        hdr = struct.pack("<IIQ", 1, 0, 0) + b"\x00" * 20 + struct.pack("<I", 0)
+        if version >= 28:
+            hdr += b"\x00" * 20
+        body = hdr + vdf
+        blobs += struct.pack("<II", appid, len(body)) + body
+    blobs += struct.pack("<I", 0)  # terminator appid
+    if version == 29:
+        head = struct.pack("<II", magic, 1)
+        table_off = len(head) + 8 + len(blobs)
+        head += struct.pack("<q", table_off)
+        table = struct.pack("<I", len(strtab)) + b"".join(
+            s.encode() + b"\x00" for s in strtab)
+        data = head + blobs + table
+    else:
+        data = struct.pack("<II", magic, 1) + blobs
+    fd, p = tempfile.mkstemp(suffix=".vdf")
+    os.write(fd, data)
+    os.close(fd)
+    return p
+
+
+def _root_with_appinfo(apps, version=29, installed=(), cached=()):
+    r = Root(installed=installed, cached=cached)
+    os.makedirs(os.path.join(r.dir, "appcache"), exist_ok=True)
+    p = _appinfo_file(apps, version)
+    shutil.move(p, os.path.join(r.dir, "appcache", "appinfo.vdf"))
+    cs._APPINFO_CACHE.update(key=None, val=None)
+    return r
+
+
+def test_appinfo_names_v29_and_v28():
+    print("test_appinfo_names_v29_and_v28")
+    apps = {620: {"name": "Portal 2", "type": "Game"},
+            1234: {"name": "Some DLC", "type": "DLC"}}
+    for ver in (29, 28):
+        r = _root_with_appinfo(apps, version=ver)
+        try:
+            got = cs._appinfo_names()
+            check("v%d: name" % ver, got.get(620), {"name": "Portal 2", "type": "game"})
+            check("v%d: type lowercased" % ver, got.get(1234)["type"], "dlc")
+        finally:
+            r.close()
+            cs._APPINFO_CACHE.update(key=None, val=None)
+
+
+def test_appinfo_degrades_closed():
+    """Garbage/missing/truncated appinfo -> {}, and the list ships appid-only."""
+    print("test_appinfo_degrades_closed")
+    r = Root(installed=[], cached=["620"])
+    try:
+        check("no appinfo file -> {}", cs._appinfo_names(), {})
+        # Garbage magic.
+        os.makedirs(os.path.join(r.dir, "appcache"), exist_ok=True)
+        with open(os.path.join(r.dir, "appcache", "appinfo.vdf"), "wb") as f:
+            f.write(b"NOTVDF\x00\x00garbage")
+        cs._APPINFO_CACHE.update(key=None, val=None)
+        check("bad magic -> {}", cs._appinfo_names(), {})
+        # Truncated real-shaped file.
+        p = _appinfo_file({620: {"name": "Portal 2", "type": "game"}})
+        data = open(p, "rb").read()[:20]
+        os.unlink(p)
+        with open(os.path.join(r.dir, "appcache", "appinfo.vdf"), "wb") as f:
+            f.write(data)
+        cs._APPINFO_CACHE.update(key=None, val=None)
+        check("truncated -> {} (degrade closed)", cs._appinfo_names(), {})
+        games = cs._installable_games()
+        check("list still ships appid-only", games, [{"appid": 620}])
+    finally:
+        r.close()
+        cs._APPINFO_CACHE.update(key=None, val=None)
+
+
+def test_installable_games_carry_names():
+    """When appinfo parses, entries gain name+type; entries it lacks stay
+    appid-only (both states observed)."""
+    print("test_installable_games_carry_names")
+    r = _root_with_appinfo({620: {"name": "Portal 2", "type": "Game"}},
+                           installed=["440"], cached=["440", "620", "570"])
+    try:
+        games = {g["appid"]: g for g in cs._installable_games()}
+        check("620 named", games[620],
+              {"appid": 620, "name": "Portal 2", "type": "game"})
+        check("570 (absent from appinfo) appid-only", games[570], {"appid": 570})
+        check("installed 440 still excluded (control)", 440 in games, False)
+    finally:
+        r.close()
+        cs._APPINFO_CACHE.update(key=None, val=None)
+
+
+def test_http_installable_carries_names():
+    print("test_http_installable_carries_names")
+    r = _root_with_appinfo({620: {"name": "Portal 2", "type": "Game"}},
+                           installed=[], cached=["620"])
+    old = cs._steam_root
+    srv, port = _server(r.dir)
+    try:
+        cs._APPINFO_CACHE.update(key=None, val=None)
+        status, body = _req(port, "GET", "/api/steam/installable")
+        check("GET -> 200", status, 200)
+        check("names over the wire", body.get("games"),
+              [{"appid": 620, "name": "Portal 2", "type": "game"}])
+    finally:
+        srv.shutdown()
+        cs._steam_root = old
+        r.close()
+        cs._APPINFO_CACHE.update(key=None, val=None)
+
+
+def test_mock_installable_has_names():
+    """Harness renders titles immediately + exercises the type=game filter."""
+    print("test_mock_installable_has_names")
+    for g in cs.MOCK_INSTALLABLE:
+        check("mock %d has name+type" % g["appid"],
+              bool(g.get("name")) and g.get("type") == "game", True)
+
+
 if __name__ == "__main__":
     for fn in (test_excludes_installed_and_tools,
                test_ignores_non_digit_dirs,
@@ -303,6 +458,11 @@ if __name__ == "__main__":
                test_install_nondigit_refused,
                test_argv_has_no_shell_and_only_a_digit_slot,
                test_http_endpoints,
+               test_appinfo_names_v29_and_v28,
+               test_appinfo_degrades_closed,
+               test_installable_games_carry_names,
+               test_http_installable_carries_names,
+               test_mock_installable_has_names,
                test_cap_present_in_mock_and_real):
         fn()
     if FAILURES:


### PR DESCRIPTION
Fixes the Not-installed page showing 88 of 1101: the store-API index rate-limits at ~200/5min and never finishes on a big library. The agent now parses Steam's own appinfo.vdf (pure stdlib, v27/28/29, degrade-closed) and ships name+type with the list — measured 100% coverage on the real 1101-app library, 0.08s parse, honest game count 441. App seeds from agent names (store lookup becomes genre/year enrichment). Harness-verified: instant titled render with the store API CORS-blocked; header count == filter-sheet count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)