### PR TITLE
Legion Go S fixes: Couch Mode gamescope-session detection/write-path + honest "last seen" banner

### DIFF
--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3601,8 +3601,9 @@ def _couchmode_platform_ok():
     So the gate asks what the switch NEEDS instead of who made the distro:
 
       1. the four tools (checked by the caller, unchanged), and
-      2. both switch TARGETS installed — `gamescope-session.desktop` to fling
-         to, and some known desktop session to come back to.
+      2. both switch TARGETS installed — a gamescope Game Mode session (any
+         name in _GAMESCOPE_SESSION_FILES, since images differ) to fling to,
+         and some known desktop session to come back to.
 
     (2) is the KI-038 lesson applied to a gate rather than a write: it is not
     enough that a *command* exists, the thing it switches to has to be really
@@ -3618,7 +3619,7 @@ def _couchmode_platform_ok():
     installed = _installed_session_files()
     if not installed:
         return True  # cannot enumerate: fall back to the tool requirement
-    if GAMESCOPE_SESSION_FILE not in installed:
+    if not any(name in installed for name in _GAMESCOPE_SESSION_FILES):
         return False
     return any(name in installed for name in _DESKTOP_SESSIONS)
 
@@ -4133,6 +4134,19 @@ def _dm_dropin_legacy(dm):
 
 
 GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"
+# The gamescope Game Mode session ships under different .desktop names across
+# images: SteamOS/Bazzite/ChimeraOS use gamescope-session.desktop, but some
+# SteamOS builds ship gamescope-wayland.desktop (MEASURED on a Legion Go S,
+# SteamOS 3.8.16, 2026-08-10: its /usr/share/wayland-sessions held
+# gamescope-wayland.desktop + plasma.desktop + plasmax11.desktop, so the single
+# hardcoded name above made _couchmode_platform_ok() refuse a box that was
+# literally sitting in Game Mode — the app then showed the Big Picture fallback).
+# This set gates DETECTION only (_couchmode_platform_ok / couchmode_available).
+# The autologin WRITE path still keys on the single GAMESCOPE_SESSION_FILE and is
+# deliberately unchanged here: writing a session name the box does not have is the
+# stranding failure _write_autologin already guards against, and resolving the
+# box's real name for that path is a separate, higher-risk change (see ROADMAP).
+_GAMESCOPE_SESSION_FILES = (GAMESCOPE_SESSION_FILE, "gamescope-wayland.desktop")
 
 
 def _steamosctl_session_ok():

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4671,7 +4671,8 @@ def session_default_get():
         cmd = _greetd_current_command()
         if not cmd:
             return {"available": True, "backend": backend, "mode": "unknown"}
-        game_cmd = _session_exec_command(GAMESCOPE_SESSION_FILE)
+        game_cmd = _session_exec_command(
+            _gamescope_session_for_autologin() or GAMESCOPE_SESSION_FILE)
         if game_cmd and cmd == game_cmd:
             return {"available": True, "backend": backend, "mode": "game"}
         for session_file in _DESKTOP_SESSIONS:
@@ -4704,7 +4705,7 @@ def session_default_get():
     # about — the app highlights that from its own state) or unset. Either way
     # the honest answer is what the box will actually come up as: its record.
     name = _dm_current_session_file(backend)
-    if name == GAMESCOPE_SESSION_FILE:
+    if name in _GAMESCOPE_SESSION_FILES:
         mode = "game"
     elif name in _DESKTOP_SESSIONS:
         mode = "desktop"
@@ -4886,7 +4887,7 @@ def _migrate_dropin_into_config(dm):
     name = _last_session_line(_dm_dropin(dm)) or _last_session_line(_dm_dropin_legacy(dm))
     if not name:
         return
-    if name == GAMESCOPE_SESSION_FILE:
+    if name in _GAMESCOPE_SESSION_FILES:
         mode = "game"
     elif name in _DESKTOP_SESSIONS:
         mode = "desktop"
@@ -4978,7 +4979,11 @@ def session_default_arm():
         _dm_disarm(dm)
         return
     if pref == "game":
-        target = GAMESCOPE_SESSION_FILE
+        target = _gamescope_session_for_autologin()
+        if not target:
+            print("[session] arm: no gamescope session installed; refusing",
+                  flush=True)
+            return
     else:
         target = _desktop_session_for_autologin()
         if not target:
@@ -5015,7 +5020,13 @@ def session_default_set(mode):
         # broke every one-shot switch (KI-051).
         target = None
     elif mode == "game":
-        target = GAMESCOPE_SESSION_FILE
+        # Resolve the box's REAL gamescope session name (images differ), mirroring
+        # the desktop branch below. steamosctl switches by mode name and needs no
+        # file, so only the file-writing backends (greetd + the drop-in managers)
+        # must refuse when none is installed.
+        target = _gamescope_session_for_autologin()
+        if not target and backend != "steamosctl":
+            return done(False, "no gamescope session installed on this box")
     else:
         # Desktop: the session must EXIST or autologin fails and the box lands
         # at the greeter with no agent (see _installed_session_files). Refusing
@@ -5037,9 +5048,9 @@ def session_default_set(mode):
     if backend == "steamosctl":
         # SteamOS proper has a real API for this that costs nobody their
         # session, so use it and skip the drop-in dance entirely.
-        arg = "game" if target == GAMESCOPE_SESSION_FILE else "desktop"
-        if target is None:  # "last": nothing to tell steamosctl
+        if mode == "last":  # nothing to tell steamosctl
             return done(True)
+        arg = "game" if mode == "game" else "desktop"
         try:
             r = subprocess.run(["steamosctl", "set-default-login-mode", arg],
                                capture_output=True, text=True, timeout=8)
@@ -5135,7 +5146,28 @@ def _desktop_session_for_autologin():
     # still only ever a file we have SEEN, and never the gamescope session
     # (that is Game Mode, the opposite of what was asked for).
     for name in sorted(installed):
-        if name.startswith("plasma") and name != GAMESCOPE_SESSION_FILE:
+        if name.startswith("plasma") and name not in _GAMESCOPE_SESSION_FILES:
+            return name
+    return None
+
+
+def _gamescope_session_for_autologin():
+    """The gamescope Game Mode session file that EXISTS on this box, or None.
+
+    The Game-Mode mirror of _desktop_session_for_autologin(): images name the
+    session differently — gamescope-session.desktop on SteamOS/Bazzite/ChimeraOS,
+    gamescope-wayland.desktop on some SteamOS builds (MEASURED on a Legion Go S,
+    SteamOS 3.8.16, 2026-08-10) — so writing the single hardcoded name into an
+    autologin entry strands a box whose real session is named otherwise, the same
+    greeter-drop _dm_write already refuses. Degrades CLOSED like the desktop side:
+    None (refuse) when the dirs cannot be enumerated or no known gamescope session
+    is installed. Callers that do NOT write a filename (steamosctl switches by mode
+    name) must not treat None as a refusal."""
+    installed = _installed_session_files()
+    if not installed:
+        return None  # cannot enumerate; refuse rather than guess
+    for name in _GAMESCOPE_SESSION_FILES:
+        if name in installed:
             return name
     return None
 

--- a/app/app/(tabs)/fleet.tsx
+++ b/app/app/(tabs)/fleet.tsx
@@ -7,6 +7,7 @@ import { TabScreen } from '@/components/TabScreen';
 import { useFocusEffect } from 'expo-router';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, Status } from '@/lib/api';
+import { fmtLastSeen, noteBoxSeen } from '@/lib/lastSeen';
 import { usePref } from '@/lib/prefs';
 import { Box } from '@/lib/settings';
 import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
@@ -33,6 +34,13 @@ type FleetMap = Record<string, FleetEntry>;
  */
 function useFleetStatus(boxes: Box[], intervalMs: number): FleetMap {
   const [map, setMap] = React.useState<FleetMap>({});
+
+  // Persist each box's last-reachable time (throttled) so a DOWN tile shows a
+  // real "last seen" after an app restart instead of "never". A ref keeps the
+  // focus effect's deps as [intervalMs] rather than re-subscribing on identity.
+  const { updateBox } = useBoxes();
+  const updateBoxRef = React.useRef(updateBox);
+  updateBoxRef.current = updateBox;
 
   const boxesRef = React.useRef<Box[]>(boxes);
   boxesRef.current = boxes;
@@ -76,9 +84,11 @@ function useFleetStatus(boxes: Box[], intervalMs: number): FleetMap {
             .status(conn)
             .then((s) => {
               if (!mounted.current) return;
+              const now = Date.now();
+              noteBoxSeen(box.id, now, (ts) => void updateBoxRef.current(box.id, { lastSeen: ts }));
               setMap((prev) => ({
                 ...prev,
-                [box.id]: { status: s, error: null, lastSuccess: Date.now() },
+                [box.id]: { status: s, error: null, lastSuccess: now },
               }));
             })
             .catch((e: unknown) => {
@@ -128,15 +138,6 @@ function useFleetStatus(boxes: Box[], intervalMs: number): FleetMap {
   );
 
   return map;
-}
-
-function fmtLastSeen(ts: number | null): string {
-  if (!ts) return 'never';
-  const s = Math.round((Date.now() - ts) / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ${m % 60}m ago`;
 }
 
 function Tile({ box, entry, active, index, onPress }: {
@@ -206,7 +207,9 @@ function Tile({ box, entry, active, index, onPress }: {
           </>
         ) : (
           <Text style={styles.downText}>
-            {entry == null ? 'probing…' : `DOWN · last seen ${fmtLastSeen(entry.lastSuccess)}`}
+            {entry == null
+              ? 'probing…'
+              : `DOWN · last seen ${fmtLastSeen(entry.lastSuccess ?? box.lastSeen ?? null)}`}
           </Text>
         )}
       </Card>

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -16,6 +16,7 @@ import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { useStreak } from '@/hooks/useStreak';
 import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
+import { fmtLastSeen, noteBoxSeen } from '@/lib/lastSeen';
 import { usePref } from '@/lib/prefs';
 import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { noteBoxReachable } from '@/lib/review';
@@ -47,15 +48,6 @@ function UnitChip({ unit }: { unit: Unit }) {
   );
 }
 
-function fmtLastSeen(ts: number | null): string {
-  if (!ts) return 'never';
-  const s = Math.round((Date.now() - ts) / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ${m % 60}m ago`;
-}
-
 /** "1h 24m" / "40m" — minutes only under an hour, so a short charge does not
  *  read as "0h 40m". */
 function fmtDuration(mins: number): string {
@@ -78,7 +70,7 @@ function ConsoleScreen() {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const { Screen, Card, Bar, Dot, Spark, BigMetric } = useSkinKit();
-  const { settings, ready } = useSettings();
+  const { settings, ready, update } = useSettings();
 
   // No host yet (fresh install): don't poll, and show the pairing hint
   // instead of the unreachable banner.
@@ -109,6 +101,17 @@ function ConsoleScreen() {
   useEffect(() => {
     if (reachable) void noteBoxReachable();
   }, [reachable]);
+
+  // Persist a per-box "last seen" so the unreachable banner shows a real elapsed
+  // time after an app restart or box switch instead of "never" — usePoll's
+  // in-memory lastSuccess is null on a cold launch to a dead box and is cleared
+  // on every box switch. Throttled in noteBoxSeen; keyed by boxKey so switching
+  // boxes records the newly-active one promptly.
+  useEffect(() => {
+    if (status.lastSuccess != null) {
+      noteBoxSeen(boxKey, status.lastSuccess, (ts) => void update({ lastSeen: ts }));
+    }
+  }, [status.lastSuccess, boxKey, update]);
 
   // How hard the box is working, 0..1. Skins use this to set the RATE of their
   // idle motion -- a busy box breathes faster. Never a colour input.
@@ -198,7 +201,7 @@ function ConsoleScreen() {
             <Text style={styles.bannerTitle}>BOX UNREACHABLE</Text>
             <Text style={styles.bannerDetail}>{status.error.message}</Text>
             <Text style={styles.bannerDetail}>
-              last seen: {fmtLastSeen(status.lastSuccess)}
+              last seen: {fmtLastSeen(status.lastSuccess ?? settings.lastSeen ?? null)}
             </Text>
             <Pressable
               style={({ pressed }) => [styles.retryBtn, pressed && styles.pressed]}

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -266,6 +266,7 @@ export function useSettings(): SettingsContextValue {
       mac: activeBox.mac,
       volumeTarget: activeBox.volumeTarget,
       caps: activeBox.caps,
+      lastSeen: activeBox.lastSeen,
     };
   }, [activeBox]);
 

--- a/app/lib/__tests__/lastSeen.test.ts
+++ b/app/lib/__tests__/lastSeen.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-box "last seen" — the persist throttle and the elapsed-time label.
+ *
+ * The bug this guards: the unreachable banner read usePoll's in-memory
+ * lastSuccess, which is null on a cold launch to an already-offline box and is
+ * cleared on every box switch, so it showed "last seen: never" for a box seen
+ * hundreds of times. The fix persists a per-box timestamp and falls back to it;
+ * these tests pin the throttle (so a healthy box does not write every poll) and
+ * the formatter (including the "never" case that started this).
+ */
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import { fmtLastSeen, noteBoxSeen, __resetLastSeenThrottle } from '../lastSeen.ts';
+
+test('fmtLastSeen: no contact reads "never", not a bogus age', () => {
+  assert.equal(fmtLastSeen(null), 'never');
+  assert.equal(fmtLastSeen(undefined), 'never');
+  assert.equal(fmtLastSeen(0), 'never'); // 0 is "never seen", not the epoch
+});
+
+test('fmtLastSeen: buckets seconds / minutes / hours', () => {
+  const now = Date.now();
+  assert.equal(fmtLastSeen(now - 5_000), '5s ago');
+  assert.equal(fmtLastSeen(now - 90_000), '1m ago');
+  assert.equal(fmtLastSeen(now - 45 * 60_000), '45m ago');
+  assert.equal(fmtLastSeen(now - (2 * 3600 + 5 * 60) * 1000), '2h 5m ago');
+});
+
+test('fmtLastSeen: a future timestamp (clock skew) reads "just now"', () => {
+  assert.equal(fmtLastSeen(Date.now() + 10_000), 'just now');
+});
+
+test('noteBoxSeen: persists the first contact, then throttles', () => {
+  __resetLastSeenThrottle();
+  const writes: number[] = [];
+  const persist = (ts: number) => writes.push(ts);
+
+  const t0 = 1_000_000_000_000;
+  noteBoxSeen('box-a', t0, persist);
+  assert.deepEqual(writes, [t0], 'first contact is persisted');
+
+  // A poll a few seconds later must NOT write (throttle window is 60s).
+  noteBoxSeen('box-a', t0 + 8_000, persist);
+  noteBoxSeen('box-a', t0 + 30_000, persist);
+  assert.deepEqual(writes, [t0], 'polls within the window are throttled');
+
+  // Past the window, it records the fresher time.
+  noteBoxSeen('box-a', t0 + 61_000, persist);
+  assert.deepEqual(writes, [t0, t0 + 61_000], 'a value >= 60s newer is persisted');
+});
+
+test('noteBoxSeen: throttle is per box, and a zero ts is ignored', () => {
+  __resetLastSeenThrottle();
+  const writes: Array<[string, number]> = [];
+  const persistFor = (key: string) => (ts: number) => writes.push([key, ts]);
+
+  const t = 2_000_000_000_000;
+  noteBoxSeen('box-a', t, persistFor('box-a'));
+  noteBoxSeen('box-b', t, persistFor('box-b')); // different box: not throttled by a's write
+  assert.deepEqual(writes, [['box-a', t], ['box-b', t]]);
+
+  // No contact to record.
+  noteBoxSeen('box-c', 0, persistFor('box-c'));
+  assert.deepEqual(writes.length, 2, 'a zero timestamp never persists');
+});

--- a/app/lib/lastSeen.ts
+++ b/app/lib/lastSeen.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-box "last seen" — persist the last time a box answered, and format an
+ * elapsed-time label. Shared by the Console unreachable banner and the Fleet
+ * tiles.
+ *
+ * WHY THIS EXISTS: usePoll's in-memory `lastSuccess` is null on a cold launch to
+ * an already-offline box and is CLEARED on every box switch (usePoll.ts:71), so
+ * the banner showed "last seen: never" for a box that had answered hundreds of
+ * times. Persisting a per-box timestamp (Box.lastSeen) and falling back to it
+ * gives an honest "last seen: 2h 4m ago" that survives app restarts and box
+ * switches.
+ */
+
+/**
+ * Only persist this often per box. A healthy box polls every few seconds and
+ * must not write storage on each tick; the banner reads this value only while
+ * the box is OFFLINE, so a value up to a minute stale is fine.
+ */
+const PERSIST_EVERY_MS = 60_000;
+
+/**
+ * Per-key timestamp of the value we last actually persisted. Module-level so the
+ * Console and Fleet writers share one throttle. Both write a MONOTONICALLY
+ * increasing timestamp and the guard below makes the write idempotent, so this
+ * cannot become the two-writer feedback loop that a mutable snapshot (e.g. caps)
+ * would — there is one right answer (now), and it only goes up.
+ */
+const lastPersisted = new Map<string, number>();
+
+/**
+ * Persist a box's last-reachable time, throttled per `key`. `persist` performs
+ * the actual box-scoped write (e.g. `update({ lastSeen: ts })`); it runs only
+ * when the value has advanced by at least PERSIST_EVERY_MS. A falsy/zero `ts` is
+ * ignored (there is no contact to record).
+ */
+export function noteBoxSeen(
+  key: string,
+  ts: number,
+  persist: (ts: number) => void,
+): void {
+  if (!ts) return;
+  const prev = lastPersisted.get(key) ?? 0;
+  if (ts - prev < PERSIST_EVERY_MS) return;
+  lastPersisted.set(key, ts);
+  persist(ts);
+}
+
+/** Clear the throttle memory. Test-only. */
+export function __resetLastSeenThrottle(): void {
+  lastPersisted.clear();
+}
+
+/**
+ * "never" / "40s ago" / "12m ago" / "3h 4m ago" — elapsed since `ts` (unix ms),
+ * or "never" when there is no known contact (null / undefined / 0). A `ts` in
+ * the future (clock skew) reads as "just now" rather than a negative age.
+ */
+export function fmtLastSeen(ts: number | null | undefined): string {
+  if (!ts) return 'never';
+  const s = Math.round((Date.now() - ts) / 1000);
+  if (s < 0) return 'just now';
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ${m % 60}m ago`;
+}

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -55,6 +55,14 @@ export type Box = {
    * poll. Undefined until first learned / on older agents.
    */
   caps?: BoxCaps;
+  /**
+   * Unix ms the app last reached this box (learned from a successful status
+   * poll while reachable, throttled). Persisted so the unreachable banner and
+   * the Fleet tile can show a real "last seen" after an app restart or box
+   * switch, instead of "never" — usePoll's in-memory lastSuccess survives
+   * neither. See lib/lastSeen.ts.
+   */
+  lastSeen?: number;
 };
 
 /**
@@ -74,6 +82,8 @@ export type Settings = {
   volumeTarget?: 'box' | 'tv';
   /** Capability summary of the active box (see Box.caps). */
   caps?: BoxCaps;
+  /** Unix ms the active box was last reached (see Box.lastSeen). */
+  lastSeen?: number;
 };
 
 /** Safe placeholder used when no box is active (nothing paired yet). */
@@ -308,9 +318,13 @@ function normalizeBox(raw: unknown): Box | null {
   const mac = normalizeMac(o.mac) ?? undefined;
   const volumeTarget = normalizeVolumeTarget(o.volumeTarget);
   const caps = normalizeCaps(o.caps);
+  const lastSeen =
+    typeof o.lastSeen === 'number' && Number.isFinite(o.lastSeen) && o.lastSeen > 0
+      ? o.lastSeen
+      : undefined;
   return {
     id, name, host, port, token, padMode: normalizePadMode(o.padMode),
-    lastIp, mac, volumeTarget, caps,
+    lastIp, mac, volumeTarget, caps, lastSeen,
   };
 }
 
@@ -401,6 +415,7 @@ export function activeSettings(state: BoxesState): Settings {
     mac: active.mac,
     volumeTarget: active.volumeTarget,
     caps: active.caps,
+    lastSeen: active.lastSeen,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -172,25 +172,28 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
-### Couch Mode: resolve the box's REAL gamescope session filename (autologin write path)
+### Couch Mode gamescope-session filename fix — DONE in code, pending on-hardware confirm
 - **priority:** P2 · **risk:** medium (touches the safety-critical session-select / autologin
-  write — the stranding failure mode) · **affects:** agent · **depends_on:** —
+  write — the stranding failure mode) · **affects:** agent · **branch:**
+  `claude/couchmode-gamescope-session-detect`
 - **Why:** the agent hardcoded `GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"`. A Legion
   Go S (SteamOS 3.8.16, owner box 10.1.1.195, 2026-08-10) ships the Game Mode session as
   `gamescope-wayland.desktop`, so `_couchmode_platform_ok()` refused a box literally in Game
   Mode and the app showed the Big Picture fallback instead of the Game Mode couch button.
-- **DETECTION already fixed** on `claude/couchmode-gamescope-session-detect`: a
-  `_GAMESCOPE_SESSION_FILES` set the gate accepts, with a Legion Go S fixture + control in
-  `tests/test_couchmode_gate.py`. That restores `couchmode:true` / `bigpicture:false`.
-- **What's left — the WRITE half.** `GAMESCOPE_SESSION_FILE` is still the single name written
-  into the autologin drop-in and read for its `Exec=` (couchsided.py ~4660/4793/4967/5004/
-  5026/5124), so on this image the persistent "Boots into Game Mode" autologin writes a
-  session name the box does not have. `_write_autologin` refuses a missing session, so it
-  degrades closed (the feature no-ops) rather than stranding — but it is still broken here.
-  Fix: resolve the installed gamescope session from `_installed_session_files()` (accept any
-  `_GAMESCOPE_SESSION_FILES`) and thread the resolved value through the write/read sites and
-  the `target == GAMESCOPE_SESSION_FILE` "game vs desktop" comparisons; degrade closed if none
-  found. Needs the session-lifecycle test (§6) and a confirm on the owner's Legion Go S.
+- **DETECTION — DONE.** A `_GAMESCOPE_SESSION_FILES` set the gate accepts, restoring
+  `couchmode:true` / `bigpicture:false`. Legion Go S fixture + control in
+  `tests/test_couchmode_gate.py`.
+- **WRITE PATH — DONE.** New `_gamescope_session_for_autologin()` (the Game-Mode mirror of
+  `_desktop_session_for_autologin()`) resolves the box's real gamescope session name and is
+  threaded through `session_default_arm` / `session_default_set` / `session_default_get` /
+  `_migrate_dropin_into_config`; the steamosctl arg now derives from `mode`, not `target`, so a
+  resolved `gamescope-wayland` name can't mislabel a request. Degrades closed (refuses) when no
+  gamescope session is installed. Coverage in `tests/test_session_default.py` (resolver +
+  arm-writes-the-real-name + read-back + steamosctl arg).
+- **OPEN — on-hardware confirm (§11).** Not yet run on the actual Legion Go S. Fixtures are
+  verbatim from the box's real `ls`, but the box itself is the remaining check: `/api/displays`
+  returns 200 with `session:gamescope`, caps show `couchmode:true` / `bigpicture:false`, and
+  "Boots into Game Mode" persists across a reboot.
 
 ### Game backlog — "Now playing" + "Up next" queue (owner ask 2026-08-09)
 - **priority:** P2 · **risk:** low (app-only, additive; no agent change to start) ·

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -172,29 +172,6 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
-### Couch Mode gamescope-session filename fix — DONE in code, pending on-hardware confirm
-- **priority:** P2 · **risk:** medium (touches the safety-critical session-select / autologin
-  write — the stranding failure mode) · **affects:** agent · **branch:**
-  `claude/couchmode-gamescope-session-detect`
-- **Why:** the agent hardcoded `GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"`. A Legion
-  Go S (SteamOS 3.8.16, owner box 10.1.1.195, 2026-08-10) ships the Game Mode session as
-  `gamescope-wayland.desktop`, so `_couchmode_platform_ok()` refused a box literally in Game
-  Mode and the app showed the Big Picture fallback instead of the Game Mode couch button.
-- **DETECTION — DONE.** A `_GAMESCOPE_SESSION_FILES` set the gate accepts, restoring
-  `couchmode:true` / `bigpicture:false`. Legion Go S fixture + control in
-  `tests/test_couchmode_gate.py`.
-- **WRITE PATH — DONE.** New `_gamescope_session_for_autologin()` (the Game-Mode mirror of
-  `_desktop_session_for_autologin()`) resolves the box's real gamescope session name and is
-  threaded through `session_default_arm` / `session_default_set` / `session_default_get` /
-  `_migrate_dropin_into_config`; the steamosctl arg now derives from `mode`, not `target`, so a
-  resolved `gamescope-wayland` name can't mislabel a request. Degrades closed (refuses) when no
-  gamescope session is installed. Coverage in `tests/test_session_default.py` (resolver +
-  arm-writes-the-real-name + read-back + steamosctl arg).
-- **OPEN — on-hardware confirm (§11).** Not yet run on the actual Legion Go S. Fixtures are
-  verbatim from the box's real `ls`, but the box itself is the remaining check: `/api/displays`
-  returns 200 with `session:gamescope`, caps show `couchmode:true` / `bigpicture:false`, and
-  "Boots into Game Mode" persists across a reboot.
-
 ### Game backlog — "Now playing" + "Up next" queue (owner ask 2026-08-09)
 - **priority:** P2 · **risk:** low (app-only, additive; no agent change to start) ·
   **affects:** app only · **depends_on:** nothing (extends the existing Bookmark store)
@@ -968,6 +945,26 @@ recommendation was wrong, not merely superseded.
 ---
 
 ## ✅ Completed
+
+### Couch Mode gamescope-session filename fix — VERIFIED on hardware 2026-08-10 (Legion Go S)
+- **was:** P2 (owner-reported 2026-08-10) · **affects:** agent · **branch/PR:**
+  `claude/couchmode-gamescope-session-detect` → #432
+- **The bug:** the agent hardcoded `GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"`; a
+  Legion Go S (SteamOS 3.8.16, 10.1.1.195) ships the Game Mode session as
+  `gamescope-wayland.desktop`, so `_couchmode_platform_ok()` refused a box literally in Game
+  Mode → `couchmode:false` → `bigpicture:true` → the app showed a Big Picture button instead of
+  the Game Mode couch control. Diagnosed live: `/api/displays` 404, caps
+  `couchmode:false`/`bigpicture:true`, session files carried the wayland name; tools + outputs
+  passed. (Also surfaced that caps are a boot-time snapshot — a restart re-runs `set_caps`.)
+- **Detection:** `_GAMESCOPE_SESSION_FILES` set the gate accepts (Legion Go S fixture + control
+  in `tests/test_couchmode_gate.py`).
+- **Write path:** new `_gamescope_session_for_autologin()` (mirror of
+  `_desktop_session_for_autologin()`) resolves the box's real gamescope session name, threaded
+  through `session_default_arm`/`set`/`get`/`_migrate_dropin_into_config`; the steamosctl arg
+  derives from `mode`, not `target`, so a resolved wayland name can't mislabel a request.
+  Degrades closed. Coverage in `tests/test_session_default.py`.
+- **HARDWARE-VERIFIED (owner, 2026-08-10):** on the real Legion Go S the Game Mode button now
+  shows correctly and session switching works.
 
 ### Install a game you own but have not downloaded — BUILT 2026-08-08 (agent 2.9.73 + app)
 - **was:** P2 Planned (owner ask 2026-08-07) · **affects:** agent + app · the design record

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -172,6 +172,26 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### Couch Mode: resolve the box's REAL gamescope session filename (autologin write path)
+- **priority:** P2 · **risk:** medium (touches the safety-critical session-select / autologin
+  write — the stranding failure mode) · **affects:** agent · **depends_on:** —
+- **Why:** the agent hardcoded `GAMESCOPE_SESSION_FILE = "gamescope-session.desktop"`. A Legion
+  Go S (SteamOS 3.8.16, owner box 10.1.1.195, 2026-08-10) ships the Game Mode session as
+  `gamescope-wayland.desktop`, so `_couchmode_platform_ok()` refused a box literally in Game
+  Mode and the app showed the Big Picture fallback instead of the Game Mode couch button.
+- **DETECTION already fixed** on `claude/couchmode-gamescope-session-detect`: a
+  `_GAMESCOPE_SESSION_FILES` set the gate accepts, with a Legion Go S fixture + control in
+  `tests/test_couchmode_gate.py`. That restores `couchmode:true` / `bigpicture:false`.
+- **What's left — the WRITE half.** `GAMESCOPE_SESSION_FILE` is still the single name written
+  into the autologin drop-in and read for its `Exec=` (couchsided.py ~4660/4793/4967/5004/
+  5026/5124), so on this image the persistent "Boots into Game Mode" autologin writes a
+  session name the box does not have. `_write_autologin` refuses a missing session, so it
+  degrades closed (the feature no-ops) rather than stranding — but it is still broken here.
+  Fix: resolve the installed gamescope session from `_installed_session_files()` (accept any
+  `_GAMESCOPE_SESSION_FILES`) and thread the resolved value through the write/read sites and
+  the `target == GAMESCOPE_SESSION_FILE` "game vs desktop" comparisons; degrade closed if none
+  found. Needs the session-lifecycle test (§6) and a confirm on the owner's Legion Go S.
+
 ### Game backlog — "Now playing" + "Up next" queue (owner ask 2026-08-09)
 - **priority:** P2 · **risk:** low (app-only, additive; no agent change to start) ·
   **affects:** app only · **depends_on:** nothing (extends the existing Bookmark store)

--- a/tests/test_couchmode_gate.py
+++ b/tests/test_couchmode_gate.py
@@ -70,6 +70,10 @@ BAZZITE = ["gamescope-session.desktop", "gamescope-session-steam.desktop",
            "plasma.desktop", "plasma-steamos-wayland-oneshot.desktop",
            "plasma-steamos-oneshot.desktop"]                       # 10.1.1.60
 STEAMOS = ["gamescope-session.desktop", "plasma.desktop", "plasmax11.desktop"]
+# Legion Go S, SteamOS 3.8.16 (owner box 10.1.1.195, 2026-08-10). Same plasma
+# sessions as STEAMOS, but the gamescope session ships as gamescope-WAYLAND
+# .desktop — the single hardcoded name refused it while it sat in Game Mode.
+LEGIONGOS = ["gamescope-wayland.desktop", "plasma.desktop", "plasmax11.desktop"]
 # Bazzite publishes GNOME variants too, and they carry "bazzite" in os-release
 # so the OLD gate said yes to them. Plasma is absent; the desktop cluster must
 # NOT depend on it (see _desktop_session_installed).
@@ -105,6 +109,21 @@ def main():
                   cs.couchmode_available(), True)
             check("%-16s offers the desktop cluster (in the desktop)" % label,
                   cs.desktop_available(), True)
+
+        print()
+        print("a gamescope session under a DIFFERENT filename still counts")
+        # Legion Go S, SteamOS 3.8.16 (owner box 10.1.1.195): ships
+        # gamescope-wayland.desktop, not gamescope-session.desktop. The old
+        # single-name gate refused it, so a box literally in Game Mode was shown
+        # the Big Picture fallback. Both states with a control, per §11.2/§11.3.
+        dirs.append(setup(LEGIONGOS))
+        check("legion go s (gamescope-wayland) offers Couch Mode",
+              cs.couchmode_available(), True)
+        check("legion go s offers the desktop cluster (in the desktop)",
+              cs.desktop_available(), True)
+        dirs.append(setup(["gamescope-wayland.desktop"]))
+        check("gamescope-wayland but NO desktop session -> refused (control)",
+              cs.couchmode_available(), False)
 
         print()
         print("...and it is the SESSIONS that decide, not the distro name")

--- a/tests/test_session_default.py
+++ b/tests/test_session_default.py
@@ -397,6 +397,144 @@ def test_boot_preference_is_armed_only_while_the_box_is_off(tmp):
          cs._DM_STATE_FILES, cs._arm_hook_installed) = real
 
 
+def test_gamescope_session_resolver():
+    """_gamescope_session_for_autologin() picks the gamescope session the box
+    ACTUALLY ships, the Game-Mode mirror of _desktop_session_for_autologin.
+
+    Legion Go S, SteamOS 3.8.16 (owner box 10.1.1.195, 2026-08-10) ships the
+    Game Mode session as gamescope-WAYLAND.desktop, not gamescope-session.desktop
+    — the single hardcoded name refused Couch Mode and would have written an
+    autologin entry the box does not have. Degrade closed (None) when neither is
+    installed or the dirs cannot be read. Both states with controls (§11.2/3)."""
+    print("test_gamescope_session_resolver")
+    saved = cs._installed_session_files
+    try:
+        cs._installed_session_files = lambda: {"gamescope-session.desktop",
+                                               "plasma.desktop"}
+        check("picks gamescope-session when that is installed",
+              cs._gamescope_session_for_autologin(), "gamescope-session.desktop")
+        cs._installed_session_files = lambda: {"gamescope-wayland.desktop",
+                                               "plasma.desktop", "plasmax11.desktop"}
+        check("picks gamescope-wayland when THAT is installed (Legion Go S)",
+              cs._gamescope_session_for_autologin(), "gamescope-wayland.desktop")
+        cs._installed_session_files = lambda: {"plasma.desktop"}
+        check("no gamescope session at all -> None (refuse, do not guess)",
+              cs._gamescope_session_for_autologin(), None)
+        cs._installed_session_files = lambda: set()
+        check("cannot enumerate -> None (refuse)",
+              cs._gamescope_session_for_autologin(), None)
+    finally:
+        cs._installed_session_files = saved
+
+
+def test_gamescope_wayland_write_and_read(tmp):
+    """The WRITE half of the Legion Go S fix. A box that ships the Game Mode
+    session as gamescope-wayland.desktop must have THAT name armed into its
+    autologin drop-in (writing gamescope-session.desktop would strand it), and
+    the getter must read it back as 'game'. Both directions + a refuse control."""
+    print("test_gamescope_wayland_write_and_read")
+    real = (cs.subprocess.run, cs._sudo_nopasswd_allows, cs.detect_display_manager,
+            cs._installed_session_files, cs.CONFIG_PATH, cs._DM_CONF_DIRS,
+            cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS, cs._DM_STATE_FILES,
+            cs._arm_hook_installed)
+    try:
+        confdir = os.path.join(tmp, "sddm.conf.d")
+        os.makedirs(confdir, exist_ok=True)
+        cs._DM_CONF_DIRS = {"sddm": confdir, "plasmalogin": confdir}
+        cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS, cs._DM_STATE_FILES = {}, {}, {}
+        cs.CONFIG_PATH = os.path.join(tmp, "config.json")
+        with open(cs.CONFIG_PATH, "w") as f:
+            f.write('{"units": []}')
+        cs._sudo_nopasswd_allows = lambda needle: True
+        cs._arm_hook_installed = lambda: True
+        cs.detect_display_manager = lambda: "sddm"
+        # Legion Go S session set: gamescope under the WAYLAND name.
+        cs._installed_session_files = lambda: {"gamescope-wayland.desktop",
+                                               "plasma.desktop", "plasmax11.desktop"}
+        dropin = cs._dm_dropin("sddm")
+
+        def fake_run(argv, **kw):
+            class R:
+                pass
+            r = R()
+            r.returncode, r.stdout, r.stderr = 0, "", ""
+            if argv[:3] == ["sudo", "-n", "tee"]:
+                with open(argv[3], "w") as fh:
+                    fh.write(kw.get("input", ""))
+            elif argv[:1] == ["steamosctl"]:
+                r.stderr = "Error: UnknownInterface"  # force the sddm backend
+            return r
+        cs.subprocess.run = fake_run
+
+        check("set('game') succeeds on a gamescope-wayland box",
+              cs.session_default_set("game")["ok"], True)
+        cs.session_default_arm()
+        check("arm writes the box's REAL gamescope name, not the hardcoded one",
+              cs._last_session_line(dropin), "gamescope-wayland.desktop")
+        # Force the name-read path (pref 'last', not 'game') so this exercises the
+        # filename->mode mapping, not the stored preference short-circuit.
+        with cs.CONFIG_LOCK:
+            cs._config_set_field(cs.SESSION_DEFAULT_CONFIG_KEY, "last")
+        check("get maps a gamescope-wayland record back to 'game'",
+              cs.session_default_get()["mode"], "game")
+        # CONTROL: a box with NO gamescope session refuses to arm rather than
+        # writing a name it does not have (the stranding guard, one layer up).
+        cs._installed_session_files = lambda: {"plasma.desktop"}
+        with cs.CONFIG_LOCK:
+            cs._config_set_field(cs.SESSION_DEFAULT_CONFIG_KEY, "game")
+        with open(dropin, "w") as f:
+            f.write("")
+        cs.session_default_arm()
+        check("arm refuses (writes nothing) when no gamescope session exists",
+              cs._last_session_line(dropin), "")
+    finally:
+        (cs.subprocess.run, cs._sudo_nopasswd_allows, cs.detect_display_manager,
+         cs._installed_session_files, cs.CONFIG_PATH, cs._DM_CONF_DIRS,
+         cs._DM_SYS_CONF_DIRS, cs._DM_MAIN_CONFS, cs._DM_STATE_FILES,
+         cs._arm_hook_installed) = real
+
+
+def test_steamosctl_set_uses_mode_arg(tmp):
+    """set('game') on a steamosctl box sends the 'game' arg — pins the
+    arg-from-mode refactor. The old code derived the arg from
+    target == GAMESCOPE_SESSION_FILE; once target resolves to
+    gamescope-wayland.desktop that comparison is False, so it would have sent
+    'desktop' for a 'game' request. Deriving from `mode` is immune."""
+    print("test_steamosctl_set_uses_mode_arg")
+    real = (cs.subprocess.run, cs.session_default_backend, cs.session_default_get,
+            cs.CONFIG_PATH, cs._installed_session_files)
+    try:
+        cs.CONFIG_PATH = os.path.join(tmp, "config.json")
+        with open(cs.CONFIG_PATH, "w") as f:
+            f.write('{"units": []}')
+        cs.session_default_backend = lambda: "steamosctl"
+        # A wayland-named box: target resolves to gamescope-wayland.desktop, which
+        # the OLD arg-from-target logic would have mislabelled 'desktop'.
+        cs._installed_session_files = lambda: {"gamescope-wayland.desktop",
+                                               "plasma.desktop"}
+        calls = []
+
+        def fake_run(argv, **kw):
+            calls.append(list(argv))
+
+            class R:
+                pass
+            r = R()
+            r.returncode, r.stdout, r.stderr = 0, "", ""
+            return r
+        cs.subprocess.run = fake_run
+        cs.session_default_get = lambda: {"mode": "game"}  # readback verification
+        r = cs.session_default_set("game")
+        sent = [c for c in calls if c[:1] == ["steamosctl"]]
+        check("steamosctl set('game') sends the 'game' arg (not 'desktop')",
+              bool(sent) and sent[-1] == ["steamosctl", "set-default-login-mode", "game"],
+              True)
+        check("...and set() reports ok", r["ok"], True)
+    finally:
+        (cs.subprocess.run, cs.session_default_backend, cs.session_default_get,
+         cs.CONFIG_PATH, cs._installed_session_files) = real
+
+
 def main():
     real_run = cs.subprocess.run
     real_sudo = cs._sudo_nopasswd_allows
@@ -547,6 +685,17 @@ def main():
     finally:
         import shutil
         shutil.rmtree(_t, ignore_errors=True)
+
+    print()
+    print("gamescope session filename varies by image (Legion Go S / SteamOS 3.8)")
+    test_gamescope_session_resolver()
+    _g = tempfile.mkdtemp()
+    try:
+        test_gamescope_wayland_write_and_read(_g)
+        test_steamosctl_set_uses_mode_arg(_g)
+    finally:
+        import shutil
+        shutil.rmtree(_g, ignore_errors=True)
 
     print("the drop-in body (both conf-dir managers)")
     written = {}


### PR DESCRIPTION
> **This PR contains two independent fixes**, both surfaced while testing on a Legion Go S (SteamOS 3.8.16): (1) the Couch Mode `gamescope-session` detection + write-path fix, and (2) the unreachable banner's false "last seen: never".

---

# Fix 1 — Couch Mode showed Big Picture instead of Game Mode

A Steam Deck / Legion Go S sitting **in Game Mode** showed a **Big Picture** button in the app header instead of **Game Mode**. Root cause: the agent hardcoded the gamescope session filename as `gamescope-session.desktop`, but some SteamOS builds (Legion Go S, SteamOS 3.8.16) ship it as `gamescope-wayland.desktop`. `_couchmode_platform_ok()` therefore refused a box that was literally in Game Mode → `couchmode:false` → `bigpicture:true` (its *exclusive* fallback) → the Big Picture button.

Diagnosed live on the owner's box (`10.1.1.195`):

```
/api/displays -> {"error":"not found"}        (couchmode_available() == False)
caps          -> couchmode:false, bigpicture:true
session files -> gamescope-wayland.desktop, plasma.desktop, plasmax11.desktop
tools + outputs -> all present (not the failing gate)
```

**Commits**
1. **Detection** (`58a796a`) — `_couchmode_platform_ok()` accepts any name in a new `_GAMESCOPE_SESSION_FILES` set. Restores `couchmode:true` / `bigpicture:false`. Legion Go S fixture + control in `tests/test_couchmode_gate.py`.
2. **Write path** (`8c0a19b`) — `GAMESCOPE_SESSION_FILE` was also written into the autologin drop-in and read back for its mode. New `_gamescope_session_for_autologin()` (mirror of `_desktop_session_for_autologin()`) resolves the box's real name, threaded through `session_default_arm`/`set`/`get`/`_migrate_dropin_into_config`; the steamosctl arg now derives from `mode`, not `target`, so a resolved `gamescope-wayland` name can't mislabel a request. Degrades **closed**. Coverage in `tests/test_session_default.py`.

**Safety (CLAUDE.md §3):** no new client input reaches a command/path — the name is matched against a frozen set and the box's own `_installed_session_files()`, never interpolated. Write path refuses when no gamescope session exists (preserves `_dm_write`'s stranding guard). steamosctl/greetd paths preserved.

**Verified on hardware ✅** — owner confirmed on the real Legion Go S (2026-08-10): Game Mode button shows correctly and Couch Mode session switching works.

---

# Fix 2 — unreachable banner "last seen: never" (commit `320cb90`)

The **BOX UNREACHABLE** banner showed **"last seen: never"** for a box reached many times. It read usePoll's `lastSuccess`, which is in-memory only — `null` on a cold launch to an already-offline box and cleared on every box switch (`usePoll.ts:71`) — so opening the app to a sleeping box always claimed it had never been seen.

- New persisted per-box `Box.lastSeen`, learned from a successful status poll while reachable, **throttled to once/min** so a healthy box doesn't write storage every tick (`lib/lastSeen.ts`).
- The banner falls back to it (`status.lastSuccess ?? settings.lastSeen`); the Fleet DOWN tiles do the same (`entry.lastSuccess ?? box.lastSeen`). "Last seen" now survives app restarts and box switches.
- `fmtLastSeen` (previously duplicated in `index.tsx` and `fleet.tsx`) is now shared from `lib/lastSeen.ts`, with a "just now" guard for clock skew.

**Testing:** `lib/__tests__/lastSeen.test.ts` — the throttle persists first contact then holds 60s, is per-box, ignores a zero ts; `fmtLastSeen` buckets never/seconds/minutes/hours. Full app unit suite green (**449** tests). `lastSeen.ts` passes `tsc --strict` standalone; the cross-file field additions mirror the existing `lastIp`/`caps` persistence and are covered by CI's `tsc -p app`.

**Not yet re-verified on-device** (no app build in this environment) — the persistence + formatting logic is unit-tested; the rendered banner is the remaining check, same posture as Fix 1's hardware confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015gwg6hQgu7M6qtXGCJj4Gq