### PR TITLE
docs: game backlog = dedicated Playlog page (spec refinement)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -182,13 +182,15 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   **Bookmark** ("note-to-self about a game"); "Up next" is a curated, *ordered* view over
   bookmarks. "Now playing" sorts the library by `last_played` / `playtime_min` the sheet
   already shows. Launch is unchanged (`steam://rungameid` already works).
-- **Phased (full spec: `docs/memory/project_game-backlog.md`):** P1 ordered "Up next" over
-  bookmarks; P2 "Now playing" auto-section by recency; P3 reorder + a dedicated Backlog view;
-  P4 (maybe) per-game status (playing / next / done / dropped). App-side state only, like
-  `lib/prefs.ts` / `hooks/useLibraryMarks`.
-- **Open question for owner before P1:** is "Up next" the SAME set as bookmarks (bookmark =
-  backlog), or a SEPARATE list? That choice decides whether we extend the bookmark store or
-  add a new one. Spec assumes "bookmark = up-next" (simplest) pending confirm.
+- **Shape (owner-decided 2026-08-09):** a **dedicated "Playlog" page** (`app/app/playlog.tsx`,
+  own route like theme-picker/licenses), NOT a Launch-tab section — "a separate page you can
+  open to manage backlogs and order games from your library you want to play."
+- **Phased (full spec: `docs/memory/project_game-backlog.md`):** P1 the Playlog page + ordered
+  queue; P2 add-from-library + reorder; P3 "Now playing" section by recency; P4 (maybe) per-game
+  status. App-side state only, like `lib/prefs.ts` / `hooks/useLibraryMarks`.
+- **Still open before P1:** is the queue the SAME set as bookmarks (bookmark = backlog) or a
+  SEPARATE store? Decides extend-bookmarks vs new store. Spec assumes bookmark==queue pending
+  confirm. (UI shape is now settled = the dedicated page.)
 
 ### Install a game you own but have not downloaded (owner ask 2026-08-07)
 - **priority:** P2 · **risk:** medium-high (needs a NEW client-supplied-appid path that

--- a/docs/memory/project_game-backlog.md
+++ b/docs/memory/project_game-backlog.md
@@ -7,10 +7,22 @@
 
 > "Sort games you are currently playing and add games you want to play next, to
 > organize what you play next."
+>
+> Refined 2026-08-09: **"the playlog should be a separate page you can open to
+> manage backlogs and order games from your library you want to play."**
 
 Two lists the user curates from their library:
 - **Now playing** — the handful they're actively in.
 - **Up next** — an ordered queue of what to play after.
+
+## Shape: a dedicated page (owner-decided 2026-08-09)
+
+The backlog is its own **full page** ("Playlog" — working name), NOT a section bolted
+onto the Launch tab. It's a management surface: **add games from your whole library,
+order them, and manage the backlog.** Route it like the other subpages
+(`app/app/theme-picker.tsx` / `licenses.tsx` — own header + back, `useLockOrientation('portrait')`).
+Entry point: a row/button on the Launch tab (and/or Setup). This resolves the earlier
+"Launch-tab section vs dedicated view" question in favour of a dedicated page from P1.
 
 ## Principle: extend, don't reinvent
 
@@ -39,30 +51,27 @@ Everything below assumes **bookmark == up-next** pending confirmation.
 
 ## Phases
 
-**P1 — Ordered "Up next" over bookmarks.**
-- Give the bookmark store an order (array of keys, or `{key: rank}`); `toggleBookmarked`
-  appends on add. Backward-compatible migration: existing unordered bookmarks seed the
-  list in any stable order.
-- A Launch-tab section (or a Setup/Launch subpage) listing bookmarked games in order,
-  each tapping into the existing `GameSheet`.
-- Verify in the web harness: bookmark 3 games, confirm they appear in "Up next" in add
-  order; press one → GameSheet opens.
+**P1 — The Playlog page (dedicated route) with an ordered "Up next".**
+- New screen `app/app/playlog.tsx` (own header + back, `useLockOrientation('portrait')`),
+  reached from a Launch-tab (and/or Setup) row. Lists the backlog in order, each entry
+  tapping into the existing `GameSheet`.
+- Give the store an order (array of keys, or `{key: rank}`); adding appends. Backward-
+  compatible migration: existing (unordered) bookmarks seed the list in a stable order.
+- Verify in the web harness: add 3 games, confirm order; reorder; press one → GameSheet.
 
-**P2 — "Now playing" auto-section.**
-- A section above "Up next" showing games with a recent `last_played` (e.g. within N days)
-  and/or non-trivial `playtime_min`, sorted most-recent-first. Purely derived; no new
-  state. Degrades to empty on an old agent that sends no playtime (say so, like GameSheet
-  already does).
+**P2 — Add games from the whole library, + reorder on the page.**
+- An "add from library" flow on the Playlog page: pick any owned/installed game to queue
+  (a picker/search over the library the Launch tab + installable page already load).
+- Drag-to-reorder (or up/down controls) for the queue.
 
-**P3 — Reorder + dedicated view.**
-- Drag-to-reorder (or up/down controls) for "Up next". A dedicated Backlog screen
-  (route like `theme-picker`/`licenses`) if the Launch-tab section gets crowded; lock
-  orientation portrait like every non-Pad screen (there is a source-reading CI guard —
-  `useLockOrientation('portrait')`).
+**P3 — "Now playing" section on the page.**
+- A section (top of the Playlog page) showing games with a recent `last_played` and/or
+  non-trivial `playtime_min`, most-recent-first. Purely derived; no new state. Degrades to
+  empty on an old agent that sends no playtime (say so, like GameSheet already does).
 
 **P4 — (maybe) explicit per-game status.**
-- playing / next / done / dropped, instead of the implicit bookmark==next. Only if the
-  two-list model proves too thin in use. Revisit after P1–P3 ship.
+- playing / next / done / dropped, instead of the implicit "in the list == next". Only if
+  the model proves too thin in use. Revisit after P1–P3 ship.
 
 ## Constraints / guardrails
 


### PR DESCRIPTION
Owner refinement (2026-08-09): the backlog should be **a separate page** to manage backlogs + order games from the whole library — not a Launch-tab section.

Docs only. Re-shapes `docs/memory/project_game-backlog.md` + the ROADMAP entry:
- **Shape:** dedicated `app/app/playlog.tsx` route (like theme-picker / licenses), reached from Launch/Setup.
- **Phases:** P1 the Playlog page + ordered queue → P2 add-from-library + reorder → P3 Now-playing section → P4 (maybe) per-game status.
- **Still open before P1:** queue == bookmarks, or a separate store? (UI shape now settled = the page.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)