### PR TITLE
fix(app): GameSheet doesn't scroll — Bookmark + Open in Steam always visible

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -7462,13 +7462,27 @@ def mock_session_default_set(mode):
 
 
 def mock_launchers():
-    """Custom launchers plus fake Steam games carrying every art kind."""
+    """Custom launchers plus fake Steam games carrying every art kind. A SUBSET
+    carry playtime/last_played/size so the harness exercises the FULL GameSheet
+    layout (Type + appid + Time played + Last opened + On disk = five rows), not
+    only the shorter no-playtime note. That fuller shape is the one that hid a
+    detail-sheet clipping bug (build 161): the mock had no playtime, so every
+    harness game rendered short and the overflow never showed."""
+    # appid -> (playtime_min, last_played_epoch, size_bytes). Only some games, so
+    # the harness ALSO still renders the "needs 2.9.71" no-playtime shape.
+    facts = {
+        1091500: (11165, int(time.time()) - 3600, 68 * 10**9),   # ~186h, today
+        292030: (8020, int(time.time()) - 5 * 86400, 50 * 10**9),
+        620: (1240, int(time.time()) - 40 * 86400, 12 * 10**9),
+    }
     out = [{"id": l["id"], "label": l["label"], "kind": "custom"} for l in LAUNCHERS]
     for appid, label, art in MOCK_STEAM_GAMES:
         e = {"id": "steam:%d" % appid, "label": label,
              "kind": "steam", "appid": appid}
         if art:
             e["art"] = art
+        if appid in facts:
+            e["playtime_min"], e["last_played"], e["size_bytes"] = facts[appid]
         out.append(e)
     # Non-Steam shortcuts, so the web harness renders the streaming tiles that
     # dominate a real SteamOS box (these are the actual names Bazzite's

--- a/app/components/GameSheet.tsx
+++ b/app/components/GameSheet.tsx
@@ -18,7 +18,7 @@
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React from 'react';
-import { Image, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import type { ImageSourcePropType } from 'react-native';
 
 import { toggleBookmarked, useLibraryMarks } from '@/hooks/useLibraryMarks';
@@ -112,7 +112,10 @@ export function GameSheet({
             </View>
           </View>
 
-          <ScrollView style={styles.detail} contentContainerStyle={styles.detailBody}>
+          {/* Facts are a plain View, NOT a ScrollView: the whole sheet must be
+              visible without scrolling (at most five short rows), so the bookmark /
+              Open-in-Steam / launch buttons below are always in view. */}
+          <View style={styles.detailBody}>
               <Row label="Type" value={KIND_LABEL[launcher.kind]} />
               {launcher.appid != null ? <Row label="Steam appid" value={String(launcher.appid)} /> : null}
               {knowsPlaytime ? (
@@ -127,9 +130,15 @@ export function GameSheet({
                   Playtime needs the Couchside service 2.9.71 or newer on the box.
                 </Text>
               )}
-            {/* Bookmark lives with the game's facts, not in the action row:
-                it is a note-to-self about this game, not a decision about what
-                happens on the TV right now. */}
+          </View>
+
+          {/* Bookmark + Open in Steam are secondary actions on the GAME. The whole
+              sheet is visible without scrolling; these sit ABOVE the launch row
+              because CANCEL / PLAY are the "act on the TV now" buttons. (Build 161
+              regressed here: the facts were a fixed-height ScrollView and a game
+              with full playtime rows pushed Open-in-Steam below the clip — now the
+              sheet doesn't scroll at all.) */}
+          <View style={styles.sheetActions}>
             <Pressable
               onPress={() => {
                 if (!key) return;
@@ -151,10 +160,7 @@ export function GameSheet({
               </Text>
             </Pressable>
 
-            {/* Open in Steam is a "look at this game" action (opens the phone's
-                Steam app / web store), not a "do something to the TV" one, so it
-                sits with the facts like the bookmark — not in the launch row.
-                Steam games only; non-Steam shortcuts have no appid. */}
+            {/* Steam games only; non-Steam shortcuts have no appid. */}
             {appid != null ? (
               <Pressable
                 onPress={() => { hapticLight(); void openInSteamStore(appid); }}
@@ -165,7 +171,7 @@ export function GameSheet({
                 <Text style={styles.bookmarkText}>OPEN IN STEAM</Text>
               </Pressable>
             ) : null}
-          </ScrollView>
+          </View>
 
           <View style={styles.actions}>
             <Pressable
@@ -230,17 +236,18 @@ const makeStyles = (t: Palette) =>
     headBody: { flex: 1, gap: 3 },
     title: { color: t.text, fontSize: 16, fontWeight: '800' },
     sub: { color: t.textDim, fontSize: 12, fontFamily: mono },
-    detail: { maxHeight: 190 },
     detailBody: { gap: 8, paddingTop: 2 },
     row: { flexDirection: 'row', justifyContent: 'space-between', gap: 12 },
     rowLabel: { color: t.textDim, fontSize: 12, fontFamily: mono },
     rowValue: { color: t.text, fontSize: 12, fontFamily: mono, flexShrink: 1, textAlign: 'right' },
+    // The two secondary-action buttons (bookmark, open-in-steam), stacked below
+    // the facts. Spacing comes from the card gap + this gap, so no marginTop here.
+    sheetActions: { gap: 10 },
     bookmark: {
       flexDirection: 'row',
       alignItems: 'center',
       justifyContent: 'center',
       gap: 8,
-      marginTop: 14,
       paddingVertical: 11,
       borderRadius: 12,
       borderWidth: 1,


### PR DESCRIPTION
## Bug (build 161, reported on device)
Opening a game's sheet with full playtime (American Truck Simulator) hid **Open in Steam** — it was clipped below the fold. Root cause: the facts sat in a fixed-height (`maxHeight: 190`) `ScrollView`; with five fact rows (Type/appid/Time played/Last opened/On disk) the Bookmark + Open-in-Steam buttons overflowed past the clip.

I missed it because the **mock had no playtime**, so every harness game rendered the short (no-playtime) shape and never overflowed — the exact §6 trap.

## Fix
- **No scrolling.** Facts are now a plain `View` (dropped the `ScrollView` + `maxHeight`). Bookmark + Open-in-Steam moved into a fixed block above the CANCEL/PLAY row. The whole popup is visible with no scroll (owner's ask).
- **Mock now carries playtime** on a subset of `MOCK_STEAM_GAMES` (playtime/last_played/size), so the harness renders the FULL five-row sheet — the shape that hid this. Durable: this class of clip is now visible in the harness.

## Verify (web harness, mock box)
Opened Portal 2 (now 20h 40m / a month ago / 11.2 GB → all five rows) → screenshot shows **Type/appid/Time played/Last opened/On disk + BOOKMARK + OPEN IN STEAM + CANCEL/PLAY all visible, no scroll.** `tsc` clean; app-input 434/434; agent `py_compile` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)