### PR TITLE
feat(app): Open in Steam for installed games (GameSheet)

### DIFF
--- a/app/app/installable.tsx
+++ b/app/app/installable.tsx
@@ -18,7 +18,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { Stack, router } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  ActivityIndicator, Alert, FlatList, Image, Linking, Modal, Platform, Pressable,
+  ActivityIndicator, Alert, FlatList, Image, Modal, Platform, Pressable,
   ScrollView, StyleSheet, Text, TextInput, useWindowDimensions, View, type ViewToken,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -29,6 +29,7 @@ import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
+import { openInSteamStore } from '@/lib/steamLinks';
 import { fetchAppDetails } from '@/lib/steamStore';
 import { fetchSteamReview } from '@/lib/steamReviews';
 import { isInstallableGameType, type AppDetails, type SteamReview } from '@/lib/steamStoreParse';
@@ -61,20 +62,6 @@ function runsWell(c: Compat | undefined): boolean {
  *  6=Positive, 7=Very Positive, 8=Overwhelmingly, plus 9). */
 function reviewIsPositive(r: SteamReview | null | undefined): boolean {
   return !!r && r.score >= 6;
-}
-
-/** Open a game's Steam store page in the user's Steam app (deep link), falling
- *  back to the web store when the Steam app / handler isn't available. */
-async function openInSteam(appid: number): Promise<void> {
-  const deep = `steam://store/${appid}`;
-  const web = `https://store.steampowered.com/app/${appid}`;
-  try {
-    if (Platform.OS !== 'web' && (await Linking.canOpenURL(deep))) {
-      await Linking.openURL(deep);
-      return;
-    }
-  } catch { /* fall through to web */ }
-  try { await Linking.openURL(web); } catch { /* nothing else to do */ }
 }
 
 /** steam://install pops an approve prompt on the box (verified) — say so. */
@@ -263,7 +250,7 @@ function GameSheet({
             <Text style={styles.gsPrimaryText}>{requested ? 'Waiting for approval…' : 'Install on box'}</Text>
           </Pressable>
           <Pressable
-            onPress={() => { hapticLight(); void openInSteam(appid); }}
+            onPress={() => { hapticLight(); void openInSteamStore(appid); }}
             style={({ pressed }) => [styles.gsGhost, { borderColor: t.cardBorder, opacity: pressed ? 0.8 : 1 }]}
             accessibilityRole="button"
             accessibilityLabel="Open in Steam">

--- a/app/components/GameSheet.tsx
+++ b/app/components/GameSheet.tsx
@@ -25,6 +25,7 @@ import { toggleBookmarked, useLibraryMarks } from '@/hooks/useLibraryMarks';
 import { hapticLight } from '@/lib/haptics';
 import type { Launcher } from '@/lib/api';
 import { bookmarkKey, playtimeLabel, sizeLabel } from '@/lib/libraryFilter';
+import { openInSteamStore } from '@/lib/steamLinks';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 /** "3 days ago" / "today" / "never". Absent last_played is honest, not zero. */
@@ -71,6 +72,9 @@ export function GameSheet({
   // a zero that would read as free space.
   const size = sizeLabel(launcher.size_bytes);
   const marked = marks.isBookmarked(key);
+  // Steam games carry an appid; non-Steam shortcuts don't, so "Open in Steam" only
+  // makes sense for the former. Captured to a const so it narrows inside onPress.
+  const appid = launcher.appid ?? null;
 
   const nowSec = Math.floor(Date.now() / 1000);
   const played = playtimeLabel(launcher.playtime_min);
@@ -146,6 +150,21 @@ export function GameSheet({
                 {marked ? 'BOOKMARKED' : 'BOOKMARK'}
               </Text>
             </Pressable>
+
+            {/* Open in Steam is a "look at this game" action (opens the phone's
+                Steam app / web store), not a "do something to the TV" one, so it
+                sits with the facts like the bookmark — not in the launch row.
+                Steam games only; non-Steam shortcuts have no appid. */}
+            {appid != null ? (
+              <Pressable
+                onPress={() => { hapticLight(); void openInSteamStore(appid); }}
+                accessibilityRole="button"
+                accessibilityLabel="Open in Steam"
+                style={({ pressed }) => [styles.bookmark, pressed && styles.pressed]}>
+                <Ionicons name="open-outline" size={15} color={t.textDim} />
+                <Text style={styles.bookmarkText}>OPEN IN STEAM</Text>
+              </Pressable>
+            ) : null}
           </ScrollView>
 
           <View style={styles.actions}>

--- a/app/lib/steamLinks.ts
+++ b/app/lib/steamLinks.ts
@@ -1,0 +1,27 @@
+/**
+ * Open a game in the user's Steam app via a deep link, falling back to the web
+ * store when the Steam app / URL handler isn't available.
+ *
+ * This leaves the PHONE (it opens Steam, or a browser); it never touches the box.
+ * Shared by the Not-installed page (installable.tsx) and the installed-game sheet
+ * (GameSheet.tsx) so both behave identically.
+ */
+import { Linking, Platform } from 'react-native';
+
+export async function openInSteamStore(appid: number): Promise<void> {
+  const deep = `steam://store/${appid}`;
+  const web = `https://store.steampowered.com/app/${appid}`;
+  try {
+    if (Platform.OS !== 'web' && (await Linking.canOpenURL(deep))) {
+      await Linking.openURL(deep);
+      return;
+    }
+  } catch {
+    /* fall through to web */
+  }
+  try {
+    await Linking.openURL(web);
+  } catch {
+    /* nothing else to do */
+  }
+}


### PR DESCRIPTION
## Why
"Open in Steam" existed only on the **Not-installed** page (`installable.tsx`). Requested: it should also appear when you open an **installed** game. Installed games open the `GameSheet` detail sheet (tap a library tile) — that's where it now lives.

## Change
- New `lib/steamLinks.ts` — shared `openInSteamStore(appid)` (Steam app deep link `steam://store/<appid>` → web-store fallback). Leaves the phone; never touches the box.
- `installable.tsx` refactored to use it (removed its local copy + now-unused `Linking` import).
- `GameSheet.tsx` — adds an **OPEN IN STEAM** button, shown only for Steam games (`launcher.appid` present). Placed with the game's facts next to Bookmark, **not** in the launch action row (that row is TV outcomes; this opens the phone's Steam).

## Verify (web harness, mock box)
- Opened Portal 2's sheet → **OPEN IN STEAM** renders (external-link icon), positioned below Bookmark.
- **Pressed it** → fired `openInSteamStore(620)` → `https://store.steampowered.com/app/620` (correct appid, web-fallback path on web).
- Caught + fixed an icon bug: `logo-steam` renders as a chevron in the bundled Ionicons (type exists, glyph doesn't) → switched to `open-outline` (proven across the app), re-verified the glyph.
- `tsc --noEmit` clean; app-input suite 434/434.

## NOT verified
- The **negative** (button absent for a non-Steam shortcut) — the mock has only Steam launchers; the `appid != null` guard is trivial + type-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)