### PR TITLE
chore(app): build 164

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "163",
+      "buildNumber": "164",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` 163 → 164 for the next local TestFlight build (2.9.43), adding not-installed games in the Playlog + install on tap (#422).

🤖 Generated with [Claude Code](https://claude.com/claude-code)