### PR TITLE
chore(app): build 161

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "160",
+      "buildNumber": "161",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 160 → 161 for the next local TestFlight build (2.9.43), adding Open in Steam for installed games (#413). ASC max is 160 (verified via API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)