### PR TITLE
feat(app): cancellable countdown for session-ending actions

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -9,6 +9,8 @@ import {
   View,
 } from 'react-native';
 
+import { useFocusEffect } from 'expo-router';
+
 import { BootSessionCard } from '@/components/BootSessionCard';
 import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
@@ -54,6 +56,14 @@ const BADGE_TEXT: Record<Danger, string> = {
   high: 'ends session',
 };
 
+/** Seconds a session-ending action waits, cancellable, before it actually fires.
+ *  This REPLACES the old blind second "Are you sure?" dialog: one confirm, then a
+ *  visible countdown you can cancel — which also catches the fleet-era mistake the
+ *  dialogs cannot, confirming with the WRONG BOX selected (the box is named in the
+ *  countdown). App-side only: the request is simply not sent until the window
+ *  elapses, so leaving the screen or switching boxes cancels it for free. */
+const COUNTDOWN_SECS = 5;
+
 /** Confirm helper that also works on web (Alert buttons are no-ops on web). */
 function confirm(title: string, message: string, onConfirm: () => void) {
   if (Platform.OS === 'web') {
@@ -90,6 +100,10 @@ function ActionsScreen() {
   const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const [run, setRun] = useState<RunRecord | null>(null);
+  // A session-ending action that has been confirmed and is counting down. Null
+  // when nothing is pending. Cleared (never fired) by Cancel, a box switch, or
+  // leaving the screen.
+  const [pending, setPending] = useState<{ action: ActionInfo; secs: number } | null>(null);
 
   const DANGER_COLOR = useMemo<Record<Danger, string>>(
     () => ({ low: t.slate, medium: t.amber, high: t.red }),
@@ -142,11 +156,8 @@ function ActionsScreen() {
       hapticLight();
       confirm(action.label, `${action.description}\n\nRun this action?`, () => {
         if (action.danger === 'high') {
-          confirm(
-            'Are you sure?',
-            `"${action.label}" ends your session on the box — anything running there stops.`,
-            () => execute(action),
-          );
+          // One confirm, then a cancellable countdown — not a second blind dialog.
+          setPending({ action, secs: COUNTDOWN_SECS });
         } else {
           execute(action);
         }
@@ -154,6 +165,40 @@ function ActionsScreen() {
     },
     [execute],
   );
+
+  // Tick the pending countdown once a second; fire the action when it reaches
+  // zero. `execute` is read through a ref so that a `settings` change (e.g. a
+  // background caps write, which re-memoizes execute) cannot re-arm the timer
+  // mid-count — that would reset the current second and, if it churned faster
+  // than 1/s, stall the countdown so it never fires. The effect depends on
+  // `pending` alone; Cancel / box-switch / tab-blur all clear it (below).
+  const executeRef = useRef(execute);
+  executeRef.current = execute;
+  useEffect(() => {
+    if (!pending) return;
+    const id = setTimeout(() => {
+      if (pending.secs <= 1) {
+        const a = pending.action;
+        setPending(null);
+        executeRef.current(a);
+      } else {
+        setPending({ action: pending.action, secs: pending.secs - 1 });
+      }
+    }, 1000);
+    return () => clearTimeout(id);
+  }, [pending]);
+
+  // Switching boxes must abort a pending countdown — otherwise it would fire on
+  // whatever box is now selected, the exact wrong-box mistake this guards against.
+  const hk = hostKey(settings);
+  useEffect(() => { setPending(null); }, [hk]);
+
+  // Leaving the Actions tab also aborts it. Tab screens are FROZEN, not
+  // unmounted, so a plain effect's cleanup never runs on blur — the setTimeout
+  // would keep counting under react-freeze and fire on a tab the user already
+  // left, with no visible countdown to cancel. useFocusEffect's cleanup runs on
+  // blur: walk away and nothing destructive happens.
+  useFocusEffect(useCallback(() => () => setPending(null), []));
 
   // "suspend" is handled by the Console tab's power control, which pairs it
   // with the Wake-on-LAN wake button and the wired-only guard, so it is left
@@ -257,6 +302,28 @@ function ActionsScreen() {
             </TourAnchor>
           ))}
       </ScrollView>
+
+      {/* Countdown before a session-ending action fires */}
+      {pending && (
+        <View style={styles.countdownPanel}>
+          <View style={styles.countdownText}>
+            <Text style={styles.countdownTitle} numberOfLines={1}>
+              {pending.action.label} in {pending.secs}s
+            </Text>
+            <Text style={styles.countdownSub} numberOfLines={1}>
+              on {settings.host}
+            </Text>
+          </View>
+          <Pressable
+            onPress={() => { hapticLight(); setPending(null); }}
+            hitSlop={8}
+            accessibilityRole="button"
+            accessibilityLabel={`Cancel ${pending.action.label}`}
+            style={({ pressed }) => [styles.countdownCancel, pressed && styles.pressed]}>
+            <Text style={styles.countdownCancelText}>CANCEL</Text>
+          </Pressable>
+        </View>
+      )}
 
       {/* Result panel */}
       {run && (
@@ -371,4 +438,25 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   resultErr: { color: t.red, fontSize: 13, fontFamily: mono },
   resultScroll: { maxHeight: 150 },
   resultOut: { color: t.textDim, fontSize: 12, fontFamily: mono, lineHeight: 17 },
+  countdownPanel: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    backgroundColor: t.redDeep,
+    borderColor: t.red,
+    borderWidth: 1,
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 8,
+  },
+  countdownText: { flex: 1 },
+  countdownTitle: { color: t.onRedDeep, fontSize: 15, fontWeight: '800' },
+  countdownSub: { color: t.onRedDeep, opacity: 0.8, fontSize: 12, marginTop: 2, fontFamily: mono },
+  countdownCancel: {
+    backgroundColor: t.red,
+    paddingVertical: 10,
+    paddingHorizontal: 22,
+    borderRadius: 8,
+  },
+  countdownCancelText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
 });


### PR DESCRIPTION
## What
Session-ending (**high** danger) actions — Reboot, Power Off, Restart Session — no longer hide behind a second blind "Are you sure?" dialog. Now: **one confirm, then a 5-second countdown you can cancel** before the request is ever sent. The countdown names the target box (`on <host>`) — which catches the one mistake two blind dialogs can't: **confirming with the wrong box selected**. Low/medium actions are unchanged (one confirm, immediate).

App-only: no agent change, no API change. The request simply isn't sent until the window elapses, so Cancel / leaving the screen / switching boxes all abort it for free.

## Adversarial review caught a HIGH bug before commit
The countdown was a plain `useEffect`. Bottom-tab screens are **frozen, not unmounted**, on tab switch (react-freeze), so the effect's cleanup would **not** run on blur — the `setTimeout` kept counting and the session-ending action fired on a tab the user had already left, with no visible countdown to cancel. That's the exact harm the feature exists to prevent.

Fix: `useFocusEffect` cancels the countdown on blur (the safe default), matching how `usePoll` handles focus. Also read `execute` through a ref so a background settings/caps write can't re-arm (drift) or stall the timer.

## Verified (web harness, pressing — both directions)
- **Cancel:** press → Cancel → **0** requests sent.
- **Elapse:** press → wait it out → **exactly 1** request, only after the window (not the immediate fire of the pre-fix bug).
- **Leave tab (the fix):** press → switch to Console mid-countdown → **0** requests — proven by contrast against the stay-put case, which fires exactly 1.
- Panel shows `<action> in Ns` / `on <host>` with a CANCEL button (screenshot below).
- `tsc --noEmit` clean.

Part of the build-167 bundle (with #427 + #428). Note mode + interactive setup card were split to their own cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)