### PR TITLE
feat(app): game ratings + review data, richer filters, detail sheet w/ Open in Steam

### DIFF
--- a/app/app/installable.tsx
+++ b/app/app/installable.tsx
@@ -18,26 +18,36 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Stack, router } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ActivityIndicator, Alert, FlatList, Image, Modal, Platform, Pressable,
+  ActivityIndicator, Alert, FlatList, Image, Linking, Modal, Platform, Pressable,
   ScrollView, StyleSheet, Text, TextInput, useWindowDimensions, View, type ViewToken,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { type Compat } from '@/lib/compat';
+import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { fetchCompat } from '@/lib/compatFetch';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { fetchAppDetails } from '@/lib/steamStore';
-import { isInstallableGameType, type AppDetails } from '@/lib/steamStoreParse';
+import { fetchSteamReview } from '@/lib/steamReviews';
+import { isInstallableGameType, type AppDetails, type SteamReview } from '@/lib/steamStoreParse';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
-type Sort = 'az' | 'za' | 'newest';
+type Sort = 'az' | 'za' | 'newest' | 'metacritic' | 'reviews';
 const SORTS: { key: Sort; label: string }[] = [
   { key: 'az', label: 'Name A–Z' },
   { key: 'za', label: 'Name Z–A' },
   { key: 'newest', label: 'Newest first' },
+  { key: 'metacritic', label: 'Metacritic' },
+  { key: 'reviews', label: 'Most reviewed' },
+];
+
+/** Metacritic filter tiers. 0 = any. */
+const RATINGS: { key: number; label: string }[] = [
+  { key: 0, label: 'Any' },
+  { key: 75, label: 'Metacritic 75+' },
+  { key: 90, label: 'Metacritic 90+' },
 ];
 
 /** "Runs well on this box": Deck verified/playable, or a good ProtonDB tier. */
@@ -45,6 +55,26 @@ function runsWell(c: Compat | undefined): boolean {
   if (!c) return false;
   if (c.deck === 'verified' || c.deck === 'playable') return true;
   return c.proton === 'platinum' || c.proton === 'gold' || c.proton === 'silver';
+}
+
+/** A Steam review is "good" for the filter at score >= 6 (Positive and up:
+ *  6=Positive, 7=Very Positive, 8=Overwhelmingly, plus 9). */
+function reviewIsPositive(r: SteamReview | null | undefined): boolean {
+  return !!r && r.score >= 6;
+}
+
+/** Open a game's Steam store page in the user's Steam app (deep link), falling
+ *  back to the web store when the Steam app / handler isn't available. */
+async function openInSteam(appid: number): Promise<void> {
+  const deep = `steam://store/${appid}`;
+  const web = `https://store.steampowered.com/app/${appid}`;
+  try {
+    if (Platform.OS !== 'web' && (await Linking.canOpenURL(deep))) {
+      await Linking.openURL(deep);
+      return;
+    }
+  } catch { /* fall through to web */ }
+  try { await Linking.openURL(web); } catch { /* nothing else to do */ }
 }
 
 /** steam://install pops an approve prompt on the box (verified) — say so. */
@@ -61,47 +91,33 @@ function confirmInstall(label: string, onConfirm: () => void) {
   ]);
 }
 
+/** Metacritic's own colour convention: green >=75, yellow 50–74, red <50. */
+function mcColor(score: number): string {
+  return score >= 75 ? '#4c8b2b' : score >= 50 ? '#a89226' : '#a02a1c';
+}
+
+/** A grid tile: cover + name + (when known) a Metacritic badge. Tapping opens the
+ *  game detail sheet — install and Open-in-Steam live there, not on the tile. */
 function Cell({
-  appid, name, requested, onRequested, colW,
+  appid, d, requested, colW, onOpen,
 }: {
-  appid: number; name?: string; requested: boolean;
-  onRequested: (appid: number) => void; colW: number;
+  appid: number; d?: AppDetails; requested: boolean;
+  colW: number; onOpen: (appid: number) => void;
 }) {
   const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
   const source = api.steamCoverSource(settings, appid);
   const [failed, setFailed] = useState(false);
-  const [busy, setBusy] = useState(false);
   useEffect(() => setFailed(false), [source.uri]);
-
-  const install = () => {
-    hapticLight();
-    confirmInstall(name || `App ${appid}`, async () => {
-      setBusy(true);
-      try {
-        const res = await api.launch(settings, `install:${appid}`);
-        if (res?.ok) onRequested(appid);
-        if (Platform.OS !== 'web') {
-          Alert.alert(
-            res?.ok ? 'Approve it on your box' : "Couldn't start install",
-            res?.ok
-              ? `A prompt for "${name || `App ${appid}`}" is on your box's screen — approve it (a controller, or your phone's Pad) to start the download.`
-              : 'The box refused the install.',
-          );
-        }
-      } finally {
-        setBusy(false);
-      }
-    });
-  };
+  const name = d?.name;
+  const mc = d?.metacritic;
 
   return (
     <Pressable
       style={[styles.cell, { width: colW }]}
-      onPress={install}
-      disabled={busy || requested}
+      onPress={() => { hapticLight(); onOpen(appid); }}
       accessibilityRole="button"
-      accessibilityLabel={requested ? `${name}, waiting for approval on your box` : `Install ${name || appid}`}>
+      accessibilityLabel={`${name || appid}${mc !== undefined ? `, Metacritic ${mc}` : ''}${requested ? ', waiting for approval on your box' : ''}`}>
       <View style={[styles.coverWrap, { width: colW - 12, height: (colW - 12) * 1.5 }]}>
         {!failed ? (
           <Image source={source} style={StyleSheet.absoluteFill} resizeMode="cover" onError={() => setFailed(true)} />
@@ -110,14 +126,153 @@ function Cell({
             <Ionicons name="cloud-download-outline" size={22} color="#8aa" />
           </View>
         )}
+        {mc !== undefined ? (
+          <View style={[styles.mcBadge, { backgroundColor: mcColor(mc) }]}>
+            <Text style={styles.mcText}>{mc}</Text>
+          </View>
+        ) : null}
         <View style={styles.badge}>
-          {busy ? <ActivityIndicator size="small" />
-            : <Ionicons name={requested ? 'hourglass-outline' : 'cloud-download-outline'} size={14} color="#fff" />}
+          <Ionicons name={requested ? 'hourglass-outline' : 'cloud-download-outline'} size={14} color="#fff" />
         </View>
       </View>
       <Text style={styles.cellLabel} numberOfLines={2}>{name || '…'}</Text>
       {requested ? <Text style={styles.cellHint} numberOfLines={1}>Approve on box…</Text> : null}
     </Pressable>
+  );
+}
+
+/** The game detail sheet: cover, name, ratings (Metacritic + Steam review),
+ *  genres + controller support, and the two actions — Install on box, Open in
+ *  Steam. Fetches the game's Steam review lazily when opened. */
+function GameSheet({
+  appid, d, compat, requested, insetBottom, onClose, onRequested,
+}: {
+  appid: number; d?: AppDetails; compat?: Compat; requested: boolean;
+  insetBottom: number; onClose: () => void; onRequested: (appid: number) => void;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { settings } = useSettings();
+  const source = api.steamCoverSource(settings, appid);
+  const [failed, setFailed] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [review, setReview] = useState<SteamReview | null | undefined>(undefined);
+  const name = d?.name || `App ${appid}`;
+
+  useEffect(() => {
+    let live = true;
+    setReview(undefined);
+    void fetchSteamReview(appid).then((r) => { if (live) setReview(r); });
+    return () => { live = false; };
+  }, [appid]);
+
+  const install = () => {
+    hapticLight();
+    confirmInstall(name, async () => {
+      setBusy(true);
+      try {
+        const res = await api.launch(settings, `install:${appid}`);
+        if (res?.ok) onRequested(appid);
+        if (Platform.OS !== 'web') {
+          Alert.alert(
+            res?.ok ? 'Approve it on your box' : "Couldn't start install",
+            res?.ok
+              ? `A prompt for "${name}" is on your box's screen — approve it (a controller, or your phone's Pad) to start the download.`
+              : 'The box refused the install.',
+          );
+        }
+        if (res?.ok) onClose();
+      } finally {
+        setBusy(false);
+      }
+    });
+  };
+
+  const mc = d?.metacritic;
+  const controller = d?.controllerSupport;
+  const runsWellHere = compat && runsWell(compat);
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable style={styles.sheetScrim} onPress={onClose} />
+      <View style={[styles.gameSheet, { paddingBottom: insetBottom + 16 }]}>
+        <View style={styles.sheetHandle} />
+        <View style={styles.gsHead}>
+          <View style={styles.gsCover}>
+            {!failed ? (
+              <Image source={source} style={StyleSheet.absoluteFill} resizeMode="cover" onError={() => setFailed(true)} />
+            ) : <View style={[StyleSheet.absoluteFill, styles.coverFallback]} />}
+          </View>
+          <View style={{ flex: 1 }}>
+            <Text style={styles.gsName} numberOfLines={3}>{name}</Text>
+            {d?.releaseYear ? <Text style={styles.gsSub}>{d.releaseYear}</Text> : null}
+          </View>
+        </View>
+
+        {/* Ratings row */}
+        <View style={styles.gsRatings}>
+          {mc !== undefined ? (
+            <View style={[styles.gsChip, { borderColor: mcColor(mc) }]}>
+              <Text style={[styles.gsChipStrong, { color: mcColor(mc) }]}>{mc}</Text>
+              <Text style={styles.gsChipText}>Metacritic</Text>
+            </View>
+          ) : null}
+          {review === undefined ? (
+            <View style={styles.gsChip}><ActivityIndicator size="small" color={t.textFaint} /></View>
+          ) : review ? (
+            <View style={styles.gsChip}>
+              <Text style={[styles.gsChipStrong, { color: review.score >= 6 ? t.green : t.red }]}>
+                {review.positivePct}%
+              </Text>
+              <Text style={styles.gsChipText} numberOfLines={1}>{review.desc}</Text>
+            </View>
+          ) : null}
+          {runsWellHere ? (
+            <View style={[styles.gsChip, { borderColor: t.green }]}>
+              <Ionicons name="game-controller-outline" size={14} color={t.green} />
+              <Text style={styles.gsChipText}>Runs well here</Text>
+            </View>
+          ) : null}
+          {controller ? (
+            <View style={styles.gsChip}>
+              <Ionicons name="game-controller-outline" size={14} color={t.textDim} />
+              <Text style={styles.gsChipText}>{controller === 'full' ? 'Full controller' : 'Partial controller'}</Text>
+            </View>
+          ) : null}
+        </View>
+
+        {d?.genres?.length ? (
+          <Text style={styles.gsGenres} numberOfLines={2}>
+            {d.genres.map((g) => g.replace(/\b\w/g, (c) => c.toUpperCase())).join(' · ')}
+          </Text>
+        ) : null}
+        {compat ? (
+          <Text style={styles.gsSub} numberOfLines={1}>
+            Deck: {deckLabel(compat.deck)} · ProtonDB: {protonLabel(compat.proton)}
+          </Text>
+        ) : null}
+
+        <View style={styles.gsActions}>
+          <Pressable
+            onPress={install}
+            disabled={busy || requested}
+            style={({ pressed }) => [styles.gsPrimary, { opacity: busy || requested ? 0.6 : pressed ? 0.85 : 1 }]}
+            accessibilityRole="button">
+            {busy ? <ActivityIndicator size="small" color="#fff" />
+              : <Ionicons name="cloud-download-outline" size={18} color="#fff" />}
+            <Text style={styles.gsPrimaryText}>{requested ? 'Waiting for approval…' : 'Install on box'}</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => { hapticLight(); void openInSteam(appid); }}
+            style={({ pressed }) => [styles.gsGhost, { borderColor: t.cardBorder, opacity: pressed ? 0.8 : 1 }]}
+            accessibilityRole="button"
+            accessibilityLabel="Open in Steam">
+            <Ionicons name="logo-steam" size={18} color={t.text} />
+            <Text style={styles.gsGhostText}>Open in Steam</Text>
+          </Pressable>
+        </View>
+      </View>
+    </Modal>
   );
 }
 
@@ -146,7 +301,12 @@ export default function InstallablePage() {
   const [sort, setSort] = useState<Sort>('az');
   const [genres, setGenres] = useState<Set<string>>(new Set());
   const [onlyRunsWell, setOnlyRunsWell] = useState(false);
-  const [sheet, setSheet] = useState(false);
+  const [minRating, setMinRating] = useState(0);          // Metacritic tier
+  const [controllerOnly, setControllerOnly] = useState(false);
+  const [onlyPositive, setOnlyPositive] = useState(false); // Steam review >= Positive
+  const [reviews, setReviews] = useState<Record<number, SteamReview | null | undefined>>({});
+  const [sheet, setSheet] = useState(false);              // the FILTER sheet
+  const [sheetAppid, setSheetAppid] = useState<number | null>(null); // the game detail sheet
 
   // Fetch the appid list once. Entries carry name/type on new agents.
   useEffect(() => {
@@ -213,6 +373,29 @@ export default function InstallablePage() {
     return () => { signal.aborted = true; };
   }, [onlyRunsWell, gameIds]);
 
+  // REVIEW INDEX: only while the Steam-review filter is on (the sentiment is a
+  // SEPARATE request from appdetails). Same lazy, 3-worker, cached-hard shape as
+  // the compat index — bounded so it doesn't hammer the store's rate limit.
+  const reviewsRef = useRef(reviews);
+  reviewsRef.current = reviews;
+  useEffect(() => {
+    if (!onlyPositive) return;
+    const signal = { aborted: false };
+    const queue = gameIds.filter((id) => reviewsRef.current[id] === undefined);
+    let next = 0;
+    const worker = async () => {
+      while (!signal.aborted && next < queue.length) {
+        const id = queue[next++];
+        try {
+          const r = await fetchSteamReview(id);
+          if (!signal.aborted) setReviews((p) => ({ ...p, [id]: r }));
+        } catch { /* unknown */ }
+      }
+    };
+    void Promise.all([worker(), worker(), worker()]);
+    return () => { signal.aborted = true; };
+  }, [onlyPositive, gameIds]);
+
   // Lazy: prioritise resolving whatever is on screen (the background index catches
   // the rest). Keeps the first screenful filling fast.
   const resolveVisible = useCallback((ids: number[]) => {
@@ -242,9 +425,17 @@ export default function InstallablePage() {
       const d = eff(id);
       if (q && !d.name.toLowerCase().includes(q)) return false;
       if (genres.size && !(d.genres ?? []).some((g) => genres.has(g))) return false;
+      // Rating / controller come from the same details payload — a game not yet
+      // resolved (no details) is kept (shown) rather than hidden while indexing.
+      if (minRating > 0 && details[id] && (details[id]!.metacritic ?? -1) < minRating) return false;
+      if (controllerOnly && details[id] && details[id]!.controllerSupport !== 'full') return false;
       if (onlyRunsWell) {
         const c = compat[id];
         if (c !== undefined && !runsWell(c)) return false; // resolved-and-not-good hidden; still-checking shown
+      }
+      if (onlyPositive) {
+        const r = reviews[id];
+        if (r !== undefined && !reviewIsPositive(r)) return false; // resolved-and-not-positive hidden
       }
       return true;
     });
@@ -252,11 +443,15 @@ export default function InstallablePage() {
       const da = eff(a), db = eff(b);
       if (sort === 'newest') return (db.releaseYear ?? -1) - (da.releaseYear ?? -1)
         || da.name.localeCompare(db.name);
+      if (sort === 'metacritic') return (details[b]?.metacritic ?? -1) - (details[a]?.metacritic ?? -1)
+        || da.name.localeCompare(db.name);
+      if (sort === 'reviews') return (details[b]?.recommendations ?? -1) - (details[a]?.recommendations ?? -1)
+        || da.name.localeCompare(db.name);
       const c = da.name.localeCompare(db.name);
       return sort === 'za' ? -c : c;
     });
     return rows;
-  }, [gameIds, details, agentMeta, compat, q, genres, onlyRunsWell, sort]);
+  }, [gameIds, details, agentMeta, compat, reviews, q, genres, onlyRunsWell, minRating, controllerOnly, onlyPositive, sort]);
 
   const [requested, setRequested] = useState<Set<number>>(new Set());
   const onRequested = useCallback((appid: number) => setRequested((p) => new Set(p).add(appid)), []);
@@ -265,8 +460,11 @@ export default function InstallablePage() {
   const resolvedCount = appids ? appids.filter((id) => details[id] !== undefined).length : 0;
   const indexing = appids ? resolvedCount < appids.length : false;
   const seeded = Object.keys(agentMeta).length > 0;
-  const activeFilters = genres.size + (onlyRunsWell ? 1 : 0);
+  const activeFilters = genres.size + (onlyRunsWell ? 1 : 0)
+    + (minRating > 0 ? 1 : 0) + (controllerOnly ? 1 : 0) + (onlyPositive ? 1 : 0);
   const sortLabel = SORTS.find((s) => s.key === sort)!.label;
+  const sheetGame = sheetAppid != null
+    ? (details[sheetAppid] ?? agentMeta[sheetAppid]) : undefined;
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>
@@ -328,8 +526,8 @@ export default function InstallablePage() {
             keyExtractor={(id) => String(id)}
             numColumns={COLUMNS}
             renderItem={({ item }) => (
-              <Cell appid={item} name={(details[item] ?? agentMeta[item])?.name}
-                requested={requested.has(item)} onRequested={onRequested} colW={colW} />
+              <Cell appid={item} d={details[item] ?? agentMeta[item] ?? undefined}
+                requested={requested.has(item)} colW={colW} onOpen={setSheetAppid} />
             )}
             onViewableItemsChanged={onViewableItemsChanged}
             viewabilityConfig={{ itemVisiblePercentThreshold: 10 }}
@@ -364,6 +562,36 @@ export default function InstallablePage() {
               ))}
             </View>
 
+            <Text style={styles.sheetH}>Rating</Text>
+            <View style={styles.chips}>
+              {RATINGS.map((r) => (
+                <Pressable key={r.key} onPress={() => setMinRating(r.key)}
+                  style={[styles.chip, minRating === r.key && styles.chipOn]}>
+                  <Text style={[styles.chipText, minRating === r.key && styles.chipTextOn]}>{r.label}</Text>
+                </Pressable>
+              ))}
+            </View>
+
+            <Text style={styles.sheetH}>Steam review</Text>
+            <Pressable onPress={() => setOnlyPositive((v) => !v)}
+              style={[styles.chip, styles.chipWide, onlyPositive && styles.chipOn]}>
+              <Ionicons name={onlyPositive ? 'checkbox' : 'square-outline'} size={16}
+                color={onlyPositive ? t.blue : t.textFaint} />
+              <Text style={[styles.chipText, onlyPositive && styles.chipTextOn]}>
+                Positive or better
+              </Text>
+            </Pressable>
+
+            <Text style={styles.sheetH}>Controller</Text>
+            <Pressable onPress={() => setControllerOnly((v) => !v)}
+              style={[styles.chip, styles.chipWide, controllerOnly && styles.chipOn]}>
+              <Ionicons name={controllerOnly ? 'checkbox' : 'square-outline'} size={16}
+                color={controllerOnly ? t.blue : t.textFaint} />
+              <Text style={[styles.chipText, controllerOnly && styles.chipTextOn]}>
+                Full controller support
+              </Text>
+            </Pressable>
+
             <Text style={styles.sheetH}>Runs well on this box</Text>
             <Pressable onPress={() => setOnlyRunsWell((v) => !v)}
               style={[styles.chip, styles.chipWide, onlyRunsWell && styles.chipOn]}>
@@ -395,7 +623,10 @@ export default function InstallablePage() {
             ) : null}
 
             <View style={styles.sheetActions}>
-              <Pressable onPress={() => { setGenres(new Set()); setOnlyRunsWell(false); setSort('az'); }}>
+              <Pressable onPress={() => {
+                setGenres(new Set()); setOnlyRunsWell(false); setSort('az');
+                setMinRating(0); setControllerOnly(false); setOnlyPositive(false);
+              }}>
                 <Text style={styles.clear}>Reset</Text>
               </Pressable>
               <Pressable style={styles.doneBtn} onPress={() => setSheet(false)}>
@@ -405,6 +636,19 @@ export default function InstallablePage() {
           </ScrollView>
         </View>
       </Modal>
+
+      {/* Game detail sheet — ratings + Install + Open in Steam. */}
+      {sheetAppid != null ? (
+        <GameSheet
+          appid={sheetAppid}
+          d={sheetGame ?? undefined}
+          compat={compat[sheetAppid]}
+          requested={requested.has(sheetAppid)}
+          insetBottom={insets.bottom}
+          onClose={() => setSheetAppid(null)}
+          onRequested={onRequested}
+        />
+      ) : null}
     </View>
   );
 }
@@ -440,6 +684,39 @@ const makeStyles = (t: Palette) =>
     cellLabel: { color: t.text, fontSize: 11, textAlign: 'center', marginTop: 4 },
     cellHint: { color: t.amber, fontSize: 10, textAlign: 'center', marginTop: 2 },
     empty: { color: t.textFaint, textAlign: 'center', marginTop: 40, fontSize: 13 },
+    mcBadge: {
+      position: 'absolute', top: 6, left: 6, minWidth: 22, height: 22, borderRadius: 5,
+      paddingHorizontal: 4, alignItems: 'center', justifyContent: 'center',
+    },
+    mcText: { color: '#fff', fontSize: 12, fontWeight: '800' },
+    // game detail sheet
+    gameSheet: {
+      backgroundColor: t.bg, borderTopLeftRadius: 18, borderTopRightRadius: 18,
+      paddingHorizontal: 16, paddingTop: 8, borderTopWidth: 1, borderColor: t.cardBorder,
+    },
+    gsHead: { flexDirection: 'row', gap: 12, alignItems: 'flex-start' },
+    gsCover: { width: 72, height: 108, borderRadius: 8, overflow: 'hidden', backgroundColor: t.card },
+    gsName: { color: t.text, fontSize: 18, fontWeight: '800' },
+    gsSub: { color: t.textFaint, fontSize: 12, marginTop: 4 },
+    gsRatings: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginTop: 14 },
+    gsChip: {
+      flexDirection: 'row', alignItems: 'center', gap: 6, paddingVertical: 6, paddingHorizontal: 10,
+      borderRadius: 10, backgroundColor: t.card, borderWidth: 1, borderColor: t.cardBorder,
+    },
+    gsChipStrong: { fontSize: 14, fontWeight: '800' },
+    gsChipText: { color: t.textDim, fontSize: 12, fontWeight: '600' },
+    gsGenres: { color: t.textFaint, fontSize: 12, marginTop: 12, lineHeight: 17 },
+    gsActions: { flexDirection: 'row', gap: 10, marginTop: 18 },
+    gsPrimary: {
+      flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+      backgroundColor: t.blue, paddingVertical: 13, borderRadius: 12,
+    },
+    gsPrimaryText: { color: '#fff', fontWeight: '700', fontSize: 14 },
+    gsGhost: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
+      paddingVertical: 13, paddingHorizontal: 16, borderRadius: 12, borderWidth: 1, backgroundColor: t.card,
+    },
+    gsGhostText: { color: t.text, fontWeight: '700', fontSize: 14 },
     // sheet
     sheetScrim: { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' },
     sheet: {

--- a/app/lib/__tests__/steamStoreParse.test.ts
+++ b/app/lib/__tests__/steamStoreParse.test.ts
@@ -15,7 +15,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { parseAppDetails, isInstallableGameType } from '../steamStoreParse.ts';
+import {
+  parseAppDetails, isInstallableGameType, parseReviewSummary,
+} from '../steamStoreParse.ts';
 
 test('parses a real game entry', () => {
   const body = { '620': { success: true, data: { type: 'game', name: 'Portal 2', steam_appid: 620 } } };
@@ -82,4 +84,45 @@ test('only type "game" is installable', () => {
   assert.equal(isInstallableGameType({ name: 'Runtime', type: 'tool' }), false);
   assert.equal(isInstallableGameType(null), false);
   assert.equal(isInstallableGameType(undefined), false);
+});
+
+test('parses metacritic, recommendations, and controller support (free fields)', () => {
+  const body = { '620': { success: true, data: {
+    type: 'game', name: 'Portal 2',
+    metacritic: { score: 95, url: 'x' },
+    recommendations: { total: 388848 },
+    controller_support: 'full',
+  } } };
+  const d = parseAppDetails(620, body);
+  assert.equal(d?.metacritic, 95);
+  assert.equal(d?.recommendations, 388848);
+  assert.equal(d?.controllerSupport, 'full');
+});
+
+test('bad rating fields are dropped, not clamped or invented', () => {
+  const mk = (data: object) => parseAppDetails(1, { '1': { success: true, data: { type: 'game', name: 'X', ...data } } });
+  assert.equal(mk({ metacritic: { score: 150 } })?.metacritic, undefined); // out of range
+  assert.equal(mk({ metacritic: { score: 'high' } })?.metacritic, undefined); // wrong type
+  assert.equal(mk({ metacritic: {} })?.metacritic, undefined); // no score
+  assert.equal(mk({})?.metacritic, undefined); // absent entirely
+  assert.equal(mk({ controller_support: 'none' })?.controllerSupport, undefined); // not full/partial
+  assert.equal(mk({ recommendations: { total: -5 } })?.recommendations, undefined);
+});
+
+test('parseReviewSummary reads the appreviews query_summary', () => {
+  const body = { success: 1, query_summary: {
+    review_score: 9, review_score_desc: 'Overwhelmingly Positive',
+    total_positive: 459021, total_negative: 6028, total_reviews: 465049,
+  } };
+  assert.deepEqual(parseReviewSummary(body), {
+    score: 9, desc: 'Overwhelmingly Positive', total: 465049, positivePct: 99,
+  });
+});
+
+test('parseReviewSummary is null for no reviews / malformed / failure', () => {
+  assert.equal(parseReviewSummary({ success: 1, query_summary: { review_score: 0, review_score_desc: '', total_reviews: 0 } }), null);
+  assert.equal(parseReviewSummary({ success: 0 }), null);
+  assert.equal(parseReviewSummary({ success: 1 }), null); // no summary
+  assert.equal(parseReviewSummary(null), null);
+  assert.equal(parseReviewSummary('nope'), null);
 });

--- a/app/lib/steamReviews.ts
+++ b/app/lib/steamReviews.ts
@@ -1,0 +1,146 @@
+/**
+ * Fetching + caching the Steam REVIEW SENTIMENT ("Very Positive", 96%) per appid.
+ * Parsing lives in ./steamStoreParse (parseReviewSummary), bare-Node tested; this
+ * file is the network + cache half, mirroring lib/steamStore.ts exactly.
+ *
+ * SAME privacy posture and opt-in as the store/compat lookups (Prefs → game
+ * lookups): it leaves the PHONE, never the box, sends one appid and nothing
+ * identifying, and hits the same host (store.steampowered.com). It is a SEPARATE
+ * request from appdetails, so callers fetch it LAZILY — only for games a surface
+ * is actually going to show a review for (e.g. when the Not-installed page's
+ * review filter/sort is on), never for the whole library up front.
+ *
+ * CACHED for 7 days: review sentiment drifts slowly and a week keeps the store's
+ * ~200/5min rate limit quiet on a big library.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+import { parseReviewSummary, type SteamReview } from './steamStoreParse';
+
+const KEY = 'couchside.steamreviews.v1';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const CONCURRENCY = 3;
+
+type Entry = { r: SteamReview | null; at: number };
+type Store = Record<string, Entry>;
+
+let mem: Store | null = null;
+const inflight = new Map<number, Promise<SteamReview | null>>();
+
+async function storageGet(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(k)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function storageSet(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) {
+        window.localStorage.setItem(k, v);
+      }
+    } catch { /* memory-only this session */ }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+async function load(): Promise<Store> {
+  if (mem) return mem;
+  try {
+    const raw = await storageGet(KEY);
+    mem = raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    mem = {};
+  }
+  return mem;
+}
+
+function persist(): void {
+  if (mem) void storageSet(KEY, JSON.stringify(mem));
+}
+
+/** Forget every cached review. Paired with the lookups opt-out. */
+export async function clearSteamReviewsCache(): Promise<void> {
+  mem = {};
+  await storageSet(KEY, JSON.stringify(mem));
+}
+
+async function getJson(url: string, timeoutMs: number): Promise<unknown | null> {
+  try {
+    const ctl = new AbortController();
+    const timer = setTimeout(() => ctl.abort(), timeoutMs);
+    const res = await fetch(url, { signal: ctl.signal });
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    return (await res.json()) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+/** Review sentiment for one appid, from cache when fresh. Null = no reviews /
+ *  unknown (never throws). A resolved-but-null is cached as a tombstone; a
+ *  TRANSPORT failure is NOT cached (so a rate-limit doesn't hide it for a week). */
+export async function fetchSteamReview(
+  appid: number,
+  timeoutMs = 8000,
+): Promise<SteamReview | null> {
+  const store = await load();
+  const hit = store[String(appid)];
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.r;
+
+  const running = inflight.get(appid);
+  if (running) return running;
+
+  const job = (async (): Promise<SteamReview | null> => {
+    const body = await getJson(
+      `https://store.steampowered.com/appreviews/${appid}`
+        + `?json=1&num_per_page=0&language=all&purchase_type=all`,
+      timeoutMs,
+    );
+    if (body === null) return null; // transport failure — do NOT cache
+    const r = parseReviewSummary(body);
+    const s = await load();
+    s[String(appid)] = { r, at: Date.now() };
+    persist();
+    return r;
+  })().finally(() => inflight.delete(appid));
+
+  inflight.set(appid, job);
+  return job;
+}
+
+/** Resolve a batch, CONCURRENCY at a time, reporting each as it lands. Cached
+ *  appids resolve with no request. Aborts cleanly when the caller navigates away. */
+export async function fetchSteamReviewsMany(
+  appids: number[],
+  onEach: (appid: number, r: SteamReview | null) => void,
+  signal?: { aborted: boolean },
+): Promise<void> {
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      if (signal?.aborted) return;
+      const i = next++;
+      if (i >= appids.length) return;
+      const id = appids[i];
+      try {
+        onEach(id, await fetchSteamReview(id));
+      } catch {
+        onEach(id, null);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, appids.length || 1) }, worker),
+  );
+}

--- a/app/lib/steamStoreParse.ts
+++ b/app/lib/steamStoreParse.ts
@@ -37,6 +37,16 @@ export type AppDetails = {
   releaseYear?: number;
   /** Store genre labels ("Action", "RPG", …), lowercased for stable matching. */
   genres?: string[];
+  /** Metacritic critic score 0–100, when the store carries one. A rating field
+   *  any surface can show — it rides in the SAME appdetails payload as name/genre,
+   *  so it costs no extra request. */
+  metacritic?: number;
+  /** Total Steam recommendations — a popularity proxy (NOT the positive/negative
+   *  sentiment; that lives in lib/steamReviews.ts). Also free from this payload. */
+  recommendations?: number;
+  /** Native controller support per the store: 'full' | 'partial' | undefined.
+   *  Relevant for a couch app — "which of these play well on the pad". */
+  controllerSupport?: 'full' | 'partial';
 };
 
 /** Pull a 4-digit year out of Steam's free-form release date ("10 Aug, 2011",
@@ -64,6 +74,9 @@ export function parseAppDetails(appid: number, body: unknown): AppDetails | null
     name?: unknown; type?: unknown;
     release_date?: { date?: unknown } | unknown;
     genres?: unknown;
+    metacritic?: { score?: unknown } | unknown;
+    recommendations?: { total?: unknown } | unknown;
+    controller_support?: unknown;
   };
   const name = typeof d.name === 'string' ? d.name.trim() : '';
   const type = typeof d.type === 'string' ? d.type.toLowerCase() : '';
@@ -84,7 +97,70 @@ export function parseAppDetails(appid: number, body: unknown): AppDetails | null
       .filter(Boolean);
     if (g.length) out.genres = g;
   }
+
+  // Metacritic: an integer 0–100. Guard the range so a malformed value is dropped.
+  const mc = d.metacritic;
+  const score = mc && typeof mc === 'object' ? (mc as { score?: unknown }).score : undefined;
+  if (typeof score === 'number' && Number.isFinite(score) && score >= 0 && score <= 100) {
+    out.metacritic = Math.round(score);
+  }
+
+  // Steam recommendation count (popularity proxy).
+  const rc = d.recommendations;
+  const total = rc && typeof rc === 'object' ? (rc as { total?: unknown }).total : undefined;
+  if (typeof total === 'number' && Number.isFinite(total) && total >= 0) {
+    out.recommendations = Math.round(total);
+  }
+
+  // Controller support: only 'full'/'partial' are meaningful; anything else absent.
+  if (d.controller_support === 'full' || d.controller_support === 'partial') {
+    out.controllerSupport = d.controller_support;
+  }
   return out;
+}
+
+/**
+ * The Steam REVIEW SENTIMENT summary, from the keyless appreviews endpoint
+ * (store.steampowered.com/appreviews/<id>?json=1) — a DIFFERENT request from
+ * appdetails, so it is fetched lazily (see lib/steamReviews.ts) only when a
+ * surface actually wants it. This is the "Overwhelmingly Positive / 98%" line
+ * people recognise; appdetails only carries the raw recommendation count.
+ */
+export type SteamReview = {
+  /** review_score, 0–9 (0 = no score, 9 = Overwhelmingly Positive). Sort key. */
+  score: number;
+  /** review_score_desc, e.g. "Very Positive". */
+  desc: string;
+  /** Positive share, 0–100 (rounded). undefined when there are no reviews. */
+  positivePct?: number;
+  /** total_reviews. */
+  total: number;
+};
+
+/** Parse the appreviews `query_summary`. Returns null on a malformed body or a
+ *  game with no reviews at all (total 0, score 0). Never throws. */
+export function parseReviewSummary(body: unknown): SteamReview | null {
+  if (!body || typeof body !== 'object') return null;
+  const b = body as { success?: unknown; query_summary?: unknown };
+  if (b.success !== 1 && b.success !== true) return null;
+  const q = b.query_summary;
+  if (!q || typeof q !== 'object') return null;
+  const s = q as {
+    review_score?: unknown; review_score_desc?: unknown;
+    total_positive?: unknown; total_reviews?: unknown;
+  };
+  const score = typeof s.review_score === 'number' ? s.review_score : NaN;
+  const desc = typeof s.review_score_desc === 'string' ? s.review_score_desc.trim() : '';
+  const total = typeof s.total_reviews === 'number' ? s.total_reviews : 0;
+  const pos = typeof s.total_positive === 'number' ? s.total_positive : 0;
+  if (!Number.isFinite(score) || score < 0 || score > 9) return null;
+  if (total <= 0 || !desc) return null; // no reviews -> nothing to show
+  return {
+    score: Math.round(score),
+    desc,
+    total: Math.round(total),
+    positivePct: Math.round((pos / total) * 100),
+  };
 }
 
 /** Is this an app the user would actually install as a GAME (not a tool/DLC/demo)?


### PR DESCRIPTION
Adds metacritic/recommendations/controllerSupport to AppDetails (free, from the payload already fetched) + a new lib/steamReviews.ts for Steam review sentiment (lazy, cached). Not-installed page: Metacritic badge on tiles; a game detail sheet (ratings + genres + Install + **Open in Steam**); filters for Rating / Steam review / Full controller; Metacritic + Most-reviewed sorts. Harness-verified (badges, sheet, filter sections); +5 parse tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)