### PR TITLE
chore(app): build 166

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "164",
+      "buildNumber": "166",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Bumps iOS `buildNumber` to 166 for a local TestFlight build to view the new feature-tour steps + Utilities note (#425). (165 was the App Store cloud build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)