### PR TITLE
chore(app): build 162

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "161",
+      "buildNumber": "162",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 161 → 162 for the next local TestFlight build (2.9.43), carrying the GameSheet no-scroll fix (#416). ASC max is 161 (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)