### PR TITLE
chore(app): android versionCode 90

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 89
+      "versionCode": 90
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
Syncs app.json `versionCode` 89 → 90 to match the AAB shipped to Play production (2.9.43). EAS autoIncrement bumped it at build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)