### PR TITLE
feat(app): Playlog page — ordered play-next queue

### DIFF
--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -25,6 +25,7 @@ import {
 import { Gated } from '@/components/Gated';
 import { GameSheet } from '@/components/GameSheet';
 import { InstallableSection } from '@/components/InstallableSection';
+import { PlaylogCard } from '@/components/PlaylogCard';
 import { useCompat } from '@/hooks/useCompat';
 import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
@@ -912,6 +913,10 @@ function LaunchScreen() {
             buried in the list. Probe-and-appear on the LIVE endpoint (no cached
             cap that could go stale); taps through to the full library page. */}
         <InstallableSection />
+
+        {/* Playlog: the ordered "play next" queue (your bookmarks). Hidden until
+            you've queued at least one game. Taps through to app/playlog.tsx. */}
+        <PlaylogCard />
 
         {/* Active Steam downloads (hidden when none / agent < 2.8) */}
         <DownloadsSection downloads={downloads} />

--- a/app/app/playlog.tsx
+++ b/app/app/playlog.tsx
@@ -1,0 +1,221 @@
+/**
+ * Playlog — a dedicated page to manage the game backlog: the ordered queue of
+ * games you want to play next. (Spec: docs/memory/project_game-backlog.md.)
+ *
+ * P1: the queue IS the bookmark set (bookmark a game = add it to the playlog),
+ * shown in a user-defined order. Reorder with the up/down controls; tap a game to
+ * open the same GameSheet the Launch grid uses (which launches it); remove takes it
+ * off the queue (un-bookmarks). No agent change — bookmarks live on the phone
+ * (hooks/useLibraryMarks), launching reuses api.launch.
+ *
+ * Reached from the Launch tab. Portrait-locked like every non-Pad screen.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Stack, router } from 'expo-router';
+import { useCallback, useMemo, useState } from 'react';
+import {
+  ActivityIndicator, FlatList, Image, Pressable, StyleSheet, Text, View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { GameSheet } from '@/components/GameSheet';
+import { useLockOrientation } from '@/hooks/useLockOrientation';
+import { reorderBookmarks, toggleBookmarked, useLibraryMarks } from '@/hooks/useLibraryMarks';
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, type ImageSource, type Launcher } from '@/lib/api';
+import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
+import { bookmarkKey } from '@/lib/libraryFilter';
+import { useSettings } from '@/lib/SettingsContext';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export default function PlaylogScreen() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const insets = useSafeAreaInsets();
+  useLockOrientation('portrait'); // like every screen but the Pad
+
+  const { settings, ready } = useSettings();
+  const configured = settings.host.trim().length > 0;
+  const marks = useLibraryMarks();
+
+  const list = usePoll<{ launchers: Launcher[] }>(
+    () => api.launchers(settings),
+    30000,
+    ready && configured,
+    hostKey(settings),
+  );
+
+  const [sheetFor, setSheetFor] = useState<Launcher | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Bookmarked games that ARE in the current library, in the saved queue order.
+  // A bookmarked key with no matching launcher (e.g. an uninstalled game) is
+  // dropped from the view; reorderBookmarks re-appends any such key so a reorder
+  // never loses it from the stored set.
+  const rows = useMemo(() => {
+    const byKey = new Map<string, Launcher>();
+    for (const l of list.data?.launchers ?? []) {
+      const k = bookmarkKey(l);
+      if (k) byKey.set(k, l);
+    }
+    const out: { key: string; launcher: Launcher }[] = [];
+    for (const key of marks.bookmarks) {
+      const launcher = byKey.get(key);
+      if (launcher) out.push({ key, launcher });
+    }
+    return out;
+  }, [list.data, marks.bookmarks]);
+
+  const move = useCallback(
+    (index: number, dir: -1 | 1) => {
+      const j = index + dir;
+      if (j < 0 || j >= rows.length) return;
+      hapticLight();
+      const keys = rows.map((r) => r.key);
+      [keys[index], keys[j]] = [keys[j], keys[index]];
+      reorderBookmarks(keys);
+    },
+    [rows],
+  );
+
+  const launch = useCallback(async () => {
+    if (!sheetFor) return;
+    hapticMedium();
+    setBusy(true);
+    try {
+      const r = await api.launch(settings, sheetFor.id);
+      if (r.ok) {
+        hapticSuccess();
+        setSheetFor(null);
+      } else {
+        hapticError();
+      }
+    } catch {
+      hapticError();
+    } finally {
+      setBusy(false);
+    }
+  }, [settings, sheetFor]);
+
+  const coverFor = (l: Launcher): ImageSource | undefined =>
+    l.kind === 'steam' && l.appid != null ? api.steamCoverSource(settings, l.appid) : undefined;
+
+  return (
+    <View style={[styles.screen, { paddingTop: insets.top }]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.header}>
+        <Pressable onPress={() => router.back()} hitSlop={12} accessibilityRole="button" accessibilityLabel="Back">
+          <Ionicons name="chevron-back" size={26} color={t.text} />
+        </Pressable>
+        <Text style={styles.title}>Playlog</Text>
+        <View style={{ width: 26 }} />
+      </View>
+      <Text style={styles.lede}>
+        Games you want to play next, in your order. Bookmark a game to add it here;
+        use the arrows to reorder. Tap one to play it.
+      </Text>
+
+      {rows.length === 0 ? (
+        <View style={styles.empty}>
+          <Ionicons name="bookmark-outline" size={30} color={t.textFaint} />
+          <Text style={styles.emptyText}>
+            {!configured
+              ? 'Connect a box to see your library.'
+              : !list.data
+                ? 'Loading your library…'
+                : 'No games queued yet. Bookmark a game (from its tile) to add it to your playlog.'}
+          </Text>
+        </View>
+      ) : (
+        <FlatList
+          data={rows}
+          keyExtractor={(r) => r.key}
+          contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24, gap: 10 }}
+          renderItem={({ item, index }) => {
+            const cover = coverFor(item.launcher);
+            return (
+              <View style={styles.row}>
+                <Pressable
+                  onPress={() => { hapticLight(); setSheetFor(item.launcher); }}
+                  style={({ pressed }) => [styles.rowMain, pressed && { opacity: 0.7 }]}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Open ${item.launcher.label}`}>
+                  <Text style={styles.rank}>{index + 1}</Text>
+                  {cover ? (
+                    <Image source={cover} style={styles.art} resizeMode="cover" />
+                  ) : (
+                    <View style={[styles.art, styles.artFallback]}>
+                      <Ionicons name="game-controller-outline" size={18} color={t.textDim} />
+                    </View>
+                  )}
+                  <Text style={styles.label} numberOfLines={2}>{item.launcher.label}</Text>
+                </Pressable>
+                <View style={styles.controls}>
+                  <Pressable
+                    onPress={() => move(index, -1)}
+                    disabled={index === 0}
+                    hitSlop={6}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Move ${item.launcher.label} up`}
+                    style={({ pressed }) => [styles.ctrl, pressed && { opacity: 0.6 }]}>
+                    <Ionicons name="chevron-up" size={18} color={index === 0 ? t.textFaint : t.text} />
+                  </Pressable>
+                  <Pressable
+                    onPress={() => move(index, 1)}
+                    disabled={index === rows.length - 1}
+                    hitSlop={6}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Move ${item.launcher.label} down`}
+                    style={({ pressed }) => [styles.ctrl, pressed && { opacity: 0.6 }]}>
+                    <Ionicons name="chevron-down" size={18} color={index === rows.length - 1 ? t.textFaint : t.text} />
+                  </Pressable>
+                  <Pressable
+                    onPress={() => { hapticLight(); toggleBookmarked(item.key); }}
+                    hitSlop={6}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Remove ${item.launcher.label} from playlog`}
+                    style={({ pressed }) => [styles.ctrl, pressed && { opacity: 0.6 }]}>
+                    <Ionicons name="close" size={18} color={t.textDim} />
+                  </Pressable>
+                </View>
+              </View>
+            );
+          }}
+        />
+      )}
+
+      <GameSheet
+        launcher={sheetFor}
+        coverSource={sheetFor ? coverFor(sheetFor) : undefined}
+        busy={busy}
+        onPlay={launch}
+        onClose={() => setSheetFor(null)}
+      />
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    screen: { flex: 1, backgroundColor: t.bg },
+    header: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+      paddingHorizontal: 12, paddingVertical: 10,
+    },
+    title: { color: t.text, fontSize: 20, fontWeight: '800' },
+    lede: { color: t.textFaint, fontSize: 13, lineHeight: 18, paddingHorizontal: 14, marginBottom: 8 },
+    empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+    emptyText: { color: t.textFaint, fontSize: 13, lineHeight: 19, textAlign: 'center', maxWidth: 300 },
+    row: {
+      flexDirection: 'row', alignItems: 'center', gap: 10,
+      backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,
+      paddingRight: 6,
+    },
+    rowMain: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 12, padding: 10 },
+    rank: { color: t.textFaint, fontSize: 13, fontWeight: '800', width: 20, textAlign: 'center' },
+    art: { width: 40, height: 60, borderRadius: 6, backgroundColor: t.inset },
+    artFallback: { alignItems: 'center', justifyContent: 'center' },
+    label: { color: t.text, fontSize: 14, fontWeight: '700', flex: 1 },
+    controls: { flexDirection: 'row', alignItems: 'center', gap: 2 },
+    ctrl: { padding: 8, alignItems: 'center', justifyContent: 'center' },
+  });

--- a/app/components/PlaylogCard.tsx
+++ b/app/components/PlaylogCard.tsx
@@ -1,0 +1,76 @@
+/**
+ * "Playlog" CARD — the Launch-tab entry point to the backlog page (app/playlog.tsx),
+ * the ordered queue of games you want to play next. Mirrors InstallableSection: a
+ * prominent card, not a buried row.
+ *
+ * The queue IS the bookmark set (see docs/memory/project_game-backlog.md), which
+ * lives on the phone (hooks/useLibraryMarks) — so this needs no box call and shows
+ * whenever you have at least one game bookmarked. Nothing queued -> hidden (you add
+ * by bookmarking a game from its tile).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { router } from 'expo-router';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { useLibraryMarks } from '@/hooks/useLibraryMarks';
+import { hapticLight } from '@/lib/haptics';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function PlaylogCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { bookmarks } = useLibraryMarks();
+  const count = bookmarks.size;
+
+  if (count === 0) return null;
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
+      onPress={() => {
+        hapticLight();
+        router.push('/playlog');
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={`Open your playlog, ${count} game${count === 1 ? '' : 's'} queued`}>
+      <View style={styles.iconWrap}>
+        <Ionicons name="bookmark" size={20} color={t.green} />
+      </View>
+      <View style={styles.textWrap}>
+        <Text style={styles.title} numberOfLines={1}>Playlog</Text>
+        <Text style={styles.subtitle} numberOfLines={1}>
+          {count} game{count === 1 ? '' : 's'} queued to play
+        </Text>
+      </View>
+      <Ionicons name="chevron-forward" size={18} color={t.textFaint} />
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    card: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      paddingVertical: 12,
+      paddingHorizontal: 14,
+      marginVertical: 8,
+      borderRadius: 14,
+      backgroundColor: t.card,
+      borderWidth: 1,
+      borderColor: t.green + '55', // green-tinted edge (bookmark accent)
+    },
+    cardPressed: { opacity: 0.7 },
+    iconWrap: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: t.green + '22',
+    },
+    textWrap: { flex: 1 },
+    title: { color: t.text, fontWeight: '700', fontSize: 15 },
+    subtitle: { color: t.textFaint, fontSize: 12, marginTop: 2 },
+  });

--- a/app/hooks/useLibraryMarks.ts
+++ b/app/hooks/useLibraryMarks.ts
@@ -114,6 +114,26 @@ export function toggleBookmarked(key: string): void {
   void set(BOOKMARKS_KEY, JSON.stringify(next));
 }
 
+/** Persist a new ORDER for the existing bookmarks — the Playlog queue order. The
+ *  bookmark set is stored as an ordered array (a JS Set iterates in insertion
+ *  order), so a "reorder" just rewrites that array. Any key not currently
+ *  bookmarked is ignored, and any bookmarked key the caller left out is appended,
+ *  so a reorder can NEVER add or drop a game — only move one. */
+export function reorderBookmarks(orderedKeys: string[]): void {
+  const cur = snap.bookmarks;
+  const seen = new Set<string>();
+  const next: string[] = [];
+  for (const k of orderedKeys) {
+    if (cur.has(k) && !seen.has(k)) {
+      next.push(k);
+      seen.add(k);
+    }
+  }
+  for (const k of cur) if (!seen.has(k)) next.push(k);
+  commit({ ...snap, bookmarks: new Set(next), ready: true });
+  void set(BOOKMARKS_KEY, JSON.stringify(next));
+}
+
 export function savePreset(name: string, filter: FilterState): void {
   const next = upsertPreset(snap.presets, name, filter);
   commit({ ...snap, presets: next, ready: true });


### PR DESCRIPTION
Owner ask: **a separate page to manage the backlog and order games from your library you want to play.** Spec: `docs/memory/project_game-backlog.md` (P1).

## What
- **New `app/app/playlog.tsx`** — dedicated route (own header/back, portrait-locked). Lists your queued games in a user-defined order; **up/down reorder**; tap opens the shared `GameSheet` (which launches); **X** removes from the queue.
- **Queue = bookmarks** (your call: bookmark == up-next). Bookmarks were already stored as an ordered array (a JS Set iterates insertion-order), so I added `reorderBookmarks()` to persist a new order. **App-side only; no agent change.**
- **New `components/PlaylogCard.tsx`** — Launch-tab entry point (mirrors InstallableSection), shown once ≥1 game is queued.

## Verified (web harness, mock box — pressed the controls, §6)
- Seeded 3 bookmarks → Playlog renders them ordered (rank + cover + label), **no scroll**.
- **Reorder**: moved #1 down → order changed AND persisted to `couchside.bookmarks.v1`.
- **Tap** a row → GameSheet opens (with the no-scroll fix + Open in Steam).
- **Remove** (X) → row drops, store updates.
- Launch tab shows **"Playlog · 2 games queued to play"** → pushes the page.
- `tsc` clean; app-input 434/434.

## Not built (later phases, per spec)
Add-from-library picker + drag-reorder (P2), Now-playing section (P3). This P1 curates from bookmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)