### PR TITLE
feat(app): Playlog — quick add-to-queue from Now-playing

### DIFF
--- a/app/app/playlog.tsx
+++ b/app/app/playlog.tsx
@@ -339,6 +339,8 @@ export default function PlaylogScreen() {
                 <Text style={styles.sectionH}>NOW PLAYING</Text>
                 {nowPlaying.map((l) => {
                   const cover = coverForAppid(l.appid);
+                  const qk = bookmarkKey({ appid: l.appid, id: l.id });
+                  const queued = marks.isBookmarked(qk);
                   return (
                     <Pressable
                       key={l.id}
@@ -360,6 +362,23 @@ export default function PlaylogScreen() {
                           {l.playtime_min ? ` · ${playtimeLabel(l.playtime_min)}` : ''}
                         </Text>
                       </View>
+                      <Pressable
+                        onPress={() => {
+                          if (!qk) return;
+                          hapticLight();
+                          toggleBookmarked(qk);
+                        }}
+                        disabled={!qk}
+                        hitSlop={10}
+                        accessibilityRole="button"
+                        accessibilityLabel={queued ? `Remove ${l.label} from Up Next` : `Add ${l.label} to Up Next`}
+                        style={({ pressed }) => [styles.npClear, pressed && { opacity: 0.6 }]}>
+                        <Ionicons
+                          name={queued ? 'bookmark' : 'bookmark-outline'}
+                          size={17}
+                          color={queued ? t.blue : t.textDim}
+                        />
+                      </Pressable>
                       <Pressable
                         onPress={() => clearNowPlaying(l)}
                         hitSlop={10}


### PR DESCRIPTION
## What
Each **NOW PLAYING** row gets a bookmark toggle: **outline** when the game isn't in UP NEXT yet (tap to add), **filled/accent** when it already is (tap to remove). See at a glance which of what you're playing is queued, and queue the rest without opening the sheet.

## Safety / scope
- App-only. Reuses the existing bookmark store (`toggleBookmarked` / `isBookmarked`) — no agent change, no API change, no new dep.
- Nested inside the row Pressable so the inner control wins (tapping it never opens the GameSheet — verified). Disabled when the launcher has no stable key.

## Verified (web harness, pressing — both states + control)
- Start: queue = `["app:620"]`; both now-playing rows show the **outline** icon.
- Tap **Add Cyberpunk** → store `["app:620","app:1091500"]`, Cyberpunk appears in UP NEXT, its icon flips to **filled** / "Remove from Up Next".
- **Control:** the Witcher row is untouched — stays outline.
- `tsc --noEmit` clean; app-input **444/444**.

Part of the build-167 bundle (with #427 already merged). Note mode + interactive setup card were split off to their own cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)