### PR TITLE
feat(app): remote-desktop P1 — fullscreen control from the screen viewer

### DIFF
--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -1,0 +1,203 @@
+/**
+ * Desktop control — a fullscreen remote-desktop surface (P1 of the remote-desktop
+ * project; see docs/memory/project_remote-desktop.md). Reached from the Console
+ * screen viewer's "Control" button.
+ *
+ * The live screen frame fills the view; a transparent trackpad overlay on top
+ * drives the desktop pointer over the SAME /ws/gamepad input path the Pad uses
+ * (relative mouse — proven + already low-latency). This is "confirm-by-frame"
+ * control at ~1.4fps, not fluid video (that is the opt-in P4 streaming module).
+ *
+ * It owns its OWN GamepadClient for the duration of the screen: connect +
+ * requestControl on mount, releaseAll + close on unmount. `noPad:true` — this
+ * surface needs mouse/keyboard only, never a virtual gamepad, so there is no
+ * d-pad axis to strand (the Pad's releaseAll-on-surface-change dance does not
+ * apply here; the trackpad releases its own left button on pointer-up).
+ *
+ * LAPTOP layout (portrait — only the Pad may allow landscape, a guarded
+ * invariant): the screen frame sits on top, a dedicated trackpad zone drives the
+ * pointer below it, and a button bar is at the bottom. Watching the screen while
+ * trackpadding beneath it beats trackpadding on a tiny letterboxed frame, and it
+ * keeps the relative-mouse model honest (tap-a-spot-on-the-frame is P2/absolute).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Stack, router } from 'expo-router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  ActivityIndicator, Image, Pressable, StyleSheet, Text, View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useLockOrientation } from '@/hooks/useLockOrientation';
+import { useScreenFrame } from '@/hooks/useScreenFrame';
+import { useTrackpad } from '@/hooks/useTrackpad';
+import { GamepadClient, type GamepadStatus } from '@/lib/gamepad';
+import { hapticLight, hapticMedium } from '@/lib/haptics';
+import { setImmersive } from '@/lib/immersive';
+import { useSettings } from '@/lib/SettingsContext';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+const FRAME_MS = 700;
+const DEVICE_LABEL = 'Couchside Desktop';
+
+export default function DesktopControlScreen() {
+  useLockOrientation('portrait'); // laptop layout; only the Pad may allow landscape
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const insets = useSafeAreaInsets();
+  const { settings, ready } = useSettings();
+  const configured = settings.host.trim().length > 0;
+  const { frame, failed } = useScreenFrame(settings, ready && configured, FRAME_MS);
+
+  const clientRef = useRef<GamepadClient | null>(null);
+  if (clientRef.current == null) clientRef.current = new GamepadClient();
+  const client = clientRef.current;
+  const [status, setStatus] = useState<GamepadStatus>('connecting');
+  const connectedOnce = useRef(false);
+
+  // Lifecycle: immersive + status subscription + teardown. Runs for the life of
+  // the screen regardless of when (or whether) the box is reachable.
+  useEffect(() => {
+    setImmersive(true);
+    client.onStatus((s) => setStatus(s));
+    return () => {
+      client.onStatus(null);
+      // Release the MOUSE buttons explicitly before closing: releaseAll() covers
+      // the pad (buttons/sticks) but NOT the pointer (see GamepadClient), and an
+      // unmount mid double-tap-drag fires no onDragEnd — a left button left down
+      // turns every later move into a drag ("the mouse does nothing"). Sent while
+      // the socket is still open; no-ops if nothing is held.
+      client.sendMouseButton('l', 0);
+      client.sendMouseButton('r', 0);
+      client.sendMouseButton('m', 0);
+      client.close(); // close() also releaseAll()s the pad + tears the socket down
+      setImmersive(false);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Connect ONCE settings have hydrated. Gating on ready && configured avoids
+  // connecting with EMPTY_SETTINGS (which errors permanently with no retry) when
+  // this route somehow mounts before the box store loads; the ref makes it fire
+  // exactly once, never reconnecting on background settings churn.
+  useEffect(() => {
+    if (!ready || !configured || connectedOnce.current) return;
+    connectedOnce.current = true;
+    client.connect(settings, { handoffAsk: false, deviceName: DEVICE_LABEL, noPad: true });
+    client.requestControl();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ready, configured]);
+
+  const leftClick = useCallback(() => {
+    hapticLight();
+    client.sendMouseButton('l', 1);
+    setTimeout(() => client.sendMouseButton('l', 0), 40);
+  }, [client]);
+  const rightClick = useCallback(() => {
+    hapticLight();
+    client.sendMouseButton('r', 1);
+    setTimeout(() => client.sendMouseButton('r', 0), 40);
+  }, [client]);
+
+  const pad = useTrackpad({
+    onMove: (dx, dy) => client.sendMouseMove(dx, dy),
+    onLeftClick: leftClick,
+    onRightClick: rightClick,
+    onScroll: (notches) => client.sendWheel(notches),
+    onDragStart: () => { hapticLight(); client.sendMouseButton('l', 1); },
+    onDragEnd: () => client.sendMouseButton('l', 0),
+  });
+
+  const exit = useCallback(() => { hapticMedium(); router.back(); }, []);
+
+  return (
+    <View style={[styles.root, { paddingTop: insets.top }]}>
+      <Stack.Screen options={{ headerShown: false }} />
+      {/* SCREEN (top): the live desktop frame */}
+      <View style={styles.stage}>
+        {frame ? (
+          <Image source={{ uri: frame }} style={StyleSheet.absoluteFill} resizeMode="contain" />
+        ) : (
+          <View style={[StyleSheet.absoluteFill, styles.center]}>
+            <ActivityIndicator color={t.textDim} />
+            <Text style={styles.dim}>
+              {!configured ? 'Connect a box first.' : 'Waiting for the screen…'}
+            </Text>
+          </View>
+        )}
+        {status !== 'connected' && (
+          <View style={[styles.pill, { top: 6 }]} pointerEvents="none">
+            <Text style={styles.pillText}>
+              {status === 'released' || status === 'waiting' ? 'no control — reopen' : status}
+            </Text>
+          </View>
+        )}
+        {failed && status === 'connected' && (
+          <View style={[styles.pill, { top: 6 }]} pointerEvents="none">
+            <Text style={styles.pillText}>screen unavailable</Text>
+          </View>
+        )}
+      </View>
+
+      {/* TRACKPAD (middle): the touch surface that drives the pointer */}
+      <View style={styles.trackpad} {...pad.panHandlers} accessibilityLabel="Desktop trackpad">
+        <Ionicons name="move-outline" size={22} color={t.textFaint} />
+        <Text style={styles.trackpadHint}>drag to move · tap to click · two-finger scroll</Text>
+      </View>
+
+      <View style={[styles.bar, { paddingBottom: insets.bottom + 8 }]}>
+        <BarBtn t={t} styles={styles} icon="close" label="Exit" onPress={exit} />
+        <BarBtn t={t} styles={styles} icon="radio-button-on" label="Left" onPress={leftClick} />
+        <BarBtn t={t} styles={styles} icon="ellipsis-horizontal" label="Right" onPress={rightClick} />
+        <BarBtn t={t} styles={styles} icon="apps" label="Start"
+          onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+        <BarBtn t={t} styles={styles} icon="arrow-undo" label="Esc"
+          onPress={() => { hapticLight(); client.sendKey('esc'); }} />
+      </View>
+    </View>
+  );
+}
+
+function BarBtn({
+  t, styles, icon, label, onPress,
+}: {
+  t: Palette; styles: ReturnType<typeof makeStyles>; icon: keyof typeof Ionicons.glyphMap;
+  label: string; onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={({ pressed }) => [styles.barBtn, pressed && { opacity: 0.6 }]}>
+      <Ionicons name={icon} size={20} color={t.text} />
+      <Text style={styles.barLabel}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    root: { flex: 1, backgroundColor: t.bg },
+    stage: { width: '100%', aspectRatio: 16 / 9, backgroundColor: '#000', overflow: 'hidden' },
+    center: { alignItems: 'center', justifyContent: 'center', gap: 10 },
+    dim: { color: t.textDim, fontSize: 13 },
+    trackpad: {
+      flex: 1, margin: 12, borderRadius: 16,
+      borderWidth: 1, borderColor: t.cardBorder, borderStyle: 'dashed',
+      backgroundColor: t.card, alignItems: 'center', justifyContent: 'center', gap: 8,
+    },
+    trackpadHint: { color: t.textFaint, fontSize: 12 },
+    pill: {
+      position: 'absolute', right: 10,
+      backgroundColor: t.redDeep, borderColor: t.red, borderWidth: 1,
+      paddingHorizontal: 10, paddingVertical: 4, borderRadius: 8,
+    },
+    pillText: { color: t.onRedDeep, fontSize: 11, fontWeight: '700' },
+    bar: {
+      flexDirection: 'row', justifyContent: 'space-around', alignItems: 'center',
+      paddingTop: 8, backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+    },
+    barBtn: { alignItems: 'center', justifyContent: 'center', gap: 3, paddingHorizontal: 10, paddingVertical: 4, minWidth: 56 },
+    barLabel: { color: t.textDim, fontSize: 11, fontWeight: '600' },
+  });

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -7,7 +7,7 @@
  * blurs or the app backgrounds. Tap the frame for a fullscreen modal.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { useFocusEffect } from 'expo-router';
+import { router, useFocusEffect } from 'expo-router';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { AppState, AppStateStatus, Image, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 
@@ -155,18 +155,28 @@ export function ScreenPreview() {
       <View style={styles.header}>
         <Text style={styles.title}>SCREEN</Text>
         {supported && (
-          <Pressable
-            onPress={toggle}
-            style={({ pressed }) => [styles.pill, active && styles.pillOn, pressed && styles.pressed]}>
-            <Ionicons
-              name={active ? 'stop' : 'play'}
-              size={12}
-              color={active ? t.bg : t.green}
-            />
-            <Text style={[styles.pillText, active && styles.pillTextOn]}>
-              {active ? 'STOP' : 'START PREVIEW'}
-            </Text>
-          </Pressable>
+          <View style={styles.headerBtns}>
+            <Pressable
+              onPress={() => { hapticLight(); router.push('/desktop'); }}
+              accessibilityRole="button"
+              accessibilityLabel="Control the desktop"
+              style={({ pressed }) => [styles.pill, pressed && styles.pressed]}>
+              <Ionicons name="game-controller-outline" size={12} color={t.blue} />
+              <Text style={styles.pillText}>CONTROL</Text>
+            </Pressable>
+            <Pressable
+              onPress={toggle}
+              style={({ pressed }) => [styles.pill, active && styles.pillOn, pressed && styles.pressed]}>
+              <Ionicons
+                name={active ? 'stop' : 'play'}
+                size={12}
+                color={active ? t.bg : t.green}
+              />
+              <Text style={[styles.pillText, active && styles.pillTextOn]}>
+                {active ? 'STOP' : 'START PREVIEW'}
+              </Text>
+            </Pressable>
+          </View>
         )}
       </View>
 
@@ -223,6 +233,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     marginBottom: 10,
   },
   header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+  headerBtns: { flexDirection: 'row', alignItems: 'center', gap: 8 },
   title: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono },
   pill: {
     flexDirection: 'row',

--- a/app/hooks/useScreenFrame.ts
+++ b/app/hooks/useScreenFrame.ts
@@ -1,0 +1,70 @@
+/**
+ * Poll the box's screen as a stream of JPEG data-URIs. Extracted from
+ * ScreenPreview so the fullscreen desktop-control route can reuse the exact
+ * same self-rescheduling loop (a fixed setInterval would stack fetches when a
+ * capture runs long — the box floor is ~2/s and a capture can take ~1.4s).
+ *
+ * A generation token cancels the in-flight chain on unmount / dep change, and
+ * a fetch that resolves after being superseded is dropped. Degrades to
+ * `failed=true` (never a stale-but-confident frame) — the caller decides how
+ * loud to be about it.
+ */
+import { useEffect, useRef, useState } from 'react';
+
+import { screenFrameSource, type ConnSettings } from '@/lib/api';
+
+/** Hard deadline per frame fetch. A capture can take ~1.4s; this only fires on a
+ *  genuinely wedged request (e.g. Android hanging on a `.local` mDNS lookup,
+ *  which can even ignore abort — hence the race below, mirroring api.ts attempt()). */
+const FRAME_TIMEOUT_MS = 5000;
+
+export function useScreenFrame(settings: ConnSettings, active: boolean, intervalMs: number) {
+  const [frame, setFrame] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [lastGood, setLastGood] = useState<number | null>(null);
+  const genRef = useRef(0);
+
+  useEffect(() => {
+    if (!active) {
+      genRef.current++; // stop any running chain
+      return undefined;
+    }
+    const myGen = ++genRef.current;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const run = async () => {
+      if (genRef.current !== myGen) return;
+      // Abort AND race a hard deadline: a wedged fetch (Android `.local` mDNS)
+      // can ignore abort and never settle, which would stall the whole poll and
+      // leave a frozen frame reading as live forever. The race guarantees the
+      // loop always moves on and re-schedules.
+      const ctrl = new AbortController();
+      const killer = setTimeout(() => ctrl.abort(), FRAME_TIMEOUT_MS);
+      let uri: string | null = null;
+      try {
+        uri = await Promise.race([
+          screenFrameSource(settings, ctrl.signal),
+          new Promise<null>((res) => setTimeout(() => res(null), FRAME_TIMEOUT_MS + 500)),
+        ]);
+      } catch {
+        uri = null;
+      }
+      clearTimeout(killer);
+      if (genRef.current !== myGen) return; // superseded / stopped mid-fetch
+      if (uri) {
+        setFrame(uri);
+        setFailed(false);
+        setLastGood(Date.now());
+      } else {
+        setFailed(true);
+      }
+      if (genRef.current === myGen) timer = setTimeout(run, intervalMs);
+    };
+    void run();
+    return () => {
+      genRef.current++;
+      if (timer) clearTimeout(timer);
+    };
+  }, [active, intervalMs, settings]);
+
+  return { frame, failed, lastGood };
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1301,11 +1301,13 @@ export async function mediaArtSource(
  * show a password prompt, so nothing is written to Fresco's disk cache. null on
  * failure or 503 (capture failed). `t` cache-busts each frame.
  */
-export async function screenFrameSource(settings: ConnSettings): Promise<string | null> {
+export async function screenFrameSource(
+  settings: ConnSettings, signal?: AbortSignal,
+): Promise<string | null> {
   const host = resolveEffectiveHost(settings);
   const url = `http://${host}:${settings.port}/api/screen/frame?t=${Date.now()}`;
   try {
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` }, signal });
     if (!res.ok) return null;
     // Same cap as album art, and it matters more here: the preview POLLS, so an
     // oversized frame gets a fresh chance at the phone's memory every tick.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -159,18 +159,98 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   socket) + inputSends / inputDropped / recoveries / opens counters.
 - **NEXT:** capture one reading during a real episode; that picks the fix.
 
-### Remote desktop "screenshot + tap"
-`priority: P2` · `risk: med` · `affects: agent, app` · `depends_on: #245 learnings`
-- MEASURED ceiling ~1.2 fps now / ~1.4 fps optimized (~0.41s of every frame is
-  spectacle's Qt startup). **True VNC is off the table** on this architecture;
-  what is achievable is tap-to-click on a slow-refreshing frame.
-- Absolute pointer PROVEN pixel-exact on Plasma Wayland (screenshot-diff, with a
-  relative-mouse control). Declare BTN_TOUCH to suppress a phantom /dev/input/js0.
-- **Unproven: gamescope.** Also needs zoom or a two-stage crosshair — a 44pt finger
-  is ~289 logical px on a 4K desktop vs a ~100x30 px button — and frame-age gating
-  so a stale frame can't produce a confident wrong click.
+### Remote desktop — fullscreen viewer + on-screen controls + lower latency (owner ask 2026-08-10)
+`priority: P2` · `risk: med (phases 1-3) → high (phase 4)` · `affects: agent, app` · `depends_on: #245 learnings`
+- **Owner:** "screen viewer, when clicked, opens fullscreen with on-screen pad controls to
+  control the desktop like remote desktop / RustDesk; reduce latency so it feels fluid."
+- **Current state (mapped 2026-08-10, two agents):**
+  - VIEWER = still-frame poller. `GET /api/screen/frame` → ONE downscaled (960px, q80) JPEG per
+    HTTP GET, Bearer header, `no-store`. Capture: `gamescopectl screenshot` (~1.4s, 4K PNG) in
+    Game Mode / `spectacle` JPEG (~0.7s) on KDE. Server-capped ~2 captures/s (`SCREEN_MIN_INTERVAL_S`
+    0.5 + 500ms cache + single-flight). App polls 1000ms (700ms in the existing tap→`<Modal>`
+    fullscreen). `components/ScreenPreview.tsx`, `api.ts:screenFrameSource`. On the Console tab.
+    `ScreenInfo` has NO width/height. `lib/immersive.ts` fullscreen store exists; no fullscreen route.
+  - INPUT = separate `/ws/gamepad` WebSocket (`lib/gamepad.ts`), injected via direct `/dev/uinput`
+    evdev writes behind a frozenset allowlist (§3-clean). Mouse is **relative-only** (`{t:'m',dx,dy}`,
+    EV_REL); coalesced ~90Hz — input latency is already LOW. `hooks/useTrackpad` + `components/RemoteView`
+    already overlay a trackpad + click/scroll/meta/overview/esc over this path.
+- **The two asks are different problems.** Controls-in-fullscreen is easy reuse; "fluid" is architectural:
+  MEASURED ceiling ~1.2/1.4 fps, and **true VNC/fluid video is off the table on the screenshot pipeline** —
+  each frame is a full screenshot+decode. Fluid (15-60fps) needs a whole new capture→encode→transport stack.
+- **Absolute pointer PROVEN pixel-exact on Plasma Wayland** (screenshot-diff, with a relative-mouse
+  control). Declare BTN_TOUCH to suppress a phantom /dev/input/js0. NOT shipped today (device is EV_REL only).
+  **Unproven: gamescope.** Needs zoom or a two-stage crosshair (a 44pt finger ≈ 289 logical px on a 4K
+  desktop vs a ~100×30px button) and frame-age gating so a stale frame can't produce a confident wrong click.
+- **Phased plan:**
+  - **P1 (low, app-only, ship-now): Fullscreen control mode.** Screen frame as a live background +
+    a RemoteView-style trackpad + button overlay + `immersive.ts` chrome-hide + landscape. Reuses the
+    whole input path — relative-mouse control at ~1.4fps ("confirm-by-frame"): genuinely useful for
+    occasional desktop tasks (click, close, type), NOT motion. No agent change.
+  - **P2 (med, agent+app): absolute tap-to-click** — add an EV_ABS uinput mouse (+BTN_TOUCH), a
+    `{t:'ma',x,y}` protocol frame (additive), width/height on `ScreenInfo`, tap→coordinate mapping,
+    frame-age gating. Proven on Plasma; gamescope needs the zoom/crosshair. Makes P1 feel like remote desktop.
+  - **P3 (med, agent+app): faster frames** — smaller region/res, and stream frames (MJPEG multipart or
+    WS-framed JPEG) instead of one HTTP GET each. Realistic ~5-10fps of small JPEGs. Better, not "fluid."
+  - **P4 (HIGH, large — the true "RustDesk" answer): fluid hardware-encoded video, as an OPT-IN MODULE.**
+    Owner framing (2026-08-10): make it "an additional option that adds more dependencies to the install
+    and more system access to enable the feature." This is the CORRECT shape and it fits the constraints:
+    - **Core agent stays pure-stdlib single-file.** No third-party PYTHON import — the module SHELLS OUT to
+      system binaries (gstreamer/ffmpeg/pipewire) via the existing argv allowlist, exactly like today's
+      gamescopectl/spectacle/ffmpeg capture. The extra DEPS are SYSTEM packages the user opts into, not
+      pip/bundled python.
+    - **Gated by caps + probe-and-appear.** A new `caps.screenstream` (six edit sites, §4) advertises the
+      module; the app shows the fluid viewer ONLY when present, else degrades to the still-frame poller
+      (P1-P3). Never a guess.
+    - **Opt-in deps + access** (precedent: Decky channel, the privileged helper). A separate install step /
+      ujust recipe installs gstreamer+VAAPI+pipewire, grants the PipeWire screencast-portal permission (and
+      maybe a unit/helper). "More access" (continuous screen capture, HW encoder) is explicit + documented.
+      Distribution like the signed helper/Decky channel, not the base install.sh.
+    - **Transport:** avoid full WebRTC (ICE/DTLS/SRTP = needs aiortc = FORBIDDEN). Either H264/VP8-over-WS
+      or MJPEG-over-WS on the existing hand-rolled RFC6455 socket; encoder subprocess stdout → framed to the WS.
+    - **The one ASYMMETRY to know:** the BOX side is cleanly opt-in, but the APP-side decoder is NOT
+      per-box optional — a single app binary ships to everyone. Two tiers:
+      - **P4a (recommended first): MJPEG "fast-capture" module** — pipewire continuous grab → small JPEGs
+        over WS. Opt-in box deps + screencast access, ~15-25fps, and **NO new app native dep** (JPEG decode
+        reuses `<Image>`). Most of the "fluid" win, cleanly optional end-to-end.
+      - **P4b (max): H264/VAAPI stream** — true 30-60fps/~50-150ms, but forces `react-native-webrtc` (or a
+        native H264 player) into EVERY app build (bloat + iOS build surface) even for non-users.
+    - gamescope continuous capture still unproven (gamescopectl is one-shot); may be desktop-session-only.
+      New stream endpoint = a new "video of your screen" data flow → security pass (token-authed, LAN-only).
+- **Next step:** P1+P2 are a reasonable near-term deliverable; P4 warrants `docs/memory/project_remote-desktop.md`
+  before any code (§10) — lead with P4a (optional, no app native dep). Note: input isn't the bottleneck — video is.
 
 ## 📋 Planned
+
+### Apple Watch + desktop widgets — quick actions (owner ask 2026-08-10)
+- **priority:** P2 · **risk:** medium-high (NEW native surfaces: WidgetKit + watchOS;
+  App Intents; runs OUTSIDE the RN runtime) · **affects:** app + a native config plugin ·
+  **depends_on:** nothing new server-side — Restart Session (`/api/actions/restart-session`,
+  bearer) and Wake-on-LAN (`app/lib/wol.ts` + `/api/wake`, magic packet) already exist.
+- **Owner:** "an Apple Watch and desktop widget with quick actions for restarting a session
+  and turning the box on/off via Wake-on-LAN if enabled."
+- **What:** home-screen / Watch complications + macOS desktop widget offering 2–3 one-taps:
+  **Wake box** (WoL magic packet, LAN — works while the box is OFF, the whole point), **Restart
+  Session**, and possibly **Power off** (a session-ending action → MUST reuse the cancellable
+  countdown safeguard, [[shipped-2.9.43-testflight]] #429, not a bare one-tap).
+- **Hard feasibility notes (before any code):**
+  - Expo/RN has no widget/Watch runtime. Needs **WidgetKit (SwiftUI)** + a **watchOS target**
+    + **App Intents** for the tappable actions, wired via a **config plugin / native module**
+    (or a bare workflow). This is real Swift, outside the JS app — a first for this repo.
+  - Widgets/Watch run in their **own process** with no access to the RN app's state. They must
+    read box host/port/token + WoL MAC from a **shared App Group container**, and the app must
+    WRITE those there. Token in an App Group = a new place a bearer token lives — security review
+    required (LAN-only model, but still).
+  - Actions fire raw HTTP from the extension (bearer for `/api/actions/*`; WoL is a UDP magic
+    packet, no auth). LAN-only: the widget does nothing useful off the home network — copy must
+    be honest about that.
+  - `restart-session`/`poweroff` are `danger:'high'`; a widget one-tap has no room for the 5s
+    countdown — gate destructive ones behind the App Intent's confirmation, or scope v1 to
+    **Wake only** (safe, additive, off-box) and add restart/poweroff behind confirmation later.
+  - Android parity is a separate lift (Glance/App Widgets, no Watch equivalent) — scope iOS
+    first, note the gap.
+- **Next step:** 3+ phases → write `docs/memory/project_watch-desktop-widgets.md` before code
+  (§10). Likely phase 1 = App Group plumbing + **Wake-only** widget (lowest risk, highest
+  "box is off" value); phase 2 = Restart Session behind confirmation; phase 3 = Watch + macOS.
 
 ### Game backlog — "Now playing" + "Up next" queue (owner ask 2026-08-09)
 - **priority:** P2 · **risk:** low (app-only, additive; no agent change to start) ·

--- a/docs/memory/project_remote-desktop.md
+++ b/docs/memory/project_remote-desktop.md
@@ -1,0 +1,132 @@
+# Project — Remote desktop: fullscreen viewer + on-screen controls + (optional) fluid streaming
+
+Status: **SPEC.** P1 in progress (`claude/remote-desktop-p1`); P2–P4 planned.
+Origin: owner, 2026-08-10 — "screen viewer, when clicked, opens fullscreen with on-screen pad
+controls to control the desktop like remote desktop / RustDesk; reduce latency so it feels fluid,"
+then: "can P4 be an additional option that adds more dependencies to the install and more system
+access, so the feature can be used?" — yes; P4 is an **opt-in module** (see below).
+
+Supersedes/absorbs the old ROADMAP "Remote desktop screenshot + tap" entry.
+
+---
+
+## 1. The two problems (they are different)
+
+1. **Controls in fullscreen** — click the viewer → fullscreen frame + an on-screen control layer
+   (trackpad + buttons) that drives the desktop. **Easy: reuse.** The input path already exists.
+2. **Fluidity / low latency** — make it feel like RustDesk. **Hard: architectural.** The current
+   viewer is a still-frame poller capped ~1.4 fps; fluid needs a new capture→encode→transport stack.
+
+Input is NOT the bottleneck — it is already low-latency. **Video is.**
+
+---
+
+## 2. Current state (mapped 2026-08-10, file:line)
+
+### Viewer (still-frame poller)
+- `GET /api/screen` — probe/info (`couchsided.py:17026`), body `{available, session, backends,
+  formats:["image/jpeg"]}` (`screen_info()` `11901`). **No width/height.** 404 → app hides the card.
+- `GET /api/screen/frame` — ONE JPEG (`17036`), Bearer header only, `Cache-Control: no-store`.
+  Capture (`real_screen_frame()` `11830`): `gamescopectl screenshot` (~1.4s, 4K PNG) in Game Mode
+  (`_grab_gamescopectl` `11690`) / `spectacle -b -n -o` JPEG (~0.7s) on KDE (`_grab_spectacle` `11724`);
+  downscale via `magick`/`ffmpeg` to `SCREEN_WIDTH=960` q80 (no PIL, off immutable rootfs). Decode dominates.
+- Server floor ~2 captures/s: `SCREEN_MIN_INTERVAL_S=0.5`, single-flight `SCREEN_LOCK`, 500ms cache.
+  **Measured ceiling ~1.2–1.4 fps** (ROADMAP/BUILD_LOG; ~0.41s of every frame is spectacle's Qt startup).
+  **No MJPEG/chunked/WebSocket stream path.** `caps.screen` exists (`1592`) but ScreenPreview probes
+  `/api/screen` directly, not the cap.
+- App: `components/ScreenPreview.tsx` — poll `1000ms` (`700ms` in the tap→`<Modal>` fullscreen), OFF by
+  default, fetches `api.ts:screenFrameSource` (base64 data-URI, Bearer header, `?t=` cache-bust),
+  `<Image resizeMode="contain">`. On the Console tab (`(tabs)/index.tsx:373`). `lib/immersive.ts`
+  fullscreen store exists; NO fullscreen route (the "fullscreen" today is the in-component Modal).
+
+### Input (separate, already fast)
+- One `/ws/gamepad` WebSocket, client = `lib/gamepad.ts` (NOT api.ts). Mouse is **relative-only**
+  (`{t:'m',dx,dy}`, coalesced ~90Hz `MOUSE_MOVE_INTERVAL_MS=11`), buttons `{t:'mb',k,v}`, wheel
+  `{t:'mw',dy}`, keys `{t:'k',key}` / `{t:'kt',text}`. Senders `sendMouseMove/Button/Wheel/Key/Text`,
+  `sendDesktopKey('meta'|'overview')`.
+- Injection: direct `/dev/uinput` evdev writes behind frozenset allowlist `_MOUSE_TYPES/_KEYBOARD_TYPES`
+  (`_gamepad_message` `18764`), decoders `mouse_events` `12610` / `keyboard_events` `12635`. §3-clean,
+  compositor-agnostic. Input dropped unless the session holds control (`18786`); devices lazy-created.
+- **No absolute pointer** anywhere (protocol or device — EV_REL only, `12402`). BUT absolute pointer was
+  PROVEN pixel-exact on Plasma Wayland in a past screenshot-diff experiment (needs an EV_ABS device +
+  BTN_TOUCH to suppress a phantom js0). Reusable primitives: `hooks/useTrackpad` (relative mouse
+  PanResponder), `components/RemoteView` (trackpad + click/scroll/meta/overview/esc over the client).
+
+---
+
+## 3. Phases
+
+### P1 — Fullscreen control mode (app-only, ship-now) — THIS BRANCH
+Click the screen viewer → a landscape, immersive fullscreen view: the live frame as background +
+a control overlay (trackpad for relative mouse, left/right click, scroll, a small key row, keyboard
+toggle) driving the existing `/ws/gamepad` client. Reuses `useTrackpad` + RemoteView's mappings +
+`immersive.ts` + `useLockOrientation('landscape')`. Frame keeps polling at the fullscreen cadence.
+- No agent change, no API change, no new dep.
+- Relative-mouse control at ~1.4fps = "confirm-by-frame": good for click/close/type, not motion.
+- **Verification reality:** the frame/layout/fullscreen IS harness-verifiable; the CONTROLS are not
+  driveable by real touch (RN-Web = mouse, and the gamepad WS is not proxied). Use the CONVENTIONS
+  fake-WebSocket harness pattern (in-page fake WS that PONGs every frame; assert the `send()`ed input
+  frames) to prove the overlay emits the right `{t:'m'/'mb'/'mw'/'k'}` frames; the feel needs a device.
+
+### P2 — Absolute tap-to-click (agent + app, medium)
+Tap a point on the frame → pointer goes there. Add: EV_ABS uinput mouse (+BTN_TOUCH), a `{t:'ma',x,y}`
+protocol frame (ADDITIVE, six-site cap if gated), width/height on `ScreenInfo`, tap→coordinate mapping
+(frame is `contain` → letterbox math), and **frame-age gating** so a stale frame can't cause a confident
+wrong click. Proven on Plasma; **gamescope unproven** → needs a zoom or two-stage crosshair (a 44pt
+finger ≈ 289 logical px on a 4K desktop vs a ~100×30px button). Makes P1 feel like real remote desktop.
+
+### P3 — Faster frames (agent + app, medium)
+Smaller region/res + stream frames (MJPEG multipart or WS-framed JPEG) instead of one HTTP GET each.
+Realistic ~5–10 fps of small JPEGs. Better for control; still not "fluid."
+
+### P4 — Fluid hardware-encoded video, as an OPT-IN MODULE (the "RustDesk" answer) — HIGH/large
+Owner: "an additional option that adds more dependencies to the install and more system access." This
+is the correct shape and it fits the constraints:
+- **Core agent stays pure-stdlib single-file.** No third-party PYTHON. The module SHELLS OUT to system
+  binaries (gstreamer/ffmpeg/pipewire) via the existing argv allowlist — same as today's capture. Extra
+  DEPS are SYSTEM packages the user opts into, not pip/bundled python.
+- **Gated by caps + probe-and-appear.** New `caps.screenstream` (six edit sites, §4) → the app shows the
+  fluid viewer ONLY when the module is present; else it degrades to the P1–P3 still-frame poller. Never a guess.
+- **Opt-in deps + access** (precedent: Decky channel, the privileged helper). A separate install step /
+  `ujust` recipe installs gstreamer+VAAPI+pipewire and grants the PipeWire **screencast-portal**
+  permission (maybe a unit/helper). "More access" (continuous capture + HW encoder) is explicit,
+  documented, off by default — distributed like the signed helper, NOT base `install.sh`.
+- **Transport avoids the forbidden bit.** No full WebRTC (ICE/DTLS/SRTP → needs `aiortc` = third-party =
+  FORBIDDEN). Use H264/VP8- or MJPEG-**over the existing hand-rolled RFC6455 WebSocket**: encoder
+  subprocess stdout → framed to the WS.
+- **The ASYMMETRY that decides sub-tiers.** The BOX side is cleanly opt-in, but the APP-side decoder is
+  NOT per-box optional — one app binary ships to everyone:
+  - **P4a (LEAD WITH THIS): MJPEG "fast-capture" module.** pipewire continuous grab → small JPEGs over
+    WS. Opt-in box deps + screencast access, ~15–25 fps, and **NO new app native dep** (JPEG decode reuses
+    `<Image>`). Most of the "fluid" win, cleanly optional end-to-end.
+  - **P4b (max): H264/VAAPI stream.** True 30–60fps / ~50–150ms, but forces `react-native-webrtc` (or a
+    native H264 player) into EVERY app build (bloat + iOS build surface) even for non-users.
+- gamescope continuous capture is unproven (gamescopectl is one-shot — may be desktop-session-only).
+- New "video of your screen" data flow → a security pass (token-authed, LAN-only, opt-in consent).
+
+---
+
+## 4. Constraints (do not violate)
+- Agent: pure-stdlib, single file. New capture/encode = argv-allowlisted subprocess, never a shell string
+  or client-supplied command (§3). No third-party python (rules out aiortc → no full WebRTC).
+- Input path is safety-critical (§4). P1's overlay drives DESKTOP mouse (relative) — lower stakes than the
+  d-pad latch, but still uinput; keep it behind the existing control/handoff gate.
+- Response shapes additive-only. `caps.screenstream` if added = all six edit sites.
+- Never `caps`-gate what should probe-and-appear; degrade closed (no module → still-frame poller, honestly).
+- RN has no native `<video>`/WebRTC — any decoder is a NEW native dep that ships to ALL app users (the P4a/P4b split).
+
+## 5. Verification plan (and how the harness lies)
+- Frame display / fullscreen / landscape / immersive: harness-verifiable (screenshot + layout).
+- **Controls: the gamepad WS is NOT proxied in the harness and RN-Web emits mouse, not touch.** Use the
+  fake-WebSocket pattern (CONVENTIONS "Harness wire-proof for gamepad surfaces"): an in-page fake WS that
+  PONGs every frame; read the `send()`ed frames and assert the overlay emits the right input JSON. The
+  actual feel + tap-to-click accuracy (P2) need a device (`adb`/screencap; a real box answers `/api/screen`).
+- P4 streaming: device-only against a box with the module installed; also measure real fps + latency before
+  any "fluid" copy (the last remote-desktop claim was tempered precisely because ~1.4fps isn't fluid).
+
+## 6. Open questions
+- P1: does the fullscreen viewer open its OWN `/ws/gamepad` client (handoff with the Pad tab) or share one?
+  (Leaning: own client, opened on enter / closed on exit, request control — you ARE the controller while in it.)
+- P2: gamescope absolute mapping (zoom vs two-stage crosshair); frame-age threshold.
+- P4: encoder availability per box (VAAPI vs software); gamescope continuous capture; module distribution
+  channel (ujust recipe vs installer flag vs signed helper); audio? clipboard? (scope to screen+input first).


### PR DESCRIPTION
## What
Tap **CONTROL** on the Console screen viewer → a fullscreen **"laptop" surface**: the live screen frame on top, a **trackpad zone** that drives the desktop pointer, and a button bar (Exit / Left / Right / Start / Esc). This is **P1** of the remote-desktop project (`docs/memory/project_remote-desktop.md`) — control at the ~1.4 fps frame cadence ("confirm-by-frame"), **not** fluid video (that's the opt-in **P4** streaming module, spec'd for its own cycle).

## Pieces
- **NEW `app/desktop.tsx`** — owns a mouse/keyboard-only `GamepadClient` (`noPad:true`) over the existing `/ws/gamepad` path. Reuses `useTrackpad` + RemoteView's mappings. Portrait (only the Pad may allow landscape — a guarded invariant).
- **NEW `hooks/useScreenFrame.ts`** — ScreenPreview's poll extracted, with abort + hard-deadline race so a wedged `.local` fetch can't freeze the poll.
- `lib/api.ts` `screenFrameSource` gains an optional `AbortSignal` (additive). `ScreenPreview` gets a CONTROL button → `/desktop`.
- Captures the **research**: `project_remote-desktop.md` (P1..P4, P4 as an opt-in streaming module) + ROADMAP entries (remote-desktop + the Apple-Watch/desktop-widgets idea).

## Safety (§4)
Mouse-only (no d-pad axis to strand). Unmount cleanup **explicitly releases mouse buttons** (l/r/m) before `close()` — `releaseAll()` covers the pad but not the pointer, so a mid-drag unmount would otherwise leave a **stuck left button**. Connect is **gated on `ready && configured`** (fires once).

## Verified (web harness, mock box)
- CONTROL navigates to `/desktop` with the correct WS URL (`handoff=takeover&name=…&nopad=1`).
- Route renders (frame + trackpad + bar). Control-bar buttons emit the right frames over a **fake WS**: `{t:mb,k:l,v:1/0}`, `{t:mb,k:r,v:1/0}`, `{t:k,key:meta}`, `{t:k,key:esc}`.
- Adversarial review: 2 confirmed issues (connect-gate, fetch-timeout) **fixed**; stuck-button finding **refuted against the fix**. `tsc` clean; app-input **444/444**.

## Real-box check + a correction
On the living-room Bazzite (gamescope `ba148`), `/api/screen/frame` returns **200 with a valid 960×540 JPEG** (~1.5s, then cached) — **screen capture is healthy**.

> ⚠️ Correction: an earlier same-session claim of a gamescopectl absolute-path bug (**KI-058**) was **RETRACTED** — it was a timing artifact (the screenshot writes async ~1.5s; the check ran after 1s). The sustained 503s seen earlier were a **transient non-rendering display**, which the agent and P1 both report honestly as "screen unavailable". No agent fix is needed.

**Not verified:** trackpad **drag** (device-only, like all pad surfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)