### PR TITLE
feat: OpenPuck firmware runtime-fetched from the EmeryTech fork (AGPL reference, not bundle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,13 @@ Valve Steam Controller Puck (sped up slightly).
 
 ![Flashing an OpenPuck receiver from the app on a real box, ending with a Steam Controller Puck connected](docs/media/couchside-openpuck.gif)
 
-OpenPuck is a separate AGPL-3.0 project by [safijari](https://github.com/safijari/openpuck);
-Couchside only automates flashing its released firmware onto a board you plugged in.
+OpenPuck is a separate AGPL-3.0 project by [safijari](https://github.com/safijari/openpuck),
+flashed here from the [EmeryTech fork](https://github.com/emerytech/openpuck). Couchside
+does **not** embed or compile it: the box downloads the released firmware binary from the
+fork at flash time and writes it to the board you plugged in. Because Couchside distributes
+that binary, the corresponding source is offered at the exact shipped tag
+([0.9.40](https://github.com/emerytech/openpuck/tree/0.9.40)) — see the app's
+**Setup → Open source licenses** screen and `agent/openpuck/OPENPUCK-NOTICE.txt`.
 
 ## Features
 

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.77
+
+**OpenPuck firmware now comes straight from the source.** Flashing an OpenPuck
+receiver fetches the firmware at flash time from the maintained OpenPuck build on
+GitHub, verifies it (exact checksum + size + UF2 format) before writing a single
+byte, and caches it so the next flash is instant. A copy is still seeded at
+install time, so flashing works with the box offline. New: an optional "check for
+newer firmware" — the box never installs a newer build on its own; you choose.
+
 ## 2.9.76
 
 **Your whole library, instantly.** The Not-installed page used to fill in game

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.76"
+VERSION = "2.9.77"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -7909,10 +7909,38 @@ _UTILITY_IDS = frozenset({"openpuck", "cec"})
 # group, and the agent cannot edit its own unit). So there is no cec RUN action.
 _UTILITY_RUN_IDS = frozenset({"openpuck"})
 
-# install.sh fetches the pinned OpenPuck release .uf2 (sha256-verified, the same
-# gate as the agent asset) and drops it HERE. The flash op reads this fixed,
-# agent-owned path, selected only by the allowlisted 'openpuck' id — the client
-# never supplies a path or the firmware bytes. Absent -> the flash degrades closed.
+# OpenPuck firmware — Couchside REFERENCES it (downloads at runtime from the fork's
+# GitHub release), it never embeds or compiles OpenPuck. OpenPuck is a separate
+# AGPL-3.0 work by safijari, modified by EmeryTech; the corresponding source for the
+# exact build below is the tag URL carried in OPENPUCK-NOTICE.txt (the §6 offer).
+#
+# §3-safety: the agent owns this fetch end to end. A client only ever selects the
+# allowlisted 'openpuck' id + a fixed {pinned|latest} variant — it never supplies a
+# URL, a path, or the firmware bytes. Every source (cache, download, install seed)
+# is verified before a single byte is written to a board.
+_OPENPUCK_FW_TAG = "0.9.40"
+_OPENPUCK_FW_NAME = "OpenPuck-0.9.40-standard.uf2"
+_OPENPUCK_FW_URL = ("https://github.com/emerytech/openpuck/releases/download/%s/%s"
+                    % (_OPENPUCK_FW_TAG, _OPENPUCK_FW_NAME))
+# sha256 of the pinned asset above (verified at author time). The fetch ABORTS on
+# any mismatch, so a tampered or served-stale byte stream is never flashed.
+_OPENPUCK_FW_SHA256 = \
+    "ee2de6a415f87cacc2999893fd7803462a6d76f1ad4acbcd7962f0115575f478"
+# A real OpenPuck build is ~370 KB. The floor/ceiling guard a truncated or garbage
+# download that still happened to start with the UF2 magic; _is_uf2 separately
+# enforces the 512-byte-block shape + magic.
+_OPENPUCK_FW_MIN_SIZE = 300_000
+_OPENPUCK_FW_MAX_SIZE = 4_000_000
+# The fork's newest release — used ONLY by the opt-in "check for newer" path and by
+# an explicit variant=latest flash; a newer build is NEVER fetched or flashed on its
+# own. Assets are matched to the standard (non-factory-reset) .uf2.
+_OPENPUCK_RELEASES_API = \
+    "https://api.github.com/repos/emerytech/openpuck/releases/latest"
+
+# install.sh fetches the pinned .uf2 straight from the fork and drops it HERE as an
+# OFFLINE fallback (root-owned; the agent only reads it). The runtime fetch below
+# prefers this seed / its own cache over the network. Absent + offline -> the flash
+# degrades closed with a clear error.
 _OPENPUCK_FIRMWARE = "/etc/couchside/openpuck/firmware.uf2"
 
 # The nRF52840 nice!nano presents its UF2 bootloader as a mass-storage volume with
@@ -8086,20 +8114,224 @@ def _is_uf2(path):
         return False
 
 
-def real_openpuck_flash():
-    """Flash the pinned OpenPuck firmware onto a plugged-in nRF52840 board that is
-    in its UF2 bootloader. Returns the standard ActionResult (ok/exit_code/stdout/
-    stderr/duration_ms).
+def _openpuck_cache_path():
+    """Agent-WRITABLE cache for the runtime-fetched firmware. The install seed at
+    _OPENPUCK_FIRMWARE is root-owned (read-only to the agent), so a downloaded copy
+    lands here instead. One file per pinned tag, so a future tag bump never reuses
+    stale bytes."""
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "couchside", "openpuck",
+                        "OpenPuck-%s.uf2" % _OPENPUCK_FW_TAG)
+
+
+def _sha256_file(path):
+    """Hex sha256 of a file, streamed. Raises OSError if it can't be read."""
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _openpuck_fw_valid(path, want_sha=None):
+    """True if `path` is a trustworthy OpenPuck firmware image: it passes _is_uf2
+    (UF2 magic + whole 512-byte blocks), its size is in the sane [MIN, MAX] window,
+    and — when want_sha is given — its sha256 matches EXACTLY. Degrades closed: any
+    error, wrong size, or hash mismatch -> False, so a bad image is never flashed."""
+    try:
+        if not path or not os.path.isfile(path):
+            return False
+        if not _is_uf2(path):
+            return False
+        size = os.path.getsize(path)
+        if size < _OPENPUCK_FW_MIN_SIZE or size > _OPENPUCK_FW_MAX_SIZE:
+            return False
+        if want_sha is not None and _sha256_file(path) != want_sha:
+            return False
+        return True
+    except OSError:
+        return False
+
+
+def _openpuck_download(url, dest, timeout=60):
+    """Download `url` to `dest` atomically (write a .part sibling, then os.replace).
+    Reads at most _OPENPUCK_FW_MAX_SIZE + 1 bytes so a wrong/huge target can't fill
+    the disk. `url` and `dest` are ALWAYS agent-chosen, never client input. Raises
+    on any failure; the caller verifies the result before trusting it."""
+    os.makedirs(os.path.dirname(dest), exist_ok=True)
+    req = urllib.request.Request(url, headers={
+        "User-Agent": "couchside-agent/%s" % VERSION})
+    tmp = dest + ".part"
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r, \
+                open(tmp, "wb") as f:
+            hdr = r.getheader("Content-Length")
+            expected = int(hdr) if (hdr or "").strip().isdigit() else None
+            written = 0
+            remaining = _OPENPUCK_FW_MAX_SIZE + 1
+            while remaining > 0:
+                chunk = r.read(min(65536, remaining))
+                if not chunk:
+                    break
+                f.write(chunk)
+                written += len(chunk)
+                remaining -= len(chunk)
+        # A clean-EOF truncation (server/CDN closes the connection early) does NOT
+        # raise in http.client — a short read would otherwise pass as a complete
+        # file, and the 'latest' path has no sha pin to catch it. If the server
+        # declared a length, the bytes written MUST match it exactly.
+        if expected is not None and written != expected:
+            raise IOError("short read: got %d of %d bytes" % (written, expected))
+        os.replace(tmp, dest)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+    return dest
+
+
+def _openpuck_pick_asset(assets):
+    """From a GitHub release 'assets' list, pick the STANDARD OpenPuck UF2: prefer a
+    name matching OpenPuck-*-standard*.uf2; otherwise the first *.uf2 that is NOT a
+    *-factory-reset* variant (a release may ship a factory-reset image we must never
+    default to). Returns the asset dict or None."""
+    uf2 = [a for a in (assets or []) if isinstance(a, dict)
+           and (a.get("name") or "").lower().endswith(".uf2")]
+    non_reset = [a for a in uf2
+                 if "factory-reset" not in (a.get("name") or "").lower()]
+    for a in non_reset:
+        n = (a.get("name") or "").lower()
+        if n.startswith("openpuck-") and "standard" in n:
+            return a
+    return non_reset[0] if non_reset else None
+
+
+def _openpuck_resolve_pinned():
+    """A path to a VERIFIED copy of the PINNED firmware, fetching from the fork only
+    if needed. Order, cheapest first: agent cache -> download from the fork ->
+    install seed. EVERY candidate must match the pinned sha256 (+ size + UF2 magic)
+    before it is returned, so an offline box only ever flashes the exact pinned
+    build. Returns (path, None) or (None, error_message). Never raises."""
+    cache = _openpuck_cache_path()
+    # 1. A verified pinned copy already on disk (runtime cache, then the install
+    #    seed) is BYTE-IDENTICAL to the fork asset — same pinned sha — so prefer it
+    #    and skip the network entirely. An offline box with a good seed must never
+    #    wait on a doomed download first: that round-trip can trip the app's flash
+    #    timeout. (A mutated re-tag can't slip through — both are sha-checked.)
+    if _openpuck_fw_valid(cache, _OPENPUCK_FW_SHA256):
+        return cache, None
+    if _openpuck_fw_valid(_OPENPUCK_FIRMWARE, _OPENPUCK_FW_SHA256):
+        return _OPENPUCK_FIRMWARE, None
+    # 2. No local pinned copy: fetch from the fork's pinned release, verify, cache.
+    try:
+        _openpuck_download(_OPENPUCK_FW_URL, cache)
+        if _openpuck_fw_valid(cache, _OPENPUCK_FW_SHA256):
+            return cache, None
+        try:
+            os.unlink(cache)
+        except OSError:
+            pass
+        return None, "the downloaded firmware failed verification (sha256/size/UF2)."
+    except Exception as e:
+        return None, "couldn't download firmware (%s)." % (str(e)[:120])
+
+
+def _openpuck_resolve_latest():
+    """Download + verify the fork's NEWEST standard firmware for the opt-in
+    variant=latest flash. No sha pin is possible for a build we haven't seen, so the
+    gate is UF2 magic + a sane size (via _openpuck_fw_valid). The download URL is
+    computed by the agent from the GitHub API — the client never supplies it.
+    Returns (path, tag, None) or (None, None, error_message). Never raises."""
+    try:
+        meta = json.loads(_http_text(_OPENPUCK_RELEASES_API))
+        tag = meta.get("tag_name") or "latest"
+        asset = _openpuck_pick_asset(meta.get("assets") or [])
+        url = asset.get("browser_download_url") if asset else None
+        if not url:
+            return None, None, "no standard .uf2 asset in the latest release."
+        safe = "".join(c for c in tag if c.isalnum() or c in "._-") or "latest"
+        dest = os.path.join(os.path.dirname(_openpuck_cache_path()),
+                            "OpenPuck-latest-%s.uf2" % safe)
+        _openpuck_download(url, dest)
+        if not _openpuck_fw_valid(dest):  # magic + size (no sha pin for latest)
+            try:
+                os.unlink(dest)
+            except OSError:
+                pass
+            return None, None, "the downloaded firmware failed verification (size/UF2)."
+        return dest, tag, None
+    except Exception as e:
+        return None, None, "couldn't fetch the newest firmware (%s)." % (str(e)[:120])
+
+
+# The fork's latest-release lookup is cached so the app's "check for newer" button
+# can't hammer GitHub; a network failure returns available:false, never raises.
+_OPENPUCK_LATEST_TTL_S = 10 * 60
+_openpuck_latest_cache = {"at": 0.0, "data": None}
+_openpuck_latest_lock = threading.Lock()
+
+
+def openpuck_latest(force=False):
+    """Read-only info about the fork's newest release for the OPT-IN newer-check:
+    {available, tag, name, size, is_newer, pinned_tag}. Cached (10 min). Never
+    raises; offline -> {available: False, error, pinned_tag}."""
+    now = time.monotonic()
+    with _openpuck_latest_lock:
+        c = _openpuck_latest_cache
+        if not force and c["data"] is not None \
+                and now - c["at"] < _OPENPUCK_LATEST_TTL_S:
+            return c["data"]
+    try:
+        meta = json.loads(_http_text(_OPENPUCK_RELEASES_API))
+        tag = meta.get("tag_name") or None
+        asset = _openpuck_pick_asset(meta.get("assets") or [])
+        if not asset:
+            data = {"available": False, "pinned_tag": _OPENPUCK_FW_TAG,
+                    "error": "no standard .uf2 asset in the latest release"}
+        else:
+            data = {"available": True, "tag": tag,
+                    "name": asset.get("name"), "size": asset.get("size"),
+                    "is_newer": _ver_tuple(tag) > _ver_tuple(_OPENPUCK_FW_TAG),
+                    "pinned_tag": _OPENPUCK_FW_TAG}
+    except Exception as e:
+        data = {"available": False, "pinned_tag": _OPENPUCK_FW_TAG,
+                "error": str(e)[:200]}
+    with _openpuck_latest_lock:
+        _openpuck_latest_cache["at"] = now
+        _openpuck_latest_cache["data"] = data
+    return data
+
+
+def mock_openpuck_latest():
+    return {"available": True, "tag": "0.9.41",
+            "name": "OpenPuck-0.9.41-standard.uf2", "size": 377856,
+            "is_newer": True, "pinned_tag": _OPENPUCK_FW_TAG}
+
+
+def real_openpuck_flash(variant="pinned"):
+    """Flash OpenPuck firmware onto a plugged-in nRF52840 board that is in its UF2
+    bootloader. Returns the standard ActionResult (ok/exit_code/stdout/stderr/
+    duration_ms).
+
+    `variant` is the allowlisted {pinned|latest} enum (validated by the caller):
+      - 'pinned' (default): the fork build pinned in source, resolved by
+        _openpuck_resolve_pinned() (cache -> fork download -> seed, sha-verified).
+      - 'latest': the fork's newest standard release, fetched + verified on demand
+        (opt-in only). Never reached without an explicit client request.
 
     §3-safe: the flash TARGET is _openpuck_bootloader_mount() (a label + UF2-marker
-    match, never client input), and the firmware is the agent-owned fixed-path
-    asset _OPENPUCK_FIRMWARE selected only by the 'openpuck' id — the client
-    supplies neither a path nor the bytes. The copy is shutil.copyfile into the
-    desktop user's own automount, so no sudo and no shell.
+    match, never client input) and the firmware is agent-owned — the client supplies
+    neither a URL, a path, nor the bytes; it only selects the id + variant enum. The
+    copy is shutil.copyfile into the desktop user's own automount: no sudo, no shell.
 
-    The board reboots the instant the UF2 lands and yanks its USB mass-storage
-    mid-write, so the copy errors (ENXIO/EIO) even on a SUCCESSFUL flash; that
-    specific errno is treated as success (both directions are tested)."""
+    The resolved firmware is ALWAYS verified (UF2 magic + size, and sha256 for the
+    pinned build) before it is written — a bootloader silently ignores a truncated /
+    non-UF2 image and never reboots, so copying garbage would falsely read as
+    success. The board then reboots the instant the UF2 lands and yanks its USB
+    mass-storage mid-write, so the copy errors (ENXIO/EIO) even on a SUCCESSFUL
+    flash; that specific errno is treated as success (both directions are tested)."""
     start = time.monotonic()
 
     def _done(ok, exit_code, stdout, stderr):
@@ -8113,19 +8345,34 @@ def real_openpuck_flash():
         return _done(False, -1, "",
                      "No board in DFU mode. Plug in an nRF52840 board (or "
                      "double-tap its reset button) and try again.")
-    fw = _OPENPUCK_FIRMWARE
-    if not os.path.isfile(fw):
+
+    if variant == "latest":
+        fw, tag, err = _openpuck_resolve_latest()
+        if tag:
+            # Carry the AGPL §6 corresponding-source offer WITH the conveyed build:
+            # a latest flash conveys a tag other than the app-pinned one, so the
+            # static NOTICE/licenses offer (0.9.40) would not cover it — name this
+            # build's own source here.
+            ok_msg = ("Flashed OpenPuck %s. The board is rebooting as a Steam "
+                      "Controller Puck. Source: "
+                      "https://github.com/emerytech/openpuck/releases/tag/%s"
+                      % (tag, tag))
+        else:
+            ok_msg = "Flashed. The board is rebooting as a Steam Controller Puck."
+    else:
+        fw, err = _openpuck_resolve_pinned()
+        ok_msg = "Flashed. The board is rebooting as a Steam Controller Puck."
+
+    if fw is None:
+        # Degrade closed: no verified firmware from any source. Surface the reason
+        # and how to recover (network, or re-run the installer to seed it).
         return _done(False, -1, "",
-                     "OpenPuck firmware is not installed on this box. Re-run the "
-                     "Couchside installer to fetch it.")
-    if not _is_uf2(fw):
-        # Degrade CLOSED: a bootloader silently ignores a truncated/garbage image
-        # and never reboots, so copying it would report a no-op flash as success.
-        return _done(False, -1, "",
-                     "OpenPuck firmware looks corrupt (not a valid UF2). Re-run "
-                     "the Couchside installer to reinstall it.")
+                     "Couldn't get the OpenPuck firmware — %s Connect the box to "
+                     "the internet and try again, or re-run the Couchside "
+                     "installer." % (err or "no source available."))
+
+    # fw is already fully verified by the resolver; write it onto the board.
     dst = os.path.join(mount, os.path.basename(fw))
-    ok_msg = "Flashed. The board is rebooting as a Steam Controller Puck."
     try:
         shutil.copyfile(fw, dst)
     except OSError as e:
@@ -8137,17 +8384,18 @@ def real_openpuck_flash():
     return _done(True, 0, ok_msg, "")
 
 
-def mock_openpuck_flash():
+def mock_openpuck_flash(variant="pinned"):
     """--mock/harness: exercise the flash PRESS end-to-end without a real board.
     Takes ~1.5s (a real UF2 burn takes several) so the app's Flashing… state is
     actually visible in the harness, then flips the mock row to puck_present so
-    the re-poll arc is exercised too."""
+    the re-poll arc is exercised too. `variant` only tweaks the note."""
     global _MOCK_OPENPUCK_FLASHED
     time.sleep(1.5)
     _MOCK_OPENPUCK_FLASHED = True
+    tag = "0.9.41 (newer)" if variant == "latest" else "pinned"
     return {"ok": True, "exit_code": 0,
-            "stdout": "Flashed (mock). The board is rebooting as a Steam "
-                      "Controller Puck.",
+            "stdout": "Flashed (mock, %s). The board is rebooting as a Steam "
+                      "Controller Puck." % tag,
             "stderr": "", "duration_ms": 1500}
 
 
@@ -16571,6 +16819,14 @@ class Handler(BaseHTTPRequestHandler):
                 # needs_enable/no_adapter). Read-only; the app gates the whole
                 # section behind an opt-in pref.
                 self._send(200, {"utilities": utilities_state(self.mock)}, started)
+            elif path == "/api/utilities/openpuck/latest":
+                # OPT-IN "check for newer firmware": the fork's newest release vs
+                # the pinned build. Read-only (contacts GitHub, cached 10 min); the
+                # app only calls it when the user asks, and NEVER auto-flashes the
+                # result. A newer build is flashed only via an explicit
+                # POST .../openpuck/run?variant=latest.
+                self._send(200, (mock_openpuck_latest() if self.mock
+                                 else openpuck_latest()), started)
             elif path == "/api/session/default":
                 # Read-only. Always 200 with available=false rather than 404 so
                 # the app can tell "old agent" (404) from "this box has no
@@ -17295,8 +17551,18 @@ class Handler(BaseHTTPRequestHandler):
                                      "error": "utility has no run action"}, started)
                     return
                 if uid == "openpuck":
-                    result = (mock_openpuck_flash() if self.mock
-                              else real_openpuck_flash())
+                    # variant is an ALLOWLISTED enum, not free input: the client
+                    # picks the pinned build (default) or, opt-in, the fork's
+                    # newest. Anything else is REJECTED (§3.6), never sanitised.
+                    variant = parse_qs(parsed.query).get(
+                        "variant", ["pinned"])[0]
+                    if variant not in ("pinned", "latest"):
+                        self._send(400, {"ok": False,
+                                         "error": "unknown firmware variant"},
+                                   started)
+                        return
+                    result = (mock_openpuck_flash(variant) if self.mock
+                              else real_openpuck_flash(variant))
                     self._send(200, result, started)
                     return
                 # Defensive: a run id in the frozen set with no dispatch branch.

--- a/agent/openpuck/OPENPUCK-NOTICE.txt
+++ b/agent/openpuck/OPENPUCK-NOTICE.txt
@@ -3,23 +3,35 @@ OpenPuck firmware — attribution and source offer
 
 Couchside's "OpenPuck receiver" utility flashes the OpenPuck firmware onto a
 plugged-in nRF52840 board. That firmware is a separate work, NOT part of
-Couchside:
+Couchside, and runs on the board — never on your phone or inside the Couchside
+app:
 
-  Project:  OpenPuck — https://github.com/safijari/openpuck
-  Author:   safijari
+  Project:  OpenPuck
+  Author:   safijari (original)          https://github.com/safijari/openpuck
+  Modified: EmeryTech (fork + fixes)     https://github.com/emerytech/openpuck
   License:  GNU Affero General Public License v3.0 (AGPL-3.0)
 
-Couchside redistributes an UNMODIFIED OpenPuck release binary
-(OpenPuck-0.9.31-standard.uf2) purely as a convenience so the flash works with
-the box offline. Couchside itself (this agent) is licensed separately and does
-NOT incorporate OpenPuck's code.
+Couchside DOWNLOADS a released OpenPuck build at flash time (it does not embed or
+compile any OpenPuck source) so the flash works with the box offline. The build
+distributed here is:
 
-Corresponding source for the exact firmware version distributed here is
-available from the upstream release it was fetched from:
+  OpenPuck 0.9.40  (EmeryTech fork build)
+  asset:  OpenPuck-0.9.40-standard.uf2
 
-  https://github.com/safijari/openpuck/releases/tag/0.9.31
+Because this is a MODIFIED version, AGPL-3.0 §5 applies. The corresponding source
+for the exact firmware version distributed here — this is the §6 source offer —
+is available at the shipped tag:
 
-The AGPL-3.0 license text is published with the OpenPuck project at the URL
-above. This notice satisfies the redistribution requirement to convey the
-license and offer the corresponding source; it does not modify the terms under
-which OpenPuck is licensed.
+  https://github.com/emerytech/openpuck/tree/0.9.40
+
+If you opt into flashing a NEWER build via the app's "Check for newer firmware",
+the corresponding source for that build is published under its own tag on the same
+fork; every release and its source are listed at:
+
+  https://github.com/emerytech/openpuck/releases
+
+The AGPL-3.0 license text is published with the OpenPuck project at the URLs
+above. This notice satisfies the requirement to convey the license and offer the
+corresponding source; it does not modify the terms under which OpenPuck is
+licensed. Couchside itself is licensed separately and does NOT incorporate
+OpenPuck's code.

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -2106,6 +2106,22 @@ function SetupBody() {
               </Text>
             </View>
 
+            <Pressable
+              onPress={() => {
+                hapticLight();
+                router.push('/licenses');
+              }}
+              style={({ pressed }) => [styles.rateRow, pressed && styles.pressed]}>
+              <Ionicons name="document-text-outline" size={18} color={t.blue} />
+              <View style={styles.rateBody}>
+                <Text style={styles.rateTitle}>Open source licenses</Text>
+                <Text style={styles.rateSub}>
+                  Attribution and licenses for third-party works, incl. OpenPuck (AGPL-3.0).
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={16} color={t.textDim} />
+            </Pressable>
+
             <Text style={styles.hint}>
               Each box&apos;s Couchside service listens on http://&lt;host&gt;:&lt;port&gt;. All routes except
               /api/ping require the bearer token.

--- a/app/app/licenses.tsx
+++ b/app/app/licenses.tsx
@@ -16,6 +16,7 @@ import { Stack, router } from 'expo-router';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { hapticLight } from '@/lib/haptics';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -53,6 +54,7 @@ export default function LicensesScreen() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const insets = useSafeAreaInsets();
+  useLockOrientation('portrait'); // like every screen but the Pad
 
   return (
     <View style={[styles.screen, { paddingTop: insets.top }]}>

--- a/app/app/licenses.tsx
+++ b/app/app/licenses.tsx
@@ -1,0 +1,131 @@
+/**
+ * Open Source Licenses — attribution + license notices for third-party works
+ * Couchside references.
+ *
+ * The load-bearing entry is OpenPuck: an AGPL-3.0 firmware (safijari's project,
+ * EmeryTech fork) that Couchside DOWNLOADS at flash time and writes to a plugged-in
+ * board. Couchside never embeds or compiles OpenPuck's source, so the app is not a
+ * derivative work; because Couchside distributes the firmware binary, AGPL-3.0 §6
+ * asks that the corresponding source be offered — the "View source" link below at
+ * the exact shipped tag IS that offer. Nothing on this screen is interactive beyond
+ * the links; it exists to satisfy attribution + the source offer.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import * as Linking from 'expo-linking';
+import { Stack, router } from 'expo-router';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { hapticLight } from '@/lib/haptics';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+// OpenPuck firmware — MUST stay in lockstep with the pinned build the agent flashes
+// (agent _OPENPUCK_FW_TAG / OPENPUCK-NOTICE.txt). The source link is the AGPL §6
+// offer and must point at the EXACT shipped tag, never a moving branch.
+const OPENPUCK = {
+  version: 'OpenPuck 0.9.40',
+  originalAuthor: 'safijari',
+  originalUrl: 'https://github.com/safijari/openpuck',
+  forkUrl: 'https://github.com/emerytech/openpuck',
+  sourceAtTagUrl: 'https://github.com/emerytech/openpuck/tree/0.9.40',
+  releasesUrl: 'https://github.com/emerytech/openpuck/releases',
+  licenseUrl: 'https://www.gnu.org/licenses/agpl-3.0.html',
+};
+
+function LinkRow({ icon, label, url }: { icon: string; label: string; url: string }) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  return (
+    <Pressable
+      onPress={() => { hapticLight(); void Linking.openURL(url); }}
+      style={({ pressed }) => [styles.linkRow, pressed && { opacity: 0.7 }]}
+      accessibilityRole="link"
+      accessibilityLabel={label}
+    >
+      <Ionicons name={icon as never} size={16} color={t.blue} />
+      <Text style={styles.linkText}>{label}</Text>
+      <Ionicons name="open-outline" size={14} color={t.textDim} />
+    </Pressable>
+  );
+}
+
+export default function LicensesScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const insets = useSafeAreaInsets();
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top }]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} hitSlop={12} accessibilityRole="button" accessibilityLabel="Back">
+          <Ionicons name="chevron-back" size={26} color={t.text} />
+        </Pressable>
+        <Text style={styles.title}>Open source licenses</Text>
+        <View style={{ width: 26 }} />
+      </View>
+
+      <ScrollView contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24 }}>
+        <Text style={styles.lede}>
+          Couchside references third-party works. Their authors and licenses are
+          credited here.
+        </Text>
+
+        <View style={styles.card}>
+          <Text style={styles.cardTitle}>OpenPuck firmware</Text>
+          <Text style={styles.cardMeta}>{OPENPUCK.version} · AGPL-3.0</Text>
+          <Text style={styles.body}>
+            OpenPuck turns a plugged-in nRF52840 board into a Steam Controller 2
+            wireless receiver. It is a separate work by {OPENPUCK.originalAuthor}
+            {', modified by EmeryTech.'} It runs on the board — never inside the
+            Couchside app. Couchside downloads the released firmware at flash time
+            and writes it to your board; it does not embed or compile OpenPuck&apos;s
+            source.
+          </Text>
+          <Text style={styles.body}>
+            OpenPuck is licensed under the GNU Affero General Public License v3.0.
+            Because Couchside distributes the firmware, the corresponding source for
+            the exact build it flashes is offered at the shipped tag below. The app
+            pins {OPENPUCK.version} by default; if you opt into flashing a newer build,
+            its source is published under that build&apos;s own tag on the fork
+            (see all releases).
+          </Text>
+          <View style={styles.links}>
+            <LinkRow icon="git-branch-outline" label="View source (at the shipped tag)" url={OPENPUCK.sourceAtTagUrl} />
+            <LinkRow icon="albums-outline" label="All releases + their source (fork)" url={OPENPUCK.releasesUrl} />
+            <LinkRow icon="person-outline" label={`Original project — ${OPENPUCK.originalAuthor}`} url={OPENPUCK.originalUrl} />
+            <LinkRow icon="git-network-outline" label="EmeryTech fork" url={OPENPUCK.forkUrl} />
+            <LinkRow icon="document-text-outline" label="AGPL-3.0 license text" url={OPENPUCK.licenseUrl} />
+          </View>
+        </View>
+
+        <Text style={styles.footer}>
+          Couchside itself is licensed separately and does not incorporate
+          OpenPuck&apos;s code.
+        </Text>
+      </ScrollView>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    screen: { flex: 1, backgroundColor: t.bg },
+    header: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+      paddingHorizontal: 12, paddingVertical: 10,
+    },
+    title: { color: t.text, fontSize: 20, fontWeight: '800' },
+    lede: { color: t.textFaint, fontSize: 13, lineHeight: 18, marginBottom: 14 },
+    card: {
+      borderRadius: 14, borderWidth: 1, borderColor: t.cardBorder,
+      backgroundColor: t.card, padding: 14,
+    },
+    cardTitle: { color: t.text, fontSize: 16, fontWeight: '800' },
+    cardMeta: { color: t.textFaint, fontSize: 12, fontWeight: '700', marginTop: 2, marginBottom: 10 },
+    body: { color: t.textDim, fontSize: 13, lineHeight: 19, marginBottom: 10 },
+    links: { marginTop: 4, gap: 4 },
+    linkRow: { flexDirection: 'row', alignItems: 'center', gap: 8, paddingVertical: 8 },
+    linkText: { color: t.blue, fontSize: 13, fontWeight: '700', flex: 1 },
+    footer: { color: t.textFaint, fontSize: 12, lineHeight: 18, marginTop: 16 },
+  });

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -15,7 +15,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { hapticLight, hapticSuccess, hapticWarning } from '@/lib/haptics';
-import { api, ApiError, type BoxCaps, type Utility } from '@/lib/api';
+import { api, ApiError, type BoxCaps, type OpenpuckLatest, type Utility } from '@/lib/api';
 import { useSettings } from '@/lib/SettingsContext';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -41,6 +41,9 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
   const [utils, setUtils] = useState<Utility[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null); // utility id being run
   const [note, setNote] = useState<Record<string, { tone: 'ok' | 'err' | 'info'; msg: string }>>({});
+  // Opt-in "check for newer firmware": null = not checked, then the box's answer.
+  const [latest, setLatest] = useState<OpenpuckLatest | null>(null);
+  const [checking, setChecking] = useState(false);
   const live = useRef(true);
   const lastUtils = useRef<Utility[] | null>(null);
 
@@ -77,13 +80,13 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
     return () => { live.current = false; };
   }, [refresh, canProbe]);
 
-  const flashOpenpuck = useCallback(() => {
+  const flashOpenpuck = useCallback((variant: 'pinned' | 'latest' = 'pinned') => {
     const doFlash = async () => {
       hapticLight();
       setBusy('openpuck');
       setNote((n) => { const c = { ...n }; delete c.openpuck; return c; });
       try {
-        const r = await api.runUtility(settings, 'openpuck');
+        const r = await api.runUtility(settings, 'openpuck', variant);
         if (!live.current) return;
         const msg = r.ok
           ? (r.stdout || 'Flashed. The board is rebooting as a Steam Controller Puck.')
@@ -117,20 +120,49 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
       }
     };
     // A firmware write is a real action — confirm first, even though the
-    // bootloader stays intact and it's re-flashable.
-    const q = 'Flash the OpenPuck firmware to the plugged-in board? It reboots as '
-      + 'a Steam Controller Puck when done. The bootloader is kept, so you can '
-      + 're-flash any time.';
+    // bootloader stays intact and it's re-flashable. The 'latest' path is opt-in
+    // and flashes a build newer than the one the app pins, so it says so.
+    const newer = latest?.tag ? ` (${latest.tag})` : '';
+    const q = variant === 'latest'
+      ? 'Flash the NEWEST OpenPuck firmware' + newer + ' to the plugged-in board? '
+        + 'This is newer than the build the app ships and pins. It reboots as a '
+        + 'Steam Controller Puck when done; the bootloader is kept, so you can '
+        + 're-flash any time.'
+      : 'Flash the OpenPuck firmware to the plugged-in board? It reboots as '
+        + 'a Steam Controller Puck when done. The bootloader is kept, so you can '
+        + 're-flash any time.';
     if (Platform.OS === 'web') {
       // eslint-disable-next-line no-alert
       if (typeof window !== 'undefined' && window.confirm(q)) void doFlash();
       return;
     }
-    Alert.alert('Flash OpenPuck receiver?', q, [
-      { text: 'Cancel', style: 'cancel' },
-      { text: 'Flash', onPress: () => { void doFlash(); } },
-    ]);
-  }, [settings, refresh]);
+    Alert.alert(
+      variant === 'latest' ? 'Flash newest firmware?' : 'Flash OpenPuck receiver?',
+      q,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Flash', onPress: () => { void doFlash(); } },
+      ],
+    );
+  }, [settings, refresh, latest]);
+
+  // Opt-in: ask the box to compare its pinned firmware against the fork's newest
+  // release. Read-only — this NEVER flashes; it only reveals the "Flash newest"
+  // control when a newer build exists.
+  const checkNewer = useCallback(async () => {
+    hapticLight();
+    setChecking(true);
+    try {
+      // null == a 404: the box's service is too old for this endpoint (distinct
+      // from a thrown error, which is an unreachable/unhealthy box).
+      const r = await api.openpuckLatest(settings);
+      if (live.current) setLatest(r ?? { available: false, pinned_tag: '', error: 'old-agent' });
+    } catch {
+      if (live.current) setLatest({ available: false, pinned_tag: '', error: 'unreachable' });
+    } finally {
+      if (live.current) setChecking(false);
+    }
+  }, [settings]);
 
   // Nothing to show if the box lacks the endpoint (old agent / Windows).
   if (!canProbe || !utils || utils.length === 0) return null;
@@ -153,7 +185,7 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
               <Text style={[styles.status, { color }]}>{p.line}</Text>
               {canFlash ? (
                 <Pressable
-                  onPress={flashOpenpuck}
+                  onPress={() => flashOpenpuck('pinned')}
                   disabled={running}
                   style={({ pressed }) => [
                     styles.btn,
@@ -176,6 +208,60 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
                 <Text style={[styles.note, {
                   color: n.tone === 'ok' ? t.green : n.tone === 'err' ? t.red : t.blue,
                 }]}>{n.msg}</Text>
+              ) : null}
+              {u.id === 'openpuck' ? (
+                <View style={styles.newer}>
+                  {latest === null ? (
+                    <Pressable
+                      onPress={checkNewer}
+                      disabled={checking}
+                      accessibilityRole="button"
+                      accessibilityLabel="Check for newer OpenPuck firmware"
+                      style={({ pressed }) => [{ opacity: checking ? 0.6 : pressed ? 0.7 : 1 }]}
+                    >
+                      <Text style={styles.link}>
+                        {checking ? 'Checking…' : 'Check for newer firmware'}
+                      </Text>
+                    </Pressable>
+                  ) : latest.available && latest.is_newer ? (
+                    <>
+                      <Text style={styles.newerLine}>
+                        {`Newer firmware available${latest.tag ? ` (${latest.tag})` : ''}.`}
+                      </Text>
+                      {canFlash ? (
+                        <Pressable
+                          onPress={() => flashOpenpuck('latest')}
+                          disabled={running}
+                          style={({ pressed }) => [
+                            styles.btn,
+                            { borderColor: t.blue, opacity: running ? 0.6 : pressed ? 0.8 : 1 },
+                          ]}
+                          accessibilityRole="button"
+                          accessibilityLabel="Flash newest OpenPuck firmware"
+                        >
+                          {running ? (
+                            <ActivityIndicator size="small" color={t.blue} />
+                          ) : (
+                            <Ionicons name="flash-outline" size={16} color={t.blue} />
+                          )}
+                          <Text style={[styles.btnText, { color: t.blue }]}>
+                            {running ? 'Flashing…' : 'Flash newest'}
+                          </Text>
+                        </Pressable>
+                      ) : (
+                        <Text style={styles.newerHint}>Plug a board in to flash it.</Text>
+                      )}
+                    </>
+                  ) : (
+                    <Text style={styles.newerLine}>
+                      {latest.available
+                        ? "You're on the newest firmware."
+                        : latest.error === 'old-agent'
+                          ? "Update the box's Couchside service to check for newer firmware."
+                          : "Couldn't reach the box to check."}
+                    </Text>
+                  )}
+                </View>
               ) : null}
             </View>
           </View>
@@ -206,4 +292,8 @@ const makeStyles = (t: Palette) =>
     },
     btnText: { fontSize: 13, fontWeight: '700' },
     note: { fontSize: 12, marginTop: 8, fontWeight: '600', lineHeight: 17 },
+    newer: { marginTop: 10 },
+    link: { color: t.blue, fontSize: 12, fontWeight: '700' },
+    newerLine: { color: t.textFaint, fontSize: 12, fontWeight: '600', lineHeight: 17 },
+    newerHint: { color: t.textFaint, fontSize: 12, marginTop: 6 },
   });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -211,6 +211,20 @@ export type BoxCaps = {
  *  cec: 'enabled' | 'needs_enable' | 'no_adapter'). */
 export type Utility = { id: string; state: string; label: string; description: string };
 
+/** GET /api/utilities/openpuck/latest — the OpenPuck fork's newest release vs the
+ *  build the box pins, for the opt-in "check for newer firmware" control. Read-only;
+ *  `available: false` means the box couldn't reach GitHub (an `error` string says
+ *  why). `is_newer` gates whether the app offers a newer flash. */
+export type OpenpuckLatest = {
+  available: boolean;
+  pinned_tag: string;
+  tag?: string | null;
+  name?: string | null;
+  size?: number | null;
+  is_newer?: boolean;
+  error?: string;
+};
+
 /** One owned-but-uninstalled entry from GET /api/steam/installable. name/type are
  *  present when the agent (>= 2.9.76) parsed them offline from appinfo.vdf; type
  *  is lowercased ('game' | 'dlc' | 'tool' | …) and drives the app's game filter. */
@@ -1661,10 +1675,30 @@ export const api = {
    * reach the box" for a flash that SUCCEEDED (observed on hardware 2026-08-08)
    * — the worst kind of wrong.
    */
-  runUtility(settings: ConnSettings, id: string): Promise<ActionResult> {
+  runUtility(
+    settings: ConnSettings,
+    id: string,
+    variant?: 'pinned' | 'latest',
+  ): Promise<ActionResult> {
+    // `variant` is an allowlisted enum the agent validates (pinned | latest); it is
+    // sent only for openpuck's opt-in "flash newer" and defaults to pinned server-
+    // side when omitted, so old agents (which ignore the query) keep working.
+    const q = variant ? `?variant=${encodeURIComponent(variant)}` : '';
     return request<ActionResult>(
-      settings, `/api/utilities/${encodeURIComponent(id)}/run`,
+      settings, `/api/utilities/${encodeURIComponent(id)}/run${q}`,
       { method: 'POST', timeoutMs: 60000 });
+  },
+
+  /**
+   * OPT-IN "check for newer OpenPuck firmware" (agent >= 2.9.77): the fork's newest
+   * release vs the build the box pins. Read-only, cached box-side; resolves null on
+   * a 404 so older agents simply don't show the control. Calling this NEVER flashes
+   * anything — flashing a newer build is a separate, explicit
+   * runUtility(settings, 'openpuck', 'latest').
+   */
+  openpuckLatest(settings: ConnSettings): Promise<OpenpuckLatest | null> {
+    return probeOrNull(
+      request<OpenpuckLatest>(settings, '/api/utilities/openpuck/latest'));
   },
 
   /**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,15 +20,29 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   `UtilitiesSection.tsx` gated on `utilitiesEnabled` pref (default false).
 - **STAGE 2 DONE (PR #399, agent 2.9.75).** OpenPuck FLASH: `POST /api/utilities/openpuck/run`
   copies the pinned firmware onto a DFU board (id in the frozen `_UTILITY_RUN_IDS`, target
-  from the bootloader-mount match, no-shell copy, ENXIO/EIO = success). Firmware = BUNDLE
-  (owner-chosen): release-agent.sh fetches from safijari/openpuck + pins sha256, install.sh
-  installs it only if it passed the signed SHA256SUMS gate, so flashing works offline; AGPL
-  notice ships alongside. CEC turned out NOT to be a runtime button — instead: honest detector
+  from the bootloader-mount match, no-shell copy, ENXIO/EIO = success). CEC turned out NOT to
+  be a runtime button — instead: honest detector
   (`enabled` now gated on `os.access` openability, so a permission gap is observable both ways,
   §11) + an install-time udev regroup-to-`input` rule for /dev/cec* (`cec` is NOT in
   `_UTILITY_RUN_IDS`; POST cec/run → 404). App Flash button harness-verified end-to-end.
   **NOT verified on hardware:** a real board in DFU, the udev rule flipping a real
   `needs_enable` box, and a real release publishing the .uf2 (box was off-subnet).
+- **STAGE 2.5 DONE (agent 2.9.77).** OpenPuck firmware = RUNTIME FETCH from the EmeryTech
+  fork, not a Couchside bundle — a licensing change (Couchside references, never embeds, the
+  AGPL-3.0 firmware). The agent downloads the pinned build (`0.9.40`,
+  `OpenPuck-0.9.40-standard.uf2`, sha `ee2de6a4…`) from the fork at flash time (cache → fork
+  download → install seed, every source re-verified sha256 + UF2 magic + ~370 KB size);
+  install.sh seeds the same file straight from the fork (its own sha pin) for offline flashing;
+  release-agent.sh no longer republishes the .uf2 (ships only the AGPL notice). Opt-in
+  "check for newer": `GET /api/utilities/openpuck/latest` + `POST …/openpuck/run?variant=latest`
+  (variant is an allowlisted enum; bogus → 400; NEVER auto-flashes). App: Utilities gains a
+  "Check for newer firmware" control + "Flash newest"; new `Setup → Account → Open source
+  licenses` screen (`app/app/licenses.tsx`) names OpenPuck AGPL-3.0, credits safijari (modified
+  by EmeryTech), links source at the shipped tag (`.../tree/0.9.40` = the §6 offer). NOTICE +
+  README updated for the modified fork. **Verified:** agent tests (verify/resolve/pick-asset/
+  variant), tsc, harness (check-newer, pinned flash on the wire as `?variant=pinned`, licenses
+  screen), and a REAL fork download (376832 B, sha match). **NOT verified on hardware:** a real
+  board in DFU flashed via the runtime-fetched firmware.
 - **STAGE 3 (later, backlog):** more tenants on the two engines — board flasher (ZMK/QMK/
   WLED/Pico), guided installer (Sunshine/Tailscale/Decky/xone/fwupd/EmuDeck).
 - **Allowlist model (non-negotiable):** a client selects WHICH utility runs; never supplies a

--- a/docs/memory/project_utilities-menu.md
+++ b/docs/memory/project_utilities-menu.md
@@ -46,8 +46,9 @@ it never supplies a command, path, firmware URL, or device.
 - **Detect:** the nRF52840 nice!nano UF2 bootloader mounts as `NICENANO` /
   `NRF52BOOT` on the box (Linux, same as macOS). Agent watches for that mount /
   the bootloader USB id.
-- **Flash:** fetch pinned `OpenPuck-<ver>-standard.uf2` from safijari/openpuck
-  (AGPL; verify pinned sha256), `cp` to the mount. The `cp` "Device not configured"
+- **Flash:** fetch pinned `OpenPuck-<ver>-standard.uf2` from the EmeryTech fork
+  `emerytech/openpuck` (AGPL-3.0; verify pinned sha256 — runtime fetch, not bundled,
+  since agent 2.9.77), `cp` to the mount. The `cp` "Device not configured"
   NON-ZERO exit **is success** (board reboots on write). Then confirm USB
   re-enumerates as Valve `0x28DE:0x1304` ("Steam Controller Puck").
 - **Open spike:** does the box automount the bootloader for the agent user (no root

--- a/install.sh
+++ b/install.sh
@@ -55,14 +55,17 @@ PLAYER_DEST_NAME="Couchside Player"
 
 SCREENSAVER_DEST_NAME="Couchside Screensaver"
 SCREENSAVER_DEST_LEGACY="couchside-screensaver.sh"
-# OpenPuck firmware .uf2 (nRF52840 nice!nano), an AGPL-3.0 build from
-# safijari/openpuck, republished as a release asset and verified by the SAME
-# SHA256SUMS gate as the agent, then dropped at a fixed path the agent reads to
-# flash a plugged-in board (Setup -> Utilities). Bundling it means flashing works
-# with the box offline. Optional: a release predating it has no such asset and the
-# flash feature stays dark (the agent degrades closed).
-OPENPUCK_FW_NAME="OpenPuck-0.9.31-standard.uf2"
-OPENPUCK_FW_URL="${AGENT_BASE}/${OPENPUCK_FW_NAME}"
+# OpenPuck firmware .uf2 (nRF52840 nice!nano), an AGPL-3.0 build from the EmeryTech
+# OpenPuck fork. Couchside does NOT republish it: the box downloads it STRAIGHT from
+# the fork's GitHub release, PINNED by tag + sha256, and drops it root-owned at a
+# fixed path as an OFFLINE SEED for Setup -> Utilities flashing. The agent
+# re-verifies (and can re-fetch the pinned or a newer build) at flash time, so a
+# failed/absent seed just means the first flash needs the box online — the flash
+# feature never depends on this file existing.
+OPENPUCK_FW_TAG="0.9.40"
+OPENPUCK_FW_NAME="OpenPuck-0.9.40-standard.uf2"
+OPENPUCK_FW_SHA256="ee2de6a415f87cacc2999893fd7803462a6d76f1ad4acbcd7962f0115575f478"
+OPENPUCK_FW_URL="https://github.com/emerytech/openpuck/releases/download/${OPENPUCK_FW_TAG}/${OPENPUCK_FW_NAME}"
 OPENPUCK_FW_DEST="/etc/couchside/openpuck/firmware.uf2"
 # Signature + checksums for the agent files above, published as sibling assets
 # in the SAME release. install.sh verifies the sig (authenticity) + hashes
@@ -658,11 +661,13 @@ else
         curl -fsSL "$SCREENSAVER_ART_LANDSCAPE_URL" -o "$WORK_DIR/screensaver-landscape.png" 2>/dev/null || true
         curl -fsSL "$SCREENSAVER_ART_LOGO_URL"      -o "$WORK_DIR/screensaver-logo.png"      2>/dev/null || true
     fi
-    # Optional OpenPuck firmware + its AGPL notice: fetched best-effort and
-    # verified by the SHA256SUMS gate below (both are listed there); installed
-    # only if they land AND are in the signed manifest. A release without them
-    # leaves the flash dark.
-    curl -fsSL "$OPENPUCK_FW_URL" -o "$WORK_DIR/$OPENPUCK_FW_NAME" 2>/dev/null || true
+    # OpenPuck firmware seed (optional): fetched best-effort DIRECT from the fork's
+    # pinned release and verified against a PINNED sha256 at install (below) — it is
+    # deliberately NOT in the signed SHA256SUMS manifest, because Couchside
+    # references the AGPL firmware rather than republishing it. Its AGPL notice DOES
+    # ride the signed manifest. A failed fetch just leaves the seed absent; the
+    # agent downloads + verifies the firmware itself at flash time.
+    curl -fsSL --max-time 60 "$OPENPUCK_FW_URL" -o "$WORK_DIR/$OPENPUCK_FW_NAME" 2>/dev/null || true
     curl -fsSL "${AGENT_BASE}/OPENPUCK-NOTICE.txt" -o "$WORK_DIR/OPENPUCK-NOTICE.txt" 2>/dev/null || true
 
     # --- Supply-chain gate (FAIL CLOSED): the fetched agent must be SIGNED by
@@ -742,23 +747,31 @@ fi
 say "Installing daemon to $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 install -m 0755 "$WORK_DIR/couchsided.py" "$INSTALL_DIR/couchsided.py"
-# OpenPuck firmware (optional): install ONLY the verified release asset. It rode
-# through the SHA256SUMS gate above like every other fetched file, so if it is
-# both present AND listed in the signed manifest it has been hash-verified;
-# anything else is not installed (fail closed, same policy as the helper). Dropped
-# root-owned at the fixed path the agent reads for Setup -> Utilities flashing.
-if [ -f "$WORK_DIR/$OPENPUCK_FW_NAME" ] \
-   && [ -f "$WORK_DIR/SHA256SUMS" ] \
-   && grep -qF " $OPENPUCK_FW_NAME" "$WORK_DIR/SHA256SUMS"; then
-    sudo install -d -m 0755 "$(dirname "$OPENPUCK_FW_DEST")"
-    sudo install -m 0644 -o root -g root "$WORK_DIR/$OPENPUCK_FW_NAME" "$OPENPUCK_FW_DEST"
-    # AGPL-3.0: the notice (attribution + source offer) rides beside the binary.
-    if [ -f "$WORK_DIR/OPENPUCK-NOTICE.txt" ] \
-       && grep -qF ' OPENPUCK-NOTICE.txt' "$WORK_DIR/SHA256SUMS"; then
-        sudo install -m 0644 -o root -g root "$WORK_DIR/OPENPUCK-NOTICE.txt" \
-            "$(dirname "$OPENPUCK_FW_DEST")/OPENPUCK-NOTICE.txt"
+# OpenPuck firmware (optional OFFLINE seed): install ONLY if the fetched .uf2
+# matches the sha256 PINNED in this installer. It comes straight from the fork, not
+# via the signed manifest, so this pin is its integrity gate — fail closed: no
+# match (or no file), no install, and the agent fetches + verifies at flash time
+# instead. Dropped root-owned at the fixed path the agent reads for Setup ->
+# Utilities flashing.
+if [ -f "$WORK_DIR/$OPENPUCK_FW_NAME" ]; then
+    openpuck_got="$( { command -v sha256sum >/dev/null 2>&1 \
+        && sha256sum "$WORK_DIR/$OPENPUCK_FW_NAME" \
+        || shasum -a 256 "$WORK_DIR/$OPENPUCK_FW_NAME"; } | cut -d' ' -f1)"
+    if [ "$openpuck_got" = "$OPENPUCK_FW_SHA256" ]; then
+        sudo install -d -m 0755 "$(dirname "$OPENPUCK_FW_DEST")"
+        sudo install -m 0644 -o root -g root "$WORK_DIR/$OPENPUCK_FW_NAME" "$OPENPUCK_FW_DEST"
+        # AGPL-3.0: the notice (attribution + source offer) rides beside the binary;
+        # it came through the signed SHA256SUMS gate above.
+        if [ -f "$WORK_DIR/OPENPUCK-NOTICE.txt" ] \
+           && [ -f "$WORK_DIR/SHA256SUMS" ] \
+           && grep -qF ' OPENPUCK-NOTICE.txt' "$WORK_DIR/SHA256SUMS"; then
+            sudo install -m 0644 -o root -g root "$WORK_DIR/OPENPUCK-NOTICE.txt" \
+                "$(dirname "$OPENPUCK_FW_DEST")/OPENPUCK-NOTICE.txt"
+        fi
+        note "installed OpenPuck firmware seed ($OPENPUCK_FW_NAME)"
+    else
+        note "OpenPuck firmware sha256 mismatch — skipping seed (agent fetches at flash time)."
     fi
-    note "installed OpenPuck firmware ($OPENPUCK_FW_NAME)"
 fi
 # The aerial-screensaver player is optional: install only if wanted AND it
 # fetched and parses (bash -n), so a failed/HTML fetch can't land as an

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -128,26 +128,13 @@ printf '%s\n' "$win_ver" > "$tmp/agent-version-win.txt"
 files+=(agent-version-win.txt)
 echo "==> windows agent version: $win_ver"
 
-# OpenPuck firmware (AGPL-3.0, safijari/openpuck), republished as a signed asset
-# so install.sh can drop it on the box — Setup -> Utilities flashing then works
-# with the box offline. Fetched from the UPSTREAM release and PINNED by sha256;
-# the build ABORTS on any mismatch so we never publish a firmware we didn't
-# verify. The AGPL notice (attribution + source offer) rides alongside it.
-openpuck_fw="OpenPuck-0.9.31-standard.uf2"
-openpuck_sha="36ef6127afc46a067b17de4fe6e79f67a5e1eef15845899f1d4c5aaaf25ba844"
-openpuck_url="https://github.com/safijari/openpuck/releases/download/0.9.31/$openpuck_fw"
-echo "==> fetching OpenPuck firmware $openpuck_fw (pinned sha256)"
-curl -fsSL --max-time 60 "$openpuck_url" -o "$tmp/$openpuck_fw" \
-    || { echo "error: could not fetch OpenPuck firmware from upstream" >&2; exit 2; }
-openpuck_got="$( { command -v sha256sum >/dev/null 2>&1 \
-    && sha256sum "$tmp/$openpuck_fw" \
-    || shasum -a 256 "$tmp/$openpuck_fw"; } | cut -d' ' -f1)"
-if [ "$openpuck_got" != "$openpuck_sha" ]; then
-    echo "error: OpenPuck firmware sha256 mismatch (got $openpuck_got, want $openpuck_sha) — not publishing" >&2
-    exit 2
-fi
-echo "==> OpenPuck firmware verified ($openpuck_sha)"
-files+=("$openpuck_fw")
+# OpenPuck firmware (AGPL-3.0, safijari/openpuck, EmeryTech fork) is NOT
+# republished by Couchside. The box downloads it straight from the fork's GitHub
+# release — pinned by tag + sha256 in the agent, re-verified before every flash —
+# so Couchside only REFERENCES the firmware, never redistributes it (and never
+# embeds or compiles it). install.sh seeds an offline copy the same way, direct
+# from the fork. Only the AGPL notice (attribution + §6 source offer) still ships
+# as a signed asset, so install.sh can drop it on the box alongside the agent.
 [ -f "$agent/openpuck/OPENPUCK-NOTICE.txt" ] \
     || { echo "error: missing agent/openpuck/OPENPUCK-NOTICE.txt" >&2; exit 2; }
 cp "$agent/openpuck/OPENPUCK-NOTICE.txt" "$tmp/OPENPUCK-NOTICE.txt"

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -367,6 +367,45 @@ class copyfile_raising:
         cs.shutil.copyfile = self._old
 
 
+class flash_env:
+    """Make real_openpuck_flash() deterministic and OFFLINE for a flash test.
+
+    Since 2.9.77 the flash resolves firmware through cache -> fork download -> seed.
+    This context forces the download to RAISE (simulating no network / a box that
+    only has its install seed), points the runtime cache at an empty temp dir, and
+    pins the agent's expected sha256 to fixture `fw` — so a VALID seed is accepted
+    and an INVALID/missing one is still refused. The install seed (_OPENPUCK_FIRMWARE)
+    is set to `fw` and becomes the only possible source. No test ever hits GitHub."""
+
+    def __init__(self, fw):
+        self._fw = fw
+
+    def __enter__(self):
+        self._tmp = tempfile.mkdtemp(prefix="op-cache-")
+        try:
+            sha = cs._sha256_file(self._fw) if os.path.isfile(self._fw) else "0" * 64
+        except OSError:
+            sha = "0" * 64
+        cache = os.path.join(self._tmp, "cache.uf2")
+
+        def _offline(*a, **k):
+            raise OSError("offline (test)")
+
+        self._p = Patch(
+            _OPENPUCK_FIRMWARE=self._fw,
+            _OPENPUCK_FW_SHA256=sha,
+            _OPENPUCK_FW_MIN_SIZE=1,
+            _openpuck_cache_path=(lambda c=cache: c),
+            _openpuck_download=_offline,
+        )
+        self._p.__enter__()
+        return self
+
+    def __exit__(self, *a):
+        self._p.__exit__(*a)
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+
 def test_flash_no_board_degrades_closed():
     """No board in DFU -> refuse, never a guessed target."""
     print("test_flash_no_board_degrades_closed")
@@ -387,8 +426,8 @@ def test_flash_missing_firmware_degrades_closed():
     print("test_flash_missing_firmware_degrades_closed")
     ready = _media_tree({"NICENANO": True})
     try:
-        with Patch(_MEDIA_ROOTS=(ready,),
-                   _OPENPUCK_FIRMWARE="/nonexistent-couchside-fw.uf2"):
+        with Patch(_MEDIA_ROOTS=(ready,)), \
+                flash_env("/nonexistent-couchside-fw.uf2"):
             r = cs.real_openpuck_flash()
             check("no firmware -> ok False", r["ok"], False)
     finally:
@@ -409,7 +448,7 @@ def test_flash_rejects_invalid_firmware():
     os.write(fd, struct.pack("<II", 0x0A324655, 0x9E5D5157)); os.close(fd)
     try:
         for bad in (empty, garbage, short):
-            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=bad):
+            with Patch(_MEDIA_ROOTS=(ready,)), flash_env(bad):
                 r = cs.real_openpuck_flash()
                 check("invalid firmware -> ok False", r["ok"], False)
     finally:
@@ -425,7 +464,7 @@ def test_flash_clean_copy_is_success():
     ready = _media_tree({"NICENANO": True})
     fw = _fw_file()
     try:
-        with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+        with Patch(_MEDIA_ROOTS=(ready,)), flash_env(fw):
             r = cs.real_openpuck_flash()
             check("clean copy -> ok True", r["ok"], True)
             landed = os.path.join(ready, "deck", "NICENANO", os.path.basename(fw))
@@ -443,7 +482,7 @@ def test_flash_device_yank_errno_is_success():
     fw = _fw_file()
     try:
         for err in (errno.ENXIO, errno.EIO):
-            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+            with Patch(_MEDIA_ROOTS=(ready,)), flash_env(fw):
                 with copyfile_raising(err):
                     r = cs.real_openpuck_flash()
                     check("errno %d -> ok True" % err, r["ok"], True)
@@ -461,7 +500,7 @@ def test_flash_other_errno_is_failure():
     fw = _fw_file()
     try:
         for err in (errno.EPERM, errno.EACCES, errno.ENOSPC):
-            with Patch(_MEDIA_ROOTS=(ready,), _OPENPUCK_FIRMWARE=fw):
+            with Patch(_MEDIA_ROOTS=(ready,)), flash_env(fw):
                 with copyfile_raising(err):
                     r = cs.real_openpuck_flash()
                     check("errno %d -> ok False" % err, r["ok"], False)
@@ -471,13 +510,262 @@ def test_flash_other_errno_is_failure():
 
 
 def test_flash_target_is_not_client_supplied():
-    """§3: real_openpuck_flash takes NO arguments — the target comes from
-    _openpuck_bootloader_mount() and the firmware from the fixed agent-owned
-    constant. The client can influence neither."""
+    """§3: the ONLY thing a client can influence about the flash is the `variant`
+    enum (pinned|latest, allowlisted at the HTTP layer, tested there). The flash
+    TARGET still comes from _openpuck_bootloader_mount() and the firmware URL/path/
+    bytes are always agent-owned — never a client-supplied path, url, or blob."""
     print("test_flash_target_is_not_client_supplied")
     import inspect
-    sig = inspect.signature(cs.real_openpuck_flash)
-    check("flash takes no client params", len(sig.parameters), 0)
+    params = list(inspect.signature(cs.real_openpuck_flash).parameters)
+    check("flash's only client param is variant", params, ["variant"])
+    check("variant defaults to pinned",
+          inspect.signature(cs.real_openpuck_flash).parameters["variant"].default,
+          "pinned")
+
+
+# ---------------------------------------------------------------------------
+print("\nruntime firmware fetch (2.9.77): verify + resolve, OFFLINE (no network)")
+# ---------------------------------------------------------------------------
+
+def _uf2_bytes(nblocks=736):
+    """Bytes of a structurally-valid UF2 of `nblocks` 512-byte blocks (default 736
+    ~= 376 KB, a real OpenPuck size), first block carrying the magic words."""
+    head = struct.pack("<II", 0x0A324655, 0x9E5D5157) + b"\x00" * (512 - 8)
+    return head + b"\x00" * (512 * (nblocks - 1))
+
+
+def test_fw_valid_both_directions():
+    """_openpuck_fw_valid: a real-shaped UF2 of the right size + matching sha PASSES;
+    every failure mode (missing, wrong magic, too small, wrong sha) FAILS. A verifier
+    is unverified until seen firing AND not firing (CLAUDE.md §11.2)."""
+    print("test_fw_valid_both_directions")
+    fd, good = tempfile.mkstemp(suffix=".uf2")
+    os.write(fd, _uf2_bytes(736)); os.close(fd)
+    fd, tiny = tempfile.mkstemp(suffix=".uf2")           # valid UF2 but too small
+    os.write(fd, _uf2_bytes(1)); os.close(fd)
+    fd, nomagic = tempfile.mkstemp(suffix=".uf2")        # right size, no magic
+    os.write(fd, b"\x00" * (512 * 736)); os.close(fd)
+    good_sha = cs._sha256_file(good)
+    try:
+        # FIRES: right size + right sha.
+        check("good uf2 (no sha) -> True", cs._openpuck_fw_valid(good), True)
+        check("good uf2 + correct sha -> True",
+              cs._openpuck_fw_valid(good, good_sha), True)
+        # DOES NOT FIRE: each failure mode.
+        check("missing path -> False", cs._openpuck_fw_valid("/no/such.uf2"), False)
+        check("wrong magic -> False", cs._openpuck_fw_valid(nomagic), False)
+        with Patch(_OPENPUCK_FW_MIN_SIZE=300_000):
+            check("too small -> False", cs._openpuck_fw_valid(tiny), False)
+        check("wrong sha -> False", cs._openpuck_fw_valid(good, "0" * 64), False)
+    finally:
+        for p in (good, tiny, nomagic):
+            os.unlink(p)
+
+
+def test_pick_asset_prefers_standard_never_factory_reset():
+    """The /releases/latest asset picker: prefer OpenPuck-*-standard*.uf2, take a
+    non-factory-reset .uf2 otherwise, and NEVER default to a factory-reset image."""
+    print("test_pick_asset_prefers_standard_never_factory_reset")
+    assets = [
+        {"name": "OpenPuck-0.9.41-factory-reset.uf2", "browser_download_url": "u1"},
+        {"name": "OpenPuck-0.9.41-standard.uf2", "browser_download_url": "u2"},
+        {"name": "notes.txt", "browser_download_url": "u3"},
+    ]
+    check("prefers -standard", cs._openpuck_pick_asset(assets)["browser_download_url"], "u2")
+    # No standard present: take the non-factory-reset .uf2, not the reset one.
+    only = [
+        {"name": "OpenPuck-0.9.41-factory-reset.uf2", "browser_download_url": "r"},
+        {"name": "OpenPuck-0.9.41.uf2", "browser_download_url": "keep"},
+    ]
+    check("skips factory-reset", cs._openpuck_pick_asset(only)["browser_download_url"], "keep")
+    # ONLY a factory-reset image -> refuse (None), never default to it.
+    check("factory-reset only -> None",
+          cs._openpuck_pick_asset(
+              [{"name": "OpenPuck-factory-reset.uf2", "browser_download_url": "r"}]),
+          None)
+    check("no assets -> None", cs._openpuck_pick_asset([]), None)
+
+
+def test_resolve_pinned_prefers_cache_no_network():
+    """A verified pinned copy already in the cache is used WITHOUT any download
+    (the download hook raises if called)."""
+    print("test_resolve_pinned_prefers_cache_no_network")
+    tmp = tempfile.mkdtemp(prefix="op-")
+    cache = os.path.join(tmp, "cache.uf2")
+    with open(cache, "wb") as f:
+        f.write(_uf2_bytes(736))
+    sha = cs._sha256_file(cache)
+
+    def _boom(*a, **k):
+        raise AssertionError("download must NOT be called on a cache hit")
+
+    try:
+        with Patch(_OPENPUCK_FW_SHA256=sha, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: cache), _openpuck_download=_boom,
+                   _OPENPUCK_FIRMWARE="/no/seed.uf2"):
+            path, err = cs._openpuck_resolve_pinned()
+            check("cache hit -> that path", path, cache)
+            check("cache hit -> no error", err, None)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_resolve_pinned_downloads_then_verifies():
+    """No cache: the resolver downloads from the fork, and only returns the copy if
+    it matches the pin. A download that verifies is returned; one that does not is
+    deleted and reported (degrade closed)."""
+    print("test_resolve_pinned_downloads_then_verifies")
+    tmp = tempfile.mkdtemp(prefix="op-")
+    cache = os.path.join(tmp, "cache.uf2")
+    good = _uf2_bytes(736)
+    good_sha = cs.hashlib.sha256(good).hexdigest()
+
+    def _dl_good(url, dest, timeout=60):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(good)
+        return dest
+
+    def _dl_bad(url, dest, timeout=60):
+        os.makedirs(os.path.dirname(dest), exist_ok=True)
+        with open(dest, "wb") as f:
+            f.write(b"\x00" * (512 * 736))  # right size, wrong bytes -> sha mismatch
+        return dest
+
+    try:
+        with Patch(_OPENPUCK_FW_SHA256=good_sha, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: cache), _openpuck_download=_dl_good,
+                   _OPENPUCK_FIRMWARE="/no/seed.uf2"):
+            path, err = cs._openpuck_resolve_pinned()
+            check("verified download -> cache path", path, cache)
+            check("verified download -> no error", err, None)
+        cache2 = os.path.join(tmp, "cache2.uf2")  # fresh path: no stale cache hit
+        with Patch(_OPENPUCK_FW_SHA256=good_sha, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: cache2), _openpuck_download=_dl_bad,
+                   _OPENPUCK_FIRMWARE="/no/seed.uf2"):
+            path, err = cs._openpuck_resolve_pinned()
+            check("bad download -> refused", path, None)
+            check("bad download -> deleted", os.path.exists(cache2), False)
+            check("bad download -> error set", bool(err), True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_resolve_pinned_offline_falls_back_to_seed():
+    """Offline (download raises) + a valid pinned SEED -> use the seed. Offline +
+    NO usable seed -> (None, error): degrade closed, never a guessed image."""
+    print("test_resolve_pinned_offline_falls_back_to_seed")
+    tmp = tempfile.mkdtemp(prefix="op-")
+    cache = os.path.join(tmp, "cache.uf2")
+    seed = os.path.join(tmp, "seed.uf2")
+    with open(seed, "wb") as f:
+        f.write(_uf2_bytes(736))
+    sha = cs._sha256_file(seed)
+
+    def _offline(*a, **k):
+        raise OSError("offline (test)")
+
+    try:
+        with Patch(_OPENPUCK_FW_SHA256=sha, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: cache), _openpuck_download=_offline,
+                   _OPENPUCK_FIRMWARE=seed):
+            path, err = cs._openpuck_resolve_pinned()
+            check("offline -> seed used", path, seed)
+            check("offline seed -> no error", err, None)
+        # A seed whose sha does NOT match the pin is refused (never flash a wrong build).
+        with Patch(_OPENPUCK_FW_SHA256="0" * 64, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: cache), _openpuck_download=_offline,
+                   _OPENPUCK_FIRMWARE=seed):
+            path, err = cs._openpuck_resolve_pinned()
+            check("offline + wrong-sha seed -> refused", path, None)
+            check("offline + no usable seed -> error", bool(err), True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_resolve_pinned_prefers_seed_over_network():
+    """A valid install SEED (or cache) is used WITHOUT any download — an offline box
+    with a good local copy must never wait on a doomed network round-trip first
+    (that latency can trip the app's flash timeout)."""
+    print("test_resolve_pinned_prefers_seed_over_network")
+    tmp = tempfile.mkdtemp(prefix="op-")
+    seed = os.path.join(tmp, "seed.uf2")
+    with open(seed, "wb") as f:
+        f.write(_uf2_bytes(736))
+    sha = cs._sha256_file(seed)
+
+    def _boom(*a, **k):
+        raise AssertionError("download must NOT be called when a valid seed exists")
+
+    try:
+        with Patch(_OPENPUCK_FW_SHA256=sha, _OPENPUCK_FW_MIN_SIZE=1,
+                   _openpuck_cache_path=(lambda: os.path.join(tmp, "absent.uf2")),
+                   _openpuck_download=_boom, _OPENPUCK_FIRMWARE=seed):
+            path, err = cs._openpuck_resolve_pinned()
+            check("seed used with no network", path, seed)
+            check("seed -> no error", err, None)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+class urlopen_patch:
+    """Swap cs.urllib.request.urlopen for the duration of a `with`."""
+
+    def __init__(self, fn):
+        self._fn = fn
+
+    def __enter__(self):
+        self._old = cs.urllib.request.urlopen
+        cs.urllib.request.urlopen = self._fn
+
+    def __exit__(self, *a):
+        cs.urllib.request.urlopen = self._old
+
+
+def test_download_rejects_truncated_content_length():
+    """_openpuck_download raises on a clean-EOF truncation when Content-Length is
+    known — the 'latest' path has no sha pin, so this is its truncation guard. A
+    complete body (bytes == Content-Length) is accepted (control)."""
+    print("test_download_rejects_truncated_content_length")
+    import io
+
+    class FakeResp:
+        def __init__(self, body, clen):
+            self._b = io.BytesIO(body)
+            self._clen = clen
+
+        def getheader(self, k, d=None):
+            return self._clen if k == "Content-Length" else d
+
+        def read(self, n=-1):
+            return self._b.read(n)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    tmp = tempfile.mkdtemp(prefix="op-")
+    dest = os.path.join(tmp, "fw.uf2")
+    body = _uf2_bytes(700)
+    try:
+        # Header claims MORE bytes than the body delivers -> a truncation -> raise.
+        with urlopen_patch(lambda req, timeout=60: FakeResp(body, str(len(body) + 512))):
+            raised = False
+            try:
+                cs._openpuck_download("https://example/y.uf2", dest)
+            except Exception:
+                raised = True
+            check("short vs Content-Length -> raises", raised, True)
+            check("truncation -> no .part left", os.path.exists(dest + ".part"), False)
+            check("truncation -> no dest written", os.path.exists(dest), False)
+        # Control: bytes == Content-Length -> accepted.
+        with urlopen_patch(lambda req, timeout=60: FakeResp(body, str(len(body)))):
+            cs._openpuck_download("https://example/y.uf2", dest)
+            check("complete download -> written", os.path.exists(dest), True)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
 
 # ---------------------------------------------------------------------------
@@ -492,6 +780,19 @@ def test_http_run_endpoint():
         st, bd = _req(port, "POST", "/api/utilities/openpuck/run")
         check("POST openpuck/run -> 200", st, 200)
         check("mock flash -> ok True", bd.get("ok"), True)
+
+        # variant is an allowlisted enum. pinned + latest are accepted (mock);
+        # anything else is REJECTED with 400 and nothing flashes (§3.6).
+        check("variant=pinned -> 200",
+              _req(port, "POST", "/api/utilities/openpuck/run?variant=pinned")[0], 200)
+        check("variant=latest -> 200",
+              _req(port, "POST", "/api/utilities/openpuck/run?variant=latest")[0], 200)
+        st, bd = _req(port, "POST", "/api/utilities/openpuck/run?variant=bogus")
+        check("variant=bogus -> 400", st, 400)
+        check("bogus variant -> not flashed", bd.get("ok"), False)
+        st, bd = _req(port, "POST",
+                      "/api/utilities/openpuck/run?variant=../../etc/passwd")
+        check("path-shaped variant -> 400", st, 400)
 
         # Auth gate.
         check("no bearer -> 401",
@@ -516,6 +817,24 @@ def test_http_run_endpoint():
         # No /run suffix is not a run route at all (falls through to a 404).
         check("openpuck without /run -> 404",
               _req(port, "POST", "/api/utilities/openpuck")[0], 404)
+    finally:
+        srv.shutdown()
+
+
+def test_http_latest_endpoint():
+    """GET /api/utilities/openpuck/latest: the opt-in newer-check. Read-only, behind
+    the bearer gate; the mock reports a newer build. It NEVER flashes."""
+    print("test_http_latest_endpoint")
+    srv, port = _server()  # mock=True -> mock_openpuck_latest
+    try:
+        st, bd = _req(port, "GET", "/api/utilities/openpuck/latest")
+        check("GET openpuck/latest -> 200", st, 200)
+        check("mock reports available", bd.get("available"), True)
+        check("mock reports is_newer", bd.get("is_newer"), True)
+        check("carries the pinned tag", bd.get("pinned_tag"), cs._OPENPUCK_FW_TAG)
+        # Auth gate: same as every other /api route.
+        check("no bearer -> 401",
+              _req(port, "GET", "/api/utilities/openpuck/latest", token=None)[0], 401)
     finally:
         srv.shutdown()
 
@@ -554,7 +873,15 @@ if __name__ == "__main__":
                test_flash_device_yank_errno_is_success,
                test_flash_other_errno_is_failure,
                test_flash_target_is_not_client_supplied,
+               test_fw_valid_both_directions,
+               test_pick_asset_prefers_standard_never_factory_reset,
+               test_resolve_pinned_prefers_cache_no_network,
+               test_resolve_pinned_downloads_then_verifies,
+               test_resolve_pinned_offline_falls_back_to_seed,
+               test_resolve_pinned_prefers_seed_over_network,
+               test_download_rejects_truncated_content_length,
                test_http_run_endpoint,
+               test_http_latest_endpoint,
                test_cap_present_in_mock_and_real):
         fn()
     if FAILURES:


### PR DESCRIPTION
## What & why

Couchside now **downloads** the OpenPuck dongle firmware from the EmeryTech fork's GitHub release at flash time instead of bundling/republishing it. This is a **licensing** change as much as a technical one: OpenPuck is AGPL-3.0, so Couchside *references* (downloads) the firmware binary rather than embedding it — the app stays its own license, App-Store-safe. **No OpenPuck source is imported, compiled, vendored, or submoduled**, and Couchside's own license is unchanged.

The app never touches firmware bytes: the agent owns the fetch end to end (CLAUDE.md §3). A client only ever selects the allowlisted `openpuck` id + a `{pinned|latest}` enum — never a URL, path, or bytes.

## Pin

- Tag `0.9.40` · `OpenPuck-0.9.40-standard.uf2` · sha256 `ee2de6a415f87cacc2999893fd7803462a6d76f1ad4acbcd7962f0115575f478` · 376832 B
- Source (AGPL §6 offer): https://github.com/emerytech/openpuck/tree/0.9.40

## Changes

**Agent (`agent/couchsided.py`, → 2.9.77)**
- Resolve firmware **cache → install seed → fork download**; every source re-verified (sha256 for pinned, UF2 magic + size window + `Content-Length` for all).
- `real_openpuck_flash(variant)`; `POST /api/utilities/openpuck/run` validates the enum (`pinned`|`latest`, bogus → 400).
- Opt-in `GET /api/utilities/openpuck/latest` + `variant=latest` flash — picks the standard (never factory-reset) asset, **never auto-flashes**. The latest-flash note carries that build's own `…/releases/tag/<tag>` source so the §6 offer tracks what's conveyed.

**Release pipeline**
- `install.sh` seeds the file **direct from the fork**, pinned by its own sha256 (no longer via the signed manifest).
- `scripts/release-agent.sh` **stops republishing the `.uf2`**; still ships the signed `OPENPUCK-NOTICE.txt`.

**App**
- `runUtility(…, variant?)` + `openpuckLatest()` in `api.ts`.
- `UtilitiesSection`: "Check for newer firmware" + "Flash newest" (opt-in; confirm dialog notes it's not the pinned build).
- New `Setup → Account → Open source licenses` screen (`app/app/licenses.tsx`): OpenPuck AGPL-3.0, credits safijari, notes "modified by EmeryTech", links source at the shipped tag + the fork's per-tag releases.
- `OPENPUCK-NOTICE.txt` + `README.md` updated for the modified fork.

## Verification

- Agent: `python3 -m py_compile` OK; `tests/test_utilities.py` all pass (new verify/resolve/pick-asset/variant/latest/truncation tests, all offline); `tests/test_protocol_parity.py` green.
- `bash -n install.sh` + `scripts/release-agent.sh` OK.
- App: `tsc --noEmit -p app` clean.
- Web harness (mock agent): pressed **Check for newer** (GET `/latest` 200 → newer shown), **Flash receiver** (POST `run?variant=pinned` 200 → state flip + stale-note clear), and Account → **Open source licenses** → `/licenses` renders.
- **Real fork download** via the agent resolver: 376832 B, sha match, valid UF2.
- Adversarial multi-agent review (§3/security, resolver, AGPL, app): 0 critical/high; the one medium (resolver did a network hop before the offline seed) and the actionable lows are fixed in this PR.

## NOT verified

- A **real nRF52840 board in DFU flashed via the runtime-fetched firmware** (no board on hand this session). Prior bundled-firmware flash was hardware-proven; the write path is unchanged, only the firmware source.
- SC2 pairing through the flashed puck.

## Known limitation

`_ver_tuple` (a pre-existing shared helper, also used by agent self-update) concatenates digits within a dotted version component, so a **digit-bearing suffix tag** (e.g. `0.9.40-rc1`) could be mis-ranked in `openpuck_latest.is_newer`. Left as-is: fork tags are currently plain numeric, and the latest flash re-fetches + verifies whatever `/releases/latest` returns regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
