### PR TITLE
chore(app): build 160

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "159",
+      "buildNumber": "160",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 159 → 160 for the next local TestFlight build of 2.9.43.

Carries what merged since build 159: OpenPuck firmware runtime-fetch from the fork (#409) and the DFU empty-state copy (#410). ASC max build is 159 (verified via the ASC API), so 160 is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)