### PR TITLE
feat(app): Playlog — Now-playing rail, drag-reorder, clear-finished

### DIFF
--- a/app/app/playlog.tsx
+++ b/app/app/playlog.tsx
@@ -26,13 +26,27 @@ import { reorderBookmarks, toggleBookmarked, useLibraryMarks } from '@/hooks/use
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, type ImageSource, type InstallableGame, type Launcher } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
-import { bookmarkKey } from '@/lib/libraryFilter';
+import { bookmarkKey, playtimeLabel } from '@/lib/libraryFilter';
 import { useSettings } from '@/lib/SettingsContext';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type Row =
   | { key: string; kind: 'installed'; launcher: Launcher }
   | { key: string; kind: 'notInstalled'; appid: number; name: string };
+
+/** Compact "when" for the Now-playing section. */
+function lastAgo(sec: number, nowSec: number): string {
+  const d = Math.floor((nowSec - sec) / 86400);
+  if (d <= 0) return 'today';
+  if (d === 1) return 'yesterday';
+  if (d < 7) return `${d}d ago`;
+  const w = Math.round(d / 7);
+  return w === 1 ? 'a week ago' : `${w}w ago`;
+}
+
+/** Games count as "now playing" if opened within this window. */
+const NOW_PLAYING_WINDOW_S = 21 * 86400;
+const NOW_PLAYING_MAX = 6;
 
 export default function PlaylogScreen() {
   const t = useTheme();
@@ -81,6 +95,20 @@ export default function PlaylogScreen() {
     }
     return out;
   }, [list.data, inst.data, marks.bookmarks]);
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  // "Now playing" = installed games opened recently, most-recent first. Purely
+  // derived from the box's playtime data (agent >= 2.9.71); empty (section
+  // hidden) on older agents that send no last_played — never a guess.
+  const nowPlaying = useMemo(
+    () => (list.data?.launchers ?? [])
+      .filter((l) => l.last_played != null && l.last_played > 0
+        && nowSec - l.last_played <= NOW_PLAYING_WINDOW_S)
+      .sort((a, b) => (b.last_played ?? 0) - (a.last_played ?? 0))
+      .slice(0, NOW_PLAYING_MAX),
+    // nowSec changes each render but the window is coarse (days); depend on data.
+    [list.data], // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   const move = useCallback(
     (index: number, dir: -1 | 1) => {
@@ -161,23 +189,59 @@ export default function PlaylogScreen() {
         arrows to reorder.
       </Text>
 
-      {rows.length === 0 ? (
-        <View style={styles.empty}>
-          <Ionicons name="bookmark-outline" size={30} color={t.textFaint} />
-          <Text style={styles.emptyText}>
-            {!configured
-              ? 'Connect a box to see your library.'
-              : !list.data
-                ? 'Loading your library…'
-                : 'No games queued yet. Bookmark a game — installed or from your Not-installed library — to add it here.'}
-          </Text>
-        </View>
-      ) : (
-        <FlatList
-          data={rows}
-          keyExtractor={(r) => r.key}
-          contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24, gap: 10 }}
-          renderItem={({ item, index }) => {
+      <FlatList
+        data={rows}
+        keyExtractor={(r) => r.key}
+        contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24, gap: 10 }}
+        ListHeaderComponent={
+          <View style={{ gap: 10 }}>
+            {nowPlaying.length > 0 ? (
+              <>
+                <Text style={styles.sectionH}>NOW PLAYING</Text>
+                {nowPlaying.map((l) => {
+                  const cover = coverForAppid(l.appid);
+                  return (
+                    <Pressable
+                      key={l.id}
+                      onPress={() => { hapticLight(); setSheetFor(l); }}
+                      style={({ pressed }) => [styles.npRow, pressed && { opacity: 0.7 }]}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Open ${l.label}`}>
+                      {cover ? (
+                        <Image source={cover} style={styles.art} resizeMode="cover" />
+                      ) : (
+                        <View style={[styles.art, styles.artFallback]}>
+                          <Ionicons name="game-controller-outline" size={18} color={t.textDim} />
+                        </View>
+                      )}
+                      <View style={styles.rowText}>
+                        <Text style={styles.label} numberOfLines={1}>{l.label}</Text>
+                        <Text style={styles.npSub}>
+                          Played {lastAgo(l.last_played ?? nowSec, nowSec)}
+                          {l.playtime_min ? ` · ${playtimeLabel(l.playtime_min)}` : ''}
+                        </Text>
+                      </View>
+                      <Ionicons name="play" size={16} color={t.green} />
+                    </Pressable>
+                  );
+                })}
+              </>
+            ) : null}
+            <Text style={styles.sectionH}>UP NEXT</Text>
+          </View>
+        }
+        ListEmptyComponent={
+          <View style={styles.emptyInline}>
+            <Text style={styles.emptyText}>
+              {!configured
+                ? 'Connect a box to see your library.'
+                : !list.data
+                  ? 'Loading your library…'
+                  : 'No games queued yet. Bookmark a game — installed or from your Not-installed library — to add it here.'}
+            </Text>
+          </View>
+        }
+        renderItem={({ item, index }) => {
             const isInstalled = item.kind === 'installed';
             const label = isInstalled ? item.launcher.label : item.name;
             const appid = isInstalled ? item.launcher.appid ?? null : item.appid;
@@ -250,7 +314,6 @@ export default function PlaylogScreen() {
             );
           }}
         />
-      )}
 
       <GameSheet
         launcher={sheetFor}
@@ -273,7 +336,14 @@ const makeStyles = (t: Palette) =>
     title: { color: t.text, fontSize: 20, fontWeight: '800' },
     lede: { color: t.textFaint, fontSize: 13, lineHeight: 18, paddingHorizontal: 14, marginBottom: 8 },
     empty: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
+    emptyInline: { paddingVertical: 20, paddingHorizontal: 8, alignItems: 'center' },
     emptyText: { color: t.textFaint, fontSize: 13, lineHeight: 19, textAlign: 'center', maxWidth: 300 },
+    sectionH: { color: t.textFaint, fontSize: 11, fontWeight: '800', letterSpacing: 1, marginTop: 2 },
+    npRow: {
+      flexDirection: 'row', alignItems: 'center', gap: 12, padding: 10,
+      backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,
+    },
+    npSub: { color: t.textDim, fontSize: 12, marginTop: 2 },
     row: {
       flexDirection: 'row', alignItems: 'center', gap: 10,
       backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,

--- a/app/app/playlog.tsx
+++ b/app/app/playlog.tsx
@@ -7,26 +7,41 @@
  * haven't downloaded:
  *   - installed  -> tap opens the shared GameSheet (which launches it),
  *   - not installed -> tap offers to install it (steam://install on the box).
- * Reorder with the up/down controls; the ✕ removes a game from the queue.
+ * Reorder by dragging the grip (the up/down arrows do the same, and stay for
+ * accessibility); the ✕ removes a game from the queue.
  *
- * No agent change — bookmarks live on the phone (hooks/useLibraryMarks); launch
- * and install both reuse api.launch. Portrait-locked like every non-Pad screen.
+ * NOW PLAYING (top) lists installed games the box reports as recently opened.
+ * Each row can be cleared once you're done with it — a clear is remembered
+ * against that game's last_played, so playing it again brings it straight back.
+ *
+ * DRAG PATH: hand-rolled on PanResponder (the house gesture primitive — pad,
+ * trackpad, remote all use it; gesture-handler is not wired at the root). The
+ * drop slot is computed by lib/playlogReorder (unit-tested) from a layout
+ * snapshot frozen when the drag begins, and the queue only mutates on release —
+ * so nothing shifts under the finger mid-drag.
+ *
+ * No agent change — bookmarks and clears live on the phone (hooks/useLibraryMarks);
+ * launch and install both reuse api.launch. Portrait-locked like every non-Pad screen.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Stack, router } from 'expo-router';
-import { useCallback, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 import {
-  ActivityIndicator, Alert, FlatList, Image, Platform, Pressable, StyleSheet, Text, View,
+  ActivityIndicator, Alert, Animated, FlatList, Image, PanResponder,
+  Platform, Pressable, StyleSheet, Text, View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { GameSheet } from '@/components/GameSheet';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
-import { reorderBookmarks, toggleBookmarked, useLibraryMarks } from '@/hooks/useLibraryMarks';
+import {
+  dismissNowPlaying, reorderBookmarks, toggleBookmarked, useLibraryMarks,
+} from '@/hooks/useLibraryMarks';
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, type ImageSource, type InstallableGame, type Launcher } from '@/lib/api';
 import { hapticError, hapticLight, hapticMedium, hapticSuccess } from '@/lib/haptics';
 import { bookmarkKey, playtimeLabel } from '@/lib/libraryFilter';
+import { arrayMove, computeDropIndex, rowCenters } from '@/lib/playlogReorder';
 import { useSettings } from '@/lib/SettingsContext';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
@@ -44,9 +59,27 @@ function lastAgo(sec: number, nowSec: number): string {
   return w === 1 ? 'a week ago' : `${w}w ago`;
 }
 
+/** Dismissal identity for a Now-playing row: the game's stable key stamped with
+ *  the play it was cleared against, so a newer play un-hides it automatically. */
+function npHiddenKey(l: Launcher): string {
+  const k = bookmarkKey({ appid: l.appid, id: l.id }) ?? `id:${l.id}`;
+  return `${k}@${l.last_played ?? 0}`;
+}
+
 /** Games count as "now playing" if opened within this window. */
 const NOW_PLAYING_WINDOW_S = 21 * 86400;
 const NOW_PLAYING_MAX = 6;
+
+/** Row gap (matches the list contentContainerStyle) and the height assumed for a
+ *  queue row FlatList has not measured yet — both feed rowCenters(). */
+const ROW_GAP = 10;
+const ROW_DEFAULT_H = 84;
+
+/** The key of the row being dragged, handed to the (stable) cell wrapper so it
+ *  can lift itself WITHOUT its component identity changing. Swapping the
+ *  CellRendererComponent type mid-gesture remounts every cell and tears down the
+ *  grip's active pan responder — the drag would then never track the finger. */
+const DragKeyContext = createContext<string | null>(null);
 
 export default function PlaylogScreen() {
   const t = useTheme();
@@ -97,18 +130,116 @@ export default function PlaylogScreen() {
   }, [list.data, inst.data, marks.bookmarks]);
 
   const nowSec = Math.floor(Date.now() / 1000);
-  // "Now playing" = installed games opened recently, most-recent first. Purely
-  // derived from the box's playtime data (agent >= 2.9.71); empty (section
-  // hidden) on older agents that send no last_played — never a guess.
+  const hiddenNP = marks.hiddenNowPlaying;
+  // "Now playing" = installed games opened recently, most-recent first, minus any
+  // the user has cleared. Purely derived from the box's playtime data (agent >=
+  // 2.9.71); empty (section hidden) on older agents that send no last_played —
+  // never a guess.
   const nowPlaying = useMemo(
     () => (list.data?.launchers ?? [])
       .filter((l) => l.last_played != null && l.last_played > 0
         && nowSec - l.last_played <= NOW_PLAYING_WINDOW_S)
+      .filter((l) => !hiddenNP.has(npHiddenKey(l)))
       .sort((a, b) => (b.last_played ?? 0) - (a.last_played ?? 0))
       .slice(0, NOW_PLAYING_MAX),
     // nowSec changes each render but the window is coarse (days); depend on data.
-    [list.data], // eslint-disable-line react-hooks/exhaustive-deps
+    [list.data, hiddenNP], // eslint-disable-line react-hooks/exhaustive-deps
   );
+
+  // --- Drag-to-reorder (UP NEXT) ------------------------------------------
+  // rowsRef lets a stable, per-row PanResponder read the CURRENT order at grant
+  // time instead of closing over a stale `rows`. rowLayout is filled from the
+  // cell wrapper's onLayout (content-space offsets). dragState freezes the layout
+  // the instant a drag starts; the queue is only rewritten on release.
+  const rowsRef = useRef<Row[]>(rows);
+  rowsRef.current = rows;
+  const rowLayout = useRef<Record<string, number>>({}); // key -> measured height
+  const dragState = useRef<{ from: number; centers: number[]; order: string[] } | null>(null);
+  const dragY = useRef(new Animated.Value(0)).current;
+  const [dragKey, setDragKey] = useState<string | null>(null);
+  const [dropTo, setDropTo] = useState<number | null>(null);
+  const grips = useRef<Record<string, ReturnType<typeof PanResponder.create>>>({});
+
+  const finishDrag = useCallback((dy: number | null) => {
+    const st = dragState.current;
+    dragState.current = null;
+    setDragKey(null);
+    setDropTo(null);
+    dragY.setValue(0);
+    if (!st || dy == null) return;
+    const to = computeDropIndex(st.centers, st.from, st.centers[st.from] + dy);
+    if (to !== st.from) {
+      hapticSuccess();
+      reorderBookmarks(arrayMove(st.order, st.from, to));
+    } else {
+      hapticLight();
+    }
+  }, [dragY]);
+
+  // One responder per row key, created once and cached. It reads live state from
+  // refs, so recreating it is unnecessary and stale closures are impossible.
+  const gripFor = (rowKey: string) => {
+    let pr = grips.current[rowKey];
+    if (pr) return pr;
+    pr = PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      // House rule (CONVENTIONS.md): a granted drag never yields — otherwise the
+      // enclosing list could steal it mid-move and strand the reorder.
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        const order = rowsRef.current.map((r) => r.key);
+        const from = order.indexOf(rowKey);
+        if (from < 0) return;
+        const centers = rowCenters(order, rowLayout.current, ROW_GAP, ROW_DEFAULT_H);
+        dragState.current = { from, centers, order };
+        dragY.setValue(0);
+        setDragKey(rowKey);
+        setDropTo(from);
+        hapticMedium();
+      },
+      onPanResponderMove: (_e, g) => {
+        const st = dragState.current;
+        if (!st) return;
+        dragY.setValue(g.dy);
+        const to = computeDropIndex(st.centers, st.from, st.centers[st.from] + g.dy);
+        setDropTo((prev) => (prev === to ? prev : to));
+      },
+      onPanResponderRelease: (_e, g) => finishDrag(g.dy),
+      onPanResponderTerminate: () => finishDrag(null),
+    });
+    grips.current[rowKey] = pr;
+    return pr;
+  };
+
+  // Custom cell wrapper: records each row's height for the drag maths, and lifts
+  // the dragged cell above its neighbours. Its identity is STABLE (built once),
+  // so the grip's pan responder is never remounted mid-gesture; it re-renders on
+  // drag purely through DragKeyContext (a context consumer re-renders even inside
+  // the list's internal PureComponent cell). It reads only refs — never stale.
+  const cellRef = useRef<React.ComponentType<any> | null>(null);
+  if (!cellRef.current) {
+    const layout = rowLayout;
+    const rowsR = rowsRef;
+    cellRef.current = function PlaylogCell(props: any) {
+      const activeKey = useContext(DragKeyContext);
+      const k = rowsR.current[props.index]?.key;
+      const lifted = k != null && k === activeKey;
+      return (
+        <View
+          {...props}
+          style={[props.style, lifted ? { zIndex: 30, elevation: 12 } : null]}
+          onLayout={(e: { nativeEvent: { layout: { height: number } } }) => {
+            if (k) layout.current[k] = e.nativeEvent.layout.height;
+            props.onLayout?.(e);
+          }}
+        >
+          {props.children}
+        </View>
+      );
+    };
+  }
+  const CellComp = cellRef.current;
 
   const move = useCallback(
     (index: number, dir: -1 | 1) => {
@@ -170,6 +301,11 @@ export default function PlaylogScreen() {
     ]);
   }, [settings]);
 
+  const clearNowPlaying = useCallback((l: Launcher) => {
+    hapticLight();
+    dismissNowPlaying(npHiddenKey(l));
+  }, []);
+
   const coverForAppid = (appid: number | null | undefined): ImageSource | undefined =>
     appid != null ? api.steamCoverSource(settings, appid) : undefined;
 
@@ -185,14 +321,17 @@ export default function PlaylogScreen() {
       </View>
       <Text style={styles.lede}>
         Games you want to play next, in your order. Installed games launch; ones you
-        haven&rsquo;t downloaded offer to install. Bookmark a game to add it; use the
-        arrows to reorder.
+        haven&rsquo;t downloaded offer to install. Bookmark a game to add it; drag the
+        grip (or use the arrows) to reorder.
       </Text>
 
+      <DragKeyContext.Provider value={dragKey}>
       <FlatList
         data={rows}
         keyExtractor={(r) => r.key}
-        contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24, gap: 10 }}
+        scrollEnabled={dragKey == null}
+        CellRendererComponent={CellComp as never}
+        contentContainerStyle={{ padding: 14, paddingBottom: insets.bottom + 24, gap: ROW_GAP }}
         ListHeaderComponent={
           <View style={{ gap: 10 }}>
             {nowPlaying.length > 0 ? (
@@ -221,6 +360,14 @@ export default function PlaylogScreen() {
                           {l.playtime_min ? ` · ${playtimeLabel(l.playtime_min)}` : ''}
                         </Text>
                       </View>
+                      <Pressable
+                        onPress={() => clearNowPlaying(l)}
+                        hitSlop={10}
+                        accessibilityRole="button"
+                        accessibilityLabel={`Clear ${l.label} from Now playing`}
+                        style={({ pressed }) => [styles.npClear, pressed && { opacity: 0.6 }]}>
+                        <Ionicons name="checkmark-done" size={18} color={t.textDim} />
+                      </Pressable>
                       <Ionicons name="play" size={16} color={t.green} />
                     </Pressable>
                   );
@@ -247,8 +394,29 @@ export default function PlaylogScreen() {
             const appid = isInstalled ? item.launcher.appid ?? null : item.appid;
             const cover = coverForAppid(appid);
             const installing = !isInstalled && installBusy === item.appid;
-            return (
+            const dragging = item.key === dragKey;
+
+            // Insertion indicator: while a drag is live, mark where the row will
+            // land. dropTo is the target index in the array once the dragged row
+            // is removed; map it to a boundary among the rows still in place.
+            let showTop = false;
+            let showBottom = false;
+            const st = dragState.current;
+            if (dragKey && dropTo != null && st && !dragging) {
+              const rank = index < st.from ? index : index - 1;
+              if (dropTo <= rows.length - 2) showTop = rank === dropTo;
+              else showBottom = rank === rows.length - 2;
+            }
+
+            const rowBody = (
               <View style={styles.row}>
+                <View
+                  style={styles.grip}
+                  {...gripFor(item.key).panHandlers}
+                  accessible={false}
+                  importantForAccessibility="no-hide-descendants">
+                  <Ionicons name="reorder-three" size={22} color={t.textDim} />
+                </View>
                 <Pressable
                   onPress={() => {
                     hapticLight();
@@ -258,7 +426,6 @@ export default function PlaylogScreen() {
                   style={({ pressed }) => [styles.rowMain, pressed && { opacity: 0.7 }]}
                   accessibilityRole="button"
                   accessibilityLabel={isInstalled ? `Open ${label}` : `Install ${label}`}>
-                  <Text style={styles.rank}>{index + 1}</Text>
                   {cover ? (
                     <Image source={cover} style={styles.art} resizeMode="cover" />
                   ) : (
@@ -312,8 +479,22 @@ export default function PlaylogScreen() {
                 </View>
               </View>
             );
+
+            return (
+              <View>
+                {showTop ? <View style={styles.dropLine} /> : null}
+                {dragging ? (
+                  <Animated.View
+                    style={[styles.dragging, { transform: [{ translateY: dragY }] }]}>
+                    {rowBody}
+                  </Animated.View>
+                ) : rowBody}
+                {showBottom ? <View style={styles.dropLine} /> : null}
+              </View>
+            );
           }}
         />
+      </DragKeyContext.Provider>
 
       <GameSheet
         launcher={sheetFor}
@@ -344,13 +525,22 @@ const makeStyles = (t: Palette) =>
       backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,
     },
     npSub: { color: t.textDim, fontSize: 12, marginTop: 2 },
+    npClear: { padding: 6, alignItems: 'center', justifyContent: 'center' },
     row: {
-      flexDirection: 'row', alignItems: 'center', gap: 10,
+      flexDirection: 'row', alignItems: 'center', gap: 8,
       backgroundColor: t.card, borderRadius: 12, borderWidth: 1, borderColor: t.cardBorder,
       paddingRight: 6,
     },
-    rowMain: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 12, padding: 10 },
-    rank: { color: t.textFaint, fontSize: 13, fontWeight: '800', width: 20, textAlign: 'center' },
+    dragging: {
+      shadowColor: '#000', shadowOpacity: 0.4, shadowRadius: 10,
+      shadowOffset: { width: 0, height: 6 }, elevation: 12,
+    },
+    dropLine: {
+      height: 2, borderRadius: 2, backgroundColor: t.blue,
+      marginVertical: 3, marginHorizontal: 6,
+    },
+    grip: { paddingLeft: 8, paddingRight: 2, paddingVertical: 14, alignItems: 'center', justifyContent: 'center' },
+    rowMain: { flex: 1, flexDirection: 'row', alignItems: 'center', gap: 12, paddingVertical: 10 },
     art: { width: 40, height: 60, borderRadius: 6, backgroundColor: t.inset },
     artFallback: { alignItems: 'center', justifyContent: 'center' },
     rowText: { flex: 1, gap: 3 },

--- a/app/hooks/useLibraryMarks.ts
+++ b/app/hooks/useLibraryMarks.ts
@@ -30,9 +30,18 @@ import {
   type FilterPreset,
   type FilterState,
 } from '@/lib/libraryFilter';
+import { reorderWithinSubset } from '@/lib/playlogReorder';
 
 const BOOKMARKS_KEY = 'couchside.bookmarks.v1';
 const PRESETS_KEY = 'couchside.filterPresets.v1';
+// Now-playing rows the user has cleared ("I'm done with this for now"). Each
+// entry is `${bookmarkKey}@${last_played}`, so it hides that game only until the
+// box reports a NEWER last_played — play it again and it re-surfaces on its own.
+// A dismissal is never a permanent block, which is why it degrades to "shown".
+const NP_HIDDEN_KEY = 'couchside.nowPlayingHidden.v1';
+// Keep at most this many dismissals — one per game normally, plus a few dead
+// keys from games that were replayed and re-cleared. Far above any real usage.
+const NP_HIDDEN_MAX = 300;
 
 async function get(k: string): Promise<string | null> {
   if (Platform.OS === 'web') {
@@ -61,11 +70,15 @@ type Snapshot = {
   /** Bookmark keys — see bookmarkKey() in lib/libraryFilter.ts. */
   bookmarks: ReadonlySet<string>;
   presets: readonly FilterPreset[];
+  /** Cleared Now-playing rows, keyed `${bookmarkKey}@${last_played}`. */
+  hiddenNowPlaying: ReadonlySet<string>;
   /** False until storage has been read. */
   ready: boolean;
 };
 
-let snap: Snapshot = { bookmarks: new Set(), presets: [], ready: false };
+let snap: Snapshot = {
+  bookmarks: new Set(), presets: [], hiddenNowPlaying: new Set(), ready: false,
+};
 const listeners = new Set<() => void>();
 
 function commit(next: Snapshot): void {
@@ -90,6 +103,7 @@ export async function loadLibraryMarks(): Promise<void> {
   loadStarted = true;
   let bookmarks: string[] = [];
   let presets: FilterPreset[] = [];
+  let hiddenNowPlaying: string[] = [];
   try {
     const raw = await get(BOOKMARKS_KEY);
     const parsed = raw ? JSON.parse(raw) : [];
@@ -103,7 +117,17 @@ export async function loadLibraryMarks(): Promise<void> {
   } catch {
     presets = [];
   }
-  commit({ bookmarks: new Set(bookmarks), presets, ready: true });
+  try {
+    const raw = await get(NP_HIDDEN_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (Array.isArray(parsed)) hiddenNowPlaying = parsed.filter((k): k is string => typeof k === 'string');
+  } catch {
+    hiddenNowPlaying = [];
+  }
+  commit({
+    bookmarks: new Set(bookmarks), presets,
+    hiddenNowPlaying: new Set(hiddenNowPlaying), ready: true,
+  });
 }
 void loadLibraryMarks();
 
@@ -116,22 +140,27 @@ export function toggleBookmarked(key: string): void {
 
 /** Persist a new ORDER for the existing bookmarks — the Playlog queue order. The
  *  bookmark set is stored as an ordered array (a JS Set iterates in insertion
- *  order), so a "reorder" just rewrites that array. Any key not currently
- *  bookmarked is ignored, and any bookmarked key the caller left out is appended,
- *  so a reorder can NEVER add or drop a game — only move one. */
+ *  order), so a "reorder" just rewrites that array. `orderedKeys` may name only
+ *  the games currently ON SCREEN (installed and owned-but-uninstalled arrive on
+ *  different polls); reorderWithinSubset permutes only those slots and leaves
+ *  every off-screen bookmark exactly where it was, so a reorder can NEVER add,
+ *  drop, or relocate an unshown game — only move a shown one. */
 export function reorderBookmarks(orderedKeys: string[]): void {
-  const cur = snap.bookmarks;
-  const seen = new Set<string>();
-  const next: string[] = [];
-  for (const k of orderedKeys) {
-    if (cur.has(k) && !seen.has(k)) {
-      next.push(k);
-      seen.add(k);
-    }
-  }
-  for (const k of cur) if (!seen.has(k)) next.push(k);
+  const next = reorderWithinSubset([...snap.bookmarks], orderedKeys);
   commit({ ...snap, bookmarks: new Set(next), ready: true });
   void set(BOOKMARKS_KEY, JSON.stringify(next));
+}
+
+/** Clear a Now-playing row. `compositeKey` is `${bookmarkKey}@${last_played}` so
+ *  the game re-appears on its own once the box reports a newer play. Bounded: a
+ *  replay makes the previous entry dead weight, so only the most recent
+ *  NP_HIDDEN_MAX are kept — the tail can never grow without limit. */
+export function dismissNowPlaying(compositeKey: string): void {
+  if (snap.hiddenNowPlaying.has(compositeKey)) return;
+  let next = [...snap.hiddenNowPlaying, compositeKey];
+  if (next.length > NP_HIDDEN_MAX) next = next.slice(next.length - NP_HIDDEN_MAX);
+  commit({ ...snap, hiddenNowPlaying: new Set(next), ready: true });
+  void set(NP_HIDDEN_KEY, JSON.stringify(next));
 }
 
 export function savePreset(name: string, filter: FilterState): void {
@@ -151,6 +180,7 @@ export function useLibraryMarks() {
   return {
     bookmarks: s.bookmarks,
     presets: s.presets,
+    hiddenNowPlaying: s.hiddenNowPlaying,
     ready: s.ready,
     isBookmarked: useCallback((key: string | null) => (key ? s.bookmarks.has(key) : false), [s.bookmarks]),
   };

--- a/app/lib/__tests__/playlogReorder.test.ts
+++ b/app/lib/__tests__/playlogReorder.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Playlog drag-to-reorder geometry — lib/playlogReorder.ts.
+ *
+ * Run: from app/, `node --experimental-strip-types --test lib/__tests__/*.test.ts`
+ *
+ * WHY THIS EXISTS: the drag gesture computes a drop slot from frozen row centres
+ * and a finger delta, then splices the queue. A wrong index here silently
+ * reorders the WRONG game — the sort of gesture-path bug that only ever shows up
+ * on a device, never in a render. Both directions and the boundaries are pinned.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  arrayMove, computeDropIndex, reorderWithinSubset, rowCenters,
+} from '../playlogReorder.ts';
+
+// Three rows, centres 10 / 30 / 50 (variable-height rows would just change the
+// numbers; the maths is the same).
+const C = [10, 30, 50];
+
+test('arrayMove: down, up, no-op, and index clamping', () => {
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], 0, 2), ['b', 'c', 'a']);
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], 2, 0), ['c', 'a', 'b']);
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], 0, 1), ['b', 'a', 'c']);
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], 1, 1), ['a', 'b', 'c']);
+  // out-of-range never throws or drops the item
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], 0, 99), ['b', 'c', 'a']);
+  assert.deepEqual(arrayMove(['a', 'b', 'c'], -5, 0), ['a', 'b', 'c']);
+  assert.deepEqual(arrayMove([], 0, 0), []);
+});
+
+test('computeDropIndex: dragging the top row DOWN', () => {
+  // held still over its own slot -> no move
+  assert.equal(computeDropIndex(C, 0, 10), 0);
+  // dragged to just past B's centre -> lands at index 1
+  assert.equal(computeDropIndex(C, 0, 40), 1);
+  // dragged past C -> lands at the bottom
+  assert.equal(computeDropIndex(C, 0, 60), 2);
+});
+
+test('computeDropIndex: dragging the bottom row UP', () => {
+  assert.equal(computeDropIndex(C, 2, 50), 2); // still
+  assert.equal(computeDropIndex(C, 2, 20), 1); // between A and B
+  assert.equal(computeDropIndex(C, 2, 5), 0);  // above everything
+});
+
+test('computeDropIndex: the round-trip actually moves the intended key', () => {
+  const keys = ['a', 'b', 'c'];
+  const to = computeDropIndex(C, 0, 60); // drag "a" to the bottom
+  assert.deepEqual(arrayMove(keys, 0, to), ['b', 'c', 'a']);
+});
+
+test('computeDropIndex: single row is always a no-op', () => {
+  assert.equal(computeDropIndex([25], 0, 999), 0);
+  assert.equal(computeDropIndex([], 0, 0), 0);
+});
+
+test('rowCenters: measured rows give a running-sum of height+gap', () => {
+  // heights 80,100,60 with gap 10 -> tops 0,90,200 -> centres 40,140,230
+  const c = rowCenters(['a', 'b', 'c'], { a: 80, b: 100, c: 60 }, 10, 84);
+  assert.deepEqual(c, [40, 140, 230]);
+});
+
+test('rowCenters: an UNMEASURED row uses the default, never 0', () => {
+  // 'c' was never laid out (virtualized out). It must NOT collapse to 0 (which
+  // would sort it to the top and corrupt the drop index) — it takes the default.
+  const c = rowCenters(['a', 'b', 'c'], { a: 80, b: 80 }, 10, 84);
+  // a: 0..80 centre 40 ; b: 90..170 centre 130 ; c: default 84 -> 180..264 centre 222
+  assert.deepEqual(c, [40, 130, 222]);
+  // strictly increasing -> ordering is preserved
+  assert.ok(c[0] < c[1] && c[1] < c[2]);
+});
+
+test('reorderWithinSubset: full reorder when every key is named', () => {
+  assert.deepEqual(reorderWithinSubset(['a', 'b', 'c'], ['c', 'a', 'b']), ['c', 'a', 'b']);
+});
+
+test('reorderWithinSubset: off-screen keys keep their exact position', () => {
+  // i1,i2 are installed (shown); n1,n2 are not-installed (still loading, hidden).
+  // Reordering the two visible rows must NOT relocate n1/n2 to the tail.
+  const full = ['i1', 'n1', 'i2', 'n2'];
+  const out = reorderWithinSubset(full, ['i2', 'i1']); // user moved i1 below i2
+  assert.deepEqual(out, ['i2', 'n1', 'i1', 'n2']);
+  // membership is unchanged (nothing added or dropped)
+  assert.deepEqual([...out].sort(), [...full].sort());
+});
+
+test('reorderWithinSubset: unknown keys are ignored, dupes collapsed', () => {
+  assert.deepEqual(reorderWithinSubset(['a', 'b'], ['b', 'zzz', 'b', 'a']), ['b', 'a']);
+});

--- a/app/lib/playlogReorder.ts
+++ b/app/lib/playlogReorder.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure geometry for the Playlog drag-to-reorder gesture. Kept out of the screen
+ * so it can be unit-tested without a renderer — the gesture path is the kind of
+ * code that ships broken when it is only ever eyeballed.
+ *
+ * The drag commits ONLY on release, against a layout snapshot frozen at the
+ * moment the drag began (row centres in content-space, in the current order).
+ * Because the data never mutates mid-drag, the snapshot stays valid and the
+ * target slot is a deterministic function of how far the finger has moved.
+ */
+
+/** Move one item within an array, returning a NEW array. Indices are clamped, so
+ *  an out-of-range from/to can never throw or drop the item. */
+export function arrayMove<T>(arr: readonly T[], from: number, to: number): T[] {
+  const out = arr.slice();
+  if (out.length === 0) return out;
+  const f = Math.max(0, Math.min(from, out.length - 1));
+  const [item] = out.splice(f, 1);
+  const insertAt = Math.max(0, Math.min(to, out.length));
+  out.splice(insertAt, 0, item);
+  return out;
+}
+
+/**
+ * Where the dragged row should land.
+ *
+ * @param centers   y-centre of every row, in the ORIGINAL (pre-drag) order,
+ *                  measured in the list's content space.
+ * @param from      index of the row being dragged.
+ * @param floatCenter  current centre of the floating (dragged) row =
+ *                     centers[from] + gesture.dy.
+ * @returns the target index to hand to arrayMove(keys, from, to). Equal to
+ *          `from` when nothing should move (single row, or hasn't crossed a
+ *          neighbour), so a stray tap on the grip is a no-op.
+ */
+export function computeDropIndex(
+  centers: readonly number[], from: number, floatCenter: number,
+): number {
+  const n = centers.length;
+  if (n <= 1) return from;
+  // Count non-dragged rows whose centre sits above the floating point. That
+  // count is exactly the insertion index in the array once the dragged row is
+  // removed — which is what arrayMove expects as `to`.
+  let count = 0;
+  for (let i = 0; i < n; i++) {
+    if (i === from) continue;
+    if (centers[i] < floatCenter) count++;
+  }
+  return Math.max(0, Math.min(count, n - 1));
+}
+
+/**
+ * y-centre of every row from measured HEIGHTS, reconstructed as a running sum.
+ *
+ * Heights (not absolute y) are the durable signal: a cell's onLayout reports its
+ * own height even when it sits inside a virtualized list, whereas a row the list
+ * has not rendered has no layout at all. Such a row gets `defaultHeight` rather
+ * than 0 — a 0 would collapse it to the top and make the drop index count it as
+ * "above the finger", teleporting the dragged game to the wrong slot in any
+ * queue longer than the render window. A positive default keeps the centres
+ * strictly increasing, so the maths degrades to an estimate, never to a guess.
+ */
+export function rowCenters(
+  order: readonly string[],
+  heightByKey: Readonly<Record<string, number>>,
+  gap: number,
+  defaultHeight: number,
+): number[] {
+  const centers: number[] = [];
+  let acc = 0;
+  for (const k of order) {
+    const h = heightByKey[k] ?? defaultHeight;
+    centers.push(acc + h / 2);
+    acc += h + gap;
+  }
+  return centers;
+}
+
+/**
+ * Apply a reordering that only names a SUBSET of the full list, permuting just
+ * the slots those keys occupy and leaving every other key exactly where it is.
+ *
+ * The Playlog queue holds both installed and owned-but-uninstalled games, and
+ * the two arrive on different polls — so at any instant the screen may be showing
+ * only some of the bookmarks. A reorder must never relocate the games that
+ * happen to be off-screen (still loading, or absent on an older agent): dropping
+ * them to the tail is silent, persisted order corruption. Keys in `orderedSubset`
+ * that are not in `current` are ignored; keys in `current` but not named keep
+ * their position.
+ */
+export function reorderWithinSubset(
+  current: readonly string[], orderedSubset: readonly string[],
+): string[] {
+  const present = new Set(current);
+  const seq: string[] = [];
+  const inSeq = new Set<string>();
+  for (const k of orderedSubset) {
+    if (present.has(k) && !inSeq.has(k)) { seq.push(k); inSeq.add(k); }
+  }
+  let i = 0;
+  return current.map((k) => (inSeq.has(k) ? seq[i++] : k));
+}

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -623,3 +623,35 @@ screensaver preview, a second controller layout).
    half-dead-socket watchdog every ~12s and clicks in the dead windows mimic
    broken buttons. Known ceiling: onPressIn-only Pressables never fire from mouse
    on react-native-web (portrait pad has the same gap) — those need a device.
+
+### Drag-to-reorder a list (Playlog `UP NEXT`)
+
+Hand-rolled on `PanResponder` (gesture-handler is present transitively but NOT
+wired at the root, so it is not an option). The pattern, and the traps a review
+caught before it shipped:
+
+1. **A grip owns the responder on `onStartShouldSetPanResponder`, and refuses to
+   yield (`onPanResponderTerminationRequest: () => false`).** `onPanResponderMove`
+   fires continuously for the *owner* (unlike an ancestor's capture handlers, per
+   the note above), so the owner reads `gestureState.dy` directly.
+2. **Commit only on release, against a snapshot frozen at grant.** The data never
+   mutates mid-drag, so row layout stays valid; the drop slot is a pure function
+   (`lib/playlogReorder.ts`, unit-tested both directions + boundaries).
+3. **`CellRendererComponent` MUST have a stable identity.** Passing a
+   `useCallback(...,[dragKey])` swaps the component *type* the instant the drag
+   starts, which remounts every cell and tears down the grip's in-flight
+   responder — the drag then never tracks the finger, and a render-only test
+   can't see it. Build the cell once (a ref) and let it re-render via a
+   `Context` consumer (context updates pierce the list's internal PureComponent).
+4. **Centres come from measured HEIGHTS as a running sum, not absolute `y`, with a
+   positive default for rows the list hasn't rendered** (`rowCenters`). A missing
+   row defaulting to `0` sorts it to the top and teleports the drag — degrade to
+   an estimate, never a guess.
+5. **A subset reorder must not relocate off-screen items** (`reorderWithinSubset`).
+   The queue mixes installed + owned-but-uninstalled games that arrive on
+   different polls; permute only the shown slots, leave every unshown bookmark
+   where it is. Appending the omitted ones to the tail is silent, persisted
+   corruption.
+6. **Keep an accessible fallback.** The grip is pointer-only (`accessible={false}`);
+   up/down arrow buttons remain for assistive tech and as the guaranteed path.
+   The drag gesture itself needs a device to verify (same RNW ceiling as above).


### PR DESCRIPTION
## What

Three additions to the Playlog page, all **app-only** — no agent change, no API-shape change, no new dependency:

1. **NOW PLAYING rail** — installed games the box reports as played within the last 21 days (max 6), most-recent-first, `Played {ago} · {playtime}`. Tap → GameSheet.
2. **Drag-to-reorder** the UP NEXT queue — a grip on each row; the up/down arrows stay as the accessible fallback and share the same commit path.
3. **Clear-finished** on NOW PLAYING rows — a ✓✓ control dismisses a game, keyed to its `last_played` so a newer play un-hides it automatically.

## How / safety

- **Drag** is hand-rolled on `PanResponder` (gesture-handler isn't wired at the root). It commits **only on release**, against a layout snapshot **frozen at drag start**, so nothing shifts under the finger. Pure geometry (`arrayMove`, `computeDropIndex`, `rowCenters`, `reorderWithinSubset`) is in `app/lib/playlogReorder.ts`, unit-tested both directions + boundaries.
- **Clear** persists on-device only (`hooks/useLibraryMarks`), bounded to 300 entries; the box never learns which games you cleared.
- Allowlist untouched: launch/install still go through the existing `api.launch` path (id looked up, never interpolated).

## Adversarial pre-commit review — 4 confirmed bugs, all fixed

A multi-agent review ran over the diff before commit and caught real defects (each verified against the code):

- **HIGH — drag was non-functional on every device.** `CellRendererComponent` was a `useCallback` keyed on `[dragKey]`, so starting a drag swapped its component *type* → RN remounted every cell → the grip's in-flight responder was torn down. Now a **stable** cell built once, re-rendering via `Context` (context pierces the list's internal `PureComponent`). Fixed by construction — the component identity never changes.
- **MED — reorder relocated off-screen games.** `reorderBookmarks` appended not-yet-loaded bookmarks to the tail, so reordering during the installable-list load window shoved those games to the end of the saved order. Now `reorderWithinSubset` permutes only the shown slots and leaves off-screen bookmarks in place.
- **MED — unmeasured rows skewed the drop slot.** Virtualized-out rows (queues longer than the render window) collapsed to centre 0. `rowCenters` now uses running-sum heights with a positive default — degrades to an estimate, never a guess.
- **LOW — grip a11y.** It announced as an actionable button that did nothing for screen readers; now hidden from AT (the arrows are the AT path).

## Verified (web harness, pressing controls — not just rendering)

- Page renders with the stable-cell refactor (no remount crash).
- **Clear-finished:** removes the tapped row, keeps the control (other now-playing row stays), persists the `bookmarkKey@last_played` key, and does **not** also open the GameSheet (nested Pressable inner-wins).
- **Arrow reorder** (the drag's shared commit path): 3-item queue reorders correctly and an off-screen/not-installed item is **held in its slot** (`reorderWithinSubset`).
- Grip's PanResponder callbacks confirmed wired on its fiber after the refactor.
- `tsc --noEmit` clean; app-input suite **444/444** (+11 new pure-helper tests).

### Not verified
- **The drag GESTURE end-to-end.** RN-web's responder needs real pointer capture the headless harness can't synthesize, and the MCP real-drag hangs on this polling page — the documented RN-web device-only ceiling (see `docs/memory/CONVENTIONS.md`). The arrows guarantee the reorder capability; the drag itself wants an on-device pass (I'll offer a build to confirm).
- On-device iOS/Android render (harness only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)