### PR TITLE
feat(app): tour steps for new features + Utilities dashboard note

### DIFF
--- a/app/components/InstallableSection.tsx
+++ b/app/components/InstallableSection.tsx
@@ -17,6 +17,7 @@ import { router } from 'expo-router';
 import { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { TourAnchor } from '@/components/TourAnchor';
 import { api } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
@@ -49,6 +50,7 @@ export function InstallableSection() {
   if (count === null || count === 0) return null;
 
   return (
+    <TourAnchor id="launch.installable">
     <Pressable
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
       onPress={() => {
@@ -68,6 +70,7 @@ export function InstallableSection() {
       </View>
       <Ionicons name="chevron-forward" size={18} color={t.textFaint} />
     </Pressable>
+    </TourAnchor>
   );
 }
 

--- a/app/components/PlaylogCard.tsx
+++ b/app/components/PlaylogCard.tsx
@@ -12,6 +12,7 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { router } from 'expo-router';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { TourAnchor } from '@/components/TourAnchor';
 import { useLibraryMarks } from '@/hooks/useLibraryMarks';
 import { hapticLight } from '@/lib/haptics';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -25,6 +26,7 @@ export function PlaylogCard() {
   if (count === 0) return null;
 
   return (
+    <TourAnchor id="launch.playlog">
     <Pressable
       style={({ pressed }) => [styles.card, pressed && styles.cardPressed]}
       onPress={() => {
@@ -44,6 +46,7 @@ export function PlaylogCard() {
       </View>
       <Ionicons name="chevron-forward" size={18} color={t.textFaint} />
     </Pressable>
+    </TourAnchor>
   );
 }
 

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -270,6 +270,10 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
           </View>
         );
       })}
+      <Text style={styles.footNote}>
+        A small set for now. As more one-click helpers land here, Utilities will move to
+        its own dashboard page.
+      </Text>
     </View>
   );
 }
@@ -299,4 +303,5 @@ const makeStyles = (t: Palette) =>
     link: { color: t.blue, fontSize: 12, fontWeight: '700' },
     newerLine: { color: t.textFaint, fontSize: 12, fontWeight: '600', lineHeight: 17 },
     newerHint: { color: t.textFaint, fontSize: 12, marginTop: 6 },
+    footNote: { color: t.textFaint, fontSize: 11, lineHeight: 16, marginTop: 4, fontStyle: 'italic' },
   });

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -95,6 +95,23 @@ export const TOUR_STEPS: TourStep[] = [
     title: 'Or let it choose',
     body: 'The shuffle picks from whatever is currently showing — so "something short I have never played" is one tap away.',
   },
+  // Anchored INSIDE the cards (components/InstallableSection, PlaylogCard), so
+  // each step only shows when its card actually rendered: the install card needs
+  // owned-but-uninstalled games, the Playlog needs at least one queued game.
+  // No card, no anchor, step skips — the same "never describe an absent control"
+  // rule as the filter/shuffle steps above.
+  {
+    tab: 'launch',
+    anchor: 'launch.installable',
+    title: 'Your whole library — even what you haven’t installed',
+    body: 'Games you own but never downloaded show up here. Kick off the install on the box from the couch; no Big Picture, no keyboard.',
+  },
+  {
+    tab: 'launch',
+    anchor: 'launch.playlog',
+    title: 'Line up what to play next',
+    body: 'Bookmark a game and it lands in your Playlog — a play-next queue you can reorder. Not installed yet? Tap it there to install.',
+  },
 
   // PAD — the hardware replacement.
   // Anchored to the mode selector rather than the surface below it: the pad


### PR DESCRIPTION
The first-run feature tour predated OpenPuck, Playlog, and install-from-library. This adds coverage for the new stuff.

## What
- **Two new Launch-tab tour steps** (`lib/tour.ts`): *'Your whole library — even what you haven't installed'* and *'Line up what to play next'* (Playlog).
- Anchored **inside** the cards (`launch.installable`, `launch.playlog`) so each step shows only when its card actually rendered — owned-but-uninstalled games exist / at least one game is queued. No card → anchor absent → step skips, exactly the tour's existing 'never describe an absent control' rule (same as the filter/shuffle steps).
- **Utilities note** (`UtilitiesSection`): 'A small set for now. As more one-click helpers land here, Utilities will move to its own dashboard page.' (owner ask.)

## Verified
- `tsc` clean; **tour test 23/23** — the anchor-registration guard (the 'typo test') confirms both new anchors are registered in source; app-input 434/434.
- The InstallableSection + PlaylogCard cards were harness-driven earlier this session; the spotlight geometry is unit-tested in tour.test.ts.
- Not re-run: the full tour drive end-to-end in the harness (requires the first-run/paired state); the automated anchor guard + unit geometry cover the failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)