### PR TITLE
feat(app): note mode — phone-side text scratchpad on the Pad

### DIFF
--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -50,6 +50,7 @@ import { setImmersive } from '@/lib/immersive';
 import { setRunningAppid } from '@/lib/gameTheme';
 import { surfaceChanged, type PadSurface } from '@/lib/padSurface';
 import { moveLayout, padLayout, verticalMoveLayout } from '@/lib/padLayout';
+import { NotePad } from '@/components/NotePad';
 import { SteamMenusPanel } from '@/components/SteamMenusPanel';
 import { RemoteView } from '@/components/RemoteView';
 import { PadDiagnostics } from '@/components/PadDiagnostics';
@@ -854,6 +855,9 @@ const MODES: { key: PadMode; label: string }[] = [
   // reach for most. Conditional -- see `modes` below; a box without Steam menus
   // never sees this segment, because an empty panel is worse than no segment.
   { key: 'menus', label: 'STEAM' },
+  // A phone-side text scratchpad, not a box control. Sits last (furthest swipe)
+  // and is hideable via the hideNoteMode pref — see `modes` below.
+  { key: 'note', label: 'NOTE' },
 ];
 
 function PadScreen() {
@@ -1087,6 +1091,7 @@ function PadScreen() {
   const keepAwakeOn = useKeepAwakeEnabled();
   const keepAwakeTimeout = useKeepAwakeTimeoutMin();
   const tvNavEnabled = usePref('tvNavEnabled');
+  const hideNoteMode = usePref('hideNoteMode');
 
   // Wake-lock state. wakeHeldRef mirrors what we last told expo-keep-awake so
   // the poll is a no-op in the steady state instead of re-issuing a native call
@@ -1409,9 +1414,12 @@ function PadScreen() {
         // PERSISTED on 'move' keeps working if the game quits — yanking the
         // surface out from under someone on a poll flap would be worse than
         // an idle stick — but the segment hides, so EXIT is the way back.
-        && (m.key !== 'move' || (runningGame && !keyboardMode) || mode === 'move'),
+        && (m.key !== 'move' || (runningGame && !keyboardMode) || mode === 'move')
+        // NOTE is a local scratchpad, available on any box; the pref hides the
+        // segment. A box already PERSISTED on 'note' keeps it so EXIT still works.
+        && (m.key !== 'note' || !hideNoteMode || mode === 'note'),
     ),
-    [hasSteamMenus, inGameMode, keyboardMode, runningGame, mode],
+    [hasSteamMenus, inGameMode, keyboardMode, runningGame, mode, hideNoteMode],
   );
   const desk = useCallback(
     (name: DesktopKey | 'esc') => () =>
@@ -2032,7 +2040,11 @@ function PadScreen() {
         </View>
       )}
 
-      {mode === 'menus' ? (
+      {mode === 'note' ? (
+        // A local text scratchpad. Renders in place of the box-driving surfaces;
+        // the mode bar above stays visible, so a swipe/tap still exits.
+        <NotePad />
+      ) : mode === 'menus' ? (
         // MUST scroll: TabScreen's body is a plain View, and this list is ~16
         // chips across five sections -- taller than the pane on a phone. The
         // Actions tab gets scrolling from its own ScrollView; Pad has none, so

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -911,6 +911,7 @@ function SetupBody() {
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
   const hideDownloads = usePref('hideDownloads');
+  const hideNoteMode = usePref('hideNoteMode');
   const appUpdateReminder = usePref('appUpdateReminder');
   const hideStreamFromPc = usePref('hideStreamFromPc');
   const hideTvVolume = usePref('hideTvVolume');
@@ -1452,6 +1453,15 @@ function SetupBody() {
                 value={hideDownloads}
                 onValueChange={(v) => {
                   void setPref('hideDownloads', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Hide note mode"
+                sub="Removes the NOTE segment from the Pad's mode bar. Note mode is a phone-side scratchpad for jotting a clue while a game runs. Your note is kept either way — this only hides the segment."
+                value={hideNoteMode}
+                onValueChange={(v) => {
+                  void setPref('hideNoteMode', v);
                   hapticSelection();
                 }}
               />

--- a/app/components/NotePad.tsx
+++ b/app/components/NotePad.tsx
@@ -1,0 +1,87 @@
+/**
+ * NOTE mode's surface — a phone-side text scratchpad for jotting a clue while a
+ * game runs. Renders in place of the swipe/trackpad surface when the Pad is on
+ * the NOTE segment. It drives NOTHING on the box: it is a local TextInput bound
+ * to lib/note (autosave + persist). No responder ownership, no d-pad path — so
+ * it carries none of the swipe surface's stuck-direction risk.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useCallback } from 'react';
+import {
+  Alert, KeyboardAvoidingView, Platform, Pressable, StyleSheet, Text, TextInput, View,
+} from 'react-native';
+
+import { hapticLight } from '@/lib/haptics';
+import { clearNote, NOTE_MAX, setNoteText, useNoteText } from '@/lib/note';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function NotePad() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const text = useNoteText();
+
+  const onClear = useCallback(() => {
+    const go = () => { hapticLight(); void clearNote(); };
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (typeof window !== 'undefined' && window.confirm('Clear this note?')) go();
+      return;
+    }
+    Alert.alert('Clear note', 'Erase everything in this note?', [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Clear', style: 'destructive', onPress: go },
+    ]);
+  }, []);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.wrap}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+      <View style={styles.head}>
+        <Text style={styles.title}>Notes</Text>
+        <Text style={styles.count}>{text.length}/{NOTE_MAX}</Text>
+        <Pressable
+          onPress={onClear}
+          disabled={text.length === 0}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel="Clear note"
+          style={({ pressed }) => [styles.clear, pressed && { opacity: 0.6 }]}>
+          <Ionicons name="trash-outline" size={18} color={text.length ? t.red : t.textFaint} />
+        </Pressable>
+      </View>
+      <TextInput
+        style={styles.input}
+        value={text}
+        onChangeText={(v) => { void setNoteText(v); }}
+        multiline
+        maxLength={NOTE_MAX}
+        placeholder="Jot a clue, a code, where you left off… saved automatically."
+        placeholderTextColor={t.textFaint}
+        textAlignVertical="top"
+        keyboardAppearance="dark"
+        accessibilityLabel="Note text"
+      />
+    </KeyboardAvoidingView>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: { flex: 1, padding: 12, gap: 8 },
+    head: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    title: { color: t.text, fontSize: 16, fontWeight: '800', flex: 1 },
+    count: { color: t.textFaint, fontSize: 12, fontVariant: ['tabular-nums'] },
+    clear: { padding: 6, alignItems: 'center', justifyContent: 'center' },
+    input: {
+      flex: 1,
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 14,
+      color: t.text,
+      fontSize: 16,
+      lineHeight: 22,
+    },
+  });

--- a/app/lib/note.ts
+++ b/app/lib/note.ts
@@ -1,0 +1,101 @@
+/**
+ * The Playlog/game note — one on-device text scratchpad for jotting a clue, a
+ * code, or where you left off while a game runs. Owner ask 2026-08-10: "text
+ * typing notes would be a big part of the experience."
+ *
+ * Module-level external store, same shape as lib/prefs.ts and
+ * hooks/useLibraryMarks.ts: the Pad's NOTE surface writes while a Setup toggle
+ * and (later) other surfaces read, and those are different components — per-hook
+ * useState was exactly the bug that made the feature-tour switch look dead.
+ *
+ * ON DEVICE ONLY. A single GLOBAL note (owner call), never sent to the box — the
+ * box has no idea you keep notes and does not need one. Persisted, so a clue you
+ * jotted is still there next session; toggling note mode off never erases it.
+ *
+ * Capped at NOTE_MAX characters: SecureStore (the native backing) is size-limited,
+ * so the store truncates rather than silently failing to persist a long note. The
+ * TextInput also enforces the same maxLength, so the cap is visible, not a trap.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+const KEY = 'couchside.note.v1';
+/** Generous for a jotted clue; bounded because SecureStore is size-limited on iOS. */
+export const NOTE_MAX = 4000;
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(key, value);
+    } catch {
+      // storage unavailable (private mode): the note lives for this session only
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+let note = '';
+let loadStarted = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+/** Read the stored note once. Safe to call repeatedly. Degrades to empty. */
+export async function loadNote(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  const raw = await storageGet(KEY);
+  if (typeof raw === 'string' && raw.length > 0) {
+    note = raw.slice(0, NOTE_MAX);
+    emit();
+  }
+}
+void loadNote();
+
+export function getNoteText(): string {
+  return note;
+}
+
+/** Set the note (autosave). Truncated to NOTE_MAX so a long paste can't silently
+ *  fail to persist on native. No-op if unchanged. */
+export async function setNoteText(next: string): Promise<void> {
+  const v = (next ?? '').slice(0, NOTE_MAX);
+  if (v === note) return;
+  note = v;
+  emit();
+  await storageSet(KEY, v);
+}
+
+/** Erase the note — a deliberate act, separate from toggling note mode off. */
+export async function clearNote(): Promise<void> {
+  return setNoteText('');
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** React hook: live note text. */
+export function useNoteText(): string {
+  return useSyncExternalStore(subscribe, () => note, () => note);
+}

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -146,6 +146,11 @@ export type Prefs = {
    *  going. Named `hide` to match hideStreamFromPc / hideTvVolume; a mixed
    *  polarity is how a toggle ends up wired backwards. */
   hideDownloads: boolean;
+  /** Hide the NOTE segment from the Pad's mode bar. Off by default (visible):
+   *  note mode is a phone-side scratchpad for jotting a clue mid-game. On for
+   *  people who don't want the extra segment. `hide` polarity to match the
+   *  other hide* prefs. The note itself is never touched by this. */
+  hideNoteMode: boolean;
   /** Show the occasional "check for an app update" reminder toast. On by
    *  default; the toast itself carries a "Don't show again" that flips this
    *  off. The update CHECK is always manual — this only governs the nudge. */
@@ -291,6 +296,7 @@ export const DEFAULTS: Prefs = {
   onboardingDone: false,
   whatsNewOffered: false,
   hideDownloads: false,
+  hideNoteMode: false,
   appUpdateReminder: true,
   defaultPadMode: 'swipe',
   statusIntervalMs: 5000,
@@ -386,6 +392,7 @@ function normalize(raw: unknown): Prefs {
   const onboardingDone = bool(o.onboardingDone, DEFAULTS.onboardingDone);
   const whatsNewOffered = bool(o.whatsNewOffered, DEFAULTS.whatsNewOffered);
   const hideDownloads = bool(o.hideDownloads, DEFAULTS.hideDownloads);
+  const hideNoteMode = bool(o.hideNoteMode, DEFAULTS.hideNoteMode);
   const appUpdateReminder = bool(o.appUpdateReminder, DEFAULTS.appUpdateReminder);
   const searchSide: 'left' | 'right' | 'off' =
     o.searchButtonSide === 'right' || o.searchButtonSide === 'off'
@@ -400,6 +407,7 @@ function normalize(raw: unknown): Prefs {
     onboardingDone,
     whatsNewOffered,
     hideDownloads,
+    hideNoteMode,
     appUpdateReminder,
     confirmSuspend:
       typeof o.confirmSuspend === 'boolean' ? o.confirmSuspend : DEFAULTS.confirmSuspend,

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -16,7 +16,7 @@ import type { BoxCaps } from './api';
  * menus (agent >= 2.9.31). Pad filters it out otherwise rather than offering a
  * mode that would open an empty panel.
  */
-export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus' | 'tvnav' | 'move';
+export type PadMode = 'gamepad' | 'swipe' | 'trackpad' | 'remote' | 'menus' | 'tvnav' | 'move' | 'note';
 
 /**
  * A single paired box (Bazzite media center, Steam Deck, ...). The app manages

--- a/docs/memory/project_note-mode.md
+++ b/docs/memory/project_note-mode.md
@@ -1,6 +1,24 @@
 # Note mode — jot a clue on the phone while the game runs
 
-**Status:** 📋 Planned. Spec only; nothing built.
+> **2026-08-10 PIVOT (owner):** "drawing is nice for doodling, but text typing notes
+> would be a big part of the experience." So v1 is a **TEXT** scratchpad, not the drag-ink
+> surface. The drawing sections below are retained for the **doodle fast-follow** (phase 2),
+> which reuses `touchTrail`/`TouchIndicatorLayer` and is the device-only-verifiable part.
+>
+> **v1 SHIPPED shape (text):** `note` is a new `PadMode` (`lib/settings.ts`); a **NOTE**
+> segment on the Pad mode bar, hideable via the `hideNoteMode` pref (`lib/prefs.ts`, Setup
+> toggle). Selecting it renders `components/NotePad.tsx` — a multiline `TextInput` bound to
+> `lib/note.ts` (single GLOBAL note string, key `couchside.note.v1`, SecureStore native /
+> localStorage web, autosave, `NOTE_MAX=4000`, persists across restart). Clear = a deliberate
+> confirmed act. It drives NOTHING on the box (no PanResponder, no d-pad) — mounts in place of
+> the swipe surface, so it carries none of the stuck-direction risk. Harness-verified fully:
+> segment show/hide by pref, type→autosave→persist across reload, Clear, works box-disconnected.
+> Decisions taken (were "ask, not assume"): single GLOBAL note; persists across app restart.
+>
+> **Doodle (phase 2, deferred):** freehand ink over/beside the text, reusing the machinery
+> below. Device-only verify (RN-Web has no touch events).
+
+**Status:** ✅ v1 (text) built on branch `claude/note-mode`. Drawing below = phase 2.
 **Origin:** owner, 2026-07-22, watching the drag stroke land on a real device:
 "the drag lines could even be a note tool in the swipe menu — a toggle to switch to note
 mode for when you are gaming and want to jot down a clue."


### PR DESCRIPTION
## What
A **NOTE** segment on the Pad's mode bar → a place to **type a clue, a code, or where you left off** while a game runs. Owner pivot: text typing is the core (freehand doodle is a deferred phase 2).

- `note` PadMode + NOTE segment, **hideable** via a new `hideNoteMode` pref (Setup toggle).
- `components/NotePad.tsx`: a multiline `TextInput` bound to `lib/note.ts` — one **global** on-device note (`couchside.note.v1`, SecureStore native / localStorage web), **autosave**, `NOTE_MAX=4000`, **persists across restart**. Clear is a separate confirmed act.
- Drives **nothing** on the box (no PanResponder, no d-pad) — renders in place of the swipe surface, so it carries none of the stuck-direction risk. The mode bar stays above it (swipe/tap always exits), and the `modes` filter keeps the segment while `mode==='note'` so hiding the pref mid-use can't strand you.

No agent change, no API change. The note never leaves the phone.

## Decisions (spec said "ask, not assume")
Single **global** note; **persists** across app restart; toggling note mode off only hides it — delete stays a deliberate Clear.

## Verified (web harness, pressing — both states)
- NOTE segment **shows** (pref off) / **hidden** (pref on).
- Tap NOTE → the pad; **typing autosaves** (count updates + written to `couchside.note.v1`) and **survives a full reload** (reloads into the field).
- **Clear** empties both the field and the store.
- Works even with the box **disconnected** (it's local).
- Adversarial review: **no confirmed defects** (one raised, verified refuted). `tsc` clean; app-input **444/444**.

### Not verified / out of scope
- Freehand **doodle** (deferred **phase 2** — device-only, RN-Web has no touch events; reuses the existing `touchTrail` machinery). Spec: `docs/memory/project_note-mode.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)