### PR TITLE
fix(app): OpenPuck empty-state tells users how to enter DFU

### DIFF
--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -24,7 +24,10 @@ function present(u: Utility): { line: string; icon: string; tone: 'good' | 'acti
   if (u.id === 'openpuck') {
     if (u.state === 'board_ready') return { line: 'Board connected — ready to flash.', icon: 'hardware-chip-outline', tone: 'action' };
     if (u.state === 'puck_present') return { line: 'A Steam Controller Puck is connected.', icon: 'checkmark-circle', tone: 'good' };
-    return { line: 'Plug an nRF52840 board into the box to flash one.', icon: 'hardware-chip-outline', tone: 'idle' };
+    // A plugged-in board only appears when it's in DFU (a mounted UF2 bootloader);
+    // a board running firmware reads as no_board and looks "invisible". Tell the
+    // user HOW to enter DFU, not just to plug one in.
+    return { line: 'Plug in an nRF52840, then put it in DFU — double-tap reset (or short RST/GND twice) — and it appears here to flash.', icon: 'hardware-chip-outline', tone: 'idle' };
   }
   if (u.id === 'cec') {
     if (u.state === 'enabled') return { line: 'On — the box can control your TV over HDMI.', icon: 'checkmark-circle', tone: 'good' };


### PR DESCRIPTION
## Why

A plugged-in nRF52840 only shows up to flash once it is in its **UF2 bootloader** (state `board_ready`). A board that's plugged in but running firmware reads as `no_board` and looks *invisible* — exactly the "my board isn't showing up" confusion.

The old `no_board` copy — *"Plug an nRF52840 board into the box to flash one."* — implied plugging in was enough, so a flashed/running board seemed unsupported.

## Change

One line in `components/UtilitiesSection.tsx` (`present()`, openpuck `no_board`):

> Plug in an nRF52840, then put it in DFU — double-tap reset (or short RST/GND twice) — and it appears here to flash.

Covers both DFU-entry methods: a reset **button** (nice!nano) and **RST↔GND** shorting twice (bare Pro-Micro boards → red LED). Once in DFU the agent picks it up automatically and shows the flash button.

## Verification

- `tsc --noEmit -p app` clean; app-input suite 434/434 pass; no test pins the copy string.
- Not harness-checked: the `no_board` empty state isn't producible under `--mock` (mock reports `board_ready`), so a harness render would prove nothing. Pure status-line string in the `no_board` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)