### PR TITLE
chore(app): build 163

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "162",
+      "buildNumber": "163",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 162 → 163 for the next local TestFlight build (2.9.43), adding the Playlog page (#419). ASC max is 162 (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)