### PR TITLE
feat: remote-desktop portal module (agent helper + /ws/screen + app fluid stream)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,14 @@ jobs:
       - name: Unit tests (helper shim in the agent)
         run: python3 tests/test_helper_shim.py
 
+      # The opt-in remote-desktop portal module's AGENT side: the _portal_call
+      # detect-and-degrade shim, the screenstream cap probe, the {t:'ma'}/{t:'mbp'}
+      # absolute-pointer holder gate + closed-set allowlist, and the /ws/screen
+      # auth failure + profile allowlist. Same class of surface as the input path
+      # and the helper socket — a client-supplied id must be refused with nothing run.
+      - name: Unit tests (remote-desktop portal module)
+        run: python3 tests/test_portal_module.py
+
       # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
       # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
       # sessions and a connected panel was refused by its NAME — hiding the

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""Couchside's remote-desktop portal helper — the OPT-IN module core.
+
+WHY THIS EXISTS
+---------------
+Wayland remote-desktop (absolute pointer + fluid screen capture) goes through
+xdg-desktop-portal, NOT raw uinput: kwin honors the RemoteDesktop/ScreenCast
+PORTAL, and a virtual absolute uinput device is silently ignored (proven on a
+KDE box — raw-uinput absolute is a dead end). The portal driver needs
+`gi`/`Gio` (PyGObject), a THIRD-PARTY import the base agent forbids
+(couchsided.py is pure-stdlib, single file). So the portal code lives HERE, in a
+separate process the agent spawns and talks to over a local socket — the same
+shape as couchside-helper.py, with one deliberate difference:
+
+  THIS RUNS AS THE USER, NOT ROOT. The portal, PipeWire and the Wayland session
+  bus are all the desktop user's. There is no privileged operation here; running
+  it as root would be both wrong (root can't reach the user's portal) and a
+  needless escalation. Auth is still two layers, both fail closed: a 0600 socket
+  under the user's XDG_RUNTIME_DIR, and an SO_PEERCRED uid check == our own uid.
+
+ONE SESSION, BOTH FEATURES
+--------------------------
+A single portal session selects RemoteDesktop POINTER + ScreenCast MONITOR, so
+ONE consent dialog grants input AND capture. Absolute input (NotifyPointerMotion
+Absolute) and the MJPEG stream (gstreamer pipewiresrc → jpegenc) are two
+independent consumers of that one session. Consent is per-session on older KDE
+(no persist checkbox); newer KDE can persist via restore_token.
+
+THE RULES THIS FILE LIVES BY (CLAUDE.md §3)
+-------------------------------------------
+1. VERBS is a frozen table. A verb is looked up, never interpolated.
+2. Each verb validates its argument against a CLOSED SET / numeric range. Unknown
+   verb or bad argument is an error reply and NOTHING RUNS.
+3. subprocess is an argv LIST, never shell=True, never a formatted command. The
+   gstreamer profile (resolution/fps/quality) is chosen from a frozen dict by the
+   client naming a KEY; no client string ever reaches gst args or a shell.
+4. No verb takes a path, a node, a command, or a pipeline from the caller. The
+   PipeWire node id comes only from the portal's own Start result.
+5. Degrade closed: no session / no consent / unreadable peer → refuse, never act.
+"""
+import json
+import os
+import secrets
+import socket
+import struct
+import subprocess
+import sys
+import threading
+
+import gi
+gi.require_version("Gio", "2.0")
+from gi.repository import GLib, Gio  # noqa: E402
+
+VERSION = "0.1.0"
+
+# The uid allowed to talk to us. Defaults to our OWN uid (agent and helper run as
+# the same desktop user); --uid/--user only narrows, never widens beyond a real
+# account. There is no "any user" mode.
+ALLOWED_UID = None
+
+# xdg-desktop-portal object + interfaces.
+_PORTAL = "org.freedesktop.portal.Desktop"
+_OBJ = "/org/freedesktop/portal/desktop"
+_IF_RD = "org.freedesktop.portal.RemoteDesktop"
+_IF_SC = "org.freedesktop.portal.ScreenCast"
+
+# Pointer button evdev codes — a CLOSED SET. A client names one of these keys.
+_BUTTONS = {"left": 0x110, "right": 0x111, "middle": 0x112}
+
+# gstreamer capture profiles — a CLOSED SET. The client names a KEY; the agent/
+# helper own every pipeline parameter. Nothing here is client-supplied. Sized for
+# a 16:9 source (the box is 1920x1080); a general build would derive w/h from the
+# stream aspect.
+_STREAM_PROFILES = {
+    "540p25":  {"width": 960,  "height": 540,  "fps": 25, "quality": 72},
+    "720p20":  {"width": 1280, "height": 720,  "fps": 20, "quality": 75},
+    "1080p15": {"width": 1920, "height": 1080, "fps": 15, "quality": 70},
+}
+
+# How long Start may wait for the user to click Share/Allow on the box.
+_CONSENT_TIMEOUT_S = 150
+
+# ---- portal D-Bus machinery (raw Gio — pydbus mangles CreateSession's return) --
+#
+# Every Create/Select/Start is Request/Response: the method returns a /request/
+# handle and the real result arrives on the Response signal, delivered only while
+# a GLib main loop runs. SelectDevices/SelectSources auto-Respond in microseconds,
+# so the AddMatch rule MUST be installed synchronously (blocking) BEFORE the call
+# or the fast Response races past. All proven on hardware.
+
+_con = Gio.bus_get_sync(Gio.BusType.SESSION, None)
+_sender_token = _con.get_unique_name()[1:].replace(".", "_")
+
+
+def _add_match_sync(path):
+    rule = ("type='signal',sender='org.freedesktop.portal.Desktop',"
+            "interface='org.freedesktop.portal.Request',member='Response',"
+            "path='%s'" % path)
+    _con.call_sync("org.freedesktop.DBus", "/org/freedesktop/DBus",
+                   "org.freedesktop.DBus", "AddMatch",
+                   GLib.Variant("(s)", (rule,)), None,
+                   Gio.DBusCallFlags.NONE, -1, None)
+
+
+def _request(iface, method, body_sig, body, opts, timeout_s):
+    """Issue a Request-pattern portal method; block until its Response signal
+    (or timeout). Returns (code, results_dict) — code 0 == success."""
+    htok = "h%s" % secrets.token_hex(4)
+    predicted = "/org/freedesktop/portal/desktop/request/%s/%s" % (_sender_token, htok)
+    _add_match_sync(predicted)                      # rule active BEFORE the call
+    holder = {}
+    loop = GLib.MainLoop()
+
+    def on_response(conn, sender, obj, iface_, sig, params):
+        if "code" in holder:
+            return
+        holder["code"], holder["results"] = params.unpack()
+        loop.quit()
+
+    sub = _con.signal_subscribe(
+        None, "org.freedesktop.portal.Request", "Response",
+        predicted, None, Gio.DBusSignalFlags.NONE, on_response)
+    full = dict(opts)
+    full["handle_token"] = GLib.Variant("s", htok)
+    args = GLib.Variant("(%sa{sv})" % body_sig, tuple(body) + (full,))
+    _con.call_sync(_PORTAL, _OBJ, iface, method, args,
+                   GLib.VariantType.new("(o)"), Gio.DBusCallFlags.NONE, -1, None)
+    timed_out = {"v": False}
+    def _on_timeout():
+        timed_out["v"] = True
+        loop.quit()
+        return False                                # one-shot
+    tid = GLib.timeout_add_seconds(timeout_s, _on_timeout)
+    loop.run()
+    if not timed_out["v"]:
+        GLib.source_remove(tid)                     # only remove a source that didn't fire
+    _con.signal_unsubscribe(sub)
+    if "code" not in holder:
+        return None, None                           # timed out (no click)
+    return holder["code"], holder["results"]
+
+
+def _notify(method, sig, body):
+    """A NotifyPointer*/NotifyKeyboard* call — direct, no Response, thread-safe."""
+    _con.call_sync(_PORTAL, _OBJ, _IF_RD, method, GLib.Variant(sig, body),
+                   None, Gio.DBusCallFlags.NONE, -1, None)
+
+
+# ---- shared portal session state -------------------------------------------
+_SLOCK = threading.RLock()
+_SESSION = None    # {"handle": str, "node": int, "w": int, "h": int} or None
+
+
+def _ensure_session():
+    """Create + consent the ONE portal session if we don't have it yet.
+    Serialized: setup happens once. Returns the session dict or None (denied/
+    timed out). Consent BLOCKS on the user clicking Share/Allow on the box."""
+    global _SESSION
+    with _SLOCK:
+        if _SESSION is not None:
+            return _SESSION
+        stok = "cs%s" % secrets.token_hex(4)
+        code, res = _request(_IF_RD, "CreateSession", "", (),
+                             {"session_handle_token": GLib.Variant("s", stok)}, 15)
+        if code != 0 or not res:
+            return None
+        handle = res["session_handle"]
+        code, _ = _request(_IF_RD, "SelectDevices", "o", (handle,),
+                           {"types": GLib.Variant("u", 2)}, 15)          # POINTER
+        if code != 0:
+            return None
+        code, _ = _request(_IF_SC, "SelectSources", "o", (handle,),
+                           {"types": GLib.Variant("u", 1),               # MONITOR
+                            "cursor_mode": GLib.Variant("u", 2),          # embedded
+                            "multiple": GLib.Variant("b", False)}, 15)
+        if code != 0:
+            return None
+        # Start pops the KDE consent dialog. persist_mode=2 asks to remember (a
+        # no-op on older KDE that lacks the checkbox — then it re-prompts).
+        code, res = _request(_IF_RD, "Start", "os", (handle, ""),
+                             {"persist_mode": GLib.Variant("u", 2)},
+                             _CONSENT_TIMEOUT_S)
+        if code != 0 or not res:
+            return None
+        streams = res.get("streams") or []
+        if not streams:
+            return None
+        node = int(streams[0][0])
+        size = streams[0][1].get("size") or (1920, 1080)
+        _SESSION = {"handle": handle, "node": node,
+                    "w": int(size[0]), "h": int(size[1])}
+        return _SESSION
+
+
+def _open_pipewire_fd():
+    """OpenPipeWireRemote on the live session → a unix fd for gstreamer. The
+    session must already exist. Returns an int fd (caller owns it) or None."""
+    with _SLOCK:
+        sess = _SESSION
+    if sess is None:
+        return None
+    ret, fdlist = _con.call_with_unix_fd_list_sync(
+        _PORTAL, _OBJ, _IF_SC, "OpenPipeWireRemote",
+        GLib.Variant("(oa{sv})", (sess["handle"], {})),
+        GLib.VariantType.new("(h)"), Gio.DBusCallFlags.NONE, -1, None, None)
+    idx = ret.unpack()[0]
+    return fdlist.get(idx)
+
+
+# ---------------------------------------------------------------- the verbs ---
+
+def verb_status():
+    with _SLOCK:
+        sess = _SESSION
+    if sess is None:
+        return {"ok": True, "session": False}
+    return {"ok": True, "session": True, "w": sess["w"], "h": sess["h"],
+            "node": sess["node"], "profiles": sorted(_STREAM_PROFILES)}
+
+
+def verb_ensure():
+    sess = _ensure_session()
+    if sess is None:
+        return {"ok": False, "error": "no consent / session"}
+    return {"ok": True, "w": sess["w"], "h": sess["h"], "node": sess["node"]}
+
+
+def verb_move(arg):
+    x, y = arg                                       # validated 0..1 floats
+    sess = _ensure_session()
+    if sess is None:
+        return {"ok": False, "error": "no session"}
+    px = float(x) * sess["w"]
+    py = float(y) * sess["h"]
+    _notify("NotifyPointerMotionAbsolute", "(oa{sv}udd)",
+            (sess["handle"], {}, sess["node"], px, py))
+    return {"ok": True}
+
+
+def verb_button(arg):
+    code, state = arg                                # validated (evdev code, 0/1)
+    sess = _ensure_session()
+    if sess is None:
+        return {"ok": False, "error": "no session"}
+    _notify("NotifyPointerButton", "(oa{sv}iu)", (sess["handle"], {}, code, state))
+    return {"ok": True}
+
+
+# ---- argument validators (return the parsed value, or None to REFUSE) -------
+
+def _move_arg(v):
+    if not isinstance(v, dict):
+        return None
+    x, y = v.get("x"), v.get("y")
+    if not (isinstance(x, (int, float)) and isinstance(y, (int, float))):
+        return None
+    if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+        return None
+    return (float(x), float(y))
+
+
+def _button_arg(v):
+    if not isinstance(v, dict):
+        return None
+    name, state = v.get("button"), v.get("state")
+    if name not in _BUTTONS or state not in (0, 1):
+        return None
+    return (_BUTTONS[name], state)
+
+
+def _profile_arg(v):
+    """A stream profile KEY. Looked up, never interpolated (§3.1)."""
+    if isinstance(v, dict):
+        v = v.get("profile")
+    return v if isinstance(v, str) and v in _STREAM_PROFILES else None
+
+
+# one-shot JSON verbs (streaming is handled separately in serve_one)
+VERBS = {
+    "status": (verb_status, None),
+    "ensure": (verb_ensure, None),
+    "move":   (verb_move,   _move_arg),
+    "button": (verb_button, _button_arg),
+}
+
+
+def dispatch(req):
+    if not isinstance(req, dict):
+        return {"ok": False, "error": "malformed request"}
+    verb = req.get("verb")
+    if not isinstance(verb, str) or verb not in VERBS:
+        return {"ok": False, "error": "unknown verb"}
+    handler, validate = VERBS[verb]
+    if validate is None:
+        return handler()
+    arg = validate(req.get("arg"))
+    if arg is None:
+        return {"ok": False, "error": "invalid argument for %s" % verb}
+    return handler(arg)
+
+
+# ---- streaming (raw MJPEG bytes, not a JSON reply) --------------------------
+
+def _stream_argv(profile, pwfd, node):
+    """gstreamer argv LIST for one profile. Every pipeline element and parameter
+    is chosen HERE; the client only picked the profile key. pipewiresrc reads the
+    portal's own node over the passed fd; jpegenc → fdsink fd=1 (stdout)."""
+    p = _STREAM_PROFILES[profile]
+    caps = "video/x-raw,framerate=%d/1,width=%d,height=%d" % (
+        p["fps"], p["width"], p["height"])
+    return ["gst-launch-1.0", "-q",
+            "pipewiresrc", "fd=%d" % pwfd, "path=%d" % node, "keepalive-time=1000",
+            "!", "videorate", "!", "videoscale", "!", "videoconvert",
+            "!", caps,
+            # TODO(backpressure): a `queue leaky=downstream` here stalled the
+            # pipeline mid-frame on hardware (2026-08-10) — needs isolated gst
+            # tuning (placement/max-size). For now no leaky queue: a slow phone
+            # backpressures gst via TCP flow control. Drop-oldest to be added
+            # once verified in isolation, not guessed on a live session.
+            "!", "jpegenc", "quality=%d" % p["quality"],
+            "!", "fdsink", "fd=1"]
+
+
+def stream(profile, conn):
+    """Spawn gst for `profile` and pipe its MJPEG stdout to `conn` until the peer
+    disconnects, then reap. The agent side splits the MJPEG byte stream on
+    FFD8..FFD9 and frames each JPEG onto /ws/screen."""
+    if _ensure_session() is None:
+        return
+    with _SLOCK:
+        node = _SESSION["node"]
+    pwfd = _open_pipewire_fd()
+    if pwfd is None:
+        return
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            _stream_argv(profile, pwfd, node),
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            pass_fds=(pwfd,))
+    finally:
+        try:
+            os.close(pwfd)                           # the child holds it now
+        except OSError:
+            pass
+    if proc is None:
+        return
+    nbytes = 0
+    try:
+        while True:
+            chunk = proc.stdout.read(65536)
+            if not chunk:
+                break                                # gst ended
+            nbytes += len(chunk)
+            conn.sendall(chunk)                      # raises when the peer is gone
+    except OSError:
+        pass                                         # peer disconnected — normal
+    finally:
+        try:
+            proc.stdout.close()
+        except OSError:
+            pass
+        proc.terminate()
+        try:
+            proc.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        if nbytes == 0:
+            err = b""
+            try:
+                err = proc.stderr.read() or b""
+            except OSError:
+                pass
+            print("[portal] stream: NO BYTES; gst stderr: %s"
+                  % err.decode("utf-8", "replace").strip()[:500], flush=True)
+        try:
+            proc.stderr.close()
+        except OSError:
+            pass
+
+
+# ------------------------------------------------------------------- serving
+
+def peer_uid(conn):
+    """The caller's uid via SO_PEERCRED, or None (REFUSE). Unknown is never
+    allowed (§3.5)."""
+    try:
+        creds = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED,
+                                struct.calcsize("3i"))
+        _pid, uid, _gid = struct.unpack("3i", creds)
+        return uid
+    except (OSError, struct.error, AttributeError):
+        return None
+
+
+def _read_line(conn, limit=65536):
+    buf = b""
+    while b"\n" not in buf and len(buf) < limit:
+        chunk = conn.recv(4096)
+        if not chunk:
+            break
+        buf += chunk
+    return buf.split(b"\n", 1)[0]
+
+
+def serve_one(conn):
+    try:
+        uid = peer_uid(conn)
+        if uid is None or ALLOWED_UID is None or uid != ALLOWED_UID:
+            try:
+                conn.sendall(json.dumps(
+                    {"ok": False, "error": "not authorized"}).encode() + b"\n")
+            except OSError:
+                pass
+            return
+        conn.settimeout(_CONSENT_TIMEOUT_S + 30)
+        try:
+            req = json.loads(_read_line(conn).decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            conn.sendall(json.dumps(
+                {"ok": False, "error": "malformed request"}).encode() + b"\n")
+            return
+        # The stream verb switches this connection to raw MJPEG bytes; every
+        # other verb is one JSON line in, one JSON line out.
+        if isinstance(req, dict) and req.get("verb") == "stream":
+            profile = _profile_arg(req.get("arg"))
+            if profile is None:
+                conn.sendall(json.dumps(
+                    {"ok": False, "error": "invalid argument for stream"}).encode()
+                    + b"\n")
+                return
+            conn.settimeout(None)                    # long-lived stream
+            stream(profile, conn)
+            return
+        reply = dispatch(req)
+        conn.sendall(json.dumps(reply).encode() + b"\n")
+    except OSError:
+        pass
+    finally:
+        try:
+            conn.close()
+        except OSError:
+            pass
+
+
+def _listen_socket(path):
+    """Our own 0600 socket under the user's runtime dir. Only our uid can even
+    reach it; SO_PEERCRED is the second, in-band check."""
+    try:
+        os.makedirs(os.path.dirname(path), mode=0o700, exist_ok=True)
+        os.unlink(path)
+    except OSError:
+        pass
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(path)
+    os.chmod(path, 0o600)
+    s.listen(8)
+    return s
+
+
+def _default_socket_path():
+    rt = os.environ.get("XDG_RUNTIME_DIR") or ("/run/user/%d" % os.getuid())
+    return os.path.join(rt, "couchside", "portal.sock")
+
+
+def main(argv=None):
+    global ALLOWED_UID
+    argv = list(sys.argv[1:] if argv is None else argv)
+    path = None
+    for i, a in enumerate(argv):
+        if a == "--uid" and i + 1 < len(argv):
+            ALLOWED_UID = int(argv[i + 1])
+        elif a == "--socket" and i + 1 < len(argv):
+            path = argv[i + 1]
+        elif a == "--version":
+            print(VERSION)
+            return 0
+    if ALLOWED_UID is None:
+        ALLOWED_UID = os.getuid()                    # same-user agent by default
+    if path is None:
+        path = _default_socket_path()
+
+    # systemd socket activation (fd 3), else bind our own.
+    srv = None
+    if os.environ.get("LISTEN_PID") == str(os.getpid()) and \
+            int(os.environ.get("LISTEN_FDS", "0") or 0) >= 1:
+        srv = socket.socket(fileno=3)
+    if srv is None:
+        srv = _listen_socket(path)
+    print("[portal] serving on %s (allowed uid %d)" % (path, ALLOWED_UID),
+          flush=True)
+    while True:
+        try:
+            conn, _ = srv.accept()
+        except OSError:
+            continue
+        threading.Thread(target=serve_one, args=(conn,), daemon=True).start()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/agent/couchside-portal.service
+++ b/agent/couchside-portal.service
@@ -1,0 +1,28 @@
+; Couchside remote-desktop portal helper: USER unit TEMPLATE (opt-in module).
+; The portal-module installer substitutes __PORTAL__ (the resolved helper path)
+; and installs the result as ~/.config/systemd/user/couchside-portal.service,
+; then `systemctl --user enable --now couchside-portal.service`.
+;
+; UNLIKE couchside-helper.service (the ROOT system unit), this runs as the USER:
+; the xdg-desktop-portal, PipeWire and the Wayland compositor are all the desktop
+; user's, and the helper has no privileged operation, so root would be both wrong
+; (root can't reach the user's portal) and a needless escalation. See
+; docs/memory/project_remote-desktop.md §3. Its entire surface is the frozen VERBS
+; table in couchside-portal.py behind a 0600 socket + SO_PEERCRED — read that
+; file's header before touching this one.
+;
+; Tied to graphical-session.target so it runs with the session bus available and
+; stops when the graphical session ends. %t is the user's XDG_RUNTIME_DIR.
+[Unit]
+Description=Couchside remote-desktop portal helper (opt-in)
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 __PORTAL__ --socket %t/couchside/portal.sock
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=graphical-session.target

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1582,7 +1582,7 @@ def set_caps(mock):
                  "screensaver", "couchmode", "bigpicture", "desktop",
                  "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
-                 "session_default", "display_info", "player")}
+                 "session_default", "display_info", "player", "screenstream")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1615,6 +1615,11 @@ def set_caps(mock):
         "file_upload": safe(lambda: os.access(_drop_dir(), os.W_OK)),
         "display_info": safe(display_info_available),
         "player": safe(player_available),
+        # OPT-IN remote-desktop module present (agent/couchside-portal.py reachable
+        # on its socket) -> the app uses the fluid /ws/screen viewer + tap-to-point;
+        # absent -> the still-frame poller + relative mouse (P1). A boot-time hint:
+        # /ws/screen re-checks the portal live and degrades closed regardless.
+        "screenstream": safe(screenstream_available),
     }
 
 
@@ -4755,6 +4760,95 @@ def _helper_call(verb, arg=None, timeout=10):
         # fallback still enforces every original constraint, so degrading to it
         # never widens anything.
         return None
+
+
+# ------------------------------------------------------ remote-desktop portal
+#
+# The OPT-IN remote-desktop module (agent/couchside-portal.py) is a SEPARATE
+# process because the xdg-desktop-portal driver needs gi/Gio, a third-party
+# import this stdlib agent forbids. It runs as the SAME user (portal/PipeWire/
+# Wayland are the user's, not root), and we reach it over its own unix socket
+# under XDG_RUNTIME_DIR. Same detect-and-degrade shape as the privileged helper:
+# absent socket -> None -> the feature simply isn't available (the app falls back
+# to the still-frame poller). A verb the portal REFUSES is a real answer.
+
+def _portal_socket_path():
+    rt = os.environ.get("XDG_RUNTIME_DIR") or ("/run/user/%d" % os.getuid())
+    return os.path.join(rt, "couchside", "portal.sock")
+
+
+PORTAL_SOCKET = _portal_socket_path()
+
+
+def _portal_connect(timeout):
+    """A connected socket to the portal helper, or None when it is not present
+    (no socket / nothing listening). None is the only 'degrade to poller' case."""
+    if not os.path.exists(PORTAL_SOCKET):
+        return None
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(PORTAL_SOCKET)
+        return s
+    except OSError:
+        return None
+
+
+def _portal_call(verb, arg=None, timeout=10):
+    """One JSON verb over the portal socket. Returns the reply dict, or None
+    when the helper is not present/dead. `ensure`/`move`/`button`/`status` only;
+    `stream` uses _portal_stream (it switches to raw bytes)."""
+    s = _portal_connect(timeout)
+    if s is None:
+        return None
+    try:
+        req = {"verb": verb}
+        if arg is not None:
+            req["arg"] = arg
+        s.sendall(json.dumps(req).encode("utf-8") + b"\n")
+        buf = b""
+        while b"\n" not in buf and len(buf) < 65536:
+            chunk = s.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+        return json.loads(buf.split(b"\n", 1)[0].decode("utf-8"))
+    except (OSError, ValueError):
+        return None
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+
+
+def _portal_stream(profile, timeout=10):
+    """Open a stream connection: send the `stream` verb, then the socket becomes
+    a raw MJPEG byte stream the caller reads until it closes the socket (which
+    makes the helper reap gstreamer). Returns the connected socket, or None."""
+    s = _portal_connect(timeout)
+    if s is None:
+        return None
+    try:
+        s.sendall(json.dumps(
+            {"verb": "stream", "arg": {"profile": profile}}).encode("utf-8") + b"\n")
+        s.settimeout(None)
+        return s
+    except OSError:
+        try:
+            s.close()
+        except OSError:
+            pass
+        return None
+
+
+def screenstream_available():
+    """True when the opt-in remote-desktop module is reachable on its socket.
+    A boot-time hint for caps.screenstream; /ws/screen re-checks live and degrades
+    closed. `status` needs no consent, so this never pops a dialog. Wrapped in
+    safe() at the call site, so any failure reads as unavailable (§3.7)."""
+    r = _portal_call("status", timeout=2)
+    return bool(r and r.get("ok"))
 
 
 def _dm_write(dm, session_file):
@@ -15641,7 +15735,7 @@ def mock_steamlink():
 # ---------------------------------------------------------------------------
 
 WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
-WS_OP_TEXT, WS_OP_CLOSE, WS_OP_PING, WS_OP_PONG = 0x1, 0x8, 0x9, 0xA
+WS_OP_TEXT, WS_OP_BINARY, WS_OP_CLOSE, WS_OP_PING, WS_OP_PONG = 0x1, 0x2, 0x8, 0x9, 0xA
 WS_MAX_FRAME = 1 << 20
 
 
@@ -15766,6 +15860,18 @@ GAMEPAD_IDLE_TIMEOUT_S = 12.0
 # Box-driven keepalive interval. Kept well under the reap window above (3 PINGs
 # per window) so a single dropped PONG can't trip a false reap.
 GAMEPAD_PING_INTERVAL_S = 4.0
+
+# Concurrent /ws/screen streams are capped: each holds a server connection slot
+# AND drives a gstreamer encoder in the portal helper, so N phones would fork N
+# heavy encoders. 2 is plenty for a home LAN; over the cap, a new stream is
+# refused (the phone falls back to the still-frame poller).
+SCREEN_STREAM_MAX = 2
+_screen_stream_sema = threading.BoundedSemaphore(SCREEN_STREAM_MAX)
+# Profile ids the client may request on /ws/screen (?profile=). A closed set,
+# looked up never interpolated; the portal helper owns the actual pipeline
+# parameters and re-validates the key. Must mirror the helper's _STREAM_PROFILES.
+_SCREEN_STREAM_PROFILES = frozenset(("540p25", "720p20", "1080p15"))
+_SCREEN_STREAM_DEFAULT = "720p20"
 
 
 def _wsend_json(entry, obj):
@@ -16748,6 +16854,13 @@ class Handler(BaseHTTPRequestHandler):
 
             if path == "/ws/gamepad":
                 self._handle_gamepad_ws(parsed, started)
+                return
+
+            if path == "/ws/screen":
+                # Pre-auth like /ws/gamepad: the handler does its own ?token=
+                # check + handshake, so it must not sit behind the JSON auth gate
+                # (a JSON 401 body onto an upgrading socket would be garbage).
+                self._handle_screen_ws(parsed, started)
                 return
 
             if path == "/pair":
@@ -18572,6 +18685,118 @@ class Handler(BaseHTTPRequestHandler):
             print("[gamepad] session error: %s: %s"
                   % (e.__class__.__name__, e), flush=True)
 
+    # -- screen stream websocket (P4a, opt-in portal module) -------------------
+
+    def _handle_screen_ws(self, parsed, started):
+        """MJPEG-over-WebSocket from the portal module. Mirrors the gamepad WS
+        handshake verbatim (same ?token= auth), then streams JPEG frames. A box
+        without the module degrades closed (the socket opens then closes; the app
+        falls back to the still-frame poller)."""
+        self.close_connection = True
+        qs = parse_qs(parsed.query)
+        supplied = qs.get("token", [""])[0]
+        if not supplied or not hmac.compare_digest(supplied, self.token):
+            self._send(401, {"error": "unauthorized"}, started,
+                       extra_headers={"Connection": "close"})
+            return
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        upgrade = (self.headers.get("Upgrade") or "").lower()
+        if upgrade != "websocket" or not key:
+            self._send(400, {"error": "websocket upgrade required"}, started,
+                       extra_headers={"Connection": "close"})
+            return
+        accept = base64.b64encode(
+            hashlib.sha1((key + WS_GUID).encode("ascii")).digest()).decode("ascii")
+        try:
+            self.connection.sendall(
+                b"HTTP/1.1 101 Switching Protocols\r\n"
+                b"Upgrade: websocket\r\n"
+                b"Connection: Upgrade\r\n"
+                b"Sec-WebSocket-Accept: " + accept.encode("ascii") + b"\r\n\r\n")
+        except OSError:
+            return
+        self._log(101, started)
+        profile = qs.get("profile", [_SCREEN_STREAM_DEFAULT])[0]
+        if profile not in _SCREEN_STREAM_PROFILES:
+            profile = _SCREEN_STREAM_DEFAULT
+        try:
+            self._screen_session(profile)
+        except Exception as e:
+            print("[screen] session error: %s: %s"
+                  % (e.__class__.__name__, e), flush=True)
+
+    def _screen_session(self, profile):
+        """One consent opens the SHARED portal session (input + capture); then
+        pipe the helper's MJPEG onto the WS. Capped concurrency; degrade closed."""
+        conn = self.connection
+        if not _screen_stream_sema.acquire(blocking=False):
+            try:
+                ws_send(conn, WS_OP_CLOSE)          # too many streams -> fall back
+            except OSError:
+                pass
+            return
+        portal_sock = None
+        try:
+            # ensure = create the session + block on the box's consent dialog.
+            # None/!ok means no module or denied -> close so the app falls back.
+            res = _portal_call("ensure", timeout=170)
+            if not res or not res.get("ok"):
+                try:
+                    ws_send(conn, WS_OP_CLOSE)
+                except OSError:
+                    pass
+                return
+            portal_sock = _portal_stream(profile)
+            if portal_sock is None:
+                try:
+                    ws_send(conn, WS_OP_CLOSE)
+                except OSError:
+                    pass
+                return
+            self._screen_pump(conn, portal_sock)
+        finally:
+            if portal_sock is not None:
+                try:
+                    portal_sock.close()             # closing -> helper reaps gst
+                except OSError:
+                    pass
+            _screen_stream_sema.release()
+
+    def _screen_pump(self, conn, portal_sock):
+        """Read the helper's MJPEG byte stream, split whole JPEGs (FFD8..FFD9),
+        send each as ONE binary WS frame. This is the ONLY writer of `conn`, so no
+        slock is needed. Backpressure is handled at the SOURCE: a slow phone
+        blocks this send, which stops draining the helper, which makes the
+        helper's gst `queue leaky=downstream` drop old frames — so the phone falls
+        behind rather than accumulating latency. A send failure = phone gone."""
+        buf = bytearray()
+        portal_sock.settimeout(30)
+        while True:
+            try:
+                chunk = portal_sock.recv(65536)
+            except OSError:
+                break
+            if not chunk:
+                break                                # helper/gst ended
+            buf += chunk
+            while True:
+                soi = buf.find(b"\xff\xd8")
+                if soi < 0:
+                    if len(buf) > (8 << 20):         # runaway guard: no SOI in 8MB
+                        del buf[:]
+                    break
+                if soi > 0:
+                    del buf[:soi]                    # drop bytes before a SOI
+                eoi = buf.find(b"\xff\xd9", 2)
+                if eoi < 0:
+                    break                            # partial frame; wait for more
+                jpg = bytes(buf[:eoi + 2])
+                del buf[:eoi + 2]
+                try:
+                    ws_send(conn, WS_OP_BINARY, jpg)
+                except OSError:
+                    return                           # phone disconnected
+
     def _gamepad_session(self):
         global GAMEPAD_HOLDER
         conn = self.connection
@@ -18754,6 +18979,31 @@ class Handler(BaseHTTPRequestHandler):
                 clipboard_paste(chunk, kbd, self.mock, entry)
         return True
 
+    # Absolute-pointer button names -> the portal helper's closed set. A client
+    # names one of these keys; anything else is dropped (the helper re-checks too).
+    _PORTAL_BTNS = {"l": "left", "r": "right", "m": "middle",
+                    "left": "left", "right": "right", "middle": "middle"}
+
+    def _handle_portal_abs(self, entry, msg):
+        """{t:'ma',x,y} -> portal absolute move (x,y normalized 0..1). Best-effort:
+        bad coords or an absent/refusing portal are dropped silently, keeping the
+        desktop-control session alive. The session is opened by /ws/screen; a tap
+        that arrives before then just quick-fails."""
+        x, y = msg.get("x"), msg.get("y")
+        if not (isinstance(x, (int, float)) and isinstance(y, (int, float))):
+            return
+        if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+            return
+        _portal_call("move", {"x": float(x), "y": float(y)}, timeout=5)
+
+    def _handle_portal_btn(self, entry, msg):
+        """{t:'mbp',k,v} -> portal pointer button (k in l/r/m, v in 0/1)."""
+        name = self._PORTAL_BTNS.get(msg.get("k"))
+        v = msg.get("v")
+        if name is None or v not in (0, 1):
+            return
+        _portal_call("button", {"button": name, "state": v}, timeout=5)
+
     # Control frames (holder handoff) — handled regardless of hold state.
     _CONTROL_TYPES = frozenset(("grant", "deny", "request", "force"))
 
@@ -18830,6 +19080,16 @@ class Handler(BaseHTTPRequestHandler):
             return self._handle_control(entry, t)
         # Input frames only from the holder; a waiter's input is ignored.
         if not entry.get("held"):
+            return True
+        # ABSOLUTE pointer (remote-desktop P2) rides the opt-in portal module, a
+        # SEPARATE channel from the uinput mouse. Additive + tolerant: an absent/
+        # refusing portal makes these a no-op, never closes the session (same
+        # spirit as kt). The portal helper re-validates every argument.
+        if t == "ma":
+            self._handle_portal_abs(entry, msg)
+            return True
+        if t == "mbp":
+            self._handle_portal_btn(entry, msg)
             return True
         if t == "kt":
             # Text passthrough is handled here, BEFORE the decode table, so it

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.43",
+    "version": "2.9.44",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "167",
+      "buildNumber": "168",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 90
+      "versionCode": 91
     },
     "web": {
       "bundler": "metro",

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -3,10 +3,17 @@
  * project; see docs/memory/project_remote-desktop.md). Reached from the Console
  * screen viewer's "Control" button.
  *
- * The live screen frame fills the view; a transparent trackpad overlay on top
- * drives the desktop pointer over the SAME /ws/gamepad input path the Pad uses
- * (relative mouse — proven + already low-latency). This is "confirm-by-frame"
- * control at ~1.4fps, not fluid video (that is the opt-in P4 streaming module).
+ * The live screen frame fills the view; a dedicated trackpad zone drives the
+ * desktop pointer over the SAME /ws/gamepad input path the Pad uses (relative
+ * mouse — proven + already low-latency).
+ *
+ * TWO modes, chosen by caps.screenstream (the opt-in xdg-desktop-portal module):
+ *   - module ABSENT (default): the P1 still-frame poller (~1.4fps, "confirm-by-
+ *     frame") + relative trackpad. Works on every box.
+ *   - module PRESENT: the FLUID /ws/screen MJPEG stream + tap-to-point (tap the
+ *     frame -> the portal's absolute pointer moves there and clicks). The relative
+ *     trackpad still works for fine control. Degrades to the poller if the stream
+ *     fails (e.g. box in Game Mode -> no portal desktop session).
  *
  * It owns its OWN GamepadClient for the duration of the screen: connect +
  * requestControl on mount, releaseAll + close on unmount. `noPad:true` — this
@@ -25,11 +32,13 @@ import { Stack, router } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator, Image, Pressable, StyleSheet, Text, View,
+  type GestureResponderEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { useScreenFrame } from '@/hooks/useScreenFrame';
+import { useScreenStream } from '@/hooks/useScreenStream';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { GamepadClient, type GamepadStatus } from '@/lib/gamepad';
 import { hapticLight, hapticMedium } from '@/lib/haptics';
@@ -47,7 +56,14 @@ export default function DesktopControlScreen() {
   const insets = useSafeAreaInsets();
   const { settings, ready } = useSettings();
   const configured = settings.host.trim().length > 0;
-  const { frame, failed } = useScreenFrame(settings, ready && configured, FRAME_MS);
+  // FLUID when the opt-in portal module is present (caps.screenstream): the
+  // /ws/screen MJPEG stream + tap-to-point. Otherwise the P1 still-frame poller +
+  // relative trackpad. Both hooks run (hooks rules); only the active one connects.
+  const streamMode = settings.caps?.screenstream === true;
+  const live = ready && configured;
+  const poll = useScreenFrame(settings, live && !streamMode, FRAME_MS);
+  const streamed = useScreenStream(settings, live && streamMode);
+  const { frame, failed } = streamMode ? streamed : poll;
 
   const clientRef = useRef<GamepadClient | null>(null);
   if (clientRef.current == null) clientRef.current = new GamepadClient();
@@ -108,6 +124,19 @@ export default function DesktopControlScreen() {
     onDragEnd: () => client.sendMouseButton('l', 0),
   });
 
+  // Tap-to-point (P2, fluid mode only): the tap's location within the frame maps
+  // to a normalized 0..1 coordinate for the portal's absolute pointer. The stage
+  // is 16:9 and the stream is 16:9, so there is no `contain` letterbox — the map
+  // is just location / measured size. (A non-16:9 source would need letterbox math.)
+  const stageSize = useRef({ w: 0, h: 0 });
+  const onTapFrame = useCallback((e: GestureResponderEvent) => {
+    const { w, h } = stageSize.current;
+    if (w <= 0 || h <= 0) return;
+    hapticLight();
+    // q01 on the client clamps to 0..1, so an edge tap past the bounds is fine.
+    client.tapAbs(e.nativeEvent.locationX / w, e.nativeEvent.locationY / h);
+  }, [client]);
+
   const exit = useCallback(() => { hapticMedium(); router.back(); }, []);
 
   return (
@@ -121,9 +150,22 @@ export default function DesktopControlScreen() {
           <View style={[StyleSheet.absoluteFill, styles.center]}>
             <ActivityIndicator color={t.textDim} />
             <Text style={styles.dim}>
-              {!configured ? 'Connect a box first.' : 'Waiting for the screen…'}
+              {!configured ? 'Connect a box first.'
+                : streamMode ? 'Approve remote control on your box…'
+                : 'Waiting for the screen…'}
             </Text>
           </View>
+        )}
+        {/* Tap-to-point overlay (fluid mode only): tapping the frame moves the
+            real cursor there and clicks, via the portal's absolute pointer. */}
+        {streamMode && frame && (
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onLayout={(e) => {
+              stageSize.current = { w: e.nativeEvent.layout.width, h: e.nativeEvent.layout.height };
+            }}
+            onPress={onTapFrame}
+            accessibilityLabel="Tap the screen to click there" />
         )}
         {status !== 'connected' && (
           <View style={[styles.pill, { top: 6 }]} pointerEvents="none">
@@ -142,7 +184,11 @@ export default function DesktopControlScreen() {
       {/* TRACKPAD (middle): the touch surface that drives the pointer */}
       <View style={styles.trackpad} {...pad.panHandlers} accessibilityLabel="Desktop trackpad">
         <Ionicons name="move-outline" size={22} color={t.textFaint} />
-        <Text style={styles.trackpadHint}>drag to move · tap to click · two-finger scroll</Text>
+        <Text style={styles.trackpadHint}>
+          {streamMode
+            ? 'tap the screen to point · drag here to move · two-finger scroll'
+            : 'drag to move · tap to click · two-finger scroll'}
+        </Text>
       </View>
 
       <View style={[styles.bar, { paddingBottom: insets.bottom + 8 }]}>

--- a/app/eas.json
+++ b/app/eas.json
@@ -30,6 +30,11 @@
     "production": {
       "autoIncrement": true
     },
+    "tf-local": {
+      "ios": {
+        "simulator": false
+      }
+    },
     "simulator": {
       "autoIncrement": true,
       "distribution": "internal",

--- a/app/hooks/useScreenStream.ts
+++ b/app/hooks/useScreenStream.ts
@@ -1,0 +1,45 @@
+/**
+ * Fluid screen frames from the opt-in portal module's /ws/screen stream, as a
+ * drop-in for useScreenFrame: it returns the SAME { frame, failed, lastGood }
+ * shape, so the desktop route swaps poll -> stream by choosing which hook feeds
+ * its <Image>, changing nothing downstream.
+ *
+ * `failed` goes true when the socket errors/closes — for a box in Game Mode (no
+ * portal desktop session) the agent degrades /ws/screen closed, so the caller
+ * can fall back to the still-frame poller.
+ */
+import { useEffect, useState } from 'react';
+
+import type { ConnSettings } from '@/lib/api';
+import { ScreenStreamClient, type StreamProfile } from '@/lib/screenstream';
+
+export function useScreenStream(
+  settings: ConnSettings,
+  active: boolean,
+  profile: StreamProfile = '720p20',
+) {
+  const [frame, setFrame] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [lastGood, setLastGood] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const client = new ScreenStreamClient();
+    client.onFrame((uri) => {
+      setFrame(uri);
+      setFailed(false);
+      setLastGood(Date.now());
+    });
+    client.onStatus((s) => {
+      if (s === 'error') setFailed(true);
+    });
+    client.start(settings, profile);
+    return () => {
+      client.onFrame(null);
+      client.onStatus(null);
+      client.stop();
+    };
+  }, [active, profile, settings]);
+
+  return { frame, failed, lastGood };
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -204,6 +204,16 @@ export type BoxCaps = {
    * probe"; only explicit false skips it.
    */
   utilities?: boolean;
+  /**
+   * Opt-in remote-desktop module present (agent + the couchside-portal helper on
+   * its socket): the fullscreen desktop view uses the FLUID /ws/screen MJPEG
+   * stream + tap-to-point (absolute pointer via xdg-desktop-portal) instead of the
+   * still-frame poller + relative mouse. Linux/Wayland-desktop only, opt-in deps +
+   * a per-session consent on the box. Optional: absent on agents without the module
+   * and on Windows, so undefined reads as "unknown, probe"; only explicit false
+   * skips the fluid path (the app then uses the P1 poller).
+   */
+  screenstream?: boolean;
 };
 
 /** One Setup → Utilities helper + its live state, from GET /api/utilities.
@@ -1179,7 +1189,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.display_info === b.display_info &&
     a.player === b.player &&
     a.steaminstall === b.steaminstall &&
-    a.utilities === b.utilities
+    a.utilities === b.utilities &&
+    a.screenstream === b.screenstream
   );
 }
 
@@ -1245,8 +1256,10 @@ export async function uploadFile(
 }
 
 const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-/** base64-encode raw bytes (no reliance on btoa/Buffer, which RN may lack). */
-function base64FromArrayBuffer(buf: ArrayBuffer): string {
+/** base64-encode raw bytes (no reliance on btoa/Buffer, which RN may lack).
+ *  Exported for the /ws/screen stream client, which turns each binary WS JPEG
+ *  frame into a data: URI for <Image> the same way the HTTP frame path does. */
+export function base64FromArrayBuffer(buf: ArrayBuffer): string {
   const bytes = new Uint8Array(buf);
   const len = bytes.length;
   let out = '';

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -16,6 +16,12 @@
  *   {"t":"m","dx":I,"dy":I}            relative move (REL_X/REL_Y)
  *   {"t":"mb","k":"l"|"r"|"m","v":0|1} button (BTN_LEFT/RIGHT/MIDDLE)
  *   {"t":"mw","dy":I}                  vertical wheel (dy>0 = scroll up)
+ *   -- absolute pointer (remote-desktop P2, opt-in portal module) --
+ *   {"t":"ma","x":F,"y":F}             absolute move, x/y normalized 0..1 of the
+ *                                      frame (xdg-desktop-portal NotifyPointer-
+ *                                      MotionAbsolute). Additive: an agent/box
+ *                                      without the module drops it (no-op).
+ *   {"t":"mbp","k":"l"|"r"|"m","v":0|1} portal pointer button (NotifyPointerButton)
  *   -- keyboard (v2) --
  *   {"t":"kt","text":S}                type a string
  *   {"t":"k","key":NAME}              a single special key
@@ -282,6 +288,12 @@ function clamp(v: number, lo: number, hi: number): number {
 /** Round to 3 decimals to keep frames small; precision beyond this is noise. */
 function q(v: number): number {
   return Math.round(clamp(v, -1, 1) * 1000) / 1000;
+}
+
+/** Quantize an ABSOLUTE normalized coordinate to 0..1 (NOT -1..1 like q()).
+ *  For {t:'ma'} portal moves; the agent multiplies by the stream dimensions. */
+function q01(v: number): number {
+  return Math.round(clamp(v, 0, 1) * 1000) / 1000;
 }
 
 // Steam search focus walk. Counts are deliberately generous: an arrow at the
@@ -808,6 +820,34 @@ export class GamepadClient {
     const idy = Math.round(dy);
     if (idy === 0) return;
     this.sendRaw({ t: 'mw', dy: idy });
+  }
+
+  // ---------- absolute pointer (remote-desktop P2, opt-in portal module) ----------
+
+  /**
+   * Absolute pointer move: x/y are normalized 0..1 of the frame (top-left
+   * origin). Routed to the xdg-desktop-portal module; a box WITHOUT the module
+   * drops it, so this is safe to send unconditionally. NOT quantized like the
+   * stick's q() (that clamps -1..1) — a NEW 0..1 quantizer keeps the on-wire
+   * value small without losing sub-pixel-irrelevant precision.
+   */
+  sendMouseAbs(x: number, y: number): void {
+    this.sendRaw({ t: 'ma', x: q01(x), y: q01(y) });
+  }
+
+  /** Portal pointer button (BTN_LEFT/RIGHT/MIDDLE) for absolute tap-to-point.
+   *  Distinct from sendMouseButton (which drives the uinput mouse); this rides
+   *  the portal so the button lands at the absolute position. */
+  sendMouseButtonPortal(k: MouseButton, v: 0 | 1): void {
+    this.sendRaw({ t: 'mbp', k, v });
+  }
+
+  /** Absolute tap-to-point: move to (x,y) 0..1 then a momentary left click,
+   *  both over the portal. One gesture = one call. */
+  tapAbs(x: number, y: number): void {
+    this.sendMouseAbs(x, y);
+    this.sendMouseButtonPortal('l', 1);
+    setTimeout(() => this.sendMouseButtonPortal('l', 0), 40);
   }
 
   // ---------- keyboard (v2) ----------

--- a/app/lib/screenstream.ts
+++ b/app/lib/screenstream.ts
@@ -1,0 +1,182 @@
+/**
+ * WebSocket client for the Couchside FLUID screen stream (remote-desktop P4a,
+ * the opt-in portal module). Endpoint: ws://<host>:<port>/ws/screen?token=<token>
+ * &profile=<id>.
+ *
+ * Receive-only: the agent pushes whole JPEG frames as BINARY WS frames (the
+ * portal helper's gstreamer MJPEG). This mirrors the essential machinery of
+ * lib/gamepad.ts — IP/host resolution, a connect watchdog, backoff reconnect,
+ * and a superseded-socket guard on every callback — but carries no senders and
+ * no keepalive (the frames themselves are the liveness).
+ *
+ * Frames are decoded to a base64 `data:` URI for <Image> the same way the HTTP
+ * still-frame path does (no raw <Image> URL: the token can't ride the src and a
+ * frame may show a password prompt, so nothing lands in Fresco's disk cache).
+ * Only the NEWEST frame is ever surfaced — base64 is CPU-heavy, so a slow phone
+ * DROPS intermediate frames rather than queueing latency.
+ *
+ * A box WITHOUT the module: /ws/screen opens then immediately closes (the agent
+ * degrades closed), so `onStatus('error')` fires and the caller falls back to
+ * the P1 still-frame poller.
+ */
+import { base64FromArrayBuffer, resolveEffectiveHost, type ConnSettings } from './api';
+import { isUsableBodySize } from './responseCap';
+
+export type StreamStatus = 'connecting' | 'connected' | 'error' | 'closed';
+export type StreamProfile = '540p25' | '720p20' | '1080p15';
+
+// A dead target leaves the socket CONNECTING with no error; cut it short so the
+// reconnect can retry. Same intent as GamepadClient's connect watchdog.
+const CONNECT_TIMEOUT_MS = 8000;
+const BACKOFF_MS = [500, 1000, 2000, 4000];
+
+export class ScreenStreamClient {
+  private ws: WebSocket | null = null;
+  private settings: ConnSettings | null = null;
+  private profile: StreamProfile = '720p20';
+  private active = false;
+  private frameCb: ((uri: string) => void) | null = null;
+  private statusCb: ((s: StreamStatus) => void) | null = null;
+  private status: StreamStatus = 'closed';
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private backoffIdx = 0;
+
+  onFrame(cb: ((uri: string) => void) | null): void {
+    this.frameCb = cb;
+  }
+
+  onStatus(cb: ((s: StreamStatus) => void) | null): void {
+    this.statusCb = cb;
+    if (cb) cb(this.status);
+  }
+
+  start(settings: ConnSettings, profile: StreamProfile = '720p20'): void {
+    this.settings = settings;
+    this.profile = profile;
+    this.active = true;
+    this.backoffIdx = 0;
+    this.open();
+  }
+
+  stop(): void {
+    this.active = false;
+    this.clearReconnect();
+    this.teardownSocket();
+    this.setStatus('closed');
+  }
+
+  private setStatus(s: StreamStatus): void {
+    if (this.status === s) return;
+    this.status = s;
+    this.statusCb?.(s);
+  }
+
+  private open(): void {
+    if (!this.active || !this.settings) return;
+    this.teardownSocket(); // drop any prior socket first
+    this.setStatus('connecting');
+    const host = resolveEffectiveHost(this.settings);
+    const { port, token } = this.settings;
+    if (!host || !port) {
+      this.setStatus('error');
+      this.scheduleReconnect();
+      return;
+    }
+    const url =
+      `ws://${host}:${port}/ws/screen?token=${encodeURIComponent(token)}` +
+      `&profile=${this.profile}`;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      this.setStatus('error');
+      this.scheduleReconnect();
+      return;
+    }
+    // RN defaults binaryType to 'blob'; we need ArrayBuffer to decode inline.
+    ws.binaryType = 'arraybuffer';
+    this.ws = ws;
+
+    this.connectTimer = setTimeout(() => {
+      this.connectTimer = null;
+      if (ws !== this.ws || ws.readyState !== 0 /* CONNECTING */) return;
+      this.teardownSocket();
+      if (this.active) {
+        this.setStatus('error');
+        this.scheduleReconnect();
+      }
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      if (ws !== this.ws) return; // superseded
+      this.clearConnectTimer();
+      this.backoffIdx = 0;
+      this.setStatus('connected');
+    };
+    ws.onmessage = (ev: WebSocketMessageEvent) => {
+      if (ws !== this.ws) return;
+      const data = ev.data as unknown;
+      if (!(data instanceof ArrayBuffer)) return; // ignore text / stray frames
+      if (!isUsableBodySize(data.byteLength)) return;
+      // Newest-only: decode + surface immediately, no queue.
+      this.frameCb?.(`data:image/jpeg;base64,${base64FromArrayBuffer(data)}`);
+    };
+    ws.onerror = () => {
+      if (ws !== this.ws) return;
+      this.setStatus('error'); // onclose follows and schedules the reconnect
+    };
+    ws.onclose = () => {
+      if (ws !== this.ws) return;
+      this.ws = null;
+      this.clearConnectTimer();
+      if (this.active) {
+        this.setStatus('error');
+        this.scheduleReconnect();
+      } else {
+        this.setStatus('closed');
+      }
+    };
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.active || this.reconnectTimer != null) return;
+    const wait = BACKOFF_MS[Math.min(this.backoffIdx, BACKOFF_MS.length - 1)];
+    this.backoffIdx++;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.open();
+    }, wait);
+  }
+
+  private clearReconnect(): void {
+    if (this.reconnectTimer != null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer != null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+
+  private teardownSocket(): void {
+    this.clearConnectTimer();
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      try {
+        ws.close();
+      } catch {
+        /* already closed */
+      }
+    }
+  }
+}

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -292,12 +292,17 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // trap: omit it here (and from capsEqual) and the cap never persists, so the
   // Utilities section re-probes on every launch.
   const utilities = bool('utilities');
+  // screenstream = the opt-in remote-desktop module (fluid /ws/screen + tap-to-point).
+  // Same optional-cap drop trap: omit it from the RETURN object below (or from
+  // capsEqual) and the cap never persists, so the desktop view can never latch onto
+  // the fluid stream and re-probes forever.
+  const screenstream = bool('screenstream');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
-    steaminstall, utilities,
+    steaminstall, utilities, screenstream,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -177,10 +177,16 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 - **The two asks are different problems.** Controls-in-fullscreen is easy reuse; "fluid" is architectural:
   MEASURED ceiling ~1.2/1.4 fps, and **true VNC/fluid video is off the table on the screenshot pipeline** —
   each frame is a full screenshot+decode. Fluid (15-60fps) needs a whole new capture→encode→transport stack.
-- **Absolute pointer PROVEN pixel-exact on Plasma Wayland** (screenshot-diff, with a relative-mouse
-  control). Declare BTN_TOUCH to suppress a phantom /dev/input/js0. NOT shipped today (device is EV_REL only).
-  **Unproven: gamescope.** Needs zoom or a two-stage crosshair (a 44pt finger ≈ 289 logical px on a 4K
-  desktop vs a ~100×30px button) and frame-age gating so a stale frame can't produce a confident wrong click.
+- **⚡ BREAKTHROUGH 2026-08-10 — the path is xdg-desktop-portal, NOT raw uinput; P2+P4a UNIFY.** Raw-uinput
+  absolute is a PROVEN DEAD END on Wayland (kwin honors the portal, not a virtual EV_ABS device — legacy = no
+  motion; modern tablet/touchscreen classify but the cursor never moves). RustDesk shows the approach (AGPL →
+  borrow mechanism, never code). **Portal cursor PROVEN pixel-exact** on the KDE box (contamination-free: mouse
+  parked, portal warped to two arbitrary targets, menu tracked to each ~8px). **Capture PROVEN** via gstreamer
+  `pipewiresrc` on the SAME portal session — ONE consent grants input AND capture ("See what's on the screen" +
+  "Control input devices"). So **P2 (absolute input) + P4a (fluid capture) are ONE opt-in portal module.** The
+  portal driver needs `gi`/`Gio` (third-party) → lives in a session-scoped helper (user, not root); the agent
+  stays pure-stdlib. Consent is per-session on this box's (older) KDE (no persist checkbox); newer KDE persists.
+  Full unified spec: **`docs/memory/project_remote-desktop.md`**. gamescope Game Mode is OUT (no portal desktop).
 - **Phased plan:**
   - **P1 (low, app-only, ship-now): Fullscreen control mode.** Screen frame as a live background +
     a RemoteView-style trackpad + button overlay + `immersive.ts` chrome-hide + landscape. Reuses the
@@ -216,11 +222,18 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
         native H264 player) into EVERY app build (bloat + iOS build surface) even for non-users.
     - gamescope continuous capture still unproven (gamescopectl is one-shot); may be desktop-session-only.
       New stream endpoint = a new "video of your screen" data flow → security pass (token-authed, LAN-only).
-- **Next step:** P1 SHIPPED (#433). P2 (tap-to-click) is the near-term app+agent deliverable. P4a is
-  fully spec'd in **`docs/memory/project_screenstream-module.md`** (opt-in MJPEG module: KDE-desktop
-  PipeWire/wlr capture → ffmpeg MJPEG → `/ws/screen`, `caps.screenstream` gating, opt-in deps+access,
-  `<Image>` decode = no app native dep; gamescope Game Mode out of scope). Note: input isn't the
-  bottleneck — video is.
+- **Next step (updated 2026-08-10):** P1 SHIPPED (#433). Portal cursor + capture PROVEN; spec rewritten around
+  the portal (P2+P4a unified). **Build not started — it is now mechanical plumbing over mapped anchors:**
+  (1) `couchside-portal` helper (session mgmt + absolute-input verbs + gstreamer capture, runs as user);
+  (2) agent `/ws/screen` (mirrors `/ws/gamepad`) + additive `{t:'ma',x,y}` + `screenstream` cap (six sites);
+  (3) app `lib/screenstream.ts` MJPEG consumer + absolute-tap overlay on `app/app/desktop.tsx`;
+  (4) signed-channel install (deps + user unit) + uninstall. Capture = **gstreamer** (box ffmpeg lacks
+  pipewiregrab). `project_screenstream-module.md` is SUPERSEDED (transport detail only). Older P4b (H264 →
+  `react-native-webrtc` app-wide) stays deferred.
+  <!-- legacy note (kept per §7): P4a was earlier spec'd standalone in project_screenstream-module.md as
+  opt-in MJPEG: KDE-desktop PipeWire/wlr capture → ffmpeg MJPEG → /ws/screen, caps.screenstream gating,
+  `<Image>` decode = no app native dep; gamescope Game Mode out of scope. -->
+  Note: input isn't the bottleneck — video is.
 
 ## 📋 Planned
 

--- a/docs/memory/project_remote-desktop.md
+++ b/docs/memory/project_remote-desktop.md
@@ -1,132 +1,268 @@
-# Project — Remote desktop: fullscreen viewer + on-screen controls + (optional) fluid streaming
+# Project — Remote desktop: fullscreen control + absolute input + fluid streaming (portal-unified)
 
-Status: **SPEC.** P1 in progress (`claude/remote-desktop-p1`); P2–P4 planned.
-Origin: owner, 2026-08-10 — "screen viewer, when clicked, opens fullscreen with on-screen pad
-controls to control the desktop like remote desktop / RustDesk; reduce latency so it feels fluid,"
-then: "can P4 be an additional option that adds more dependencies to the install and more system
-access, so the feature can be used?" — yes; P4 is an **opt-in module** (see below).
+Status: **P1 SHIPPED (#433). Portal cursor PROVEN pixel-exact on KDE (2026-08-10).** P2 (absolute
+input) + P4a (fluid capture) are now **one opt-in module** riding the SAME xdg-desktop-portal session.
+Spec rewritten around the portal 2026-08-10. Absorbs `project_screenstream-module.md` (now superseded;
+its MJPEG-over-WS transport survives verbatim, its capture backend is replaced by the portal).
 
-Supersedes/absorbs the old ROADMAP "Remote desktop screenshot + tap" entry.
-
----
-
-## 1. The two problems (they are different)
-
-1. **Controls in fullscreen** — click the viewer → fullscreen frame + an on-screen control layer
-   (trackpad + buttons) that drives the desktop. **Easy: reuse.** The input path already exists.
-2. **Fluidity / low latency** — make it feel like RustDesk. **Hard: architectural.** The current
-   viewer is a still-frame poller capped ~1.4 fps; fluid needs a new capture→encode→transport stack.
-
-Input is NOT the bottleneck — it is already low-latency. **Video is.**
+Origin: owner, 2026-08-10 — "screen viewer → fullscreen with on-screen pad controls like RustDesk;
+reduce latency so it feels fluid," then "can it be an additional option that adds more dependencies +
+system access, so the feature can be used?" — yes. That opt-in IS this module.
 
 ---
 
-## 2. Current state (mapped 2026-08-10, file:line)
+## 0. The one decision that reframes everything (GROUNDED, do not relitigate)
 
-### Viewer (still-frame poller)
-- `GET /api/screen` — probe/info (`couchsided.py:17026`), body `{available, session, backends,
-  formats:["image/jpeg"]}` (`screen_info()` `11901`). **No width/height.** 404 → app hides the card.
-- `GET /api/screen/frame` — ONE JPEG (`17036`), Bearer header only, `Cache-Control: no-store`.
-  Capture (`real_screen_frame()` `11830`): `gamescopectl screenshot` (~1.4s, 4K PNG) in Game Mode
-  (`_grab_gamescopectl` `11690`) / `spectacle -b -n -o` JPEG (~0.7s) on KDE (`_grab_spectacle` `11724`);
-  downscale via `magick`/`ffmpeg` to `SCREEN_WIDTH=960` q80 (no PIL, off immutable rootfs). Decode dominates.
-- Server floor ~2 captures/s: `SCREEN_MIN_INTERVAL_S=0.5`, single-flight `SCREEN_LOCK`, 500ms cache.
-  **Measured ceiling ~1.2–1.4 fps** (ROADMAP/BUILD_LOG; ~0.41s of every frame is spectacle's Qt startup).
-  **No MJPEG/chunked/WebSocket stream path.** `caps.screen` exists (`1592`) but ScreenPreview probes
-  `/api/screen` directly, not the cap.
-- App: `components/ScreenPreview.tsx` — poll `1000ms` (`700ms` in the tap→`<Modal>` fullscreen), OFF by
-  default, fetches `api.ts:screenFrameSource` (base64 data-URI, Bearer header, `?t=` cache-bust),
-  `<Image resizeMode="contain">`. On the Console tab (`(tabs)/index.tsx:373`). `lib/immersive.ts`
-  fullscreen store exists; NO fullscreen route (the "fullscreen" today is the in-component Modal).
+**Wayland remote-desktop goes through `xdg-desktop-portal`, NOT raw uinput.** kwin honors the PORTAL,
+not a virtual absolute uinput device — that is exactly why the raw-uinput P2 attempt failed (legacy =
+no motion; modern tablet/touchscreen classify but the cursor never moves; buttons work, positioning
+doesn't). RustDesk proves the approach but is **AGPL-3.0** → we borrow the mechanism, never its code.
 
-### Input (separate, already fast)
-- One `/ws/gamepad` WebSocket, client = `lib/gamepad.ts` (NOT api.ts). Mouse is **relative-only**
-  (`{t:'m',dx,dy}`, coalesced ~90Hz `MOUSE_MOVE_INTERVAL_MS=11`), buttons `{t:'mb',k,v}`, wheel
-  `{t:'mw',dy}`, keys `{t:'k',key}` / `{t:'kt',text}`. Senders `sendMouseMove/Button/Wheel/Key/Text`,
-  `sendDesktopKey('meta'|'overview')`.
-- Injection: direct `/dev/uinput` evdev writes behind frozenset allowlist `_MOUSE_TYPES/_KEYBOARD_TYPES`
-  (`_gamepad_message` `18764`), decoders `mouse_events` `12610` / `keyboard_events` `12635`. §3-clean,
-  compositor-agnostic. Input dropped unless the session holds control (`18786`); devices lazy-created.
-- **No absolute pointer** anywhere (protocol or device — EV_REL only, `12402`). BUT absolute pointer was
-  PROVEN pixel-exact on Plasma Wayland in a past screenshot-diff experiment (needs an EV_ABS device +
-  BTN_TOUCH to suppress a phantom js0). Reusable primitives: `hooks/useTrackpad` (relative mouse
-  PanResponder), `components/RemoteView` (trackpad + click/scroll/meta/overview/esc over the client).
+- **ScreenCast portal** → the video (a PipeWire node).
+- **RemoteDesktop portal** → the input (`NotifyPointerMotionAbsolute` / `NotifyPointerButton` / keyboard).
+- **ONE session selects BOTH** (RemoteDesktop devices + ScreenCast sources) → **ONE consent dialog**
+  grants input *and* capture together. Proven: our proof session got `devices:2` AND `streams:[…]`
+  from a single `Start`. So P2 and P4a are not two features — they are two consumers of one session.
 
----
+**PROVEN pixel-exact (2026-08-10, lenovodesktop, KDE Plasma 6 / xdg-desktop-portal 1.20.4).**
+Contamination-free control run: owner parked the PHYSICAL mouse bottom-left (hands off); the portal
+warped the cursor to (700,140) and (1400,140) and right-clicked; KDE's desktop context menu anchored at
+≈(700,148) and ≈(1408,148) — both at our targets (~8px = menu border offset), NOT at the parked mouse.
+Menu TRACKED across two distinct arbitrary targets. Driver: scratchpad `portal.py` (raw-Gio edition).
 
-## 3. Phases
-
-### P1 — Fullscreen control mode (app-only, ship-now) — THIS BRANCH
-Click the screen viewer → a landscape, immersive fullscreen view: the live frame as background +
-a control overlay (trackpad for relative mouse, left/right click, scroll, a small key row, keyboard
-toggle) driving the existing `/ws/gamepad` client. Reuses `useTrackpad` + RemoteView's mappings +
-`immersive.ts` + `useLockOrientation('landscape')`. Frame keeps polling at the fullscreen cadence.
-- No agent change, no API change, no new dep.
-- Relative-mouse control at ~1.4fps = "confirm-by-frame": good for click/close/type, not motion.
-- **Verification reality:** the frame/layout/fullscreen IS harness-verifiable; the CONTROLS are not
-  driveable by real touch (RN-Web = mouse, and the gamepad WS is not proxied). Use the CONVENTIONS
-  fake-WebSocket harness pattern (in-page fake WS that PONGs every frame; assert the `send()`ed input
-  frames) to prove the overlay emits the right `{t:'m'/'mb'/'mw'/'k'}` frames; the feel needs a device.
-
-### P2 — Absolute tap-to-click (agent + app, medium)
-Tap a point on the frame → pointer goes there. Add: EV_ABS uinput mouse (+BTN_TOUCH), a `{t:'ma',x,y}`
-protocol frame (ADDITIVE, six-site cap if gated), width/height on `ScreenInfo`, tap→coordinate mapping
-(frame is `contain` → letterbox math), and **frame-age gating** so a stale frame can't cause a confident
-wrong click. Proven on Plasma; **gamescope unproven** → needs a zoom or two-stage crosshair (a 44pt
-finger ≈ 289 logical px on a 4K desktop vs a ~100×30px button). Makes P1 feel like real remote desktop.
-
-### P3 — Faster frames (agent + app, medium)
-Smaller region/res + stream frames (MJPEG multipart or WS-framed JPEG) instead of one HTTP GET each.
-Realistic ~5–10 fps of small JPEGs. Better for control; still not "fluid."
-
-### P4 — Fluid hardware-encoded video, as an OPT-IN MODULE (the "RustDesk" answer) — HIGH/large
-Owner: "an additional option that adds more dependencies to the install and more system access." This
-is the correct shape and it fits the constraints:
-- **Core agent stays pure-stdlib single-file.** No third-party PYTHON. The module SHELLS OUT to system
-  binaries (gstreamer/ffmpeg/pipewire) via the existing argv allowlist — same as today's capture. Extra
-  DEPS are SYSTEM packages the user opts into, not pip/bundled python.
-- **Gated by caps + probe-and-appear.** New `caps.screenstream` (six edit sites, §4) → the app shows the
-  fluid viewer ONLY when the module is present; else it degrades to the P1–P3 still-frame poller. Never a guess.
-- **Opt-in deps + access** (precedent: Decky channel, the privileged helper). A separate install step /
-  `ujust` recipe installs gstreamer+VAAPI+pipewire and grants the PipeWire **screencast-portal**
-  permission (maybe a unit/helper). "More access" (continuous capture + HW encoder) is explicit,
-  documented, off by default — distributed like the signed helper, NOT base `install.sh`.
-- **Transport avoids the forbidden bit.** No full WebRTC (ICE/DTLS/SRTP → needs `aiortc` = third-party =
-  FORBIDDEN). Use H264/VP8- or MJPEG-**over the existing hand-rolled RFC6455 WebSocket**: encoder
-  subprocess stdout → framed to the WS.
-- **The ASYMMETRY that decides sub-tiers.** The BOX side is cleanly opt-in, but the APP-side decoder is
-  NOT per-box optional — one app binary ships to everyone:
-  - **P4a (LEAD WITH THIS): MJPEG "fast-capture" module.** pipewire continuous grab → small JPEGs over
-    WS. Opt-in box deps + screencast access, ~15–25 fps, and **NO new app native dep** (JPEG decode reuses
-    `<Image>`). Most of the "fluid" win, cleanly optional end-to-end.
-  - **P4b (max): H264/VAAPI stream.** True 30–60fps / ~50–150ms, but forces `react-native-webrtc` (or a
-    native H264 player) into EVERY app build (bloat + iOS build surface) even for non-users.
-- gamescope continuous capture is unproven (gamescopectl is one-shot — may be desktop-session-only).
-- New "video of your screen" data flow → a security pass (token-authed, LAN-only, opt-in consent).
+### The hard-won D-Bus recipe (this WILL bite the next person — use raw `Gio.bus_get_sync(SESSION)`)
+1. **pydbus MANGLES `CreateSession`'s return** — it handed back a `/session/…` path built from
+   `session_handle_token` instead of the real `/request/…` handle. `gdbus` proved the portal is
+   spec-compliant. Using pydbus's bogus path as the session → `SelectDevices` "Ended" (code 2).
+   **=> do not use pydbus for the portal calls.**
+2. Every Create/Select/Start is **Request/Response**: the method returns a `/request/…` handle; the real
+   result (incl. `session_handle`, and Start's `streams`) arrives in the async `Response` signal on that
+   path. Response is delivered ONLY while a GLib main loop runs.
+3. **`SelectDevices`/`SelectSources` auto-Respond in MICROSECONDS** → install the `AddMatch` rule
+   **synchronously** (blocking `org.freedesktop.DBus.AddMatch` via `con.call_sync`) BEFORE issuing the
+   call, or the fast Response races past `signal_subscribe`'s async AddMatch and you time out. Start is
+   human-gated (seconds) so it never races. Subscribe on the predicted path
+   `/request/<uniqname_with_dots_as_underscores>/<handle_token>`.
+4. Response codes: 0=success, 1=cancelled, 2=ended/invalid-session.
+5. Flow: `CreateSession` → `SelectDevices(types=2 POINTER)` → `SelectSources(types=1 MONITOR,
+   cursor_mode=2 embedded)` → **`Start('',opts)` pops the KDE "Share your screen / Remote control"
+   dialog — user clicks Share/Allow** → results `{devices:2, streams:[(node,{position,size:(1920,1080),
+   source_type:1})]}`. Then `NotifyPointerMotionAbsolute(session,{},node,float(px),float(py))` (px,py =
+   PIXELS in the stream) and `NotifyPointerButton(session,{},0x111,1/0)` (BTN_RIGHT=0x111, LEFT=0x110).
+6. **Consent persistence — RESOLVED: version-dependent, NOT on this box → plan for per-session consent.**
+   The `RemoteDesktopDialog` has a "remember" checkbox (`allowRestore`), shown only when `persistenceRequested`
+   (persist_mode≠None); `remotedesktop.cpp` forces NoPersist if unticked. BUT this box's captured dialog shows
+   only **Approve/Deny, no checkbox**, its text reads **"Control input devices"** (KDE master reads "Move the
+   pointer and type keystrokes" → the box runs an OLDER portal-kde without the RemoteDesktop persist checkbox),
+   and `restore_token` came back None. Three consistent signals → **the combined session RE-PROMPTS every agent
+   session here.** Newer KDE adds the checkbox. So: attended/per-session consent is the baseline (fine — the
+   user is initiating remote control of their own box, like RustDesk attended mode); silent headless reconnect
+   is a NEWER-KDE bonus (tick "remember" once, replay the token), **not guaranteed**. Do NOT design around or
+   claim headless. Capture (ScreenCast) persist is broader, but the unified session ties both to RemoteDesktop.
 
 ---
 
-## 4. Constraints (do not violate)
-- Agent: pure-stdlib, single file. New capture/encode = argv-allowlisted subprocess, never a shell string
-  or client-supplied command (§3). No third-party python (rules out aiortc → no full WebRTC).
-- Input path is safety-critical (§4). P1's overlay drives DESKTOP mouse (relative) — lower stakes than the
-  d-pad latch, but still uinput; keep it behind the existing control/handoff gate.
-- Response shapes additive-only. `caps.screenstream` if added = all six edit sites.
-- Never `caps`-gate what should probe-and-appear; degrade closed (no module → still-frame poller, honestly).
-- RN has no native `<video>`/WebRTC — any decoder is a NEW native dep that ships to ALL app users (the P4a/P4b split).
+## 1. The two problems (unchanged framing, now both solved by the portal)
+1. **Controls in fullscreen** — SHIPPED as P1 (#433): still-frame background + relative-mouse overlay
+   over `/ws/gamepad`. Easy reuse; input was never the bottleneck.
+2. **Fluidity + precision** — the still-frame poller is capped ~1.4 fps and relative-only. The portal
+   module fixes BOTH: PipeWire capture → fluid; `NotifyPointerMotionAbsolute` → tap-to-point.
 
-## 5. Verification plan (and how the harness lies)
-- Frame display / fullscreen / landscape / immersive: harness-verifiable (screenshot + layout).
-- **Controls: the gamepad WS is NOT proxied in the harness and RN-Web emits mouse, not touch.** Use the
-  fake-WebSocket pattern (CONVENTIONS "Harness wire-proof for gamepad surfaces"): an in-page fake WS that
-  PONGs every frame; read the `send()`ed frames and assert the overlay emits the right input JSON. The
-  actual feel + tap-to-click accuracy (P2) need a device (`adb`/screencap; a real box answers `/api/screen`).
-- P4 streaming: device-only against a box with the module installed; also measure real fps + latency before
-  any "fluid" copy (the last remote-desktop claim was tempered precisely because ~1.4fps isn't fluid).
+---
 
-## 6. Open questions
-- P1: does the fullscreen viewer open its OWN `/ws/gamepad` client (handoff with the Pad tab) or share one?
-  (Leaning: own client, opened on enter / closed on exit, request control — you ARE the controller while in it.)
-- P2: gamescope absolute mapping (zoom vs two-stage crosshair); frame-age threshold.
-- P4: encoder availability per box (VAAPI vs software); gamescope continuous capture; module distribution
-  channel (ujust recipe vs installer flag vs signed helper); audio? clipboard? (scope to screen+input first).
+## 2. Current shipped state (anchors verified 2026-08-10 by a code map; couchsided.py is 19031 lines)
+
+### Viewer / capture (still-frame poller — the fallback the module degrades to)
+- `GET /api/screen` = probe-and-appear `screen_info()` (`couchsided.py:11947`), 404 hides the card.
+- `GET /api/screen/frame` = one JPEG, `no-store` (`17082`), `real_screen_frame()` (`11876`): single-flight
+  `SCREEN_LOCK` + 500ms cache → ~2 captures/s ceiling. Backends resolved PER CALL by `_screen_live()`
+  (`11673`, degrade-closed → None); `_screen_env()` (`11701`) sets `WAYLAND_DISPLAY`/`DISPLAY`.
+- Capture argv is an **allowlist**: `_grab_gamescopectl` (`11736`) / `_grab_spectacle` (`11770`) are
+  literal argv LISTs; `subprocess.run([...], timeout=SCREEN_CAPTURE_TIMEOUT_S)`. **No client string ever
+  reaches a subprocess** — the backend is a fixed-string switch in `real_screen_frame` (`11905`).
+- `screen` cap set in `set_caps` (`1592`, `_SCREEN is not None`).
+
+### Input (`/ws/gamepad`, already fast, RELATIVE only)
+- Hand-rolled RFC6455 (`15640-15733`): `ws_send(conn,opcode,payload)` (`15717`, opcode-generic, UNMASKED,
+  u16/u64 length escape, blocking `sendall`); `ws_try_parse`/`ws_recv_frame`. `WS_OP_TEXT/CLOSE/PING/PONG`
+  at `15644` — **no `WS_OP_BINARY`**. Per-socket send serialized through `entry["slock"]` (`_wsend_op`
+  `15780`, rationale `15742-15745`) — mandatory: a socket is written from the recv loop AND other threads.
+- Route: `/ws/gamepad` dispatched at `16749`, in the **pre-auth zone** (before `_authorized()` at `16827`)
+  — the handler auths itself. `_handle_gamepad_ws` (`18536`): `?token=` + `hmac.compare_digest` → 401,
+  then `Sec-WebSocket-Accept`, 101, `_gamepad_session` (`18575`). Holder gate: `if not entry.get("held")`
+  drops input from non-holders (`18832`). Cleanup on every exit path (`18673`).
+- Mouse is **relative-only** (`{t:'m',dx,dy}` etc.). **No absolute pointer** anywhere yet.
+
+### App (P1)
+- Route `app/app/desktop.tsx` (NESTED app/ dir — not `app/desktop.tsx`). Own `GamepadClient` (`noPad:true`,
+  relative mouse via `useTrackpad`); frame via `useScreenFrame` (`app/hooks/useScreenFrame.ts`) poll of
+  `api.screenFrameSource` → base64 data-URI → `<Image resizeMode="contain">` in a 16:9 stage. Reached from
+  `components/ScreenPreview.tsx` CONTROL pill (gated by `caps.screen`).
+- `GamepadClient` (`app/lib/gamepad.ts`) is the reference WS client: IP-first/mDNS URL, connect watchdog,
+  backoff reconnect, superseded-socket guard, one `sendRaw()` choke point (JSON TEXT). `base64FromArrayBuffer`
+  (`api.ts:1249`) is module-private (must export for a binary consumer).
+
+---
+
+## 3. Architecture of the opt-in portal module (the unification)
+
+```
+ KDE Wayland session  ── ONE xdg-desktop-portal session (RemoteDesktop POINTER + ScreenCast MONITOR),
+        │                 ONE consent, restore_token persisted
+        ▼
+ couchside-portal  (NEW helper file; python3 + gi/Gio; runs as User=<user>, session bus)
+   ├─ owns the portal session (consent flow + restore_token save/replay)
+   ├─ INPUT verbs  : move<x,y> / button<code,state> / key  → NotifyPointerMotionAbsolute / Button
+   └─ CAPTURE      : OpenPipeWireRemote(fd) → ffmpeg(-f pipewire … -c:v mjpeg) → MJPEG frames
+        │  AF_UNIX socket, 0600, user-owned  (detect-and-degrade, like _helper_call at 4731)
+        ▼
+ couchsided.py  (STAYS pure-stdlib, single file)
+   ├─ spawns + supervises couchside-portal; _portal_call() → None only when socket absent/dead (=fallback)
+   ├─ /ws/gamepad : NEW allowlisted {t:'ma',x,y} branch → forward to helper (ABSOLUTE input = P2)
+   └─ /ws/screen  : NEW endpoint — reads MJPEG frames from helper → one binary WS frame each (P4a)
+        │  ws + ?token=, LAN only, drop-oldest backpressure
+        ▼
+ app  ├─ lib/screenstream.ts  : ScreenStreamClient (binary MJPEG consumer) → newest JPEG → <Image>
+      └─ desktop.tsx          : swap poll→stream when caps.screenstream; absolute-tap overlay (P2)
+```
+
+### Why a separate helper (non-negotiable)
+The portal driver needs `gi`/`Gio` (PyGObject) = a **third-party Python import**, which the base agent
+**forbids** (`agent stays pure Python 3 stdlib, single file`). So the portal code CANNOT live in
+`couchsided.py`. It is a separate process, exactly the **privileged-helper pattern** — EXCEPT it runs as
+the **user** (session bus / PipeWire / Wayland need the user session), NOT root. So: NO root, NO
+`/usr/local/libexec`; a user systemd unit + a user-owned socket. This is the session-scoped variant of
+`couchside-helper.py` (`agent/couchside-helper.py`, VERBS table `:359`, argv-list `_run` `:140`,
+SO_PEERCRED auth `:393`) — copy its frozen-verb-table + argv-list + fail-closed discipline, drop the root.
+
+### Two independent consumers of one session
+Input needs the session UP with a stream selected (for coord space) — it does NOT need ffmpeg running.
+Capture needs ffmpeg reading the node. So a phone can drive the cursor (P2) with capture idle, or stream
+(P4a) without touching the pointer. One `Start`, two consumers.
+
+---
+
+## 4. Phases
+
+### P1 — Fullscreen relative control — ✅ SHIPPED (#433). The permanent fallback.
+No agent/API change. When the module is absent, this is what the user gets: relative mouse + ~1.4fps
+still frames. Honest, always-available.
+
+### P2 — Absolute tap-to-point (portal input) — part of the module
+- Helper: input verbs → `NotifyPointerMotionAbsolute` (px in the stream) + `NotifyPointerButton`.
+- Agent: `/ws/gamepad` gains an **allowlisted** `{t:'ma',x,y}` branch (x,y normalized 0..1) →
+  `_portal_call("move", …)`. Additive frame; the holder gate still applies (`18832`).
+- App: `sendMouseAbs(x,y)` in `gamepad.ts` (`sendRaw({t:'ma',x:q01(x),y:q01(y)})`, NEW 0..1 quantizer —
+  NOT `q()` which is −1..1); a transparent tap overlay on the stage mapping touch → normalized content
+  rect (mind `contain` letterbox) → `sendMouseAbs` + momentary left click.
+- Coord mapping: px = x * stream_width, py = y * stream_height (agent knows the stream size from the
+  helper). Pixel-exact PROVEN. **gamescope is out of scope** (Game Mode has no portal desktop session).
+
+### P4a — Fluid MJPEG capture (portal ScreenCast) — the rest of the module
+- **Capture = gstreamer, NOT ffmpeg** (PROVEN: this box's ffmpeg has no `pipewiregrab` filter; gstreamer has
+  `pipewiresrc` + `jpegenc`). Helper: `OpenPipeWireRemote(session,{})` via `call_with_unix_fd_list_sync` →
+  unix fd → `gst-launch-1.0 -q pipewiresrc fd=<fd> path=<node> ! videorate ! video/x-raw,framerate=20/1 !
+  videoconvert ! jpegenc quality=<q> ! fdsink` spawned with `Popen(..., pass_fds=(fd,))` → MJPEG to the agent.
+  argv is a LIST built from an **allowlisted profile enum** (e.g. `720p20` = cap-height 720 / q~85 / 20fps);
+  the client only names a profile KEY, never a resolution/filter string. One-frame proof used `num-buffers=1
+  ! jpegenc ! filesink` → a valid 1920×1080 JPEG.
+- Agent `/ws/screen` (NEW): add `WS_OP_BINARY=0x2` (`15644`); dispatch in the pre-auth zone right after
+  `/ws/gamepad` (`16751`); `_handle_screen_ws` mirrors `_handle_gamepad_ws` (same `?token=` +
+  `compare_digest`, handshake); `_screen_session` builds `entry={conn,slock}`, reads MJPEG (split on
+  `\xff\xd8…\xff\xd9`), keeps ONLY the newest JPEG in a single slot (drop-oldest — blocking `sendall`
+  means a slow phone MUST fall behind, never queue), sends `_wsend_op(entry,WS_OP_BINARY,jpeg)`; recv loop
+  handles the `{t:'start',profile}` control frame + disconnect; `finally` REAPS the helper's capture
+  (a leaked encoder keeps filming the screen — privacy failure). A per-server stream cap (like
+  `SCREEN_LOCK` single-flights the poll path) so N phones can't spawn N encoders.
+- App: `lib/screenstream.ts` = stripped `GamepadClient` copy but `/ws/screen`, **`ws.binaryType =
+  'arraybuffer'`**, onmessage → `isUsableBodySize` → `base64FromArrayBuffer` (export it) → data-URI, keep
+  only newest, fire `onFrame`. `useScreenStream(settings,active)` returns the SAME `{frame,failed,lastGood}`
+  as `useScreenFrame`; `desktop.tsx:50` branches on `caps.screenstream`. Separate socket from input.
+- **P4b (H264/VAAPI) stays deferred** — forces `react-native-webrtc`/native decoder into EVERY app build.
+  MJPEG decodes with the existing `<Image>` → no new app native dep. Lead with P4a.
+
+### P3 — (folded) faster still-frames — only if the module can't be installed; not a priority now.
+
+---
+
+## 5. The `screenstream` capability — all SIX edit sites (CLAUDE.md §4; enforced by test_protocol_parity.py)
+Linux-only (Wayland portal path) → goes in `linuxOnlyCapabilities`, NOT the cross-platform group, and
+must NOT be added to `agent/win/couchsided-win.py` (parity's "leaked" branch asserts its absence there).
+1. Agent real dict `set_caps` `couchsided.py:1587-1618` → `"screenstream": safe(screenstream_available),`
+   before the `}` at 1618 (define `screenstream_available()`: static probe = helper installed + ffmpeg +
+   pipewire + persisted token; returns False on any failure = degrade closed).
+2. Agent mock tuple `couchsided.py:1580-1585` → append `"screenstream"`.
+3. App `BoxCaps` `app/lib/api.ts:80-207` → `screenstream?: boolean;` at EXACTLY 2-space indent (parity
+   regex `^\s{2}([a-z_]+)\??:`). Optional `?` — old agents omit it.
+4. App `normalizeCaps` `app/lib/settings.ts:218-302` → `const screenstream = bool('screenstream');` AND add
+   it to the RETURN object (295-301). **Omitting the return entry is the classic silent bug** (parses,
+   never persists, app re-probes forever).
+5. App `capsEqual` `app/lib/api.ts:1157-1184` → `&& a.screenstream === b.screenstream`.
+6. `protocol/protocol.json` `linuxOnlyCapabilities.keys` (`:176-194`) → `"screenstream"` after `"player"`.
+
+**Gating nuance:** `caps.screenstream` may FLIP with the Game↔Desktop session (portal needs a desktop
+session). If so, gate the fluid viewer via a LIVE `usePoll(api.status)` like `caps.desktop` does
+(`app/app/(tabs)/pad.tsx:1336`, `deskPoll`), not persisted `settings.caps`. The endpoint ALSO degrades
+closed on `_screen_live() is None` regardless of the cap — cap is the hint, the live probe is the truth.
+
+---
+
+## 6. Distribution / install / consent (precedent: the privileged helper + ujust; map 3)
+- Base agent stays pure-stdlib; base `install.sh` unchanged. The helper + units + a deps step ship via the
+  **signed release channel**: add the new files to `scripts/release-agent.sh` `files[]` (like the
+  `couchside-helper.{py,socket,service}` trio) so they land in `SHA256SUMS` and get Ed25519-signed;
+  `install.sh` verifies against the two embedded pubkeys; **system/root code present-but-not-in-the-signed-
+  manifest is DROPPED**, and it must `py_compile`. Front door = an installer flag and/or a
+  `ujust get-couchside` action (status|install|uninstall).
+- Install: user systemd unit for `couchside-portal` (User=<user>, NOT root; ProtectHome would BREAK it —
+  it needs the session bus). Install ffmpeg/pipewire (or verify present — Bazzite ships pipewire; ffmpeg
+  is common). On immutable/ostree distros there is no pip/rpm path (the whole reason the base is stdlib) —
+  the deps step must handle-or-honestly-refuse. **Uninstall must remove every artifact** (unit, socket dir,
+  the persisted portal token, deps marker) — a hard ujust-PR requirement.
+- Consent: **per-session on this box's KDE** (no persist checkbox — §0.6). Still pass `persist_mode=2` and
+  save/replay any `restore_token` for newer KDE that offers it, but design the UX for a click each session
+  (the phone triggers a "approve on the box" prompt; honest copy: "your box will ask you to allow this").
+
+---
+
+## 7. Constraints (do not violate)
+- Base agent pure-stdlib single file → the portal driver is a SEPARATE process; NO third-party Python in
+  `couchsided.py`. This ALSO rules out `aiortc`/WebRTC → MJPEG over the hand-rolled WS (P4a), never full
+  WebRTC.
+- **Allowlist (§3):** the encoder profile and every input verb are dict-key LOOKUPS from frozen tables;
+  argv is always a LIST, never `shell=True`, never a formatted command string. A client names a profile
+  KEY / sends `{t:'ma',x,y}` (numbers) — no client string reaches ffmpeg, the portal, or a shell.
+- **Input path is safety-critical (§4):** `{t:'ma'}` is additive on `/ws/gamepad`, behind the existing
+  holder gate. Do NOT put pixel traffic on the input socket; `/ws/screen` is a SEPARATE socket and a
+  SEPARATE app client. Do not refactor the gamepad lifecycle.
+- Response shapes additive-only; `screenstream` = all six sites or it never persists.
+- Degrade closed: no module / no desktop session / no token → still-frame poller (P1), never a black or
+  guessed stream, never a fake "moved" cursor.
+- Reap the encoder on EVERY `/ws/screen` exit path (a leaked ffmpeg keeps filming the screen).
+
+## 8. Verification plan (device-only; the harness has no real screen, no WS video proxy)
+- Portal input: PROVEN (cursor→menu, contamination-free). Re-prove after the helper refactor.
+- Capture: **measure real fps + end-to-end latency** (capture→encode→WS→decode→paint) BEFORE any "fluid"
+  copy. Target ~15–25fps / ~100–250ms. The last remote-desktop claim was tempered precisely because
+  ~1.4fps isn't fluid; hold this to a MEASURED number.
+- Observe BOTH states (§11): cap fires (module present → fluid + tap-to-point) AND does not (absent →
+  P1 poller + relative). A detector seen firing only once is unverified.
+- Backpressure: a slow/paused consumer must fall BEHIND (drop frames), never accumulate latency/memory.
+- Consent persistence: tick "remember" once, restart, confirm silent-or-reprompt (§0.6).
+- Security pass: new "video of your screen" + absolute-input flow — token-authed, LAN-only, holder-gated
+  input, encoder argv agent-built, helper socket user-owned + peer-checked, no CORS.
+- Tests: `/ws/screen` auth-fail (401, no handshake); unknown-profile → fallback/refuse (no arbitrary argv);
+  subprocess lifecycle (connect→frames→disconnect→reaped) + drop-on-backpressure; `{t:'ma'}` non-allowlisted
+  guard; the six-site cap parity (`python3 tests/test_protocol_parity.py`).
+
+## 9. Open questions (decide on hardware)
+- ~~restore_token headless~~ RESOLVED (§0.6): per-session consent on this box; headless is a newer-KDE bonus.
+- ~~ffmpeg vs gstreamer~~ RESOLVED: gstreamer `pipewiresrc ! jpegenc` (box ffmpeg lacks pipewiregrab). Helper
+  owns capture (OpenPipeWireRemote fd + gst), streams JPEGs to the agent → keeps `couchsided.py` stdlib.
+- Capture-while-idle-input: confirm the ONE session serves gst capture AND portal input concurrently (both
+  proven separately; test simultaneously — should be fine, they're independent consumers of the session).
+- Keyboard over the portal (KDE historically incomplete) — POINTER first; add KEYBOARD device only if kwin
+  honors it (verify). Text entry can stay on the existing uinput keyboard meanwhile.
+- Profiles: start `720p20` (q6). Bandwidth/CPU of MJPEG at 20fps on the box — measure.
+- gamescope Game Mode: explicitly OUT (no portal desktop session; in-game fluid = Steam Remote Play).
+- Multi-phone: one portal session, one holder for input; capture could fan out but bound the encoder count.

--- a/docs/memory/project_screenstream-module.md
+++ b/docs/memory/project_screenstream-module.md
@@ -1,6 +1,13 @@
 # Project — Screen-stream module (P4a): fluid remote desktop, as an OPT-IN add-on
 
-Status: **SPEC.** Not built. Written 2026-08-10.
+> **SUPERSEDED 2026-08-10 by `project_remote-desktop.md`** (portal-unified). The MJPEG-over-WebSocket
+> TRANSPORT here (§3b, §4 caps, §6 security) is still exact and carried forward verbatim. What CHANGED:
+> the capture backend is now the **xdg-desktop-portal ScreenCast PipeWire node** (proven), not a
+> wlr-grabber/pw-dump match, and it shares ONE portal session with P2 absolute input — both live in a
+> session-scoped helper (needs `gi`/`Gio`, so it can't be in the stdlib agent). Read the unified spec
+> first; keep this only for the transport/backpressure/security detail.
+
+Status: **SPEC (superseded — see banner).** Written 2026-08-10.
 Origin: owner wants the screen viewer to feel **fluid** ("like RustDesk"), and agreed it should be
 "an additional option that adds more dependencies to the install and more system access to enable
 the feature." This is the P4a tier of `docs/memory/project_remote-desktop.md` (P1 shipped in #433).

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -185,6 +185,7 @@
       "file_upload",
       "gaming",
       "player",
+      "screenstream",
       "session_default",
       "steaminstall",
       "steamlink",

--- a/scripts/portal-module.sh
+++ b/scripts/portal-module.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Couchside remote-desktop PORTAL MODULE — opt-in install / uninstall.
+#
+# The base agent stays pure-stdlib and the base install.sh is untouched; this is
+# the SEPARATE opt-in step (like the privileged helper / a ujust recipe) that
+# turns on absolute tap-to-point + fluid /ws/screen streaming. It runs as the
+# USER (no root, no sudo): the portal, PipeWire and Wayland are all the user's.
+#
+#   scripts/portal-module.sh install     # verify deps, install helper + user unit, enable
+#   scripts/portal-module.sh uninstall   # disable + remove everything it installed
+#   scripts/portal-module.sh status      # is it installed + running?
+#
+# On immutable distros (Bazzite/SteamOS) there is no usable package step, so this
+# VERIFIES the system deps (which the KDE desktop already ships) and refuses
+# honestly if any are missing — it never pretends to install what it cannot.
+set -euo pipefail
+
+INSTALL_DIR="${HOME}/.local/opt/couchside"
+UNIT_DIR="${HOME}/.config/systemd/user"
+UNIT="couchside-portal.service"
+HELPER="couchside-portal.py"
+RUNTIME="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+SOCK="${RUNTIME}/couchside/portal.sock"
+
+# Where the module files (couchside-portal.py + couchside-portal.service) live:
+# next to this script (a released bundle), else <repo>/agent.
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="${PORTAL_SRC:-}"
+if [ -z "${SRC}" ]; then
+  if [ -f "${SELF_DIR}/${HELPER}" ]; then SRC="${SELF_DIR}"
+  elif [ -f "${SELF_DIR}/../agent/${HELPER}" ]; then SRC="$(cd "${SELF_DIR}/../agent" && pwd)"
+  else SRC="${SELF_DIR}"; fi
+fi
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+check_deps() {
+  local missing=()
+  python3 -c 'import gi; gi.require_version("Gio","2.0"); from gi.repository import GLib, Gio' 2>/dev/null \
+    || missing+=("python3 gobject bindings (python3-gobject / gi + Gio)")
+  command -v gst-launch-1.0 >/dev/null 2>&1 || missing+=("gstreamer (gst-launch-1.0)")
+  gst-inspect-1.0 pipewiresrc >/dev/null 2>&1 || missing+=("gstreamer pipewiresrc (gstreamer1-plugin-pipewire)")
+  gst-inspect-1.0 jpegenc   >/dev/null 2>&1 || missing+=("gstreamer jpegenc (gstreamer1-plugins-good)")
+  # PipeWire: a running socket under the runtime dir is the honest signal.
+  ls "${RUNTIME}"/pipewire-* >/dev/null 2>&1 || missing+=("a running PipeWire (pipewire)")
+  if [ "${#missing[@]}" -ne 0 ]; then
+    say "This box is missing system dependencies the portal module needs:"
+    printf '  - %s\n' "${missing[@]}"
+    say ""
+    say "On a KDE desktop (Bazzite/SteamOS Desktop Mode) these normally ship already."
+    say "Install them with your distro's package manager (they are NOT bundled), then re-run."
+    die "dependencies missing"
+  fi
+}
+
+cmd_install() {
+  [ -f "${SRC}/${HELPER}" ] || die "cannot find ${HELPER} (looked in ${SRC}); set PORTAL_SRC"
+  [ -f "${SRC}/${UNIT}" ]   || die "cannot find ${UNIT} (looked in ${SRC}); set PORTAL_SRC"
+  say "Verifying dependencies..."
+  check_deps
+  say "Installing helper -> ${INSTALL_DIR}/${HELPER}"
+  install -Dm0755 "${SRC}/${HELPER}" "${INSTALL_DIR}/${HELPER}"
+  say "Installing user unit -> ${UNIT_DIR}/${UNIT}"
+  mkdir -p "${UNIT_DIR}"
+  sed "s#__PORTAL__#${INSTALL_DIR}/${HELPER}#g" "${SRC}/${UNIT}" > "${UNIT_DIR}/${UNIT}"
+  systemctl --user daemon-reload
+  systemctl --user enable --now "${UNIT}"
+  # The helper binds its socket a moment after start (gi import + D-Bus connect);
+  # wait briefly so `status` below reports honestly rather than racing the bind.
+  for _ in 1 2 3 4 5 6; do [ -S "${SOCK}" ] && break; sleep 0.5; done
+  say ""
+  say "Portal module installed and running."
+  say "The FIRST time the phone opens the fluid desktop view, your box will show a"
+  say "'Remote Control' dialog (See what's on the screen + Control input devices) —"
+  say "click Approve. On this KDE version consent is asked once per session."
+  cmd_status || true
+}
+
+cmd_uninstall() {
+  systemctl --user disable --now "${UNIT}" 2>/dev/null || true
+  rm -f "${UNIT_DIR}/${UNIT}"
+  rm -f "${INSTALL_DIR}/${HELPER}"
+  rm -f "${SOCK}"
+  systemctl --user daemon-reload 2>/dev/null || true
+  say "Portal module removed (helper, user unit, socket)."
+}
+
+cmd_status() {
+  local active; active="$(systemctl --user is-active "${UNIT}" 2>/dev/null || echo inactive)"
+  say "unit ${UNIT}: ${active}"
+  if [ -S "${SOCK}" ]; then say "socket: ${SOCK} present"; else say "socket: absent"; fi
+  [ "${active}" = "active" ]
+}
+
+case "${1:-}" in
+  install)   cmd_install ;;
+  uninstall) cmd_uninstall ;;
+  status)    cmd_status ;;
+  *) die "usage: $0 {install|uninstall|status}" ;;
+esac

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -39,9 +39,15 @@ agent="$root/agent"
 # Publishing them here is what lets a fetch-mode install gain the helper at
 # all — a release without them simply installs the sudo-only agent, which
 # keeps working (the shim detects absence and falls back).
+#
+# couchside-portal.{py,service} are the OPT-IN remote-desktop module (agent >=
+# 2.9.77): shipped + signed here so scripts/portal-module.sh can install them,
+# but NEVER enabled by base install.sh. A release without them just means no
+# fluid /ws/screen + tap-to-point; the agent's screenstream cap probes the
+# helper socket and degrades to the still-frame poller when absent.
 files=(couchsided.py couchside.service qr.py couchside-screensaver.sh \
        couchside-player.sh couchside-helper.py couchside-helper.socket \
-       couchside-helper.service)
+       couchside-helper.service couchside-portal.py couchside-portal.service)
 for f in "${files[@]}"; do
     [ -f "$agent/$f" ] || { echo "error: missing agent/$f" >&2; exit 2; }
 done

--- a/tests/test_portal_module.py
+++ b/tests/test_portal_module.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Agent side of the opt-in remote-desktop portal module (couchside-portal.py).
+
+Run: python3 tests/test_portal_module.py
+
+Pins the §6 requirements for the new surface, all pure-stdlib (no box, no gi):
+  1. _portal_call shim: helper PRESENT -> reply; ABSENT / DEAD socket -> None
+     (the only "degrade to the still-frame poller" case), like the helper shim.
+  2. screenstream_available(): reachable + ok -> True; absent -> False.
+  3. Absolute pointer input {t:'ma'}/{t:'mbp'} on /ws/gamepad:
+       - a NON-HOLDER's frame is DROPPED (the holder gate), nothing reaches the portal;
+       - a bad coordinate / unknown button is DROPPED (allowlist), nothing runs;
+       - a good frame forwards the validated verb+arg to _portal_call.
+  4. /ws/screen: auth FAILURE (bad/absent token -> 401, no session); bad Upgrade
+     -> 400; and an UNKNOWN ?profile is replaced by the default (never a client
+     string reaches the helper).
+"""
+import importlib.util
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+from urllib.parse import urlparse
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def fake_portal(replies):
+    """A one-shot portal helper: serves len(replies) JSON connections then stops.
+    Returns (socket_path, seen_requests)."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "portal.sock")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(path)
+    srv.listen(4)
+    seen = []
+
+    def serve():
+        for reply in replies:
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                return
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            try:
+                seen.append(json.loads(buf.split(b"\n", 1)[0].decode()))
+            except ValueError:
+                seen.append(None)
+            conn.sendall(json.dumps(reply).encode() + b"\n")
+            conn.close()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return path, seen
+
+
+saved_portal_socket = cs.PORTAL_SOCKET
+
+# --- 1. _portal_call shim ---------------------------------------------------
+print("1. _portal_call: present -> reply, absent/dead -> None")
+try:
+    path, seen = fake_portal([{"ok": True, "w": 1920, "h": 1080, "node": 7}])
+    cs.PORTAL_SOCKET = path
+    r = cs._portal_call("ensure")
+    check("present helper returns the reply dict", r and r.get("ok"), True)
+    check("helper saw the verb", seen[0].get("verb"), "ensure")
+
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    check("absent socket -> None", cs._portal_call("ensure"), None)
+
+    d = tempfile.mkdtemp()
+    stale = os.path.join(d, "portal.sock")
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.bind(stale)
+    s.close()  # path exists, nothing listens
+    cs.PORTAL_SOCKET = stale
+    check("dead socket FILE -> None (not a hang/crash)", cs._portal_call("ensure"), None)
+
+    # --- 2. screenstream_available() ---------------------------------------
+    print()
+    print("2. screenstream_available: reachable+ok -> True, absent -> False")
+    path, _ = fake_portal([{"ok": True, "session": False}])
+    cs.PORTAL_SOCKET = path
+    check("reachable helper -> cap True", cs.screenstream_available(), True)
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    check("absent helper -> cap False (degrade closed)", cs.screenstream_available(), False)
+
+    # --- 3. absolute pointer input on /ws/gamepad --------------------------
+    print()
+    print("3. {t:'ma'}/{t:'mbp'}: holder gate + allowlist")
+    cs._wsend_json = lambda entry, obj: None
+    cs._wsend_op = lambda entry, op, payload=b"": None
+    PORTAL_CALLS = []
+    cs._portal_call = lambda verb, arg=None, timeout=10: PORTAL_CALLS.append((verb, arg))
+
+    class _Stub:
+        mock = True
+        _MOUSE_TYPES = cs.Handler._MOUSE_TYPES
+        _KEYBOARD_TYPES = cs.Handler._KEYBOARD_TYPES
+        _CONTROL_TYPES = cs.Handler._CONTROL_TYPES
+        _PORTAL_BTNS = cs.Handler._PORTAL_BTNS
+        _handle_portal_abs = cs.Handler._handle_portal_abs
+        _handle_portal_btn = cs.Handler._handle_portal_btn
+        _handle_kt = cs.Handler._handle_kt
+        _gamepad_message = cs.Handler._gamepad_message
+
+    def feed(entry, msg):
+        PORTAL_CALLS.clear()
+        return _Stub()._gamepad_message(None, entry, json.dumps(msg).encode())
+
+    held = {"held": True}
+    waiter = {"held": False}
+
+    # holder gate: a non-holder's absolute frame reaches the portal never
+    feed(waiter, {"t": "ma", "x": 0.5, "y": 0.5})
+    check("non-holder {ma} dropped (nothing to portal)", PORTAL_CALLS, [])
+
+    # good move forwards move + normalized coords
+    feed(held, {"t": "ma", "x": 0.25, "y": 0.75})
+    check("holder {ma} forwards move", PORTAL_CALLS, [("move", {"x": 0.25, "y": 0.75})])
+
+    # out-of-range coord is dropped (never reaches the portal)
+    feed(held, {"t": "ma", "x": 5, "y": 0.5})
+    check("out-of-range {ma} dropped", PORTAL_CALLS, [])
+
+    # good button maps l->left and forwards
+    feed(held, {"t": "mbp", "k": "r", "v": 1})
+    check("holder {mbp r,1} forwards right button",
+          PORTAL_CALLS, [("button", {"button": "right", "state": 1})])
+
+    # unknown button name is dropped
+    feed(held, {"t": "mbp", "k": "boop", "v": 1})
+    check("unknown button dropped", PORTAL_CALLS, [])
+
+    # bad button state is dropped
+    feed(held, {"t": "mbp", "k": "l", "v": 9})
+    check("bad button state dropped", PORTAL_CALLS, [])
+
+    # the session stays alive across all of these (returns True, never closes)
+    check("{ma} keeps the session alive", feed(held, {"t": "ma", "x": 0.1, "y": 0.1}), True)
+
+    # --- 4. /ws/screen auth + profile allowlist ----------------------------
+    print()
+    print("4. /ws/screen: auth failure + profile allowlist")
+
+    class _WSStub:
+        token = "s3cr3t"
+        close_connection = False
+
+        def __init__(self, headers):
+            self.headers = headers
+            self.sent = None
+            self.session_profile = "UNSET"
+            self._sendall = []
+
+        # real handler under test:
+        _handle_screen_ws = cs.Handler._handle_screen_ws
+
+        # collaborators stubbed:
+        def _send(self, code, body, started, extra_headers=None):
+            self.sent = code
+
+        def _log(self, code, started):
+            pass
+
+        class _Conn:
+            def __init__(self, out):
+                self.out = out
+
+            def sendall(self, b):
+                self.out.append(b)
+
+        def _screen_session(self, profile):
+            self.session_profile = profile
+
+    # (a) absent token -> 401, no session
+    st = _WSStub({})
+    st.connection = _WSStub._Conn(st._sendall)
+    st._handle_screen_ws(urlparse("/ws/screen"), 0.0)
+    check("no token -> 401", st.sent, 401)
+    check("no token -> no session", st.session_profile, "UNSET")
+
+    # (b) wrong token -> 401
+    st = _WSStub({})
+    st.connection = _WSStub._Conn(st._sendall)
+    st._handle_screen_ws(urlparse("/ws/screen?token=WRONG"), 0.0)
+    check("wrong token -> 401", st.sent, 401)
+
+    # (c) right token but no Upgrade header -> 400
+    st = _WSStub({})
+    st.connection = _WSStub._Conn(st._sendall)
+    st._handle_screen_ws(urlparse("/ws/screen?token=s3cr3t"), 0.0)
+    check("valid token, no upgrade -> 400", st.sent, 400)
+
+    # (d) valid handshake + BOGUS profile -> _screen_session gets the DEFAULT,
+    #     never the client string.
+    st = _WSStub({"Sec-WebSocket-Key": "dGhlIHNhbXBsZQ==", "Upgrade": "websocket"})
+    st.connection = _WSStub._Conn(st._sendall)
+    st._handle_screen_ws(urlparse("/ws/screen?token=s3cr3t&profile=rm -rf"), 0.0)
+    check("bogus profile replaced by default", st.session_profile, cs._SCREEN_STREAM_DEFAULT)
+    check("default profile is in the allowlist",
+          cs._SCREEN_STREAM_DEFAULT in cs._SCREEN_STREAM_PROFILES, True)
+
+    # (e) valid handshake + KNOWN profile -> passed through
+    st = _WSStub({"Sec-WebSocket-Key": "dGhlIHNhbXBsZQ==", "Upgrade": "websocket"})
+    st.connection = _WSStub._Conn(st._sendall)
+    st._handle_screen_ws(urlparse("/ws/screen?token=s3cr3t&profile=540p25"), 0.0)
+    check("known profile passed through", st.session_profile, "540p25")
+
+finally:
+    cs.PORTAL_SOCKET = saved_portal_socket
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all portal-module tests passed")


### PR DESCRIPTION
## Remote-desktop portal module (opt-in)

Wayland remote desktop for the phone: **absolute tap-to-point** (P2) and **fluid MJPEG streaming** (P4a), sharing **one xdg-desktop-portal session** — so a single on-box consent grants both input and capture.

**Why the portal, not raw uinput:** kwin honors the `RemoteDesktop`/`ScreenCast` portal, not a virtual absolute uinput device — a virtual EV_ABS pointer is silently ignored (proven a dead end on a KDE box). RustDesk shows the mechanism (it is AGPL, so we borrow the approach, never its code).

### Architecture

```
KDE Wayland ── one portal session (RemoteDesktop POINTER + ScreenCast MONITOR, one consent)
   │
   ▼
couchside-portal  (NEW helper: python3 + gi/Gio, runs as the USER, not root)
   ├─ owns the portal session; INPUT verbs → NotifyPointerMotionAbsolute/Button
   └─ CAPTURE → gstreamer pipewiresrc → jpegenc MJPEG
   │  0600 AF_UNIX socket, SO_PEERCRED
   ▼
couchsided.py  (stays pure-stdlib; the gi/Gio driver lives in the helper)
   ├─ _portal_call/_portal_stream shim (detect-and-degrade, like the helper shim)
   ├─ /ws/gamepad: additive {t:'ma'}/{t:'mbp'} absolute pointer (holder-gated)
   └─ /ws/screen: NEW MJPEG-over-WebSocket endpoint
   ▼
app  ├─ lib/screenstream.ts MJPEG consumer + useScreenStream hook
     └─ desktop.tsx swaps the poller for the stream when caps.screenstream + tap-to-point overlay
```

The portal driver needs `gi`/`Gio` (a third-party import the base agent forbids), so it lives in a separate **session-scoped** helper — the privileged-helper pattern, but run as the user (the portal/PipeWire/Wayland are the user's; there is no privileged op here).

### What's in it

- `agent/couchside-portal.py` — the helper: frozen `VERBS` over a 0600 socket + SO_PEERCRED; `ensure`/`move`/`button`/`status`, and a `stream` verb that pipes gstreamer MJPEG.
- `agent/couchsided.py` — `_portal_call`/`_portal_stream` shim; additive `{t:'ma'}`/`{t:'mbp'}` on `/ws/gamepad`; `WS_OP_BINARY`; `/ws/screen` (mirrors the gamepad WS auth/handshake); `screenstream` capability.
- App — `lib/screenstream.ts` (mirrors `gamepad.ts`, `binaryType='arraybuffer'`, newest-frame-only) + `useScreenStream`; `desktop.tsx` fluid/tap; `gamepad.ts` `sendMouseAbs`/`sendMouseButtonPortal`/`tapAbs`.
- `screenstream` capability across all six sites (`test_protocol_parity` green); `protocol.json` linuxOnly.
- `agent/couchside-portal.service` (USER unit template) + `scripts/portal-module.sh` (opt-in install/uninstall/status, verifies deps, refuses honestly if missing) + `release-agent.sh` ships the two files on the signed channel — **never enabled by base install.sh**.
- `tests/test_portal_module.py` (19 checks) wired into CI.

### Constraints held

- Base agent stays **pure-stdlib, single file** (no third-party Python → no aiortc/WebRTC; MJPEG over the hand-rolled WS).
- **Allowlist (§3):** the gstreamer profile and every input verb are dict-key lookups from frozen tables; argv is always a list, never a shell string. `{t:'ma'}`/`{t:'mbp'}` are holder-gated and re-validated by the helper.
- **Additive only** — `screenstream` is a new optional cap; input path untouched (pixels and input stay on separate sockets).
- **Degrade closed** — no module / no desktop session / denied consent → the still-frame poller (P1), never a black or guessed stream.

### Verification

- **Hardware-proven on a KDE box** (lenovodesktop, Plasma 6): the portal moves the cursor pixel-exact (contamination-free control run); gstreamer captures the portal node; `/ws/screen` delivered **35 real 720p JPEG frames end-to-end** to a WS client; the `portal-module.sh` install → uninstall → reinstall lifecycle, agent `screenstream:true` throughout.
- `test_protocol_parity` + `test_portal_module` (19 checks) + `test_ci_wiring` pass; both agent files `py_compile`; app `tsc --noEmit` 0 errors.

### Not yet verified / follow-ups

- On-device app stream render + tap **feel** (device-only; the app is on TestFlight as **2.9.44 build 168**).
- fps (~10–14 in short server-side windows) — measure over a longer window and tune.
- Backpressure/drop-oldest: a `queue leaky=downstream` stalled gst mid-frame and was reverted; needs isolated gst tuning.
- Auto-fallback-to-poller when the stream fails; portal keyboard (POINTER-first); a dedicated stream lifecycle/reap test.
- Consent persistence is per-session on this box's (older) KDE (no "remember" checkbox); silent headless reconnect is a newer-KDE bonus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
