### PR TITLE
chore(app): build 167

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "166",
+      "buildNumber": "167",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
iOS **build 167** (local TestFlight build, uploaded via altool — UPLOAD SUCCEEDED).

Bundles the build-167 features already merged to `main`:
- Playlog: Now-playing rail + drag-reorder + clear-finished (#427)
- Playlog: quick add-to-queue from Now-playing (#428)
- Cancellable countdown for session-ending actions (#429)

`app.json` iOS `buildNumber` 166 → 167 (ASC max was 166 VALID). `eas.json` `autoIncrement` was temporarily frozen for the deterministic number, then reverted (not in this diff). Version stays 2.9.43.

Local build → TestFlight only (INVALID_BINARY at App Store review; App Store submission stays cloud). iOS 2.9.43 build 165 remains in App Store review separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)