### PR TITLE
Remote desktop P4b: fluid MJPEG landscape control + reopen-wedge fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,14 @@ jobs:
       - name: Unit tests (remote-desktop portal module)
         run: python3 tests/test_portal_module.py
 
+      # P4b: the H.264/WebRTC signaling relay (/ws/webrtc). Same class of surface:
+      # the screenstream_h264 cap probe (honest — needs a WORKING webrtcbin), the
+      # _portal_webrtc shim, the app->box SDP/ICE allowlist boundary (only
+      # answer/ice/bye + known fields forward, no arbitrary client JSON reaches
+      # webrtcbin), and the /ws/webrtc auth failure + profile allowlist + cap.
+      - name: Unit tests (remote-desktop WebRTC relay)
+        run: python3 tests/test_webrtc_relay.py
+
       # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
       # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
       # sessions and a connected panel was refused by its NAME — hiding the

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -46,6 +46,7 @@ import struct
 import subprocess
 import sys
 import threading
+import time
 
 import gi
 gi.require_version("Gio", "2.0")
@@ -304,6 +305,15 @@ def verb_button(arg):
     return {"ok": True}
 
 
+# NOTE deliberately NO keyboard verbs here: phone-keyboard typing rides the
+# AGENT's existing uinput path ({t:'kt'}/{t:'k'} on /ws/gamepad), which is
+# PROVEN on the KDE desktop (typed into a konsole + opened Kickoff via a
+# virtual uinput keyboard on hardware, 2026-08-11). The portal alternative
+# (NotifyKeyboardKeysym) was probed the same day: the call chain exists in
+# xdg-desktop-portal-kde 6.6.4 but no keystrokes ever landed — and the uinput
+# path needs no extra portal capability in the consent dialog.
+
+
 # ---- argument validators (return the parsed value, or None to REFUSE) -------
 
 def _move_arg(v):
@@ -426,7 +436,40 @@ def _stream_argv(profile, pwfd, node):
 # which is also instant. Idle (no subscriber) keeps encoding + discards — the
 # hardware JPEG path makes that ~free, and NOT respawning is the entire point.
 _STREAM_LOCK = threading.Lock()
-_STREAM = {"proc": None, "profile": None, "sub": None, "done": None}
+_STREAM = {"proc": None, "profile": None, "sub": None, "done": None,
+           # wall-clock when the last subscriber left (None while subscribed);
+           # the reader enforces the idle TTL from it.
+           "idle_since": None}
+
+# No viewer for this long -> tear down the encoder AND the portal session, so an
+# abandoned Control screen stops costing GPU/CPU (and stops holding the KWin
+# screencast, which disables direct scanout for fullscreen apps). The next use
+# re-ensures the session — on KDE without RemoteDesktop persist that re-pops ONE
+# consent; short exit/reopen cycles stay instant (well under the TTL).
+_STREAM_IDLE_TTL_S = 900
+
+
+def _close_session():
+    """Tear down the portal session (Session.Close) + cached PipeWire fd. The
+    next ensure re-creates from scratch (fresh consent where persist is
+    unavailable). Degrade-closed: failures still clear local state."""
+    global _SESSION
+    with _SLOCK:
+        sess, _SESSION = _SESSION, None
+    if sess is None:
+        return
+    pwfd = sess.get("pwfd")
+    if pwfd is not None:
+        try:
+            os.close(pwfd)
+        except OSError:
+            pass
+    try:
+        _con.call_sync(_PORTAL, sess["handle"], "org.freedesktop.portal.Session",
+                       "Close", None, None, Gio.DBusCallFlags.NONE, -1, None)
+    except Exception:
+        pass
+    print("[portal] idle TTL: session closed (re-consent on next use)", flush=True)
 
 
 def _stream_reader(proc):
@@ -435,6 +478,7 @@ def _stream_reader(proc):
     nobody is watching. A dead/slow subscriber is dropped (its socket has a
     timeout); the encoder is NEVER stopped here."""
     buf = bytearray()
+    idle_teardown = False
     while True:
         try:
             chunk = proc.stdout.read(65536)
@@ -458,8 +502,15 @@ def _stream_reader(proc):
             del buf[:eoi + 2]
             with _STREAM_LOCK:
                 sub, done = _STREAM["sub"], _STREAM["done"]
+                idle_since = _STREAM["idle_since"]
             if sub is None:
-                continue                             # idle: discard, keep draining
+                # Idle: discard + keep draining (the node must stay serviced) —
+                # until the TTL, then tear the whole thing down (gst + session).
+                if (idle_since is not None
+                        and time.time() - idle_since > _STREAM_IDLE_TTL_S):
+                    idle_teardown = True
+                    proc.terminate()                 # read() EOFs; cleanup below
+                continue
             try:
                 sub.sendall(jpg)                     # timeout set at subscribe
             except OSError:
@@ -467,19 +518,25 @@ def _stream_reader(proc):
                     if _STREAM["sub"] is sub:
                         _STREAM["sub"] = None
                         _STREAM["done"] = None
+                        _STREAM["idle_since"] = time.time()
                 try:
                     sub.close()
                 except OSError:
                     pass
                 if done is not None:
                     done.set()
-    # gst ended (helper shutdown or crash): clear state, wake any subscriber so
-    # its stream() call returns; the NEXT stream() may then respawn cleanly.
+    # gst ended (idle TTL, helper shutdown, or crash): clear state, wake any
+    # subscriber so its stream() call returns; the NEXT stream() may respawn —
+    # after an idle teardown that goes through a FRESH session (re-consent),
+    # which is exactly what makes the respawn safe (new node, healthy pool).
     with _STREAM_LOCK:
         done = _STREAM["done"]
-        _STREAM.update(proc=None, profile=None, sub=None, done=None)
+        _STREAM.update(proc=None, profile=None, sub=None, done=None,
+                       idle_since=None)
     if done is not None:
         done.set()
+    if idle_teardown:
+        _close_session()
 
 
 def stream(profile, conn):
@@ -520,6 +577,7 @@ def stream(profile, conn):
         done = threading.Event()
         old_sub, old_done = _STREAM["sub"], _STREAM["done"]
         _STREAM["sub"], _STREAM["done"] = conn, done
+        _STREAM["idle_since"] = None                 # someone is watching again
     if old_done is not None:
         old_done.set()
     if old_sub is not None:

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -228,18 +228,37 @@ def _ensure_session():
 
 
 def _open_pipewire_fd():
-    """OpenPipeWireRemote on the live session → a unix fd for gstreamer. The
-    session must already exist. Returns an int fd (caller owns it) or None."""
+    """A unix fd to the session's PipeWire remote, for gstreamer. Returns an int
+    fd the CALLER OWNS (must close) or None.
+
+    OpenPipeWireRemote is called at most ONCE per session; the fd is CACHED on the
+    session and every caller gets an `os.dup()` of it. A SECOND OpenPipeWireRemote
+    on a KDE portal session hands back a DEAD remote (0 frames) — proven on
+    hardware: the FIRST /ws/screen streamed, every reopen showed nothing because
+    the agent re-opened the remote per connect. Caching + dup keeps the one good
+    remote alive for the session's life, so reopens (and the WebRTC path) work.
+    Closing a dup only drops that consumer; the cached original stays open."""
     with _SLOCK:
         sess = _SESSION
-    if sess is None:
-        return None
-    ret, fdlist = _con.call_with_unix_fd_list_sync(
-        _PORTAL, _OBJ, _IF_SC, "OpenPipeWireRemote",
-        GLib.Variant("(oa{sv})", (sess["handle"], {})),
-        GLib.VariantType.new("(h)"), Gio.DBusCallFlags.NONE, -1, None, None)
-    idx = ret.unpack()[0]
-    return fdlist.get(idx)
+        if sess is None:
+            return None
+        cached = sess.get("pwfd")
+        if cached is None:
+            try:
+                ret, fdlist = _con.call_with_unix_fd_list_sync(
+                    _PORTAL, _OBJ, _IF_SC, "OpenPipeWireRemote",
+                    GLib.Variant("(oa{sv})", (sess["handle"], {})),
+                    GLib.VariantType.new("(h)"), Gio.DBusCallFlags.NONE, -1, None, None)
+                cached = fdlist.get(ret.unpack()[0])
+            except Exception:
+                return None
+            if cached is None:
+                return None
+            sess["pwfd"] = cached
+        try:
+            return os.dup(cached)
+        except OSError:
+            return None
 
 
 # ---------------------------------------------------------------- the verbs ---

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -412,97 +412,122 @@ def _stream_argv(profile, pwfd, node):
     return argv
 
 
-# The portal ScreenCast pipewire node allows exactly ONE gst consumer. A SECOND
-# concurrent gst on the same node fails ("Buffer allocation failed" /
-# "not-negotiated (-4)" — proven on hardware). That is the "reopen shows nothing"
-# wedge: an abrupt phone background leaves the previous stream's gst alive (its
-# dead socket not yet noticed) while the reopened stream spawns a second gst on
-# the same node -> the new one gets 0 bytes. So streams are serialized to ONE at
-# a time: a new stream REAPS the prior gst before spawning (last-opener wins).
+# The stream gst is spawned ONCE per portal session and NEVER killed while the
+# session lives. Proven on hardware, in stages:
+#   1. TWO concurrent gsts on the session's node -> the second fails ("Buffer
+#      allocation failed" / "not-negotiated (-4)", 0 bytes).
+#   2. Kill-then-respawn (preempting) LOOKED fixed but was not: the respawned
+#      gst receives (almost) no fresh buffers — pipewiresrc's keepalive-time
+#      re-encodes the last STALE buffer at full fps, so the stream "flows"
+#      while showing seconds-old content (constant-size JPEGs are the tell;
+#      a killed consumer's held buffers starve the node's small pool).
+# So: one persistent encoder per session, and a reader thread fans its frames
+# out to the ONE current subscriber (last-opener wins). Reopen = re-subscribe,
+# which is also instant. Idle (no subscriber) keeps encoding + discards — the
+# hardware JPEG path makes that ~free, and NOT respawning is the entire point.
 _STREAM_LOCK = threading.Lock()
-_CUR_STREAM = None                                   # the running stream gst, or None
+_STREAM = {"proc": None, "profile": None, "sub": None, "done": None}
 
 
-def _preempt_stream():
-    """Reap the currently-running stream gst (if any) so a new stream gets the
-    single-consumer pipewire node clean. Called before spawning a new stream."""
-    global _CUR_STREAM
-    with _STREAM_LOCK:
-        old, _CUR_STREAM = _CUR_STREAM, None
-    if old is not None and old.poll() is None:
-        old.terminate()
+def _stream_reader(proc):
+    """Read the persistent gst's MJPEG stdout forever; split whole JPEGs
+    (FFD8..FFD9) and forward each to the current subscriber, or discard when
+    nobody is watching. A dead/slow subscriber is dropped (its socket has a
+    timeout); the encoder is NEVER stopped here."""
+    buf = bytearray()
+    while True:
         try:
-            old.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            old.kill()
+            chunk = proc.stdout.read(65536)
+        except (OSError, ValueError):
+            break
+        if not chunk:
+            break                                    # gst ended
+        buf.extend(chunk)
+        while True:
+            soi = buf.find(b"\xff\xd8")
+            if soi < 0:
+                if len(buf) > (8 << 20):             # runaway guard: no SOI in 8MB
+                    del buf[:]
+                break
+            if soi > 0:
+                del buf[:soi]                        # drop bytes before a SOI
+            eoi = buf.find(b"\xff\xd9", 2)
+            if eoi < 0:
+                break                                # partial frame; wait for more
+            jpg = bytes(buf[:eoi + 2])
+            del buf[:eoi + 2]
+            with _STREAM_LOCK:
+                sub, done = _STREAM["sub"], _STREAM["done"]
+            if sub is None:
+                continue                             # idle: discard, keep draining
+            try:
+                sub.sendall(jpg)                     # timeout set at subscribe
+            except OSError:
+                with _STREAM_LOCK:
+                    if _STREAM["sub"] is sub:
+                        _STREAM["sub"] = None
+                        _STREAM["done"] = None
+                try:
+                    sub.close()
+                except OSError:
+                    pass
+                if done is not None:
+                    done.set()
+    # gst ended (helper shutdown or crash): clear state, wake any subscriber so
+    # its stream() call returns; the NEXT stream() may then respawn cleanly.
+    with _STREAM_LOCK:
+        done = _STREAM["done"]
+        _STREAM.update(proc=None, profile=None, sub=None, done=None)
+    if done is not None:
+        done.set()
 
 
 def stream(profile, conn):
-    """Spawn gst for `profile` and pipe its MJPEG stdout to `conn` until the peer
-    disconnects, then reap. The agent side splits the MJPEG byte stream on
-    FFD8..FFD9 and frames each JPEG onto /ws/screen. Serialized: reaps any prior
-    stream first so only one gst ever holds the (single-consumer) portal node."""
-    global _CUR_STREAM
+    """Subscribe `conn` to the session's persistent MJPEG encoder (spawning it
+    on first use), then block until the subscription ends — a newer subscriber
+    kicked us (last-opener wins), the peer vanished, or gst ended. The agent
+    splits the MJPEG bytes on FFD8..FFD9 and frames each JPEG onto /ws/screen.
+    The FIRST subscriber's profile wins for the encoder's lifetime (the app
+    always asks 720p20 today)."""
     if _ensure_session() is None:
         return
-    _preempt_stream()                                # single-consumer node (see above)
-    with _SLOCK:
-        node = _SESSION["node"]
-    pwfd = _open_pipewire_fd()
-    if pwfd is None:
-        return
-    proc = None
-    try:
-        proc = subprocess.Popen(
-            _stream_argv(profile, pwfd, node),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-            pass_fds=(pwfd,))
-    finally:
-        try:
-            os.close(pwfd)                           # the child holds it now
-        except OSError:
-            pass
-    if proc is None:
-        return
     with _STREAM_LOCK:
-        _CUR_STREAM = proc                           # register as the active stream
-    nbytes = 0
-    try:
-        while True:
-            chunk = proc.stdout.read(65536)
-            if not chunk:
-                break                                # gst ended
-            nbytes += len(chunk)
-            conn.sendall(chunk)                      # raises when the peer is gone
-    except OSError:
-        pass                                         # peer disconnected — normal
-    finally:
-        try:
-            proc.stdout.close()
-        except OSError:
-            pass
-        proc.terminate()
-        try:
-            proc.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-        # Deregister only if still the active stream — a newer stream that
-        # preempted us already replaced _CUR_STREAM with its own proc.
-        with _STREAM_LOCK:
-            if _CUR_STREAM is proc:
-                _CUR_STREAM = None
-        if nbytes == 0:
-            err = b""
+        proc = _STREAM["proc"]
+        if proc is not None and proc.poll() is not None:
+            proc = None                              # crashed: allow respawn
+            _STREAM.update(proc=None, profile=None)
+        if proc is None:
+            with _SLOCK:
+                node = _SESSION["node"]
+            pwfd = _open_pipewire_fd()
+            if pwfd is None:
+                return
             try:
-                err = proc.stderr.read() or b""
-            except OSError:
-                pass
-            print("[portal] stream: NO BYTES; gst stderr: %s"
-                  % err.decode("utf-8", "replace").strip()[:500], flush=True)
+                proc = subprocess.Popen(
+                    _stream_argv(profile, pwfd, node),
+                    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                    pass_fds=(pwfd,))
+            finally:
+                try:
+                    os.close(pwfd)                   # the child holds it now
+                except OSError:
+                    pass
+            _STREAM.update(proc=proc, profile=profile)
+            threading.Thread(target=_stream_reader, args=(proc,),
+                             daemon=True).start()
+        # Subscribe, last-opener wins: kick + close any current subscriber.
+        conn.settimeout(10)                          # a wedged peer can't block the reader
+        done = threading.Event()
+        old_sub, old_done = _STREAM["sub"], _STREAM["done"]
+        _STREAM["sub"], _STREAM["done"] = conn, done
+    if old_done is not None:
+        old_done.set()
+    if old_sub is not None:
         try:
-            proc.stderr.close()
+            old_sub.close()
         except OSError:
             pass
+    done.wait()                                      # until kicked / gone / gst end
 
 
 # ---- H.264 / WebRTC (P4b) --------------------------------------------------

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -412,12 +412,40 @@ def _stream_argv(profile, pwfd, node):
     return argv
 
 
+# The portal ScreenCast pipewire node allows exactly ONE gst consumer. A SECOND
+# concurrent gst on the same node fails ("Buffer allocation failed" /
+# "not-negotiated (-4)" — proven on hardware). That is the "reopen shows nothing"
+# wedge: an abrupt phone background leaves the previous stream's gst alive (its
+# dead socket not yet noticed) while the reopened stream spawns a second gst on
+# the same node -> the new one gets 0 bytes. So streams are serialized to ONE at
+# a time: a new stream REAPS the prior gst before spawning (last-opener wins).
+_STREAM_LOCK = threading.Lock()
+_CUR_STREAM = None                                   # the running stream gst, or None
+
+
+def _preempt_stream():
+    """Reap the currently-running stream gst (if any) so a new stream gets the
+    single-consumer pipewire node clean. Called before spawning a new stream."""
+    global _CUR_STREAM
+    with _STREAM_LOCK:
+        old, _CUR_STREAM = _CUR_STREAM, None
+    if old is not None and old.poll() is None:
+        old.terminate()
+        try:
+            old.wait(timeout=3)
+        except subprocess.TimeoutExpired:
+            old.kill()
+
+
 def stream(profile, conn):
     """Spawn gst for `profile` and pipe its MJPEG stdout to `conn` until the peer
     disconnects, then reap. The agent side splits the MJPEG byte stream on
-    FFD8..FFD9 and frames each JPEG onto /ws/screen."""
+    FFD8..FFD9 and frames each JPEG onto /ws/screen. Serialized: reaps any prior
+    stream first so only one gst ever holds the (single-consumer) portal node."""
+    global _CUR_STREAM
     if _ensure_session() is None:
         return
+    _preempt_stream()                                # single-consumer node (see above)
     with _SLOCK:
         node = _SESSION["node"]
     pwfd = _open_pipewire_fd()
@@ -436,6 +464,8 @@ def stream(profile, conn):
             pass
     if proc is None:
         return
+    with _STREAM_LOCK:
+        _CUR_STREAM = proc                           # register as the active stream
     nbytes = 0
     try:
         while True:
@@ -456,6 +486,11 @@ def stream(profile, conn):
             proc.wait(timeout=3)
         except subprocess.TimeoutExpired:
             proc.kill()
+        # Deregister only if still the active stream — a newer stream that
+        # preempted us already replaced _CUR_STREAM with its own proc.
+        with _STREAM_LOCK:
+            if _CUR_STREAM is proc:
+                _CUR_STREAM = None
         if nbytes == 0:
             err = b""
             try:

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -366,24 +366,50 @@ def dispatch(req):
 
 # ---- streaming (raw MJPEG bytes, not a JSON reply) --------------------------
 
+_HW_JPEG = None
+
+
+def _hw_jpeg():
+    """True if the box has a hardware JPEG encoder (vapostproc + vajpegenc).
+    Cached. Degrade closed to software jpegenc."""
+    global _HW_JPEG
+    if _HW_JPEG is None:
+        try:
+            import gi as _gi
+            _gi.require_version("Gst", "1.0")
+            from gi.repository import Gst as _Gst
+            _Gst.init(None)
+            _HW_JPEG = (_Gst.ElementFactory.find("vajpegenc") is not None
+                        and _Gst.ElementFactory.find("vapostproc") is not None)
+        except Exception:
+            _HW_JPEG = False
+    return _HW_JPEG
+
+
 def _stream_argv(profile, pwfd, node):
     """gstreamer argv LIST for one profile. Every pipeline element and parameter
     is chosen HERE; the client only picked the profile key. pipewiresrc reads the
-    portal's own node over the passed fd; jpegenc → fdsink fd=1 (stdout)."""
+    portal's own node over the passed fd; encoder → fdsink fd=1 (stdout).
+
+    Prefer HARDWARE JPEG (vapostproc VAMemory → vajpegenc): on an Intel iGPU the
+    software jpegenc capped the box at ~6fps @720p — the display 'lag'. vajpegenc
+    clears 300+fps, so the box no longer bottlenecks the MJPEG. Software jpegenc
+    is the fallback where no VA encoder exists."""
     p = _STREAM_PROFILES[profile]
-    caps = "video/x-raw,framerate=%d/1,width=%d,height=%d" % (
-        p["fps"], p["width"], p["height"])
-    return ["gst-launch-1.0", "-q",
+    argv = ["gst-launch-1.0", "-q",
             "pipewiresrc", "fd=%d" % pwfd, "path=%d" % node, "keepalive-time=1000",
-            "!", "videorate", "!", "videoscale", "!", "videoconvert",
-            "!", caps,
-            # TODO(backpressure): a `queue leaky=downstream` here stalled the
-            # pipeline mid-frame on hardware (2026-08-10) — needs isolated gst
-            # tuning (placement/max-size). For now no leaky queue: a slow phone
-            # backpressures gst via TCP flow control. Drop-oldest to be added
-            # once verified in isolation, not guessed on a live session.
-            "!", "jpegenc", "quality=%d" % p["quality"],
-            "!", "fdsink", "fd=1"]
+            "!", "videorate", "!", "video/x-raw,framerate=%d/1" % p["fps"]]
+    if _hw_jpeg():
+        argv += ["!", "vapostproc",
+                 "!", "video/x-raw(memory:VAMemory),format=NV12,width=%d,height=%d"
+                 % (p["width"], p["height"]),
+                 "!", "vajpegenc", "quality=%d" % p["quality"]]
+    else:
+        argv += ["!", "videoscale", "!", "videoconvert",
+                 "!", "video/x-raw,width=%d,height=%d" % (p["width"], p["height"]),
+                 "!", "jpegenc", "quality=%d" % p["quality"]]
+    argv += ["!", "fdsink", "fd=1"]
+    return argv
 
 
 def stream(profile, conn):

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -77,6 +77,15 @@ _STREAM_PROFILES = {
     "1080p15": {"width": 1920, "height": 1080, "fps": 15, "quality": 70},
 }
 
+# H.264/WebRTC profiles (P4b) — a CLOSED SET, same discipline as _STREAM_PROFILES.
+# The client names a KEY; the helper owns every pipeline parameter. bitrate in kbps.
+_H264_PROFILES = {
+    "720p30":  {"width": 1280, "height": 720,  "fps": 30, "bitrate": 5000},
+    "720p60":  {"width": 1280, "height": 720,  "fps": 60, "bitrate": 8000},
+    "1080p30": {"width": 1920, "height": 1080, "fps": 30, "bitrate": 10000},
+    "1080p60": {"width": 1920, "height": 1080, "fps": 60, "bitrate": 16000},
+}
+
 # How long Start may wait for the user to click Share/Allow on the box.
 _CONSENT_TIMEOUT_S = 150
 
@@ -210,12 +219,16 @@ def _open_pipewire_fd():
 # ---------------------------------------------------------------- the verbs ---
 
 def verb_status():
+    h264 = _h264_available()
     with _SLOCK:
         sess = _SESSION
+    base = {"ok": True, "h264": h264, "h264_profiles": sorted(_H264_PROFILES)}
     if sess is None:
-        return {"ok": True, "session": False}
-    return {"ok": True, "session": True, "w": sess["w"], "h": sess["h"],
-            "node": sess["node"], "profiles": sorted(_STREAM_PROFILES)}
+        base["session"] = False
+        return base
+    base.update({"session": True, "w": sess["w"], "h": sess["h"],
+                 "node": sess["node"], "profiles": sorted(_STREAM_PROFILES)})
+    return base
 
 
 def verb_ensure():
@@ -273,6 +286,13 @@ def _profile_arg(v):
     if isinstance(v, dict):
         v = v.get("profile")
     return v if isinstance(v, str) and v in _STREAM_PROFILES else None
+
+
+def _h264_profile_arg(v):
+    """An H.264/WebRTC profile KEY. Looked up, never interpolated (§3.1)."""
+    if isinstance(v, dict):
+        v = v.get("profile")
+    return v if isinstance(v, str) and v in _H264_PROFILES else None
 
 
 # one-shot JSON verbs (streaming is handled separately in serve_one)
@@ -379,6 +399,238 @@ def stream(profile, conn):
             pass
 
 
+# ---- H.264 / WebRTC (P4b) --------------------------------------------------
+# In-process `webrtcbin` (NOT gst-launch — it needs async create-offer / ICE
+# callbacks). H264-only, sendonly, host candidates only (stun-server=NULL: the
+# app and box share a LAN). The agent's /ws/webrtc relays OPAQUE SDP/ICE JSON
+# between the app and this socket; THIS builds the whole pipeline. §3: no client
+# string ever reaches gst — the client only names a profile KEY (looked up), and
+# the PipeWire node/fd come only from the portal's own Start result.
+#
+# All GStreamer gi imports are LAZY + guarded so a box missing GstWebRTC/GstSdp
+# (or the libnice `nice` plugin webrtcbin needs) degrades closed to no-h264 —
+# it must NOT break import (that would take the shipped P4a MJPEG path down too).
+
+_ALLOWED_WEBRTC_IN = ("answer", "ice", "bye")   # frozen set of inbound msg types
+_WEBRTC_LOCK = threading.Lock()                 # one WebRTC session at a time (heavy)
+
+
+class _ByeSignal(Exception):
+    """Internal: the peer sent {t:bye}; unwind the signaling read loop."""
+
+
+def _h264_available():
+    """True only if webrtcbin can ACTUALLY run here — which requires the libnice
+    `nice` elements (nicesrc/nicesink), NOT just that webrtcbin is registered.
+    Proven on hardware: `gst-inspect webrtcbin` succeeds but any media pad errors
+    'libnice elements are not available' without the nice plugin. Also needs a VA
+    H.264 encoder + the RTP/portal path. Degrade closed on any failure."""
+    try:
+        import gi as _gi
+        _gi.require_version("Gst", "1.0")
+        _gi.require_version("GstWebRTC", "1.0")
+        _gi.require_version("GstSdp", "1.0")
+        from gi.repository import Gst as _Gst
+        _Gst.init(None)
+        need = ("webrtcbin", "nicesrc", "nicesink", "rtph264pay",
+                "vapostproc", "pipewiresrc", "h264parse", "videorate")
+        if any(_Gst.ElementFactory.find(e) is None for e in need):
+            return False
+        if _Gst.ElementFactory.find("vah264enc") is None and \
+           _Gst.ElementFactory.find("vah264lpenc") is None:
+            return False
+        return True
+    except Exception:
+        return False
+
+
+def _webrtc_desc(profile, pwfd, node, Gst):
+    """gstreamer-parse description for one profile. Every element/parameter is
+    chosen HERE. Prefer the full `vah264enc` (CBR = predictable bitrate for
+    streaming); fall back to the low-power `vah264lpenc` (CQP-only on some GPUs).
+    webrtcbin is declared and linked via the trailing-dot request-pad syntax
+    (inline `! webrtcbin` fails to link — proven)."""
+    p = _H264_PROFILES[profile]
+    if Gst.ElementFactory.find("vah264enc") is not None:
+        enc = ("vah264enc rate-control=cbr bitrate=%d target-usage=7 "
+               "key-int-max=%d b-frames=0 ref-frames=1"
+               % (p["bitrate"], p["fps"] * 2))
+    else:
+        enc = ("vah264lpenc rate-control=cqp target-usage=7 "
+               "key-int-max=%d b-frames=0 ref-frames=1" % (p["fps"] * 2))
+    return ("webrtcbin name=sendrecv bundle-policy=max-bundle latency=0 "
+            "pipewiresrc fd=%d path=%d do-timestamp=true keepalive-time=1000 "
+            "! videorate ! video/x-raw,framerate=%d/1 "
+            "! vapostproc ! video/x-raw(memory:VAMemory),format=NV12,width=%d,height=%d "
+            "! %s ! h264parse config-interval=-1 "
+            "! rtph264pay pt=96 config-interval=-1 aggregate-mode=zero-latency mtu=1200 "
+            "! queue ! application/x-rtp,media=video,encoding-name=H264,payload=96 "
+            "! sendrecv."
+            % (pwfd, node, p["fps"], p["width"], p["height"], enc))
+
+
+def _webrtc_session(profile, conn):
+    """One WebRTC streaming session: build the webrtcbin pipeline for `profile`,
+    exchange OPAQUE SDP/ICE as JSON lines over `conn` (the agent relays them to
+    the app), stream until the peer sends {t:bye} or disconnects, then REAP the
+    pipeline (a leaked encoder keeps filming the screen).
+
+    webrtcbin is built and driven on a DEDICATED GLib main-loop thread (default
+    context) — proven on hardware: driving it from a private thread-default
+    context yields an empty offer (webrtcbin's DTLS/ICE machinery expects the
+    global default context). The socket read loop runs on THIS thread and hands
+    inbound answer/ICE to the loop thread via idle_add. One session at a time
+    (_WEBRTC_LOCK) — webrtcbin is heavy and shares the default context."""
+    try:
+        import gi as _gi
+        _gi.require_version("Gst", "1.0")
+        _gi.require_version("GstWebRTC", "1.0")
+        _gi.require_version("GstSdp", "1.0")
+        from gi.repository import GLib as _GLib, Gst, GstWebRTC, GstSdp
+        Gst.init(None)
+    except Exception:
+        _send_json(conn, {"t": "error", "error": "no webrtc support"})
+        return
+    if _ensure_session() is None:
+        _send_json(conn, {"t": "error", "error": "no session"})
+        return
+    if not _WEBRTC_LOCK.acquire(blocking=False):
+        _send_json(conn, {"t": "error", "error": "busy"})       # cap 1
+        return
+
+    with _SLOCK:
+        node = _SESSION["node"]
+    loop = _GLib.MainLoop()                                      # default context
+    state = {"pipeline": None, "webrtc": None, "pwfd": None,
+             "wlock": threading.Lock()}
+
+    def send(obj):
+        # webrtcbin fires offer/ICE on internal gst threads → serialize writes.
+        with state["wlock"]:
+            try:
+                conn.sendall((json.dumps(obj) + "\n").encode())
+            except OSError:
+                loop.quit()
+
+    def on_offer_created(promise, _elem, _u):
+        promise.wait()
+        reply = promise.get_reply()
+        offer = reply.get_value("offer") if reply else None
+        if offer is None:
+            return
+        state["webrtc"].emit("set-local-description", offer, Gst.Promise.new())
+        send({"t": "offer", "sdp": offer.sdp.as_text()})
+
+    def on_negotiation_needed(elem):
+        pr = Gst.Promise.new_with_change_func(on_offer_created, elem, None)
+        elem.emit("create-offer", None, pr)
+
+    def on_ice(_elem, mline, cand):
+        send({"t": "ice", "sdpMLineIndex": int(mline), "candidate": cand})
+
+    def build():                                                # on the loop thread
+        pwfd = _open_pipewire_fd()
+        if pwfd is None:
+            send({"t": "error", "error": "no pw fd"})
+            loop.quit()
+            return False
+        state["pwfd"] = pwfd
+        try:
+            pipeline = Gst.parse_launch(_webrtc_desc(profile, pwfd, node, Gst))
+            state["pipeline"] = pipeline
+            wb = pipeline.get_by_name("sendrecv")
+            state["webrtc"] = wb
+            try:
+                wb.set_property("stun-server", None)   # host candidates only (LAN)
+            except Exception:
+                pass
+            wb.connect("on-negotiation-needed", on_negotiation_needed)
+            wb.connect("on-ice-candidate", on_ice)
+
+            # Pump the pipeline bus: webrtcbin relies on its bus being serviced
+            # (without a watch the negotiation stalls / yields an empty offer,
+            # proven on hardware). Log errors; end the session on a fatal one.
+            def _on_bus(_b, m):
+                if m.type == Gst.MessageType.ERROR:
+                    err, dbg = m.parse_error()
+                    print("[portal] webrtc bus error: %s | %s"
+                          % (err.message, dbg), flush=True)
+                    loop.quit()
+            bus = pipeline.get_bus()
+            bus.add_signal_watch()
+            bus.connect("message", _on_bus)
+            state["bus"] = bus
+            pipeline.set_state(Gst.State.PLAYING)
+        except Exception:
+            send({"t": "error", "error": "pipeline failed"})
+            loop.quit()
+        return False
+
+    def do_answer(sdp):
+        _res, m = GstSdp.SDPMessage.new()
+        GstSdp.sdp_message_parse_buffer(sdp.encode(), m)
+        ans = GstWebRTC.WebRTCSessionDescription.new(
+            GstWebRTC.WebRTCSDPType.ANSWER, m)
+        state["webrtc"].emit("set-remote-description", ans, Gst.Promise.new())
+        return False
+
+    def do_ice(cand, mline):
+        state["webrtc"].emit("add-ice-candidate", mline, cand)
+        return False
+
+    lt = threading.Thread(target=loop.run, daemon=True)
+    lt.start()
+    _GLib.idle_add(build)
+
+    # Inbound signaling: read JSON lines on THIS thread, marshal to the loop.
+    buf = b""
+    try:
+        while True:
+            chunk = conn.recv(65536)
+            if not chunk:
+                break
+            buf += chunk
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                if not line.strip():
+                    continue
+                try:
+                    msg = json.loads(line.decode("utf-8"))
+                except (ValueError, UnicodeDecodeError):
+                    continue
+                if not isinstance(msg, dict):
+                    continue
+                t = msg.get("t")
+                if t not in _ALLOWED_WEBRTC_IN:            # frozen inbound set (§3.2)
+                    continue
+                if t == "answer" and isinstance(msg.get("sdp"), str):
+                    _GLib.idle_add(do_answer, msg["sdp"])
+                elif t == "ice":
+                    cand, mline = msg.get("candidate"), msg.get("sdpMLineIndex", 0)
+                    if isinstance(cand, str) and isinstance(mline, int):
+                        _GLib.idle_add(do_ice, cand, mline)
+                elif t == "bye":
+                    raise _ByeSignal()
+    except (OSError, _ByeSignal):
+        pass
+    finally:
+        loop.quit()
+        lt.join(timeout=3)
+        if state.get("bus") is not None:
+            try:
+                state["bus"].remove_signal_watch()
+            except Exception:
+                pass
+        if state["pipeline"] is not None:
+            state["pipeline"].set_state(Gst.State.NULL)   # REAP the encoder
+        if state["pwfd"] is not None:
+            try:
+                os.close(state["pwfd"])
+            except OSError:
+                pass
+        _WEBRTC_LOCK.release()
+
+
 # ------------------------------------------------------------------- serving
 
 def peer_uid(conn):
@@ -391,6 +643,13 @@ def peer_uid(conn):
         return uid
     except (OSError, struct.error, AttributeError):
         return None
+
+
+def _send_json(conn, obj):
+    try:
+        conn.sendall((json.dumps(obj) + "\n").encode())
+    except OSError:
+        pass
 
 
 def _read_line(conn, limit=65536):
@@ -431,6 +690,18 @@ def serve_one(conn):
                 return
             conn.settimeout(None)                    # long-lived stream
             stream(profile, conn)
+            return
+        # The webrtc verb switches this connection to a JSON SDP/ICE signaling
+        # channel (H.264 over webrtcbin); every other verb is one line in/out.
+        if isinstance(req, dict) and req.get("verb") == "webrtc":
+            profile = _h264_profile_arg(req.get("arg"))
+            if profile is None:
+                conn.sendall(json.dumps(
+                    {"ok": False, "error": "invalid argument for webrtc"}).encode()
+                    + b"\n")
+                return
+            conn.settimeout(None)                    # long-lived signaling
+            _webrtc_session(profile, conn)
             return
         reply = dispatch(req)
         conn.sendall(json.dumps(reply).encode() + b"\n")

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -160,6 +160,31 @@ _SLOCK = threading.RLock()
 _SESSION = None    # {"handle": str, "node": int, "w": int, "h": int} or None
 
 
+# Audible alert players tried in order when a consent dialog is about to pop —
+# the phone cannot click Approve, someone has to at the box, so a chime helps a
+# user who is not looking at the screen. argv LISTs, fixed strings, no client
+# input (§3). Fire-and-forget; a box with no player / no audio stays silent.
+_CHIME_PLAYERS = (
+    ["canberra-gtk-play", "-i", "dialog-warning"],
+    ["pw-play", "/usr/share/sounds/freedesktop/stereo/dialog-warning.oga"],
+    ["paplay", "/usr/share/sounds/freedesktop/stereo/dialog-warning.oga"],
+)
+
+
+def _consent_chime():
+    """Best-effort audible alert that the box is showing a consent dialog. Non-
+    blocking, degrade-closed: any failure (no player, no audio) is ignored."""
+    import shutil
+    for argv in _CHIME_PLAYERS:
+        if shutil.which(argv[0]):
+            try:
+                subprocess.Popen(argv, stdout=subprocess.DEVNULL,
+                                 stderr=subprocess.DEVNULL)
+            except OSError:
+                continue
+            return
+
+
 def _ensure_session():
     """Create + consent the ONE portal session if we don't have it yet.
     Serialized: setup happens once. Returns the session dict or None (denied/
@@ -186,6 +211,7 @@ def _ensure_session():
             return None
         # Start pops the KDE consent dialog. persist_mode=2 asks to remember (a
         # no-op on older KDE that lacks the checkbox — then it re-prompts).
+        _consent_chime()                              # alert: Approve at the box
         code, res = _request(_IF_RD, "Start", "os", (handle, ""),
                              {"persist_mode": GLib.Variant("u", 2)},
                              _CONSENT_TIMEOUT_S)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1582,7 +1582,8 @@ def set_caps(mock):
                  "screensaver", "couchmode", "bigpicture", "desktop",
                  "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
-                 "session_default", "display_info", "player", "screenstream")}
+                 "session_default", "display_info", "player", "screenstream",
+                 "screenstream_h264")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1620,6 +1621,10 @@ def set_caps(mock):
         # absent -> the still-frame poller + relative mouse (P1). A boot-time hint:
         # /ws/screen re-checks the portal live and degrades closed regardless.
         "screenstream": safe(screenstream_available),
+        # P4b: the module ALSO exposes a working H.264/WebRTC path (webrtcbin +
+        # libnice + a VA encoder). Linux-only, additive; absent -> the app uses
+        # MJPEG (caps.screenstream) then the poller. /ws/webrtc re-checks live.
+        "screenstream_h264": safe(screenstream_h264_available),
     }
 
 
@@ -4849,6 +4854,37 @@ def screenstream_available():
     safe() at the call site, so any failure reads as unavailable (§3.7)."""
     r = _portal_call("status", timeout=2)
     return bool(r and r.get("ok"))
+
+
+def screenstream_h264_available():
+    """True when the portal module reports a WORKING H.264/WebRTC path — which
+    means webrtcbin is actually functional (the libnice `nice` elements present),
+    NOT merely registered, plus a VA H.264 encoder. A boot-time hint for
+    caps.screenstream_h264; /ws/webrtc re-checks live and degrades closed. The
+    helper's `status` computes h264 honestly (see _h264_available there)."""
+    r = _portal_call("status", timeout=2)
+    return bool(r and r.get("ok") and r.get("h264"))
+
+
+def _portal_webrtc(profile, timeout=10):
+    """Open a WebRTC signaling connection to the helper: send the `webrtc` verb,
+    then the socket carries newline-delimited JSON SDP/ICE both ways until it is
+    closed (which makes the helper reap webrtcbin). Returns the socket, or None.
+    The agent NEVER parses the SDP — it relays opaque offer/answer/ice lines."""
+    s = _portal_connect(timeout)
+    if s is None:
+        return None
+    try:
+        s.sendall(json.dumps(
+            {"verb": "webrtc", "arg": {"profile": profile}}).encode("utf-8") + b"\n")
+        s.settimeout(None)
+        return s
+    except OSError:
+        try:
+            s.close()
+        except OSError:
+            pass
+        return None
 
 
 def _dm_write(dm, session_file):
@@ -15873,6 +15909,45 @@ _screen_stream_sema = threading.BoundedSemaphore(SCREEN_STREAM_MAX)
 _SCREEN_STREAM_PROFILES = frozenset(("540p25", "720p20", "1080p15"))
 _SCREEN_STREAM_DEFAULT = "720p20"
 
+# --- P4b: H.264/WebRTC signaling relay (/ws/webrtc) -------------------------
+# Only ONE WebRTC session at a time: webrtcbin + a hardware H.264 encoder is far
+# heavier than the MJPEG path, and the helper itself caps at one. Over the cap a
+# new /ws/webrtc is refused (the app auto-falls back to MJPEG then the poller).
+WEBRTC_MAX = 1
+_webrtc_sema = threading.BoundedSemaphore(WEBRTC_MAX)
+# Profile ids the client may request on /ws/webrtc (?profile=). Closed set,
+# looked up never interpolated; the helper owns the pipeline and re-validates.
+# Must mirror the helper's _H264_PROFILES.
+_WEBRTC_PROFILES = frozenset(("720p30", "720p60", "1080p30", "1080p60"))
+_WEBRTC_DEFAULT = "720p60"
+# The agent is a DUMB relay: it forwards only these message TYPES and, per type,
+# only the known fields (never arbitrary client JSON). The opaque SDP/ICE strings
+# ride inside; the agent never parses them (they go to webrtcbin/libnice, a
+# parser like json.loads — never an argv/shell/path, §3). app->box is untrusted.
+_WEBRTC_APP_MSG = frozenset(("answer", "ice", "bye"))          # app -> box
+_WEBRTC_BOX_MSG = frozenset(("offer", "ice", "error", "bye"))  # box -> app
+_WEBRTC_MAX_MSG = 64 * 1024        # an SDP is a few KB; cap generously, reject over
+
+
+def _webrtc_app_msg(msg):
+    """Validate one app->box signaling message and return the EXACT dict to
+    forward to the helper (known fields only), or None to drop it. This is the
+    allowlist boundary for the untrusted direction (§3.2/§3.6)."""
+    if not isinstance(msg, dict):
+        return None
+    t = msg.get("t")
+    if t not in _WEBRTC_APP_MSG:
+        return None
+    if t == "answer":
+        sdp = msg.get("sdp")
+        return {"t": "answer", "sdp": sdp} if isinstance(sdp, str) else None
+    if t == "ice":
+        cand, mline = msg.get("candidate"), msg.get("sdpMLineIndex", 0)
+        if isinstance(cand, str) and isinstance(mline, int):
+            return {"t": "ice", "candidate": cand, "sdpMLineIndex": mline}
+        return None
+    return {"t": "bye"}                                         # t == "bye"
+
 
 def _wsend_json(entry, obj):
     """Send one JSON text frame to a session, serialised per-socket. Never raises."""
@@ -16861,6 +16936,13 @@ class Handler(BaseHTTPRequestHandler):
                 # check + handshake, so it must not sit behind the JSON auth gate
                 # (a JSON 401 body onto an upgrading socket would be garbage).
                 self._handle_screen_ws(parsed, started)
+                return
+
+            if path == "/ws/webrtc":
+                # P4b: same pre-auth-zone rationale as /ws/screen. The handler
+                # self-auths (?token=), then relays opaque SDP/ICE to the portal
+                # helper's webrtcbin. Absent module / no H.264 -> degrades closed.
+                self._handle_webrtc_ws(parsed, started)
                 return
 
             if path == "/pair":
@@ -18796,6 +18878,155 @@ class Handler(BaseHTTPRequestHandler):
                     ws_send(conn, WS_OP_BINARY, jpg)
                 except OSError:
                     return                           # phone disconnected
+
+    # -- H.264/WebRTC signaling websocket (P4b, opt-in portal module) ----------
+
+    def _handle_webrtc_ws(self, parsed, started):
+        """WebRTC SDP/ICE signaling relay. Mirrors the gamepad/screen WS handshake
+        verbatim (same ?token= auth), then relays OPAQUE JSON between the app and
+        the portal helper's webrtcbin. A box without the module (or without a
+        working H.264 path) degrades closed: the socket opens then closes and the
+        app falls back to MJPEG, then the still-frame poller."""
+        self.close_connection = True
+        qs = parse_qs(parsed.query)
+        supplied = qs.get("token", [""])[0]
+        if not supplied or not hmac.compare_digest(supplied, self.token):
+            self._send(401, {"error": "unauthorized"}, started,
+                       extra_headers={"Connection": "close"})
+            return
+        key = self.headers.get("Sec-WebSocket-Key", "")
+        upgrade = (self.headers.get("Upgrade") or "").lower()
+        if upgrade != "websocket" or not key:
+            self._send(400, {"error": "websocket upgrade required"}, started,
+                       extra_headers={"Connection": "close"})
+            return
+        accept = base64.b64encode(
+            hashlib.sha1((key + WS_GUID).encode("ascii")).digest()).decode("ascii")
+        try:
+            self.connection.sendall(
+                b"HTTP/1.1 101 Switching Protocols\r\n"
+                b"Upgrade: websocket\r\n"
+                b"Connection: Upgrade\r\n"
+                b"Sec-WebSocket-Accept: " + accept.encode("ascii") + b"\r\n\r\n")
+        except OSError:
+            return
+        self._log(101, started)
+        profile = qs.get("profile", [_WEBRTC_DEFAULT])[0]
+        if profile not in _WEBRTC_PROFILES:            # closed set, never interpolated
+            profile = _WEBRTC_DEFAULT
+        try:
+            self._webrtc_relay_session(profile)
+        except Exception as e:
+            print("[webrtc] session error: %s: %s"
+                  % (e.__class__.__name__, e), flush=True)
+
+    def _webrtc_relay_session(self, profile):
+        """One WebRTC session: consent opens the shared portal session, then relay
+        SDP/ICE both ways between the app WS and the helper `webrtc` socket. The
+        agent is a DUMB relay (never parses SDP); it forwards only allowlisted
+        message types + known fields. Capped at one; degrade closed; reap on exit
+        (closing the helper socket makes the helper tear down webrtcbin)."""
+        conn = self.connection
+        if not _webrtc_sema.acquire(blocking=False):
+            try:
+                ws_send(conn, WS_OP_CLOSE)             # over cap -> app falls back
+            except OSError:
+                pass
+            return
+        hsock = None
+        pump_thread = None
+        wlock = threading.Lock()                       # 2 threads write conn -> lock
+        try:
+            # ensure = create the session + block on the box's consent dialog.
+            res = _portal_call("ensure", timeout=170)
+            if not res or not res.get("ok"):
+                try:
+                    ws_send(conn, WS_OP_CLOSE)
+                except OSError:
+                    pass
+                return
+            hsock = _portal_webrtc(profile)
+            if hsock is None:
+                try:
+                    ws_send(conn, WS_OP_CLOSE)
+                except OSError:
+                    pass
+                return
+
+            def pump_box_to_app():
+                """Helper -> app: forward only allowlisted box message types."""
+                hbuf = b""
+                try:
+                    while True:
+                        chunk = hsock.recv(65536)
+                        if not chunk:
+                            break
+                        hbuf += chunk
+                        while b"\n" in hbuf:
+                            line, hbuf = hbuf.split(b"\n", 1)
+                            if not line.strip():
+                                continue
+                            try:
+                                m = json.loads(line.decode("utf-8"))
+                            except (ValueError, UnicodeDecodeError):
+                                continue
+                            if not isinstance(m, dict) or \
+                                    m.get("t") not in _WEBRTC_BOX_MSG:
+                                continue
+                            try:
+                                with wlock:
+                                    ws_send_json(conn, m)
+                            except OSError:
+                                return
+                except OSError:
+                    pass
+                finally:
+                    try:
+                        conn.shutdown(socket.SHUT_RDWR)   # unblock the app read loop
+                    except OSError:
+                        pass
+
+            pump_thread = threading.Thread(target=pump_box_to_app, daemon=True)
+            pump_thread.start()
+
+            # App -> helper (this thread). Untrusted direction: strict allowlist.
+            buf = bytearray()
+            while True:
+                frame = ws_recv_frame(conn, buf)
+                if frame is None:
+                    break
+                opcode, payload = frame
+                if opcode == WS_OP_CLOSE:
+                    break
+                if opcode == WS_OP_PING:
+                    try:
+                        with wlock:
+                            ws_send(conn, WS_OP_PONG, payload)
+                    except OSError:
+                        break
+                    continue
+                if opcode != WS_OP_TEXT or len(payload) > _WEBRTC_MAX_MSG:
+                    continue
+                try:
+                    msg = json.loads(payload.decode("utf-8"))
+                except (ValueError, UnicodeDecodeError):
+                    continue
+                out = _webrtc_app_msg(msg)
+                if out is None:
+                    continue
+                try:
+                    hsock.sendall(json.dumps(out).encode("utf-8") + b"\n")
+                except OSError:
+                    break
+        finally:
+            if hsock is not None:
+                try:
+                    hsock.close()                      # closing -> helper reaps
+                except OSError:
+                    pass
+            if pump_thread is not None:
+                pump_thread.join(timeout=2)
+            _webrtc_sema.release()
 
     def _gamepad_session(self):
         global GAMEPAD_HOLDER

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -18846,21 +18846,34 @@ class Handler(BaseHTTPRequestHandler):
 
     def _screen_pump(self, conn, portal_sock):
         """Read the helper's MJPEG byte stream, split whole JPEGs (FFD8..FFD9),
-        send each as ONE binary WS frame. This is the ONLY writer of `conn`, so no
-        slock is needed. Backpressure is handled at the SOURCE: a slow phone
-        blocks this send, which stops draining the helper, which makes the
-        helper's gst `queue leaky=downstream` drop old frames — so the phone falls
-        behind rather than accumulating latency. A send failure = phone gone."""
+        send NEWEST-ONLY to `conn`: before each send, drain everything the helper
+        has ready and keep only the LATEST complete JPEG, dropping older ones.
+        This is the ONLY writer of `conn`, so no slock is needed. A send failure =
+        phone gone.
+
+        WHY NEWEST-ONLY: hardware jpeg (vajpegenc) produces frames faster than a
+        phone can base64-decode + <Image>-render on high motion. Sending EVERY
+        frame lets a backlog build in transit (seconds of lag when a window opens
+        — observed). Dropping to the freshest frame each send-cycle bounds
+        end-to-end latency to ~one frame: the phone gets fewer, CURRENT frames
+        instead of a growing pile of stale ones. Frames produced during the
+        (blocking) send land in the OS recv buffer and are dropped-but-newest on
+        the next cycle; a truly slow phone also backpressures gst at the source."""
         buf = bytearray()
-        portal_sock.settimeout(30)
-        while True:
-            try:
-                chunk = portal_sock.recv(65536)
-            except OSError:
-                break
-            if not chunk:
-                break                                # helper/gst ended
-            buf += chunk
+
+        def _drain_newest(first):
+            # Append `first` + any immediately-available bytes; return the LATEST
+            # complete JPEG in the buffer (older complete frames are discarded).
+            buf.extend(first)
+            while select.select([portal_sock], [], [], 0)[0]:
+                try:
+                    more = portal_sock.recv(262144)
+                except OSError:
+                    more = b""
+                if not more:
+                    break
+                buf.extend(more)
+            newest = None
             while True:
                 soi = buf.find(b"\xff\xd8")
                 if soi < 0:
@@ -18872,12 +18885,25 @@ class Handler(BaseHTTPRequestHandler):
                 eoi = buf.find(b"\xff\xd9", 2)
                 if eoi < 0:
                     break                            # partial frame; wait for more
-                jpg = bytes(buf[:eoi + 2])
+                newest = bytes(buf[:eoi + 2])        # keep the last complete JPEG
                 del buf[:eoi + 2]
-                try:
-                    ws_send(conn, WS_OP_BINARY, jpg)
-                except OSError:
-                    return                           # phone disconnected
+            return newest
+
+        portal_sock.settimeout(30)
+        while True:
+            try:
+                chunk = portal_sock.recv(65536)
+            except OSError:
+                break
+            if not chunk:
+                break                                # helper/gst ended
+            jpg = _drain_newest(chunk)
+            if jpg is None:
+                continue                             # only a partial frame so far
+            try:
+                ws_send(conn, WS_OP_BINARY, jpg)     # blocking; gst buffers meanwhile
+            except OSError:
+                return                               # phone disconnected
 
     # -- H.264/WebRTC signaling websocket (P4b, opt-in portal module) ----------
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -18835,6 +18835,12 @@ class Handler(BaseHTTPRequestHandler):
                 except OSError:
                     pass
                 return
+            # An abruptly-backgrounded phone leaves its socket half-dead: sends
+            # stop draining but never error, so a bare sendall blocks FOREVER —
+            # a zombie thread holding one of the two stream slots (two zombies
+            # = every reopen refused). With a timeout the zombie dies in ≤20s
+            # (normal sends are <1s), releasing the slot + reaping the stream.
+            conn.settimeout(20)
             self._screen_pump(conn, portal_sock)
         finally:
             if portal_sock is not None:
@@ -18860,6 +18866,9 @@ class Handler(BaseHTTPRequestHandler):
         (blocking) send land in the OS recv buffer and are dropped-but-newest on
         the next cycle; a truly slow phone also backpressures gst at the source."""
         buf = bytearray()
+        # TEMP instrumentation (remove before ship): sent/dropped per interval +
+        # how long ws_send blocks (TCP backpressure = the phone not draining).
+        stats = {"sent": 0, "drop": 0, "block": 0.0, "last": time.time()}
 
         def _drain_newest(first):
             # Append `first` + any immediately-available bytes; return the LATEST
@@ -18885,6 +18894,8 @@ class Handler(BaseHTTPRequestHandler):
                 eoi = buf.find(b"\xff\xd9", 2)
                 if eoi < 0:
                     break                            # partial frame; wait for more
+                if newest is not None:
+                    stats["drop"] += 1               # superseded before send
                 newest = bytes(buf[:eoi + 2])        # keep the last complete JPEG
                 del buf[:eoi + 2]
             return newest
@@ -18901,9 +18912,25 @@ class Handler(BaseHTTPRequestHandler):
             if jpg is None:
                 continue                             # only a partial frame so far
             try:
+                # TEMP: box wall-clock as a TEXT frame right before each binary
+                # frame — the app computes (phone_now - ms) to expose transit
+                # backlog. Additive: clients ignore non-binary frames.
+                ws_send_json(conn, {"t": "ts", "ms": int(time.time() * 1000)})
+                t0 = time.time()
                 ws_send(conn, WS_OP_BINARY, jpg)     # blocking; gst buffers meanwhile
+                stats["block"] += time.time() - t0
+                stats["sent"] += 1
             except OSError:
                 return                               # phone disconnected
+            now = time.time()
+            if now - stats["last"] >= 2.0:
+                el = now - stats["last"]
+                print("[screenstat-agent] sent/s=%.1f drop/s=%.1f "
+                      "avg_send_ms=%.0f kb=%d"
+                      % (stats["sent"] / el, stats["drop"] / el,
+                         stats["block"] * 1000 / max(1, stats["sent"]),
+                         len(jpg) // 1024), flush=True)
+                stats.update(sent=0, drop=0, block=0.0, last=now)
 
     # -- H.264/WebRTC signaling websocket (P4b, opt-in portal module) ----------
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -18866,9 +18866,6 @@ class Handler(BaseHTTPRequestHandler):
         (blocking) send land in the OS recv buffer and are dropped-but-newest on
         the next cycle; a truly slow phone also backpressures gst at the source."""
         buf = bytearray()
-        # TEMP instrumentation (remove before ship): sent/dropped per interval +
-        # how long ws_send blocks (TCP backpressure = the phone not draining).
-        stats = {"sent": 0, "drop": 0, "block": 0.0, "last": time.time()}
 
         def _drain_newest(first):
             # Append `first` + any immediately-available bytes; return the LATEST
@@ -18894,8 +18891,6 @@ class Handler(BaseHTTPRequestHandler):
                 eoi = buf.find(b"\xff\xd9", 2)
                 if eoi < 0:
                     break                            # partial frame; wait for more
-                if newest is not None:
-                    stats["drop"] += 1               # superseded before send
                 newest = bytes(buf[:eoi + 2])        # keep the last complete JPEG
                 del buf[:eoi + 2]
             return newest
@@ -18912,25 +18907,9 @@ class Handler(BaseHTTPRequestHandler):
             if jpg is None:
                 continue                             # only a partial frame so far
             try:
-                # TEMP: box wall-clock as a TEXT frame right before each binary
-                # frame — the app computes (phone_now - ms) to expose transit
-                # backlog. Additive: clients ignore non-binary frames.
-                ws_send_json(conn, {"t": "ts", "ms": int(time.time() * 1000)})
-                t0 = time.time()
                 ws_send(conn, WS_OP_BINARY, jpg)     # blocking; gst buffers meanwhile
-                stats["block"] += time.time() - t0
-                stats["sent"] += 1
             except OSError:
                 return                               # phone disconnected
-            now = time.time()
-            if now - stats["last"] >= 2.0:
-                el = now - stats["last"]
-                print("[screenstat-agent] sent/s=%.1f drop/s=%.1f "
-                      "avg_send_ms=%.0f kb=%d"
-                      % (stats["sent"] / el, stats["drop"] / el,
-                         stats["block"] * 1000 / max(1, stats["sent"]),
-                         len(jpg) // 1024), flush=True)
-                stats.update(sent=0, drop=0, block=0.0, last=now)
 
     # -- H.264/WebRTC signaling websocket (P4b, opt-in portal module) ----------
 

--- a/app/.npmrc
+++ b/app/.npmrc
@@ -1,0 +1,6 @@
+# @config-plugins/react-native-webrtc@15 declares peer expo@^56 (the config
+# plugins lag the Expo SDK by a major); this app is on Expo 57. The plugin only
+# writes Info.plist keys, Android permissions, and build props, which are stable
+# across 56/57, so accept the peer mismatch rather than block install. Required
+# for clean installs and EAS builds (npm would otherwise ERESOLVE-fail).
+legacy-peer-deps=true

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "168",
+      "buildNumber": "169",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -42,6 +42,13 @@
     "plugins": [
       "expo-router",
       [
+        "@config-plugins/react-native-webrtc",
+        {
+          "cameraPermission": "Couchside does not use your camera. This permission is declared by the WebRTC video library Couchside uses to stream your computer's screen to this device.",
+          "microphonePermission": "Couchside does not use your microphone. This permission is declared by the WebRTC video library Couchside uses to stream your computer's screen to this device."
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "170",
+      "buildNumber": "171",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "169",
+      "buildNumber": "170",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -361,19 +361,19 @@ function ConsoleScreen() {
           </>
         )}
 
-        {/* What the box is driving: mode, panel, HDR/VRR, default audio in/out
-            (probe-and-appear; agent >= 2.9.59).
-            HERE, directly above the preview, on purpose: the two are one
-            region — the specs of the screen, then the picture on it. Below the
-            vitals you opened this tab to read, above UNITS, which is reference
-            config rather than something you watch. */}
-        <TourAnchor id="console.display">
-          <DisplayAudioCard />
-        </TourAnchor>
-
-        {/* Live screen preview (probe-and-appear; hidden when no capture path) */}
+        {/* Live screen preview (probe-and-appear; hidden when no capture path).
+            RIGHT UNDER THE VITALS (above DISPLAY + UNITS) on purpose: the SCREEN
+            card carries the CONTROL button, so it must be reachable without
+            scrolling past the display specs. */}
         <TourAnchor id="console.screen">
           <ScreenPreview />
+        </TourAnchor>
+
+        {/* What the box is driving: mode, panel, HDR/VRR, default audio in/out
+            (probe-and-appear; agent >= 2.9.59). Below the preview it describes,
+            above UNITS (reference config rather than something you watch). */}
+        <TourAnchor id="console.display">
+          <DisplayAudioCard />
         </TourAnchor>
 
         {/* Units */}

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -1,6 +1,7 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import { EditableSection } from '@/components/EditableSection';
 import { Gated } from '@/components/Gated';
 import { TourAnchor } from '@/components/TourAnchor';
 import { registerScroller } from '@/hooks/useTourAnchor';
@@ -17,6 +18,7 @@ import { usePoll } from '@/hooks/usePoll';
 import { useStreak } from '@/hooks/useStreak';
 import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { fmtLastSeen, noteBoxSeen } from '@/lib/lastSeen';
+import { useConsoleLayout, effectiveOrder, moveSection, setConsoleLayout } from '@/lib/consoleLayout';
 import { usePref } from '@/lib/prefs';
 import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { noteBoxReachable } from '@/lib/review';
@@ -133,6 +135,181 @@ function ConsoleScreen() {
     [],
   );
 
+  // --- Console card layout: hold-to-edit reorder + hide (persisted) --------
+  const CARD_ORDER_CANON = [
+    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'units', 'filedrop',
+  ];
+  const cardLayout = useConsoleLayout();
+  const [editingCards, setEditingCards] = useState(false);
+  const [cardPresent, setCardPresent] = useState<Record<string, boolean>>({});
+  const cardOrder = effectiveOrder(cardLayout.order, CARD_ORDER_CANON);
+  const cardHidden = new Set(cardLayout.hidden);
+  const setPresent = (id: string, p: boolean) =>
+    setCardPresent((prev) => (prev[id] === p ? prev : { ...prev, [id]: p }));
+  const visibleCards = cardOrder.filter((id) => cardPresent[id]);
+  const moveCard = (id: string, dir: -1 | 1) =>
+    setConsoleLayout({ order: moveSection(cardOrder, visibleCards, id, dir), hidden: cardLayout.hidden });
+  const toggleHideCard = (id: string) => {
+    const h = new Set(cardLayout.hidden);
+    if (h.has(id)) h.delete(id); else h.add(id);
+    setConsoleLayout({ order: cardOrder, hidden: [...h] });
+  };
+
+  // The movable cards, by id. null = not applicable on this box/state (skipped).
+  // The self-gating (probe-and-appear) cards render null internally when absent;
+  // EditableSection then shows no edit controls for them.
+  const cardNodes: Record<string, React.ReactNode> = {
+    nowplaying: <NowPlayingCard />,
+    streamhost: <StreamHostCard />,
+    gaming: <GamingCard />,
+    vitals: s ? (
+      <>
+        <View style={styles.row}>
+          {/* TourAnchor REPLACES the half View rather than wrapping it, so
+              the flex row is untouched — see components/TourAnchor.tsx. */}
+          <TourAnchor id="console.cpu" style={styles.half}>
+            <Card title="CPU TEMP" index={0}>
+              <BigMetric
+                value={s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
+                numeric={s.cpu_temp_c}
+                color={tempColor(s.cpu_temp_c, t)}
+              />
+              <Spark values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
+            </Card>
+          </TourAnchor>
+          <View style={styles.half}>
+            <Card title="UPTIME" index={1}>
+              <BigMetric value={humanizeUptime(s.uptime_s)} numeric={null} color={t.text} />
+              {s.ip ? <Text style={styles.ipLine}>{s.ip}</Text> : null}
+            </Card>
+          </View>
+        </View>
+
+        <Card title="LOAD 1m / 5m / 15m" index={2}>
+          <View style={styles.loadRow}>
+            {s.load.map((l, i) => (
+              <Text key={i} style={styles.loadVal}>
+                {l.toFixed(2)}
+              </Text>
+            ))}
+          </View>
+          <Spark values={s.history?.load} color={t.blue} />
+        </Card>
+
+        <Card title="MEMORY" index={3}>
+          <View style={styles.barLabelRow}>
+            <Text style={styles.barLabel}>
+              {(s.mem.used_mb / 1024).toFixed(1)} / {(s.mem.total_mb / 1024).toFixed(1)} GB
+            </Text>
+            <Text style={[styles.barLabel, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
+          </View>
+          <Bar pct={memPct} color={pctColor(memPct, t)} />
+          <Spark values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
+          {(memPressure != null || (s.mem.swap_used_mb ?? 0) > 0) && (
+            <Text style={styles.ipLine}>
+              {[
+                memPressure != null ? `stalled ${memPressure.toFixed(1)}%` : null,
+                (s.mem.swap_used_mb ?? 0) > 0
+                  ? `swap ${(s.mem.swap_used_mb! / 1024).toFixed(1)}G`
+                  : null,
+              ]
+                .filter(Boolean)
+                .join('  ·  ')}
+            </Text>
+          )}
+        </Card>
+
+        <Card title="DISKS" index={4}>
+          {s.disks.map((d) => (
+            <View key={d.mount} style={styles.diskRow}>
+              <View style={styles.barLabelRow}>
+                <Text style={styles.diskMount}>{d.mount}</Text>
+                <Text style={styles.barLabel}>
+                  {d.used_gb.toFixed(1)} / {d.total_gb.toFixed(1)} GB
+                  {'   '}
+                  <Text style={{ color: pctColor(d.pct, t) }}>{d.pct}%</Text>
+                </Text>
+              </View>
+              <Bar pct={d.pct} color={pctColor(d.pct, t)} />
+            </View>
+          ))}
+        </Card>
+
+        {/* Probe-and-appear: the agent OMITS `battery` on a mains desktop
+            and on agents older than 2.9.40, so presence of the key is the
+            whole gate -- no cap check, no placeholder, no "0%" on a machine
+            that has no pack. */}
+        {s.battery && (
+          <Card title="BATTERY" index={5}>
+            <View style={styles.barLabelRow}>
+              <Text style={styles.barLabel}>
+                {s.battery.status === 'Charging'
+                  ? 'Charging'
+                  : s.battery.on_ac
+                    ? 'On AC'
+                    : 'On battery'}
+                {s.battery.minutes_to_full != null
+                  ? `   ${fmtDuration(s.battery.minutes_to_full)} to full`
+                  : s.battery.minutes != null
+                    ? `   ${fmtDuration(s.battery.minutes)} left`
+                    : ''}
+              </Text>
+              <Text style={[styles.barLabel, { color: batteryColor(s.battery.pct, t) }]}>
+                {s.battery.pct}%
+              </Text>
+            </View>
+            <Bar pct={s.battery.pct} color={batteryColor(s.battery.pct, t)} />
+            {(s.battery.watts != null || s.battery.profile) && (
+              <Text style={styles.ipLine}>
+                {[
+                  s.battery.watts != null
+                    ? `${s.battery.watts.toFixed(1)}W ${
+                        s.battery.status === 'Charging' ? 'in' : 'draw'
+                      }`
+                    : null,
+                  s.battery.profile,
+                ]
+                  .filter(Boolean)
+                  .join('  ·  ')}
+              </Text>
+            )}
+          </Card>
+        )}
+      </>
+    ) : null,
+    screen: (
+      <TourAnchor id="console.screen">
+        <ScreenPreview />
+      </TourAnchor>
+    ),
+    display: (
+      <TourAnchor id="console.display">
+        <DisplayAudioCard />
+      </TourAnchor>
+    ),
+    units: configured ? (
+      <Card title="UNITS" index={5}>
+        {units.error != null && !units.data ? (
+          <Text style={styles.unitErr}>{units.error.message}</Text>
+        ) : units.data ? (
+          <View style={styles.chips}>
+            {units.data.units.filter((u) => !u.log_only).map((u) => (
+              <UnitChip key={`${u.scope}:${u.name}`} unit={u} />
+            ))}
+          </View>
+        ) : (
+          <Text style={styles.unitErr}>loading…</Text>
+        )}
+        <Text style={styles.unitHint}>
+          {(s?.agent_version ?? '').endsWith('-win')
+            ? 'watchlist: config.json in the Couchside folder on the box (units[]), then restart the agent'
+            : 'watchlist: /etc/couchside/config.json on the box (units[]), then restart couchside.service'}
+        </Text>
+      </Card>
+    ) : null,
+    filedrop: <FileDropCard />,
+  };
+
   return (
     <VitalsContext.Provider value={vitals}>
     <View style={styles.screen}>
@@ -214,207 +391,44 @@ function ConsoleScreen() {
           </View>
         )}
 
-        {/* Now Playing (MPRIS) — probe-and-appear; hidden when no media backend */}
-        <NowPlayingCard />
-
-        {/* Serving a Remote Play session (hidden unless one is live) */}
-        <StreamHostCard />
-
-        {/* Gaming card (probe-and-appear; hidden when the box has no Steam) */}
-        <GamingCard />
-
-        {s && (
-          <>
-            <View style={styles.row}>
-              {/* TourAnchor REPLACES the half View rather than wrapping it, so
-                  the flex row is untouched — see components/TourAnchor.tsx. */}
-              <TourAnchor id="console.cpu" style={styles.half}>
-                <Card title="CPU TEMP" index={0}>
-                  <BigMetric
-                    value={s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
-                    numeric={s.cpu_temp_c}
-                    color={tempColor(s.cpu_temp_c, t)}
-                  />
-                  <Spark values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
-                </Card>
-              </TourAnchor>
-              <View style={styles.half}>
-                <Card title="UPTIME" index={1}>
-                  {/* Not numeric: "1d 2h 7m" must never be interpolated. */}
-                  <BigMetric value={humanizeUptime(s.uptime_s)} numeric={null} color={t.text} />
-                  {/* The address the phone actually reached the box on, straight
-                      from the socket (agent >= 2.9.22). Worth showing because it
-                      is what you need when mDNS breaks and the box has to be
-                      re-added by IP — the exact moment the app is hardest to
-                      use. Rides the poll that is already happening. */}
-                  {s.ip ? <Text style={styles.ipLine}>{s.ip}</Text> : null}
-                </Card>
-              </View>
-            </View>
-
-            <Card title="LOAD 1m / 5m / 15m" index={2}>
-              <View style={styles.loadRow}>
-                {s.load.map((l, i) => (
-                  <Text key={i} style={styles.loadVal}>
-                    {l.toFixed(2)}
-                  </Text>
-                ))}
-              </View>
-              <Spark values={s.history?.load} color={t.blue} />
-            </Card>
-
-            <Card title="MEMORY" index={3}>
-              <View style={styles.barLabelRow}>
-                <Text style={styles.barLabel}>
-                  {(s.mem.used_mb / 1024).toFixed(1)} / {(s.mem.total_mb / 1024).toFixed(1)} GB
-                </Text>
-                <Text style={[styles.barLabel, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
-              </View>
-              <Bar pct={memPct} color={pctColor(memPct, t)} />
-              {/* Fixed 0-100 scale: a memory sparkline that auto-scales would
-                  make a 2% wiggle look like a cliff. */}
-              <Spark values={s.history?.mem_pct} color={pctColor(memPct, t)} min={0} max={100} />
-              {/* Swap and stall pressure, each shown ONLY when it is saying
-                  something. Zero pressure on an idle box is the normal state and
-                  printing "0.0%" every second would train you to ignore the row
-                  that matters. PSI is absent entirely on kernels without
-                  CONFIG_PSI, which is why undefined and 0 are treated
-                  differently here. */}
-              {(memPressure != null || (s.mem.swap_used_mb ?? 0) > 0) && (
-                <Text style={styles.ipLine}>
-                  {[
-                    memPressure != null ? `stalled ${memPressure.toFixed(1)}%` : null,
-                    (s.mem.swap_used_mb ?? 0) > 0
-                      ? `swap ${(s.mem.swap_used_mb! / 1024).toFixed(1)}G`
-                      : null,
-                  ]
-                    .filter(Boolean)
-                    .join('  ·  ')}
-                </Text>
-              )}
-            </Card>
-
-            <Card title="DISKS" index={4}>
-              {s.disks.map((d) => (
-                <View key={d.mount} style={styles.diskRow}>
-                  <View style={styles.barLabelRow}>
-                    <Text style={styles.diskMount}>{d.mount}</Text>
-                    <Text style={styles.barLabel}>
-                      {d.used_gb.toFixed(1)} / {d.total_gb.toFixed(1)} GB
-                      {'   '}
-                      <Text style={{ color: pctColor(d.pct, t) }}>{d.pct}%</Text>
-                    </Text>
-                  </View>
-                  <Bar pct={d.pct} color={pctColor(d.pct, t)} />
-                </View>
-              ))}
-            </Card>
-
-            {/* Probe-and-appear: the agent OMITS `battery` on a mains desktop
-                and on agents older than 2.9.40, so presence of the key is the
-                whole gate -- no cap check, no placeholder, no "0%" on a machine
-                that has no pack. */}
-            {s.battery && (
-              <Card title="BATTERY" index={5}>
-                <View style={styles.barLabelRow}>
-                  <Text style={styles.barLabel}>
-                    {s.battery.status === 'Charging'
-                      ? 'Charging'
-                      : s.battery.on_ac
-                        ? 'On AC'
-                        : 'On battery'}
-                    {/* Two different clocks, never both: time-to-full while
-                        charging, runtime-left while discharging. The agent
-                        keeps them as separate fields for exactly that reason. */}
-                    {s.battery.minutes_to_full != null
-                      ? `   ${fmtDuration(s.battery.minutes_to_full)} to full`
-                      : s.battery.minutes != null
-                        ? `   ${fmtDuration(s.battery.minutes)} left`
-                        : ''}
-                  </Text>
-                  <Text style={[styles.barLabel, { color: batteryColor(s.battery.pct, t) }]}>
-                    {s.battery.pct}%
-                  </Text>
-                </View>
-                <Bar pct={s.battery.pct} color={batteryColor(s.battery.pct, t)} />
-                {/* Draw and power profile, each independently optional so a box
-                    that reports only one still shows it. The watts figure is
-                    labelled by STATUS -- the same counter is the charge rate
-                    when plugged in, so calling it "draw" while charging would
-                    be wrong. */}
-                {(s.battery.watts != null || s.battery.profile) && (
-                  <Text style={styles.ipLine}>
-                    {[
-                      s.battery.watts != null
-                        ? `${s.battery.watts.toFixed(1)}W ${
-                            s.battery.status === 'Charging' ? 'in' : 'draw'
-                          }`
-                        : null,
-                      s.battery.profile,
-                    ]
-                      .filter(Boolean)
-                      .join('  ·  ')}
-                  </Text>
-                )}
-              </Card>
-            )}
-          </>
-        )}
-
-        {/* Live screen preview (probe-and-appear; hidden when no capture path).
-            RIGHT UNDER THE VITALS (above DISPLAY + UNITS) on purpose: the SCREEN
-            card carries the CONTROL button, so it must be reachable without
-            scrolling past the display specs. */}
-        <TourAnchor id="console.screen">
-          <ScreenPreview />
-        </TourAnchor>
-
-        {/* What the box is driving: mode, panel, HDR/VRR, default audio in/out
-            (probe-and-appear; agent >= 2.9.59). Below the preview it describes,
-            above UNITS (reference config rather than something you watch). */}
-        <TourAnchor id="console.display">
-          <DisplayAudioCard />
-        </TourAnchor>
-
-        {/* Units */}
-        {configured && (
-          <Card title="UNITS" index={5}>
-            {units.error != null && !units.data ? (
-              <Text style={styles.unitErr}>{units.error.message}</Text>
-            ) : units.data ? (
-              <View style={styles.chips}>
-                {/* log_only entries are LOG SOURCES, not services (the
-                    Windows agent's own log). Rendering one as a unit showed a
-                    permanent "inactive/not-found" warning for something that
-                    cannot run. They stay in the Logs picker, which is why they
-                    are in the watchlist at all. */}
-                {units.data.units.filter((u) => !u.log_only).map((u) => (
-                  <UnitChip key={`${u.scope}:${u.name}`} unit={u} />
-                ))}
-              </View>
-            ) : (
-              <Text style={styles.unitErr}>loading…</Text>
-            )}
-            {/* The watchlist is box-side config, not app state — point at it so
-                homelab users know they can watch their own services. */}
-            {/* Platform-aware: the Linux paths below are meaningless on a
-                Windows box, which has neither /etc/couchside nor systemd — it
-                was still printing them (reported from a real Windows box). */}
-            <Text style={styles.unitHint}>
-              {(s?.agent_version ?? '').endsWith('-win')
-                ? 'watchlist: config.json in the Couchside folder on the box (units[]), then restart the agent'
-                : 'watchlist: /etc/couchside/config.json on the box (units[]), then restart couchside.service'}
-            </Text>
-          </Card>
-        )}
-
-        {/* Send a file to the box (probe-and-appear; agent >= 2.9.54).
-            LAST on purpose: sending a file is a deliberate errand you go
-            looking for, not something you monitor, so it does not earn space
-            above the vitals you opened this tab to read. */}
-        <FileDropCard />
+        {/* Movable cards: order + hidden from the hold-to-edit layout pref.
+            Each wrapped in EditableSection (long-press → edit; ↑ ↓ hide). The
+            self-gating cards still render null internally when their box lacks
+            the feature; EditableSection shows no controls for a null card. */}
+        {cardOrder.map((id) => {
+          const node = cardNodes[id];
+          if (node == null) return null;
+          return (
+            <EditableSection
+              key={id}
+              editing={editingCards}
+              hidden={cardHidden.has(id)}
+              isFirst={visibleCards[0] === id}
+              isLast={visibleCards[visibleCards.length - 1] === id}
+              onEnterEdit={() => setEditingCards(true)}
+              onPresent={(p) => setPresent(id, p)}
+              onUp={() => moveCard(id, -1)}
+              onDown={() => moveCard(id, 1)}
+              onToggleHide={() => toggleHideCard(id)}>
+              {node}
+            </EditableSection>
+          );
+        })}
         </Screen>
       </ScrollView>
+      {/* Edit-layout bar: hold any card to enter, then reorder/hide + Done. */}
+      {editingCards && (
+        <View style={styles.editBar}>
+          <Text style={styles.editHint}>Reorder or hide cards</Text>
+          <Pressable
+            onPress={() => setEditingCards(false)}
+            accessibilityRole="button"
+            accessibilityLabel="Done editing layout"
+            style={({ pressed }) => [styles.doneBtn, pressed && styles.pressed]}>
+            <Text style={styles.doneText}>Done</Text>
+          </Pressable>
+        </View>
+      )}
     </View>
     </VitalsContext.Provider>
   );
@@ -423,6 +437,18 @@ function ConsoleScreen() {
 const makeStyles = (t: Palette) => StyleSheet.create({
   screen: { flex: 1, backgroundColor: t.bg },
   scroll: { flex: 1 },
+  editBar: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 16, paddingTop: 12, paddingBottom: 28,
+    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  },
+  editHint: { color: t.textDim, fontSize: 13 },
+  doneBtn: {
+    backgroundColor: t.blue, borderRadius: 999,
+    paddingVertical: 8, paddingHorizontal: 22,
+  },
+  doneText: { color: t.bg, fontWeight: '700', fontSize: 14 },
   header: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -88,9 +88,19 @@ export default function DesktopControlScreen() {
   const streamMode = !webrtcMode && settings.caps?.screenstream === true;
   const fluidMode = webrtcMode || streamMode;
   const live = ready && configured;
-  const poll = useScreenFrame(settings, live && !fluidMode, FRAME_MS);
   const streamed = useScreenStream(settings, live && streamMode);
   const webrtc = useWebRtcStream(settings, live && webrtcMode);
+  // Still-frame poller. Runs when there is no fluid tier — AND as a STOPGAP VIEW
+  // while a selected fluid tier has not produced its first frame yet. That gap
+  // is not rare: an app background can leave the box's previous gst still on the
+  // shared portal capture when the reopened stream starts, so the new /ws/screen
+  // is OPEN but silent (0 frames) — which used to spin "Approve…" forever with
+  // no escape. The poller captures via spectacle/gamescopectl (NOT the portal),
+  // so it shows the desktop even when the portal session is wedged, and it gates
+  // OFF the instant the fluid tier delivers a frame (reopening retries fluid).
+  const fluidHasFrame = (webrtcMode && webrtc.streamURL != null)
+    || (streamMode && streamed.frame != null);
+  const poll = useScreenFrame(settings, live && (!fluidMode || !fluidHasFrame), FRAME_MS);
 
   // Auto-fallback: a hard WebRTC failure (negotiation/timeout) demotes to MJPEG
   // for the rest of this screen. One-way — we do not re-try WebRTC (that re-pops
@@ -100,10 +110,19 @@ export default function DesktopControlScreen() {
   }, [webrtcMode, webrtc.failed]);
 
   const streamURL = webrtcMode ? webrtc.streamURL : null;
-  // The <Image> frame (tiers 2/3). In WebRTC mode a "failure" means we are
-  // demoting, not that the screen is unavailable, so don't surface it as such.
-  const frame = webrtcMode ? null : streamMode ? streamed.frame : poll.frame;
-  const failed = webrtcMode ? false : streamMode ? streamed.failed : poll.failed;
+  // The <Image> frame (tiers 2/3). Prefer the fluid stream frame; fall back to
+  // the poller frame during the first-frame gap / a wedged portal session. In
+  // WebRTC mode a "failure" means we are demoting, not that the screen is
+  // unavailable, so don't surface it as such.
+  const frame = webrtcMode ? null
+    : streamMode ? (streamed.frame ?? poll.frame)
+    : poll.frame;
+  // "failed" only when we have NO visual path left — the fluid stream failed AND
+  // the poller fallback also failed. A silent/wedged stream with a working
+  // poller is NOT a failure (the desktop is still on screen).
+  const failed = webrtcMode ? false
+    : streamMode ? (streamed.failed && poll.failed)
+    : poll.failed;
   const hasVisual = streamURL != null || frame != null;
 
   const clientRef = useRef<GamepadClient | null>(null);
@@ -186,7 +205,7 @@ export default function DesktopControlScreen() {
   if (landscape) {
     return (
       <>
-        <Stack.Screen options={{ headerShown: false }} />
+        <Stack.Screen options={{ headerShown: false, gestureEnabled: false, fullScreenGestureEnabled: false }} />
         <DesktopFullscreen
           client={client}
           streamURL={streamURL}
@@ -203,7 +222,7 @@ export default function DesktopControlScreen() {
 
   return (
     <View style={[styles.root, { paddingTop: insets.top }]}>
-      <Stack.Screen options={{ headerShown: false }} />
+      <Stack.Screen options={{ headerShown: false, gestureEnabled: false, fullScreenGestureEnabled: false }} />
       {/* SCREEN (top): the live desktop frame */}
       <View style={styles.stage}>
         {streamURL ? (

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -53,6 +53,14 @@ import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 const FRAME_MS = 700;
 const DEVICE_LABEL = 'Couchside Desktop';
 
+// The H.264/WebRTC tier is DISABLED: react-native-webrtc@124 is incompatible with
+// React Native 0.86's new architecture — RTCView crashes on render and
+// setRemoteDescription takes 10+ seconds before the peer connection aborts
+// (diagnosed on-device 2026-08-10). Until a react-native-webrtc release supports
+// RN 0.86, the app uses the MJPEG stream (caps.screenstream) + the still-frame
+// poller. Flip to true to re-enable once the native dep catches up.
+const WEBRTC_TIER_ENABLED = false;
+
 export default function DesktopControlScreen() {
   // Portrait = the laptop layout; landscape = the fullscreen "Remote Desktop"
   // surface (the whole screen is the touch input). Rotate freely between them.
@@ -75,7 +83,8 @@ export default function DesktopControlScreen() {
   // Tiers 1 & 2 both get tap-to-point (the portal's absolute pointer).
   const [webrtcGaveUp, setWebrtcGaveUp] = useState(false);
   const webrtcMode =
-    webrtcSupported && settings.caps?.screenstream_h264 === true && !webrtcGaveUp;
+    WEBRTC_TIER_ENABLED && webrtcSupported
+    && settings.caps?.screenstream_h264 === true && !webrtcGaveUp;
   const streamMode = !webrtcMode && settings.caps?.screenstream === true;
   const fluidMode = webrtcMode || streamMode;
   const live = ready && configured;

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -32,10 +32,11 @@ import { Stack, router } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   ActivityIndicator, Image, Pressable, StyleSheet, Text, View,
-  type GestureResponderEvent,
+  useWindowDimensions, type GestureResponderEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { DesktopFullscreen } from '@/components/DesktopFullscreen';
 import { ScreenVideo } from '@/components/ScreenVideo';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { useScreenFrame } from '@/hooks/useScreenFrame';
@@ -53,7 +54,11 @@ const FRAME_MS = 700;
 const DEVICE_LABEL = 'Couchside Desktop';
 
 export default function DesktopControlScreen() {
-  useLockOrientation('portrait'); // laptop layout; only the Pad may allow landscape
+  // Portrait = the laptop layout; landscape = the fullscreen "Remote Desktop"
+  // surface (the whole screen is the touch input). Rotate freely between them.
+  useLockOrientation('allow-landscape');
+  const { width, height } = useWindowDimensions();
+  const landscape = width > height;
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const insets = useSafeAreaInsets();
@@ -165,6 +170,27 @@ export default function DesktopControlScreen() {
   }, [client]);
 
   const exit = useCallback(() => { hapticMedium(); router.back(); }, []);
+
+  // LANDSCAPE: the fullscreen "Remote Desktop" surface — the whole screen is the
+  // touch input (Mouse trackpad + local cursor, or direct Touch). Absolute input
+  // (the local cursor lock) needs the portal, i.e. a fluid tier.
+  if (landscape) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <DesktopFullscreen
+          client={client}
+          streamURL={streamURL}
+          frame={frame}
+          status={status}
+          failed={failed}
+          configured={configured}
+          absoluteInput={fluidMode}
+          onExit={exit}
+        />
+      </>
+    );
+  }
 
   return (
     <View style={[styles.root, { paddingTop: insets.top }]}>

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -37,6 +37,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { DesktopFullscreen } from '@/components/DesktopFullscreen';
+import { useDesktopKeyboard } from '@/components/DesktopKeyboard';
 import { ScreenVideo } from '@/components/ScreenVideo';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { useScreenFrame } from '@/hooks/useScreenFrame';
@@ -131,13 +132,20 @@ export default function DesktopControlScreen() {
   const [status, setStatus] = useState<GamepadStatus>('connecting');
   const connectedOnce = useRef(false);
 
+  // Phone keyboard -> box (existing {t:'kt'}/{t:'k'} uinput path). The box's
+  // own {t:'osk'} event (Steam raised a text field) auto-raises it.
+  const [oskSignal, setOskSignal] = useState(0);
+  const kb = useDesktopKeyboard(client, { autoOpenSignal: oskSignal });
+
   // Lifecycle: immersive + status subscription + teardown. Runs for the life of
   // the screen regardless of when (or whether) the box is reachable.
   useEffect(() => {
     setImmersive(true);
     client.onStatus((s) => setStatus(s));
+    client.onOsk(() => setOskSignal((n) => n + 1));
     return () => {
       client.onStatus(null);
+      client.onOsk(null);
       // Release the MOUSE buttons explicitly before closing: releaseAll() covers
       // the pad (buttons/sticks) but NOT the pointer (see GamepadClient), and an
       // unmount mid double-tap-drag fires no onDragEnd — a left button left down
@@ -215,6 +223,7 @@ export default function DesktopControlScreen() {
           configured={configured}
           absoluteInput={fluidMode}
           onExit={exit}
+          keyboard={kb}
         />
       </>
     );
@@ -282,9 +291,11 @@ export default function DesktopControlScreen() {
         <BarBtn t={t} styles={styles} icon="ellipsis-horizontal" label="Right" onPress={rightClick} />
         <BarBtn t={t} styles={styles} icon="apps" label="Start"
           onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+        <BarBtn t={t} styles={styles} icon="keypad-outline" label="Keys" onPress={kb.toggle} />
         <BarBtn t={t} styles={styles} icon="arrow-undo" label="Esc"
           onPress={() => { hapticLight(); client.sendKey('esc'); }} />
       </View>
+      {kb.bar}
     </View>
   );
 }

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -36,11 +36,14 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { ScreenVideo } from '@/components/ScreenVideo';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { useScreenFrame } from '@/hooks/useScreenFrame';
 import { useScreenStream } from '@/hooks/useScreenStream';
+import { useWebRtcStream } from '@/hooks/useWebRtcStream';
 import { useTrackpad } from '@/hooks/useTrackpad';
 import { GamepadClient, type GamepadStatus } from '@/lib/gamepad';
+import { webrtcSupported } from '@/lib/webrtcstream';
 import { hapticLight, hapticMedium } from '@/lib/haptics';
 import { setImmersive } from '@/lib/immersive';
 import { useSettings } from '@/lib/SettingsContext';
@@ -56,14 +59,38 @@ export default function DesktopControlScreen() {
   const insets = useSafeAreaInsets();
   const { settings, ready } = useSettings();
   const configured = settings.host.trim().length > 0;
-  // FLUID when the opt-in portal module is present (caps.screenstream): the
-  // /ws/screen MJPEG stream + tap-to-point. Otherwise the P1 still-frame poller +
-  // relative trackpad. Both hooks run (hooks rules); only the active one connects.
-  const streamMode = settings.caps?.screenstream === true;
+  // THREE tiers, best-first (all hooks run — hooks rules — only the active one
+  // connects):
+  //   1. WebRTC H.264 (fluid, 30–60fps): app built WITH react-native-webrtc AND
+  //      the box advertising a WORKING H.264 path (caps.screenstream_h264). On a
+  //      hard failure we demote to tier 2 for the rest of the session.
+  //   2. MJPEG /ws/screen (fluid, ~15fps): caps.screenstream. Also what every
+  //      in-the-wild app (no WebRTC) gets.
+  //   3. P1 still-frame poller (~1.4fps): always available.
+  // Tiers 1 & 2 both get tap-to-point (the portal's absolute pointer).
+  const [webrtcGaveUp, setWebrtcGaveUp] = useState(false);
+  const webrtcMode =
+    webrtcSupported && settings.caps?.screenstream_h264 === true && !webrtcGaveUp;
+  const streamMode = !webrtcMode && settings.caps?.screenstream === true;
+  const fluidMode = webrtcMode || streamMode;
   const live = ready && configured;
-  const poll = useScreenFrame(settings, live && !streamMode, FRAME_MS);
+  const poll = useScreenFrame(settings, live && !fluidMode, FRAME_MS);
   const streamed = useScreenStream(settings, live && streamMode);
-  const { frame, failed } = streamMode ? streamed : poll;
+  const webrtc = useWebRtcStream(settings, live && webrtcMode);
+
+  // Auto-fallback: a hard WebRTC failure (negotiation/timeout) demotes to MJPEG
+  // for the rest of this screen. One-way — we do not re-try WebRTC (that re-pops
+  // the box's consent); reopening the desktop starts fresh.
+  useEffect(() => {
+    if (webrtcMode && webrtc.failed) setWebrtcGaveUp(true);
+  }, [webrtcMode, webrtc.failed]);
+
+  const streamURL = webrtcMode ? webrtc.streamURL : null;
+  // The <Image> frame (tiers 2/3). In WebRTC mode a "failure" means we are
+  // demoting, not that the screen is unavailable, so don't surface it as such.
+  const frame = webrtcMode ? null : streamMode ? streamed.frame : poll.frame;
+  const failed = webrtcMode ? false : streamMode ? streamed.failed : poll.failed;
+  const hasVisual = streamURL != null || frame != null;
 
   const clientRef = useRef<GamepadClient | null>(null);
   if (clientRef.current == null) clientRef.current = new GamepadClient();
@@ -144,21 +171,25 @@ export default function DesktopControlScreen() {
       <Stack.Screen options={{ headerShown: false }} />
       {/* SCREEN (top): the live desktop frame */}
       <View style={styles.stage}>
-        {frame ? (
+        {streamURL ? (
+          // Tier 1: native H.264 video (hardware decode).
+          <ScreenVideo streamURL={streamURL} style={StyleSheet.absoluteFill} />
+        ) : frame ? (
+          // Tier 2/3: MJPEG stream / still-frame poller, as a base64 <Image>.
           <Image source={{ uri: frame }} style={StyleSheet.absoluteFill} resizeMode="contain" />
         ) : (
           <View style={[StyleSheet.absoluteFill, styles.center]}>
             <ActivityIndicator color={t.textDim} />
             <Text style={styles.dim}>
               {!configured ? 'Connect a box first.'
-                : streamMode ? 'Approve remote control on your box…'
+                : fluidMode ? 'Approve remote control on your box…'
                 : 'Waiting for the screen…'}
             </Text>
           </View>
         )}
-        {/* Tap-to-point overlay (fluid mode only): tapping the frame moves the
+        {/* Tap-to-point overlay (fluid tiers only): tapping the frame moves the
             real cursor there and clicks, via the portal's absolute pointer. */}
-        {streamMode && frame && (
+        {fluidMode && hasVisual && (
           <Pressable
             style={StyleSheet.absoluteFill}
             onLayout={(e) => {
@@ -185,7 +216,7 @@ export default function DesktopControlScreen() {
       <View style={styles.trackpad} {...pad.panHandlers} accessibilityLabel="Desktop trackpad">
         <Ionicons name="move-outline" size={22} color={t.textFaint} />
         <Text style={styles.trackpadHint}>
-          {streamMode
+          {fluidMode
             ? 'tap the screen to point · drag here to move · two-finger scroll'
             : 'drag to move · tap to click · two-finger scroll'}
         </Text>

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -135,7 +135,7 @@ export default function DesktopControlScreen() {
   // Phone keyboard -> box (existing {t:'kt'}/{t:'k'} uinput path). The box's
   // own {t:'osk'} event (Steam raised a text field) auto-raises it.
   const [oskSignal, setOskSignal] = useState(0);
-  const kb = useDesktopKeyboard(client, { autoOpenSignal: oskSignal });
+  const kb = useDesktopKeyboard(client, { autoOpenSignal: oskSignal, landscape });
 
   // Lifecycle: immersive + status subscription + teardown. Runs for the life of
   // the screen regardless of when (or whether) the box is reachable.

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -1,0 +1,294 @@
+/**
+ * Fullscreen LANDSCAPE remote-desktop surface (P4b P0 UX) — the "Microsoft
+ * Remote Desktop" layout the owner asked for: the remote screen fills the phone
+ * and the whole surface is the input area, with two touch modes:
+ *
+ *   - MOUSE (trackpad): drag anywhere to move a LOCAL cursor; tap = left click at
+ *     the cursor; two-finger drag = scroll. The local cursor is the lag fix — it
+ *     tracks your finger instantly and every move sends an ABSOLUTE position to
+ *     the box (portal), so the real cursor stays locked to the local one instead
+ *     of lagging behind the video feedback.
+ *   - TOUCH (direct): tap where you want to click (tap-to-point); drag moves the
+ *     cursor to your finger.
+ *
+ * Absolute positioning needs the portal module (caps.screenstream / _h264). On a
+ * box without it (still-frame poller) we fall back to a relative trackpad and hide
+ * the local cursor (there is no absolute pointer to lock it to).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { useMemo, useRef, useState } from 'react';
+import {
+  Animated, Image, PanResponder, Pressable, StyleSheet, Text, View,
+  useWindowDimensions, type GestureResponderEvent,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { ScreenVideo } from '@/components/ScreenVideo';
+import type { GamepadClient, GamepadStatus } from '@/lib/gamepad';
+import { hapticLight, hapticMedium } from '@/lib/haptics';
+import { useTheme, type Palette } from '@/lib/theme';
+
+type Mode = 'mouse' | 'touch';
+
+const TAP_MS = 250;
+const TAP_SLOP = 8;
+const SCROLL_STEP = 26;
+const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+export function DesktopFullscreen({
+  client, streamURL, frame, status, failed, configured, absoluteInput, onExit,
+}: {
+  client: GamepadClient;
+  streamURL: string | null;
+  frame: string | null;
+  status: GamepadStatus;
+  failed: boolean;
+  configured: boolean;
+  absoluteInput: boolean;
+  onExit: () => void;
+}) {
+  const t = useTheme();
+  const { width, height } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const [mode, setMode] = useState<Mode>(absoluteInput ? 'mouse' : 'mouse');
+  const [barOpen, setBarOpen] = useState(true);
+
+  // 16:9 content rect, contain-fit + centered (letterbox on the wider phone).
+  const rect = useMemo(() => {
+    const ar = 16 / 9;
+    let w = width;
+    let h = width / ar;
+    if (h > height) { h = height; w = height * ar; }
+    return { w, h, x: (width - w) / 2, y: (height - h) / 2 };
+  }, [width, height]);
+
+  // Local predicted cursor (mouse mode): screen px, kept inside `rect`.
+  const cur = useRef({ x: rect.x + rect.w / 2, y: rect.y + rect.h / 2 });
+  const curXY = useRef(new Animated.ValueXY(cur.current)).current;
+
+  const moveCursorTo = (px: number, py: number) => {
+    const x = clamp(px, rect.x, rect.x + rect.w);
+    const y = clamp(py, rect.y, rect.y + rect.h);
+    cur.current = { x, y };
+    curXY.setValue({ x, y });
+    client.sendMouseAbs((x - rect.x) / rect.w, (y - rect.y) / rect.h);
+  };
+
+  const g = useRef({
+    t0: 0, lastDx: 0, lastDy: 0, moved: false, touches: 1,
+    scrollAccum: 0, scrollLastY: 0, startX: 0, startY: 0,
+  });
+
+  const leftClick = () => {
+    if (absoluteInput) {
+      client.sendMouseButtonPortal('l', 1);
+      setTimeout(() => client.sendMouseButtonPortal('l', 0), 40);
+    } else {
+      client.sendMouseButton('l', 1);
+      setTimeout(() => client.sendMouseButton('l', 0), 40);
+    }
+  };
+  const rightClick = () => {
+    if (absoluteInput) {
+      client.sendMouseButtonPortal('r', 1);
+      setTimeout(() => client.sendMouseButtonPortal('r', 0), 40);
+    } else {
+      client.sendMouseButton('r', 1);
+      setTimeout(() => client.sendMouseButton('r', 0), 40);
+    }
+  };
+
+  const pan = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => true,
+        onMoveShouldSetPanResponder: () => true,
+        onPanResponderTerminationRequest: () => false,
+        onPanResponderGrant: (e: GestureResponderEvent) => {
+          const s = g.current;
+          s.t0 = Date.now();
+          s.lastDx = 0; s.lastDy = 0; s.moved = false;
+          s.touches = e.nativeEvent.touches.length || 1;
+          s.scrollAccum = 0; s.scrollLastY = 0;
+          s.startX = e.nativeEvent.locationX;
+          s.startY = e.nativeEvent.locationY;
+          // Touch mode: the cursor jumps to the finger immediately.
+          if (mode === 'touch' && absoluteInput) {
+            moveCursorTo(e.nativeEvent.locationX, e.nativeEvent.locationY);
+          }
+        },
+        onPanResponderMove: (e, gs) => {
+          const s = g.current;
+          const touches = e.nativeEvent.touches.length;
+          if (touches > s.touches) s.touches = touches;
+          if (!s.moved && Math.hypot(gs.dx, gs.dy) > TAP_SLOP) s.moved = true;
+
+          if (s.touches >= 2) {
+            const dd = gs.dy - s.scrollLastY;
+            s.scrollAccum += dd;
+            s.scrollLastY = gs.dy;
+            while (Math.abs(s.scrollAccum) >= SCROLL_STEP) {
+              const dir = s.scrollAccum > 0 ? 1 : -1;
+              s.scrollAccum -= dir * SCROLL_STEP;
+              client.sendWheel(-dir); // drag down -> wheel down
+            }
+            return;
+          }
+
+          const ddx = gs.dx - s.lastDx;
+          const ddy = gs.dy - s.lastDy;
+          s.lastDx = gs.dx; s.lastDy = gs.dy;
+
+          if (mode === 'touch' && absoluteInput) {
+            moveCursorTo(e.nativeEvent.locationX, e.nativeEvent.locationY);
+          } else if (absoluteInput) {
+            moveCursorTo(cur.current.x + ddx, cur.current.y + ddy);
+          } else {
+            client.sendMouseMove(ddx, ddy);
+          }
+        },
+        onPanResponderRelease: () => {
+          const s = g.current;
+          const dt = Date.now() - s.t0;
+          if (!s.moved && dt < TAP_MS && s.touches < 2) {
+            hapticLight();
+            leftClick(); // both modes: a tap is a left click at the cursor
+          }
+          s.touches = 1;
+        },
+      }),
+    // Rebuild when the mode / capability / geometry changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mode, absoluteInput, rect.w, rect.h, rect.x, rect.y],
+  );
+
+  const styles = makeStyles(t);
+  const showCursor = absoluteInput && (streamURL != null || frame != null);
+
+  return (
+    <View style={styles.root}>
+      {/* VIDEO (fills the 16:9 content rect) */}
+      <View
+        style={{
+          position: 'absolute', left: rect.x, top: rect.y, width: rect.w, height: rect.h,
+        }}>
+        {streamURL ? (
+          <ScreenVideo streamURL={streamURL} style={StyleSheet.absoluteFill} />
+        ) : frame ? (
+          <Image source={{ uri: frame }} style={StyleSheet.absoluteFill} resizeMode="contain" />
+        ) : (
+          <View style={[StyleSheet.absoluteFill, styles.center]}>
+            <Text style={styles.dim}>
+              {!configured ? 'Connect a box first.'
+                : 'Approve remote control on your box…'}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* INPUT SURFACE (whole screen) */}
+      <View style={StyleSheet.absoluteFill} {...pan.panHandlers} />
+
+      {/* LOCAL CURSOR (mouse/touch, portal only) */}
+      {showCursor && (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.cursor, { transform: curXY.getTranslateTransform() }]}>
+          <Ionicons name="navigate" size={22} color="#fff" style={styles.cursorIcon} />
+        </Animated.View>
+      )}
+
+      {/* FLOATING TOOLBAR */}
+      {barOpen ? (
+        <View style={[styles.bar, { top: insets.top + 6, right: insets.right + 8 }]}>
+          <TB icon="close" label="Exit" styles={styles} t={t}
+            onPress={() => { hapticMedium(); onExit(); }} />
+          <TB icon={mode === 'mouse' ? 'move' : 'finger-print'}
+            label={mode === 'mouse' ? 'Mouse' : 'Touch'} styles={styles} t={t}
+            active
+            onPress={() => { hapticLight(); setMode((m) => (m === 'mouse' ? 'touch' : 'mouse')); }} />
+          <TB icon="radio-button-on" label="Left" styles={styles} t={t}
+            onPress={() => { hapticLight(); leftClick(); }} />
+          <TB icon="ellipsis-horizontal" label="Right" styles={styles} t={t}
+            onPress={() => { hapticLight(); rightClick(); }} />
+          <TB icon="apps" label="Start" styles={styles} t={t}
+            onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+          <TB icon="arrow-undo" label="Esc" styles={styles} t={t}
+            onPress={() => { hapticLight(); client.sendKey('esc'); }} />
+          <TB icon="chevron-up" label="Hide" styles={styles} t={t}
+            onPress={() => setBarOpen(false)} />
+        </View>
+      ) : (
+        <Pressable
+          onPress={() => setBarOpen(true)}
+          style={[styles.handle, { top: insets.top + 6, right: insets.right + 8 }]}
+          accessibilityLabel="Show controls">
+          <Ionicons name="chevron-down" size={18} color={t.text} />
+        </Pressable>
+      )}
+
+      {/* status pills */}
+      {status !== 'connected' && (
+        <View style={[styles.pill, { top: insets.top + 6, left: insets.left + 10 }]} pointerEvents="none">
+          <Text style={styles.pillText}>
+            {status === 'released' || status === 'waiting' ? 'no control — reopen' : status}
+          </Text>
+        </View>
+      )}
+      {failed && status === 'connected' && (
+        <View style={[styles.pill, { top: insets.top + 6, left: insets.left + 10 }]} pointerEvents="none">
+          <Text style={styles.pillText}>screen unavailable</Text>
+        </View>
+      )}
+    </View>
+  );
+}
+
+function TB({
+  icon, label, onPress, active, styles, t,
+}: {
+  icon: keyof typeof Ionicons.glyphMap; label: string; onPress: () => void;
+  active?: boolean; styles: ReturnType<typeof makeStyles>; t: Palette;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={({ pressed }) => [styles.tb, active && styles.tbActive, pressed && { opacity: 0.6 }]}>
+      <Ionicons name={icon} size={18} color={active ? t.accent : t.text} />
+      <Text style={[styles.tbLabel, active && { color: t.accent }]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    root: { flex: 1, backgroundColor: '#000' },
+    center: { alignItems: 'center', justifyContent: 'center' },
+    dim: { color: t.textDim, fontSize: 13 },
+    cursor: {
+      position: 'absolute', left: -11, top: -11, width: 22, height: 22,
+    },
+    cursorIcon: {
+      textShadowColor: 'rgba(0,0,0,0.9)', textShadowRadius: 3,
+      transform: [{ rotate: '-45deg' }],
+    },
+    bar: {
+      position: 'absolute', flexDirection: 'row', alignItems: 'center', gap: 2,
+      backgroundColor: 'rgba(20,24,33,0.82)', borderColor: t.cardBorder, borderWidth: 1,
+      borderRadius: 12, paddingHorizontal: 4, paddingVertical: 3,
+    },
+    tb: { alignItems: 'center', justifyContent: 'center', gap: 2, paddingHorizontal: 9, paddingVertical: 4, minWidth: 46 },
+    tbActive: { backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: 8 },
+    tbLabel: { color: t.textDim, fontSize: 10, fontWeight: '600' },
+    handle: {
+      position: 'absolute', backgroundColor: 'rgba(20,24,33,0.82)',
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 10, padding: 6,
+    },
+    pill: {
+      position: 'absolute', backgroundColor: t.redDeep, borderColor: t.red, borderWidth: 1,
+      paddingHorizontal: 10, paddingVertical: 4, borderRadius: 8,
+    },
+    pillText: { color: t.onRedDeep, fontSize: 11, fontWeight: '700' },
+  });

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -33,6 +33,7 @@ type Mode = 'mouse' | 'touch';
 const TAP_MS = 250;
 const TAP_SLOP = 8;
 const SCROLL_STEP = 26;
+const SEND_MS = 25; // coalesce absolute-move sends to ~40/s (box round-trip cap)
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 export function DesktopFullscreen({
@@ -66,12 +67,36 @@ export function DesktopFullscreen({
   const cur = useRef({ x: rect.x + rect.w / 2, y: rect.y + rect.h / 2 });
   const curXY = useRef(new Animated.ValueXY(cur.current)).current;
 
+  // The local sprite moves at touch rate (instant), but the ABSOLUTE position
+  // sent to the box is COALESCED to ~40/s: the box does a portal round-trip per
+  // move, and flooding it at 60/s queues the real cursor behind. Always send the
+  // LATEST position (drop intermediate), so the box cursor tracks in real time.
+  const send = useRef<{ x: number; y: number } | null>(null);
+  const sendAt = useRef(0);
+  const sendTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushSend = () => {
+    sendTimer.current = null;
+    const p = send.current;
+    if (!p) return;
+    send.current = null;
+    sendAt.current = Date.now();
+    client.sendMouseAbs(p.x, p.y);
+  };
+  const queueSend = (nx: number, ny: number) => {
+    send.current = { x: nx, y: ny };
+    const dt = Date.now() - sendAt.current;
+    if (dt >= SEND_MS) { flushSend(); return; }
+    if (sendTimer.current == null) {
+      sendTimer.current = setTimeout(flushSend, SEND_MS - dt);
+    }
+  };
+
   const moveCursorTo = (px: number, py: number) => {
     const x = clamp(px, rect.x, rect.x + rect.w);
     const y = clamp(py, rect.y, rect.y + rect.h);
     cur.current = { x, y };
-    curXY.setValue({ x, y });
-    client.sendMouseAbs((x - rect.x) / rect.w, (y - rect.y) / rect.h);
+    curXY.setValue({ x, y });                    // sprite: instant
+    queueSend((x - rect.x) / rect.w, (y - rect.y) / rect.h); // box: coalesced
   };
 
   const g = useRef({

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -34,6 +34,10 @@ const TAP_MS = 250;
 const TAP_SLOP = 8;
 const SCROLL_STEP = 26;
 const SEND_MS = 25; // coalesce absolute-move sends to ~40/s (box round-trip cap)
+// A second touch starting within this of a tap release ARMS a drag: the first
+// move then holds the left button, so you can drag a window title bar (or
+// marquee-select). Matches the trackpad's double-tap-drag feel.
+const DOUBLE_TAP_MS = 300;
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 export function DesktopFullscreen({
@@ -106,26 +110,20 @@ export function DesktopFullscreen({
   const g = useRef({
     t0: 0, lastDx: 0, lastDy: 0, moved: false, touches: 1,
     scrollAccum: 0, scrollLastY: 0, startX: 0, startY: 0,
+    lastTapEndT: 0, armed: false, dragging: false,
   });
 
-  const leftClick = () => {
-    if (absoluteInput) {
-      client.sendMouseButtonPortal('l', 1);
-      setTimeout(() => client.sendMouseButtonPortal('l', 0), 40);
-    } else {
-      client.sendMouseButton('l', 1);
-      setTimeout(() => client.sendMouseButton('l', 0), 40);
-    }
+  // Left button down/up, held across a drag (portal abs vs uinput relative).
+  const mouseDown = (btn: 'l' | 'r') => {
+    if (absoluteInput) client.sendMouseButtonPortal(btn, 1);
+    else client.sendMouseButton(btn, 1);
   };
-  const rightClick = () => {
-    if (absoluteInput) {
-      client.sendMouseButtonPortal('r', 1);
-      setTimeout(() => client.sendMouseButtonPortal('r', 0), 40);
-    } else {
-      client.sendMouseButton('r', 1);
-      setTimeout(() => client.sendMouseButton('r', 0), 40);
-    }
+  const mouseUp = (btn: 'l' | 'r') => {
+    if (absoluteInput) client.sendMouseButtonPortal(btn, 0);
+    else client.sendMouseButton(btn, 0);
   };
+  const leftClick = () => { mouseDown('l'); setTimeout(() => mouseUp('l'), 40); };
+  const rightClick = () => { mouseDown('r'); setTimeout(() => mouseUp('r'), 40); };
 
   const pan = useMemo(
     () =>
@@ -135,12 +133,18 @@ export function DesktopFullscreen({
         onPanResponderTerminationRequest: () => false,
         onPanResponderGrant: (e: GestureResponderEvent) => {
           const s = g.current;
-          s.t0 = Date.now();
+          const now = Date.now();
+          s.t0 = now;
           s.lastDx = 0; s.lastDy = 0; s.moved = false;
           s.touches = e.nativeEvent.touches.length || 1;
           s.scrollAccum = 0; s.scrollLastY = 0;
           s.startX = e.nativeEvent.locationX;
           s.startY = e.nativeEvent.locationY;
+          // A single touch landing just after a tap ARMS a drag (button held on
+          // first move — see below). A plain double-tap that never moves stays a
+          // second click, so double-click still maximizes a window.
+          s.armed = s.touches < 2 && now - s.lastTapEndT < DOUBLE_TAP_MS;
+          s.dragging = false;
           // Touch mode: the cursor jumps to the finger immediately.
           if (mode === 'touch' && absoluteInput) {
             moveCursorTo(e.nativeEvent.locationX, e.nativeEvent.locationY);
@@ -168,6 +172,14 @@ export function DesktopFullscreen({
           const ddy = gs.dy - s.lastDy;
           s.lastDx = gs.dx; s.lastDy = gs.dy;
 
+          // Armed double-tap: the first real movement presses + HOLDS the left
+          // button, so the drag that follows moves a window / marquee-selects.
+          if (s.armed && !s.dragging && s.moved) {
+            s.dragging = true;
+            hapticLight();
+            mouseDown('l');
+          }
+
           if (mode === 'touch' && absoluteInput) {
             moveCursorTo(e.nativeEvent.locationX, e.nativeEvent.locationY);
           } else if (absoluteInput) {
@@ -178,10 +190,23 @@ export function DesktopFullscreen({
         },
         onPanResponderRelease: () => {
           const s = g.current;
-          const dt = Date.now() - s.t0;
+          const now = Date.now();
+          if (s.dragging) {
+            // End the held-button drag; not a tap, and don't chain another.
+            s.dragging = false;
+            s.armed = false;
+            s.lastTapEndT = 0;
+            mouseUp('l');
+            s.touches = 1;
+            return;
+          }
+          const dt = now - s.t0;
           if (!s.moved && dt < TAP_MS && s.touches < 2) {
             hapticLight();
             leftClick(); // both modes: a tap is a left click at the cursor
+            s.lastTapEndT = now; // arm a possible double-tap-drag next
+          } else {
+            s.lastTapEndT = 0;
           }
           s.touches = 1;
         },

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -214,12 +214,15 @@ export function DesktopFullscreen({
       {/* INPUT SURFACE (whole screen) */}
       <View style={StyleSheet.absoluteFill} {...pan.panHandlers} />
 
-      {/* LOCAL CURSOR (mouse/touch, portal only) */}
+      {/* LOCAL CURSOR (mouse/touch, portal only). A small ring with a center dot:
+          the DOT is the exact click point (curXY), so what you aim IS what clicks —
+          no hotspot offset like an arrow whose tip differs from its body. */}
       {showCursor && (
         <Animated.View
           pointerEvents="none"
           style={[styles.cursor, { transform: curXY.getTranslateTransform() }]}>
-          <Ionicons name="navigate" size={22} color="#fff" style={styles.cursorIcon} />
+          <View style={styles.cursorRing} />
+          <View style={styles.cursorDot} />
         </Animated.View>
       )}
 
@@ -294,10 +297,16 @@ const makeStyles = (t: Palette) =>
     dim: { color: t.textDim, fontSize: 13 },
     cursor: {
       position: 'absolute', left: -11, top: -11, width: 22, height: 22,
+      alignItems: 'center', justifyContent: 'center',
     },
-    cursorIcon: {
-      textShadowColor: 'rgba(0,0,0,0.9)', textShadowRadius: 3,
-      transform: [{ rotate: '-45deg' }],
+    cursorRing: {
+      position: 'absolute', width: 18, height: 18, borderRadius: 9,
+      borderWidth: 1.5, borderColor: 'rgba(255,255,255,0.95)',
+      shadowColor: '#000', shadowOpacity: 0.85, shadowRadius: 2,
+    },
+    cursorDot: {
+      width: 4, height: 4, borderRadius: 2, backgroundColor: '#fff',
+      shadowColor: '#000', shadowOpacity: 0.9, shadowRadius: 1.5,
     },
     bar: {
       position: 'absolute', flexDirection: 'row', alignItems: 'center', gap: 2,

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -38,6 +38,7 @@ const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v
 
 export function DesktopFullscreen({
   client, streamURL, frame, status, failed, configured, absoluteInput, onExit,
+  keyboard,
 }: {
   client: GamepadClient;
   streamURL: string | null;
@@ -47,6 +48,9 @@ export function DesktopFullscreen({
   configured: boolean;
   absoluteInput: boolean;
   onExit: () => void;
+  /** From useDesktopKeyboard (owned by the parent so one instance serves both
+   *  orientations): toolbar Keys button calls toggle; bar renders here. */
+  keyboard?: { bar: React.ReactNode; open: boolean; toggle: () => void };
 }) {
   const t = useTheme();
   const { width, height } = useWindowDimensions();
@@ -241,6 +245,10 @@ export function DesktopFullscreen({
             onPress={() => { hapticLight(); rightClick(); }} />
           <TB icon="apps" label="Start" styles={styles} t={t}
             onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+          {keyboard && (
+            <TB icon="keypad-outline" label="Keys" styles={styles} t={t}
+              active={keyboard.open} onPress={keyboard.toggle} />
+          )}
           <TB icon="arrow-undo" label="Esc" styles={styles} t={t}
             onPress={() => { hapticLight(); client.sendKey('esc'); }} />
           <TB icon="chevron-up" label="Hide" styles={styles} t={t}
@@ -268,6 +276,9 @@ export function DesktopFullscreen({
           <Text style={styles.pillText}>screen unavailable</Text>
         </View>
       )}
+
+      {/* Phone-keyboard compose bar (absolute at the screen bottom) */}
+      {keyboard?.bar}
     </View>
   );
 }

--- a/app/components/DesktopKeyboard.tsx
+++ b/app/components/DesktopKeyboard.tsx
@@ -1,0 +1,176 @@
+/**
+ * Phone-keyboard input for the desktop Control screens (portrait + landscape).
+ *
+ * A hook rather than a component so the TOGGLE BUTTON (inline in a toolbar)
+ * and the COMPOSE BAR (absolute at the screen root) can live in different
+ * spots of the tree while sharing one closure — the button's onPress must
+ * focus the TextInput SYNCHRONOUSLY inside the touch handler or iOS refuses
+ * to raise the keyboard (proven on the Pad's KeyboardBar, whose mechanics
+ * this reuses: textDelta diff so paste works, empty-field Backspace
+ * forwarding, keyboard-height lift, dismiss-on-OS-hide).
+ *
+ * Typing rides the EXISTING {t:'kt'} / {t:'k'} uinput keyboard path on
+ * /ws/gamepad — proven on the KDE desktop on hardware (typed into a konsole,
+ * opened Kickoff) — NOT the portal (whose keysym path delivered nothing).
+ *
+ * `autoOpenSignal`: increment to raise the keyboard from outside a touch
+ * handler (the box's {t:'osk'} event — Steam text fields). iOS may refuse a
+ * non-touch focus; that degrades to "stays closed", same as the Pad.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  Keyboard, Platform, Pressable, StyleSheet, TextInput, View,
+} from 'react-native';
+
+import { textDelta } from '@/app/(tabs)/pad';
+import { GamepadClient } from '@/lib/gamepad';
+import { hapticLight } from '@/lib/haptics';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function useDesktopKeyboard(
+  client: GamepadClient,
+  opts?: { autoOpenSignal?: number },
+): { bar: React.ReactNode; open: boolean; toggle: () => void } {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const inputRef = useRef<TextInput>(null);
+  const [open, setOpen] = useState(false);
+  const openRef = useRef(false);
+  const [value, setValue] = useState('');
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  const setOpenSynced = useCallback((v: boolean) => {
+    openRef.current = v;
+    setOpen(v);
+  }, []);
+
+  const focus = useCallback(() => {
+    setOpenSynced(true);
+    // Synchronous inside the tap handler — deferring loses the touch context
+    // and iOS refuses to raise the keyboard. The input is always mounted.
+    inputRef.current?.focus();
+  }, [setOpenSynced]);
+
+  const dismiss = useCallback(() => {
+    Keyboard.dismiss();
+    inputRef.current?.blur();
+    setOpenSynced(false);
+    setValue('');
+  }, [setOpenSynced]);
+
+  const toggle = useCallback(() => {
+    hapticLight();
+    if (openRef.current) dismiss();
+    else focus();
+  }, [dismiss, focus]);
+
+  // Box raised its keyboard (Steam text field) -> raise ours. Skips mount.
+  const autoOpenSignal = opts?.autoOpenSignal ?? 0;
+  const lastAutoOpen = useRef(autoOpenSignal);
+  useEffect(() => {
+    if (autoOpenSignal === lastAutoOpen.current) return;
+    lastAutoOpen.current = autoOpenSignal;
+    if (autoOpenSignal > 0 && !openRef.current) focus();
+  }, [autoOpenSignal, focus]);
+
+  // Diff-based send (the field keeps its text): backspaces + insert. Paste is
+  // just a large insert. Same contract as the Pad's KeyboardBar.
+  const onChangeText = useCallback((next: string) => {
+    const { backspaces, insert } = textDelta(valueRef.current, next);
+    for (let i = 0; i < backspaces; i += 1) client.sendKey('backspace');
+    if (insert.length > 0) client.sendText(insert);
+    setValue(next);
+  }, [client]);
+
+  const onKeyPress = useCallback((e: { nativeEvent: { key: string } }) => {
+    const key = e.nativeEvent.key;
+    // Backspace on an EMPTY field can't show as a diff but must still delete
+    // on the box; a non-empty field is left to onChangeText (else doubled).
+    if (key === 'Backspace') {
+      if (valueRef.current.length === 0) client.sendKey('backspace');
+    } else if (key === 'Enter') {
+      client.sendKey('enter');
+    }
+  }, [client]);
+
+  // Lift the bar above the OS keyboard: window-coord math (edge-to-edge
+  // Android doesn't resize the window; iOS KAV misses late mounts).
+  const [kbLift, setKbLift] = useState(0);
+  const anchorRef = useRef<View>(null);
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const show = Keyboard.addListener(showEvent, (e) => {
+      const kbTop = e.endCoordinates?.screenY;
+      if (kbTop == null) return;
+      anchorRef.current?.measureInWindow((_x, y) => {
+        if (typeof y === 'number') setKbLift(Math.max(0, y - kbTop));
+      });
+    });
+    const hide = Keyboard.addListener('keyboardDidHide', () => setKbLift(0));
+    return () => { show.remove(); hide.remove(); };
+  }, []);
+
+  // Any OS dismissal (Done, swipe, backgrounding) closes the bar for real.
+  useEffect(() => {
+    const sub = Keyboard.addListener('keyboardDidHide', () => {
+      openRef.current = false;
+      setOpen(false);
+      setValue('');
+    });
+    return () => sub.remove();
+  }, []);
+
+  const bar = (
+    <>
+      {/* zero-size anchor marking the container's bottom in window coords */}
+      <View ref={anchorRef} style={styles.kbAnchor} pointerEvents="none" />
+      <View
+        style={[styles.kbBar, { bottom: kbLift }, !open && styles.kbBarHidden]}
+        pointerEvents={open ? 'auto' : 'none'}>
+        <TextInput
+          ref={inputRef}
+          style={styles.kbInput}
+          value={value}
+          onChangeText={onChangeText}
+          onKeyPress={onKeyPress}
+          onSubmitEditing={() => client.sendKey('enter')}
+          blurOnSubmit={false}
+          autoCapitalize="none"
+          autoCorrect={false}
+          spellCheck={false}
+          keyboardAppearance="dark"
+          placeholder="Type on the box…"
+          placeholderTextColor={t.textFaint}
+        />
+        <Pressable onPress={dismiss} hitSlop={8}
+          accessibilityLabel="Hide keyboard"
+          style={({ pressed }) => [styles.kbHide, pressed && styles.pressed]}>
+          <Ionicons name="chevron-down" size={18} color={t.textDim} />
+        </Pressable>
+      </View>
+    </>
+  );
+
+  return { bar, open, toggle };
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  pressed: { opacity: 0.7 },
+  kbAnchor: { position: 'absolute', bottom: 0, left: 0, width: 0, height: 0 },
+  kbBar: {
+    position: 'absolute', left: 0, right: 0,
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    paddingHorizontal: 10, paddingVertical: 6,
+    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  },
+  kbBarHidden: { opacity: 0, height: 0, paddingVertical: 0, overflow: 'hidden' },
+  kbInput: {
+    flex: 1, color: t.text, fontSize: 15, fontFamily: mono,
+    paddingVertical: 8, paddingHorizontal: 10,
+    backgroundColor: t.bg, borderRadius: 8,
+    borderColor: t.cardBorder, borderWidth: 1,
+  },
+  kbHide: { padding: 6 },
+});

--- a/app/components/DesktopKeyboard.tsx
+++ b/app/components/DesktopKeyboard.tsx
@@ -30,8 +30,9 @@ import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 export function useDesktopKeyboard(
   client: GamepadClient,
-  opts?: { autoOpenSignal?: number },
+  opts?: { autoOpenSignal?: number; landscape?: boolean },
 ): { bar: React.ReactNode; open: boolean; toggle: () => void } {
+  const landscape = opts?.landscape ?? false;
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const inputRef = useRef<TextInput>(null);
@@ -139,7 +140,9 @@ export function useDesktopKeyboard(
         onKeyPress={onKeyPress}
         onSubmitEditing={() => client.sendKey('enter')}
         onBlur={() => { setOpenSynced(false); setValue(''); }}
-        style={open ? [styles.kbInput, { bottom: 10 + kbLift }] : styles.hiddenInput}
+        style={open
+          ? [styles.kbInput, landscape && styles.kbInputLandscape, { bottom: 10 + kbLift }]
+          : styles.hiddenInput}
         placeholder={open ? 'Type on the box…' : undefined}
         placeholderTextColor={t.textFaint}
         autoCapitalize="none"
@@ -179,6 +182,14 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingVertical: 10, paddingHorizontal: 12, paddingRight: 40,
     backgroundColor: t.card, borderRadius: 10,
     borderColor: t.cardBorder, borderWidth: 1,
+  },
+  // LANDSCAPE: the remote screen fills the phone, so the field must not wall it
+  // off — translucent (see the desktop through it) + narrower (leave the right
+  // side clear). Portrait keeps the solid full-width field (plenty of room).
+  kbInputLandscape: {
+    right: '42%', paddingVertical: 7,
+    backgroundColor: 'rgba(12,14,20,0.62)',
+    borderColor: 'rgba(255,255,255,0.18)',
   },
   kbHide: {
     position: 'absolute', right: 16, zIndex: 61,

--- a/app/components/DesktopKeyboard.tsx
+++ b/app/components/DesktopKeyboard.tsx
@@ -24,6 +24,7 @@ import {
 } from 'react-native';
 
 import { textDelta } from '@/app/(tabs)/pad';
+import { DesktopKeys } from '@/components/DesktopKeys';
 import { GamepadClient } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -49,17 +50,20 @@ export function useDesktopKeyboard(
 
   const focus = useCallback(() => {
     setOpenSynced(true);
-    // Synchronous inside the tap handler — deferring loses the touch context
-    // and iOS refuses to raise the keyboard. The input is always mounted.
-    inputRef.current?.focus();
-  }, [setOpenSynced]);
+    // Landscape uses our own drawn keys — no system-keyboard focus. Portrait
+    // focuses SYNCHRONOUSLY inside the tap handler (deferring loses the touch
+    // context and iOS refuses to raise the keyboard). The input is always mounted.
+    if (!landscape) inputRef.current?.focus();
+  }, [setOpenSynced, landscape]);
 
   const dismiss = useCallback(() => {
-    Keyboard.dismiss();
-    inputRef.current?.blur();
+    if (!landscape) {
+      Keyboard.dismiss();
+      inputRef.current?.blur();
+    }
     setOpenSynced(false);
     setValue('');
-  }, [setOpenSynced]);
+  }, [setOpenSynced, landscape]);
 
   const toggle = useCallback(() => {
     hapticLight();
@@ -122,6 +126,23 @@ export function useDesktopKeyboard(
     });
     return () => sub.remove();
   }, []);
+
+  // LANDSCAPE: our own translucent floating keys over the desktop — no opaque
+  // system keyboard walling off the screen. Same uinput send path.
+  if (landscape) {
+    return {
+      open,
+      toggle,
+      bar: (
+        <DesktopKeys
+          visible={open}
+          onChar={(ch) => client.sendText(ch)}
+          onSpecial={(k) => client.sendKey(k)}
+          onHide={dismiss}
+        />
+      ),
+    };
+  }
 
   const bar = (
     <>

--- a/app/components/DesktopKeyboard.tsx
+++ b/app/components/DesktopKeyboard.tsx
@@ -124,32 +124,39 @@ export function useDesktopKeyboard(
 
   const bar = (
     <>
-      {/* zero-size anchor marking the container's bottom in window coords */}
-      <View ref={anchorRef} style={styles.kbAnchor} pointerEvents="none" />
-      <View
-        style={[styles.kbBar, { bottom: kbLift }, !open && styles.kbBarHidden]}
-        pointerEvents={open ? 'auto' : 'none'}>
-        <TextInput
-          ref={inputRef}
-          style={styles.kbInput}
-          value={value}
-          onChangeText={onChangeText}
-          onKeyPress={onKeyPress}
-          onSubmitEditing={() => client.sendKey('enter')}
-          blurOnSubmit={false}
-          autoCapitalize="none"
-          autoCorrect={false}
-          spellCheck={false}
-          keyboardAppearance="dark"
-          placeholder="Type on the box…"
-          placeholderTextColor={t.textFaint}
-        />
-        <Pressable onPress={dismiss} hitSlop={8}
+      {/* Zero-size anchor at the container's bottom edge — window-coord measure
+          feeds the keyboard lift. collapsable=false so Android keeps it. */}
+      <View ref={anchorRef} collapsable={false} style={styles.kbAnchor} pointerEvents="none" />
+      {/* ONE input, restyled — NOT hidden in a 0-height box. Closed it is a 1x1
+          opacity-0.02 focusable sliver: iOS refuses first-responder on a
+          zero-size/transparent/overflow-hidden view, so hiding the container
+          made focus() bounce ("flash and close"). Open it becomes the compose
+          field above the keyboard. (Proven pattern from the Pad's KeyboardBar.) */}
+      <TextInput
+        ref={inputRef}
+        value={value}
+        onChangeText={onChangeText}
+        onKeyPress={onKeyPress}
+        onSubmitEditing={() => client.sendKey('enter')}
+        onBlur={() => { setOpenSynced(false); setValue(''); }}
+        style={open ? [styles.kbInput, { bottom: 10 + kbLift }] : styles.hiddenInput}
+        placeholder={open ? 'Type on the box…' : undefined}
+        placeholderTextColor={t.textFaint}
+        autoCapitalize="none"
+        autoCorrect={false}
+        autoComplete="off"
+        spellCheck={false}
+        blurOnSubmit={false}
+        caretHidden={!open}
+        keyboardAppearance="dark"
+      />
+      {open && (
+        <Pressable onPress={dismiss} hitSlop={12}
           accessibilityLabel="Hide keyboard"
-          style={({ pressed }) => [styles.kbHide, pressed && styles.pressed]}>
-          <Ionicons name="chevron-down" size={18} color={t.textDim} />
+          style={({ pressed }) => [styles.kbHide, { bottom: 10 + kbLift + 52 }, pressed && styles.pressed]}>
+          <Ionicons name="chevron-down" size={16} color={t.textDim} />
         </Pressable>
-      </View>
+      )}
     </>
   );
 
@@ -159,18 +166,23 @@ export function useDesktopKeyboard(
 const makeStyles = (t: Palette) => StyleSheet.create({
   pressed: { opacity: 0.7 },
   kbAnchor: { position: 'absolute', bottom: 0, left: 0, width: 0, height: 0 },
-  kbBar: {
-    position: 'absolute', left: 0, right: 0,
-    flexDirection: 'row', alignItems: 'center', gap: 8,
-    paddingHorizontal: 10, paddingVertical: 6,
-    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  // CLOSED: invisible but FOCUSABLE 1x1 sliver (iOS won't focus a 0-size or
+  // fully transparent view). Transparent text keeps keystrokes unseen.
+  hiddenInput: {
+    position: 'absolute', bottom: 0, left: 0, width: 1, height: 1,
+    opacity: 0.02, color: 'transparent',
   },
-  kbBarHidden: { opacity: 0, height: 0, paddingVertical: 0, overflow: 'hidden' },
+  // OPEN: the compose field pinned above the keyboard (lift added inline).
   kbInput: {
-    flex: 1, color: t.text, fontSize: 15, fontFamily: mono,
-    paddingVertical: 8, paddingHorizontal: 10,
-    backgroundColor: t.bg, borderRadius: 8,
+    position: 'absolute', left: 10, right: 10, zIndex: 60,
+    color: t.text, fontSize: 15, fontFamily: mono,
+    paddingVertical: 10, paddingHorizontal: 12, paddingRight: 40,
+    backgroundColor: t.card, borderRadius: 10,
     borderColor: t.cardBorder, borderWidth: 1,
   },
-  kbHide: { padding: 6 },
+  kbHide: {
+    position: 'absolute', right: 16, zIndex: 61,
+    backgroundColor: t.card, borderColor: t.cardBorder, borderWidth: 1,
+    borderRadius: 999, padding: 8,
+  },
 });

--- a/app/components/DesktopKeys.tsx
+++ b/app/components/DesktopKeys.tsx
@@ -46,17 +46,17 @@ export function DesktopKeys({
   const rows = sym ? ROWS_SYM : ROWS_ABC;
   const styles = makeStyles(t);
 
-  const tapChar = (ch: string) => {
-    hapticLight();
-    onChar(shift && !sym ? ch.toUpperCase() : ch);
-  };
-  const tapSpecial = (k: SpecialKey) => { hapticLight(); onSpecial(k); };
+  const tapChar = (ch: string) => onChar(shift && !sym ? ch.toUpperCase() : ch);
+  const tapSpecial = (k: SpecialKey) => onSpecial(k);
 
   const Key = ({ label, onPress, flex = 1, active, wide }: {
     label: React.ReactNode; onPress: () => void; flex?: number;
     active?: boolean; wide?: boolean;
   }) => (
     <Pressable
+      // Haptic on key-DOWN, not release — a real key ticks the instant you touch
+      // it. Firing on onPress (release) felt laggy/absent while typing fast.
+      onPressIn={hapticLight}
       onPress={onPress}
       style={({ pressed }) => [
         styles.key, { flexGrow: flex, flexBasis: 0 },
@@ -91,7 +91,7 @@ export function DesktopKeys({
           label={<Ionicons name={sym ? 'text' : 'arrow-up'} size={17}
             color={shift ? t.bg : 'rgba(255,255,255,0.9)'} />}
           active={shift && !sym}
-          onPress={() => { hapticLight(); sym ? setSym(false) : setShift((s) => !s); }} />
+          onPress={() => { sym ? setSym(false) : setShift((s) => !s); }} />
         {rows[2].map((c) => (
           <Key key={c} label={shift && !sym ? c.toUpperCase() : c} onPress={() => tapChar(c)} />
         ))}
@@ -102,14 +102,14 @@ export function DesktopKeys({
       {/* Row 4: layer toggle · space · enter · hide */}
       <View style={styles.row}>
         <Key flex={1.4} label={sym ? 'ABC' : '?123'}
-          onPress={() => { hapticLight(); setSym((v) => !v); setShift(false); }} />
+          onPress={() => { setSym((v) => !v); setShift(false); }} />
         <Key flex={4} wide label="space" onPress={() => tapSpecial('space')} />
         <Key flex={1.4}
           label={<Ionicons name="return-down-back-outline" size={18} color="rgba(255,255,255,0.9)" />}
           onPress={() => tapSpecial('enter')} />
         <Key flex={1.2}
           label={<Ionicons name="chevron-down" size={18} color="rgba(255,255,255,0.9)" />}
-          onPress={() => { hapticLight(); onHide(); }} />
+          onPress={onHide} />
       </View>
     </View>
   );

--- a/app/components/DesktopKeys.tsx
+++ b/app/components/DesktopKeys.tsx
@@ -10,7 +10,7 @@
  * has the room. This is landscape-only.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -41,13 +41,28 @@ export function DesktopKeys({
   const insets = useSafeAreaInsets();
   const [shift, setShift] = useState(false);
   const [sym, setSym] = useState(false);
+  // Local echo of what was sent this open — the box's own field is often hidden
+  // behind the keys, so this is the "what am I typing" feedback. Cleared when
+  // the keyboard hides or Enter submits. Best-effort mirror, not the truth.
+  const [typed, setTyped] = useState('');
+  useEffect(() => { if (!visible) setTyped(''); }, [visible]);
   if (!visible) return null;
 
   const rows = sym ? ROWS_SYM : ROWS_ABC;
   const styles = makeStyles(t);
+  const PREVIEW_MAX = 40;
 
-  const tapChar = (ch: string) => onChar(shift && !sym ? ch.toUpperCase() : ch);
-  const tapSpecial = (k: SpecialKey) => onSpecial(k);
+  const tapChar = (ch: string) => {
+    const out = shift && !sym ? ch.toUpperCase() : ch;
+    onChar(out);
+    setTyped((v) => (v + out).slice(-PREVIEW_MAX));
+  };
+  const tapSpecial = (k: SpecialKey) => {
+    onSpecial(k);
+    if (k === 'backspace') setTyped((v) => v.slice(0, -1));
+    else if (k === 'space') setTyped((v) => (v + ' ').slice(-PREVIEW_MAX));
+    else if (k === 'enter') setTyped('');
+  };
 
   const Key = ({ label, onPress, flex = 1, active, wide }: {
     label: React.ReactNode; onPress: () => void; flex?: number;
@@ -73,6 +88,12 @@ export function DesktopKeys({
     <View
       style={[styles.wrap, { paddingBottom: insets.bottom + 6, right: insets.right + 6, left: insets.left + 6 }]}
       pointerEvents="box-none">
+      {/* Local echo of what's been typed (the box field may sit behind the keys) */}
+      {typed.length > 0 && (
+        <View style={styles.preview}>
+          <Text style={styles.previewText} numberOfLines={1}>{typed}</Text>
+        </View>
+      )}
       {/* Row 1 */}
       <View style={styles.row}>
         {rows[0].map((c) => (
@@ -121,6 +142,16 @@ const makeStyles = (_t: Palette) => StyleSheet.create({
   },
   row: { flexDirection: 'row', gap: 5, justifyContent: 'center' },
   rowIndent: { paddingHorizontal: '3%' },
+  preview: {
+    alignSelf: 'flex-start', maxWidth: '75%', marginBottom: 3,
+    backgroundColor: 'rgba(12,14,20,0.72)', borderRadius: 8,
+    borderColor: 'rgba(255,255,255,0.18)', borderWidth: 1,
+    paddingVertical: 5, paddingHorizontal: 10,
+  },
+  previewText: {
+    color: 'rgba(255,255,255,0.95)', fontSize: 14, fontFamily: mono,
+    textShadowColor: 'rgba(0,0,0,0.85)', textShadowRadius: 3,
+  },
   key: {
     height: 40, borderRadius: 7,
     alignItems: 'center', justifyContent: 'center',

--- a/app/components/DesktopKeys.tsx
+++ b/app/components/DesktopKeys.tsx
@@ -69,10 +69,14 @@ export function DesktopKeys({
     active?: boolean; wide?: boolean;
   }) => (
     <Pressable
-      // Haptic on key-DOWN, not release — a real key ticks the instant you touch
-      // it. Firing on onPress (release) felt laggy/absent while typing fast.
-      onPressIn={hapticLight}
-      onPress={onPress}
+      // Fire the key on key-DOWN, not release. A real key ticks the instant you
+      // touch it — and release-fire (onPress) DROPPED keys while typing fast: a
+      // finger that rolls slightly before lifting cancels Pressable's onPress,
+      // and the mouse zone underneath can claim the moved touch. Press-down fires
+      // the char AND the haptic together, before either can steal it, so every
+      // tap lands. hitSlop widens the small chips without overlapping neighbours.
+      onPressIn={() => { hapticLight(); onPress(); }}
+      hitSlop={{ top: 2, bottom: 2, left: 2, right: 2 }}
       style={({ pressed }) => [
         styles.key, { flexGrow: flex, flexBasis: 0 },
         wide && styles.keyWide, active && styles.keyActive,

--- a/app/components/DesktopKeys.tsx
+++ b/app/components/DesktopKeys.tsx
@@ -1,0 +1,139 @@
+/**
+ * A custom, VERY TRANSLUCENT on-screen keyboard for the landscape desktop
+ * Control. The iOS/Android system keyboard is opaque and un-restylable and it
+ * walls off the remote screen — so in landscape we draw our own floating keys
+ * instead: barely-there key chips over the live desktop, so you can see what
+ * you are typing into. Each key rides the SAME uinput path everything else uses
+ * (client.sendText for printable chars, client.sendKey for specials).
+ *
+ * Portrait keeps the real system keyboard (autocorrect, paste, dictation) — it
+ * has the room. This is landscape-only.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { hapticLight } from '@/lib/haptics';
+import type { SpecialKey } from '@/lib/gamepad';
+import { mono, useTheme, type Palette } from '@/lib/theme';
+
+const ROWS_ABC = [
+  ['q', 'w', 'e', 'r', 't', 'y', 'u', 'i', 'o', 'p'],
+  ['a', 's', 'd', 'f', 'g', 'h', 'j', 'k', 'l'],
+  ['z', 'x', 'c', 'v', 'b', 'n', 'm'],
+];
+const ROWS_SYM = [
+  ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+  ['@', '#', '$', '_', '&', '-', '+', '(', ')', '/'],
+  ['*', '"', "'", ':', ';', '!', '?'],
+];
+
+export function DesktopKeys({
+  visible, onChar, onSpecial, onHide,
+}: {
+  visible: boolean;
+  onChar: (ch: string) => void;
+  onSpecial: (k: SpecialKey) => void;
+  onHide: () => void;
+}) {
+  const t = useTheme();
+  const insets = useSafeAreaInsets();
+  const [shift, setShift] = useState(false);
+  const [sym, setSym] = useState(false);
+  if (!visible) return null;
+
+  const rows = sym ? ROWS_SYM : ROWS_ABC;
+  const styles = makeStyles(t);
+
+  const tapChar = (ch: string) => {
+    hapticLight();
+    onChar(shift && !sym ? ch.toUpperCase() : ch);
+  };
+  const tapSpecial = (k: SpecialKey) => { hapticLight(); onSpecial(k); };
+
+  const Key = ({ label, onPress, flex = 1, active, wide }: {
+    label: React.ReactNode; onPress: () => void; flex?: number;
+    active?: boolean; wide?: boolean;
+  }) => (
+    <Pressable
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.key, { flexGrow: flex, flexBasis: 0 },
+        wide && styles.keyWide, active && styles.keyActive,
+        pressed && styles.keyPressed,
+      ]}>
+      {typeof label === 'string'
+        ? <Text style={styles.keyLabel}>{label}</Text>
+        : label}
+    </Pressable>
+  );
+
+  return (
+    <View
+      style={[styles.wrap, { paddingBottom: insets.bottom + 6, right: insets.right + 6, left: insets.left + 6 }]}
+      pointerEvents="box-none">
+      {/* Row 1 */}
+      <View style={styles.row}>
+        {rows[0].map((c) => (
+          <Key key={c} label={shift && !sym ? c.toUpperCase() : c} onPress={() => tapChar(c)} />
+        ))}
+      </View>
+      {/* Row 2 (indented) */}
+      <View style={[styles.row, styles.rowIndent]}>
+        {rows[1].map((c) => (
+          <Key key={c} label={shift && !sym ? c.toUpperCase() : c} onPress={() => tapChar(c)} />
+        ))}
+      </View>
+      {/* Row 3: shift/layer + chars + backspace */}
+      <View style={styles.row}>
+        <Key flex={1.5}
+          label={<Ionicons name={sym ? 'text' : 'arrow-up'} size={17}
+            color={shift ? t.bg : 'rgba(255,255,255,0.9)'} />}
+          active={shift && !sym}
+          onPress={() => { hapticLight(); sym ? setSym(false) : setShift((s) => !s); }} />
+        {rows[2].map((c) => (
+          <Key key={c} label={shift && !sym ? c.toUpperCase() : c} onPress={() => tapChar(c)} />
+        ))}
+        <Key flex={1.5}
+          label={<Ionicons name="backspace-outline" size={18} color="rgba(255,255,255,0.9)" />}
+          onPress={() => tapSpecial('backspace')} />
+      </View>
+      {/* Row 4: layer toggle · space · enter · hide */}
+      <View style={styles.row}>
+        <Key flex={1.4} label={sym ? 'ABC' : '?123'}
+          onPress={() => { hapticLight(); setSym((v) => !v); setShift(false); }} />
+        <Key flex={4} wide label="space" onPress={() => tapSpecial('space')} />
+        <Key flex={1.4}
+          label={<Ionicons name="return-down-back-outline" size={18} color="rgba(255,255,255,0.9)" />}
+          onPress={() => tapSpecial('enter')} />
+        <Key flex={1.2}
+          label={<Ionicons name="chevron-down" size={18} color="rgba(255,255,255,0.9)" />}
+          onPress={() => { hapticLight(); onHide(); }} />
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (_t: Palette) => StyleSheet.create({
+  wrap: {
+    position: 'absolute', bottom: 0, zIndex: 70, gap: 5,
+  },
+  row: { flexDirection: 'row', gap: 5, justifyContent: 'center' },
+  rowIndent: { paddingHorizontal: '3%' },
+  key: {
+    height: 40, borderRadius: 7,
+    alignItems: 'center', justifyContent: 'center',
+    // VERY translucent — the desktop reads through; a hairline + shadow keep the
+    // chip and its glyph legible over any content behind it.
+    backgroundColor: 'rgba(255,255,255,0.10)',
+    borderColor: 'rgba(255,255,255,0.16)', borderWidth: 1,
+  },
+  keyWide: { backgroundColor: 'rgba(255,255,255,0.07)' },
+  keyActive: { backgroundColor: 'rgba(120,180,255,0.85)', borderColor: 'rgba(120,180,255,0.9)' },
+  keyPressed: { backgroundColor: 'rgba(255,255,255,0.28)' },
+  keyLabel: {
+    color: 'rgba(255,255,255,0.95)', fontSize: 15, fontFamily: mono,
+    textShadowColor: 'rgba(0,0,0,0.85)', textShadowRadius: 3,
+  },
+});

--- a/app/components/EditableSection.tsx
+++ b/app/components/EditableSection.tsx
@@ -1,0 +1,119 @@
+/**
+ * One movable Console card. Wraps a card so the tab's hold-to-edit mode can
+ * reorder + hide it:
+ *   - LONG-PRESS (when not editing) enters edit mode.
+ *   - In edit mode a control strip (↑ ↓ hide) overlays the card — but only when
+ *     the card actually RENDERED something (measured height), so a
+ *     probe-and-appear card that returned null shows no orphan controls.
+ *   - Hidden + not editing → renders nothing. Hidden + editing → dimmed with an
+ *     eye-off, so you can un-hide it.
+ * Reorder/hide are TAPS (not a drag) — no drag-responder traps, and fully
+ * exercisable in the web harness.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useRef, useState } from 'react';
+import { Pressable, StyleSheet, View } from 'react-native';
+
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function EditableSection({
+  editing, hidden, isFirst, isLast,
+  onEnterEdit, onUp, onDown, onToggleHide, onPresent, children,
+}: {
+  editing: boolean;
+  hidden: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+  onEnterEdit: () => void;
+  onUp: () => void;
+  onDown: () => void;
+  onToggleHide: () => void;
+  /** Reports whether the card actually rendered content (measured height > 0),
+   *  so the parent's arrow bounds skip probe-and-appear cards that are null. */
+  onPresent?: (present: boolean) => void;
+  children: React.ReactNode;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [h, setH] = useState(0);
+  const present = h > 8; // a null-rendering card measures ~0
+  const presentRef = useRef<boolean | null>(null);
+  const measure = (height: number) => {
+    setH(height);
+    const p = height > 8;
+    if (p !== presentRef.current) { presentRef.current = p; onPresent?.(p); }
+  };
+
+  // Hidden and not editing: gone. (In edit mode it stays, dimmed, to un-hide.)
+  if (hidden && !editing) return null;
+
+  const content = (
+    <View
+      onLayout={(e) => measure(e.nativeEvent.layout.height)}
+      style={hidden && editing ? styles.dim : undefined}>
+      {children}
+    </View>
+  );
+
+  if (!editing) {
+    // Long-press anywhere on the card enters edit mode; child taps still work
+    // (RN hands a tap to whichever child claims it, the hold to us).
+    return (
+      <Pressable onLongPress={onEnterEdit} delayLongPress={450}>
+        {content}
+      </Pressable>
+    );
+  }
+
+  return (
+    <View>
+      {content}
+      {present && (
+        <View style={styles.strip} pointerEvents="box-none">
+          <Ctrl t={t} styles={styles} icon="chevron-up" disabled={isFirst}
+            onPress={onUp} label="Move up" />
+          <Ctrl t={t} styles={styles} icon="chevron-down" disabled={isLast}
+            onPress={onDown} label="Move down" />
+          <Ctrl t={t} styles={styles} icon={hidden ? 'eye-off' : 'eye'}
+            onPress={onToggleHide} label={hidden ? 'Show' : 'Hide'} tint={hidden ? t.amber : t.blue} />
+        </View>
+      )}
+    </View>
+  );
+}
+
+function Ctrl({
+  icon, onPress, disabled, label, tint, t, styles,
+}: {
+  icon: keyof typeof Ionicons.glyphMap; onPress: () => void; disabled?: boolean;
+  label: string; tint?: string; t: Palette; styles: ReturnType<typeof makeStyles>;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      hitSlop={6}
+      style={({ pressed }) => [styles.ctrl, disabled && styles.ctrlDisabled, pressed && styles.ctrlPressed]}>
+      <Ionicons name={icon} size={18} color={disabled ? t.textFaint : (tint ?? t.text)} />
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  dim: { opacity: 0.42 },
+  strip: {
+    position: 'absolute', top: 6, right: 6, flexDirection: 'row', gap: 6,
+    backgroundColor: t.bg, borderColor: t.cardBorder, borderWidth: 1,
+    borderRadius: 999, padding: 4,
+    shadowColor: '#000', shadowOpacity: 0.4, shadowRadius: 6, shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
+  },
+  ctrl: {
+    width: 34, height: 30, alignItems: 'center', justifyContent: 'center',
+    borderRadius: 999, backgroundColor: t.card,
+  },
+  ctrlDisabled: { opacity: 0.4 },
+  ctrlPressed: { opacity: 0.6 },
+});

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -54,6 +54,16 @@ export function ScreenPreview() {
   }
   if (probe.data && probe.dataKey === boxKey) everSupported.current = true;
   const supported = probe.data != null;
+  // CONTROL (portal remote-desktop: absolute cursor + input) is DESKTOP-ONLY.
+  // gamescope Game Mode has no xdg-desktop-portal RemoteDesktop path, so a
+  // Control button there leads to a dead surface — hide it (degrade closed).
+  // START PREVIEW stays available in both: gamescopectl grabs game-mode frames.
+  // 'mock' = dev harness. Live + non-sticky (reads probe.data, not the sticky
+  // ref), so a desktop<->game switch flips this within one probe (~30s) rather
+  // than needing an agent restart. `session` is recomputed per /api/screen call
+  // agent-side from the live wayland socket, so it never goes stale.
+  const controllable =
+    probe.data?.session === 'desktop' || probe.data?.session === 'mock';
 
   const [active, setActive] = useState(false);
   const [frame, setFrame] = useState<string | null>(null);
@@ -156,14 +166,16 @@ export function ScreenPreview() {
         <Text style={styles.title}>SCREEN</Text>
         {supported && (
           <View style={styles.headerBtns}>
-            <Pressable
-              onPress={() => { hapticLight(); router.push('/desktop'); }}
-              accessibilityRole="button"
-              accessibilityLabel="Control the desktop"
-              style={({ pressed }) => [styles.pill, pressed && styles.pressed]}>
-              <Ionicons name="game-controller-outline" size={12} color={t.blue} />
-              <Text style={styles.pillText}>CONTROL</Text>
-            </Pressable>
+            {controllable && (
+              <Pressable
+                onPress={() => { hapticLight(); router.push('/desktop'); }}
+                accessibilityRole="button"
+                accessibilityLabel="Control the desktop"
+                style={({ pressed }) => [styles.pill, pressed && styles.pressed]}>
+                <Ionicons name="game-controller-outline" size={12} color={t.blue} />
+                <Text style={styles.pillText}>CONTROL</Text>
+              </Pressable>
+            )}
             <Pressable
               onPress={toggle}
               style={({ pressed }) => [styles.pill, active && styles.pillOn, pressed && styles.pressed]}>

--- a/app/components/ScreenVideo.native.tsx
+++ b/app/components/ScreenVideo.native.tsx
@@ -1,0 +1,18 @@
+/**
+ * Native remote-video surface for the WebRTC H.264 screen stream (P4b P0).
+ * Renders the box's sendonly track with <RTCView> — hardware decode. Metro picks
+ * this on iOS/Android; the web build gets components/ScreenVideo.tsx (null), so
+ * react-native-webrtc is never pulled into the web bundle.
+ */
+import type { StyleProp, ViewStyle } from 'react-native';
+import { RTCView } from 'react-native-webrtc';
+
+export function ScreenVideo({
+  streamURL, style,
+}: {
+  streamURL: string;
+  style?: StyleProp<ViewStyle>;
+}) {
+  // 16:9 source in a 16:9 stage -> 'contain' is exact (no letterbox math).
+  return <RTCView streamURL={streamURL} objectFit="contain" style={style} />;
+}

--- a/app/components/ScreenVideo.tsx
+++ b/app/components/ScreenVideo.tsx
@@ -1,0 +1,14 @@
+/**
+ * WEB / no-native-module fallback for the WebRTC remote-video surface (P4b P0).
+ * react-native-webrtc is native-only; the web build never reaches the WebRTC
+ * tier (webrtcSupported is false there), so this renders nothing. Keeping the
+ * RTCView reference out of this file is what keeps it out of the web bundle.
+ */
+import type { StyleProp, ViewStyle } from 'react-native';
+
+export function ScreenVideo(_props: {
+  streamURL: string;
+  style?: StyleProp<ViewStyle>;
+}) {
+  return null;
+}

--- a/app/eas.json
+++ b/app/eas.json
@@ -35,6 +35,12 @@
         "simulator": false
       }
     },
+    "tf-dev": {
+      "developmentClient": true,
+      "ios": {
+        "simulator": false
+      }
+    },
     "simulator": {
       "autoIncrement": true,
       "distribution": "internal",

--- a/app/hooks/useScreenStream.ts
+++ b/app/hooks/useScreenStream.ts
@@ -8,9 +8,9 @@
  * portal desktop session) the agent degrades /ws/screen closed, so the caller
  * can fall back to the still-frame poller.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import type { ConnSettings } from '@/lib/api';
+import { resolveEffectiveHost, type ConnSettings } from '@/lib/api';
 import { ScreenStreamClient, type StreamProfile } from '@/lib/screenstream';
 
 export function useScreenStream(
@@ -21,6 +21,15 @@ export function useScreenStream(
   const [frame, setFrame] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
   const [lastGood, setLastGood] = useState<number | null>(null);
+
+  // Connect with the freshest settings without making them a dep: `settings` is
+  // a new object on every reachability poll (lastSeen/lastIp/caps), so a
+  // `[settings]` dep reconnected the stream every few seconds. Key ONLY on the
+  // connection identity (effective host, port, token).
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+  const effHost = resolveEffectiveHost(settings);
+  const { port, token } = settings;
 
   useEffect(() => {
     if (!active) return undefined;
@@ -33,13 +42,13 @@ export function useScreenStream(
     client.onStatus((s) => {
       if (s === 'error') setFailed(true);
     });
-    client.start(settings, profile);
+    client.start(settingsRef.current, profile);
     return () => {
       client.onFrame(null);
       client.onStatus(null);
       client.stop();
     };
-  }, [active, profile, settings]);
+  }, [active, profile, effHost, port, token]);
 
   return { frame, failed, lastGood };
 }

--- a/app/hooks/useWebRtcStream.ts
+++ b/app/hooks/useWebRtcStream.ts
@@ -1,0 +1,47 @@
+/**
+ * Fluid H.264 screen video from the opt-in portal module's /ws/webrtc stream
+ * (remote-desktop P4b P0). Returns { streamURL, failed, connected }: streamURL
+ * feeds <ScreenVideo> (RTCView); `failed` goes true on a hard WebRTC failure so
+ * the desktop route can demote to the MJPEG stream (caps.screenstream).
+ *
+ * Mirror of useScreenStream, but the payload is a native RTCView stream URL
+ * rather than a base64 <Image> data URI. On web / a build without
+ * react-native-webrtc, the underlying client is the no-op stub and this never
+ * activates (the desktop route gates it on webrtcSupported).
+ */
+import { useEffect, useState } from 'react';
+
+import type { ConnSettings } from '@/lib/api';
+import { WebRtcStreamClient } from '@/lib/webrtcstream';
+import type { WebRtcProfile } from '@/lib/webrtcstreamTypes';
+
+export function useWebRtcStream(
+  settings: ConnSettings,
+  active: boolean,
+  profile: WebRtcProfile = '720p60',
+) {
+  const [streamURL, setStreamURL] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const [connected, setConnected] = useState(false);
+
+  useEffect(() => {
+    if (!active) return undefined;
+    setStreamURL(null);
+    setFailed(false);
+    setConnected(false);
+    const client = new WebRtcStreamClient();
+    client.onStream((url) => setStreamURL(url));
+    client.onStatus((s) => {
+      if (s === 'error') setFailed(true);
+      if (s === 'connected') setConnected(true);
+    });
+    client.start(settings, profile);
+    return () => {
+      client.onStream(null);
+      client.onStatus(null);
+      client.stop();
+    };
+  }, [active, profile, settings]);
+
+  return { streamURL, failed, connected };
+}

--- a/app/hooks/useWebRtcStream.ts
+++ b/app/hooks/useWebRtcStream.ts
@@ -8,10 +8,17 @@
  * rather than a base64 <Image> data URI. On web / a build without
  * react-native-webrtc, the underlying client is the no-op stub and this never
  * activates (the desktop route gates it on webrtcSupported).
+ *
+ * STABLE DEPS (load-bearing): the effect keys ONLY on the connection identity
+ * (effective host, port, token) — NOT the whole `settings` object. `settings`
+ * is a fresh object on every reachability poll (it carries lastSeen/lastIp/caps),
+ * so a `[settings]` dep tore down and rebuilt the native RTCPeerConnection every
+ * few seconds, which crashed react-native-webrtc after a minute of churn. The
+ * latest settings is read from a ref at connect time.
  */
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import type { ConnSettings } from '@/lib/api';
+import { resolveEffectiveHost, type ConnSettings } from '@/lib/api';
 import { WebRtcStreamClient } from '@/lib/webrtcstream';
 import type { WebRtcProfile } from '@/lib/webrtcstreamTypes';
 
@@ -24,6 +31,14 @@ export function useWebRtcStream(
   const [failed, setFailed] = useState(false);
   const [connected, setConnected] = useState(false);
 
+  // Always connect with the freshest settings, without making them a dep.
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+
+  // The connection identity: re-run ONLY when one of these actually changes.
+  const effHost = resolveEffectiveHost(settings);
+  const { port, token } = settings;
+
   useEffect(() => {
     if (!active) return undefined;
     setStreamURL(null);
@@ -35,13 +50,13 @@ export function useWebRtcStream(
       if (s === 'error') setFailed(true);
       if (s === 'connected') setConnected(true);
     });
-    client.start(settings, profile);
+    client.start(settingsRef.current, profile);
     return () => {
       client.onStream(null);
       client.onStatus(null);
       client.stop();
     };
-  }, [active, profile, settings]);
+  }, [active, profile, effHost, port, token]);
 
   return { streamURL, failed, connected };
 }

--- a/app/lib/__tests__/onboarding.test.ts
+++ b/app/lib/__tests__/onboarding.test.ts
@@ -128,10 +128,16 @@ test('every screen locks orientation except the Pad, which allows landscape', as
     assert.ok(src.includes('useLockOrientation('), `${rel} must state an orientation policy`);
     const mentionsLandscape =
       src.includes("'allow-landscape'") || src.includes("'landscape-locked'");
+    // Two screens legitimately rotate, because each has a REAL landscape layout:
+    // the Pad (conditional on gamepad mode) and the desktop Control screen — its
+    // fullscreen "Remote Desktop" mode IS the landscape layout (portrait renders
+    // the laptop layout). Any OTHER screen that rotates is the silent bug this
+    // guard exists to catch.
+    const mayRotate = rel.endsWith('pad.tsx') || rel.endsWith('desktop.tsx');
     assert.equal(
       mentionsLandscape,
-      rel.endsWith('pad.tsx'),
-      `only the Pad may allow landscape; ${rel} disagrees`,
+      mayRotate,
+      `only the Pad and the desktop Control screen may allow landscape; ${rel} disagrees`,
     );
     if (rel.endsWith('pad.tsx')) {
       // And even there it is CONDITIONAL on the gamepad mode. A flat

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -214,6 +214,15 @@ export type BoxCaps = {
    * skips the fluid path (the app then uses the P1 poller).
    */
   screenstream?: boolean;
+  /**
+   * P4b: the remote-desktop module ALSO exposes a working H.264/WebRTC video
+   * path (webrtcbin + libnice + a VA encoder) — 30–60fps via react-native-webrtc
+   * instead of MJPEG-over-<Image>. Linux/Wayland-desktop only, opt-in. Optional +
+   * additive: absent on agents without it and on Windows, so undefined reads as
+   * "unknown"; the app only uses the WebRTC path when this is true AND the app was
+   * built with react-native-webrtc, else it falls back to screenstream (MJPEG).
+   */
+  screenstream_h264?: boolean;
 };
 
 /** One Setup → Utilities helper + its live state, from GET /api/utilities.
@@ -1190,7 +1199,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.player === b.player &&
     a.steaminstall === b.steaminstall &&
     a.utilities === b.utilities &&
-    a.screenstream === b.screenstream
+    a.screenstream === b.screenstream &&
+    a.screenstream_h264 === b.screenstream_h264
   );
 }
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2,6 +2,7 @@
  * Typed client for the Couchside agent API (contract v1).
  * Base URL: http://<host>:<port>  (default port 8787)
  */
+import { Buffer } from 'buffer';
 import { isDeclaredTooLarge, isUsableBodySize } from './responseCap';
 import { Settings } from './settings';
 
@@ -1265,24 +1266,13 @@ export async function uploadFile(
   }
 }
 
-const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-/** base64-encode raw bytes (no reliance on btoa/Buffer, which RN may lack).
- *  Exported for the /ws/screen stream client, which turns each binary WS JPEG
- *  frame into a data: URI for <Image> the same way the HTTP frame path does. */
+/** base64-encode raw bytes for the /ws/screen stream client, which turns each
+ *  binary WS JPEG frame into a data: URI for <Image>. Uses the `buffer` lib
+ *  (base64-js under the hood): chunked typed-array work, no per-char string
+ *  concat — meaningfully faster than a hand loop on the per-frame MJPEG path,
+ *  which trims app-side video latency. */
 export function base64FromArrayBuffer(buf: ArrayBuffer): string {
-  const bytes = new Uint8Array(buf);
-  const len = bytes.length;
-  let out = '';
-  for (let i = 0; i < len; i += 3) {
-    const b0 = bytes[i];
-    const b1 = i + 1 < len ? bytes[i + 1] : 0;
-    const b2 = i + 2 < len ? bytes[i + 2] : 0;
-    out += B64_ALPHABET[b0 >> 2];
-    out += B64_ALPHABET[((b0 & 3) << 4) | (b1 >> 4)];
-    out += i + 1 < len ? B64_ALPHABET[((b1 & 15) << 2) | (b2 >> 6)] : '=';
-    out += i + 2 < len ? B64_ALPHABET[b2 & 63] : '=';
-  }
-  return out;
+  return Buffer.from(buf).toString('base64');
 }
 
 /**

--- a/app/lib/consoleLayout.ts
+++ b/app/lib/consoleLayout.ts
@@ -1,0 +1,114 @@
+/**
+ * Console tab card layout — user order + hidden set, persisted.
+ *
+ * The Console tab renders a fixed set of movable "sections" (NOW PLAYING,
+ * GAMING, the vitals block, SCREEN, DISPLAY/AUDIO, UNITS, file drop). This store
+ * remembers the user's ORDER (an id list) and which ids they HID, set from the
+ * tab's hold-to-edit mode. An external store (same shape as lib/haptics) so a
+ * `<Switch>`/arrow tap re-renders live and the pref survives restarts.
+ *
+ * The stored order is reconciled against the canonical id list at render time
+ * (see effectiveOrder): ids no longer known are dropped, new ids appended — so
+ * a future card is never lost and a removed one never errors.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+const KEY = 'couchside.consoleLayout.v1';
+
+export type ConsoleLayout = { order: string[]; hidden: string[] };
+
+let layout: ConsoleLayout = { order: [], hidden: [] };
+const listeners = new Set<() => void>();
+let loadStarted = false;
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key) : null;
+    } catch { return null; }
+  }
+  return SecureStore.getItemAsync(key);
+}
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try { if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(key, value); }
+    catch { /* private mode: in-memory this session */ }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+function emit(): void { for (const l of listeners) l(); }
+function persist(): void { void storageSet(KEY, JSON.stringify(layout)); }
+
+export async function loadConsoleLayout(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  const raw = await storageGet(KEY);
+  if (!raw) return;
+  try {
+    const p = JSON.parse(raw) as Partial<ConsoleLayout>;
+    if (Array.isArray(p.order) && Array.isArray(p.hidden)
+        && p.order.every((x) => typeof x === 'string')
+        && p.hidden.every((x) => typeof x === 'string')) {
+      layout = { order: p.order, hidden: p.hidden };
+      emit();
+    }
+  } catch { /* corrupt pref: keep defaults */ }
+}
+void loadConsoleLayout();
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+function getSnapshot(): ConsoleLayout { return layout; }
+
+/** Live layout pref. New object on every change, so getSnapshot re-renders. */
+export function useConsoleLayout(): ConsoleLayout {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+export function setConsoleLayout(next: ConsoleLayout): void {
+  layout = { order: [...next.order], hidden: [...next.hidden] };
+  emit();
+  persist();
+}
+
+/**
+ * The order to actually render: the stored order filtered to ids that still
+ * exist, then any canonical id the user has never ordered appended in its
+ * canonical position (so a new card shows near where it was added, not lost).
+ */
+export function effectiveOrder(stored: string[], canonical: string[]): string[] {
+  const known = new Set(canonical);
+  const out = stored.filter((id) => known.has(id));
+  const seen = new Set(out);
+  for (let i = 0; i < canonical.length; i += 1) {
+    const id = canonical[i];
+    if (seen.has(id)) continue;
+    // insert at the canonical index, clamped to the current length
+    out.splice(Math.min(i, out.length), 0, id);
+    seen.add(id);
+  }
+  return out;
+}
+
+/** Move `id` one step up/down among the CURRENTLY-VISIBLE ids (skips absent). */
+export function moveSection(
+  order: string[], visible: string[], id: string, dir: -1 | 1,
+): string[] {
+  const vis = order.filter((x) => visible.includes(x));
+  const vi = vis.indexOf(id);
+  const target = vis[vi + dir];
+  if (vi < 0 || target == null) return order; // at an end
+  // swap id and target in the FULL order array
+  const out = [...order];
+  const a = out.indexOf(id);
+  const b = out.indexOf(target);
+  [out[a], out[b]] = [out[b], out[a]];
+  return out;
+}

--- a/app/lib/screenstream.ts
+++ b/app/lib/screenstream.ts
@@ -50,18 +50,6 @@ export class ScreenStreamClient {
   private pendingFrame: ArrayBuffer | null = null;
   private decodeScheduled = false;
   private rafId: ReturnType<typeof requestAnimationFrame> | null = null;
-  // TEMP instrumentation (remove before ship): where does display latency live?
-  private statRecv = 0;         // frames received from the WS
-  private statShown = 0;        // frames actually decoded + surfaced
-  private statDecodeMs = 0;     // total ms spent in base64 decode
-  private statRafDelayMs = 0;   // total ms between schedule and rAF firing
-  private statPendingAt = 0;    // when the currently-pending frame arrived
-  private statAgeMs = 0;        // total ms frames sat pending before decode
-  private statLastLog = 0;
-  private statBoxTs = 0;        // box wall-clock from the ts text frame
-  private statLagMs = 0;        // total (phone_now - box_ts) at binary arrival
-  private statLagMax = 0;       // worst single-frame transit lag this interval
-  private statLagN = 0;
 
   onFrame(cb: ((uri: string) => void) | null): void {
     this.frameCb = cb;
@@ -138,34 +126,13 @@ export class ScreenStreamClient {
     ws.onmessage = (ev: WebSocketMessageEvent) => {
       if (ws !== this.ws) return;
       const data = ev.data as unknown;
-      // TEMP instrumentation: the agent sends {"t":"ts","ms":<box clock>} as a
-      // text frame right before each binary frame; (phone_now - ms) exposes how
-      // long the frame spent in transit/buffers upstream of JS. Clock skew makes
-      // the absolute value approximate — the TREND is what matters.
-      if (typeof data === 'string') {
-        if (data.length < 64 && data.includes('"ts"')) {
-          try {
-            const m = JSON.parse(data) as { t?: string; ms?: number };
-            if (m.t === 'ts' && typeof m.ms === 'number') this.statBoxTs = m.ms;
-          } catch { /* not ours */ }
-        }
-        return;
-      }
+      if (typeof data === 'string') return; // this stream carries no text frames
       if (!(data instanceof ArrayBuffer)) return; // ignore stray frames
       if (!isUsableBodySize(data.byteLength)) return;
-      if (this.statBoxTs > 0) {
-        const lag = Date.now() - this.statBoxTs;
-        this.statLagMs += lag;
-        this.statLagN++;
-        if (lag > this.statLagMax) this.statLagMax = lag;
-        this.statBoxTs = 0;
-      }
       // Store the newest raw frame and decode on the next tick — do NOT decode
       // here. Decoding every frame the native WS delivers serializes a backlog
       // into display lag; overwriting keeps only the freshest and the piled-up
       // older frames are dropped UNDECODED.
-      this.statRecv++;
-      this.statPendingAt = Date.now();
       this.pendingFrame = data;
       this.scheduleDecode();
     };
@@ -214,11 +181,7 @@ export class ScreenStreamClient {
   private scheduleDecode(): void {
     if (this.decodeScheduled) return;
     this.decodeScheduled = true;
-    const scheduledAt = Date.now();
-    this.rafId = requestAnimationFrame(() => {
-      this.statRafDelayMs += Date.now() - scheduledAt;
-      this.decodePending();
-    });
+    this.rafId = requestAnimationFrame(() => this.decodePending());
   }
 
   private decodePending(): void {
@@ -227,34 +190,8 @@ export class ScreenStreamClient {
     const data = this.pendingFrame;
     this.pendingFrame = null;
     if (!data) return;
-    const t0 = Date.now();
-    this.statAgeMs += t0 - this.statPendingAt;
     const uri = `data:image/jpeg;base64,${base64FromArrayBuffer(data)}`;
-    this.statDecodeMs += Date.now() - t0;
-    this.statShown++;
     this.frameCb?.(uri);
-    // TEMP instrumentation: once per ~2s, log where time goes. recv vs shown =
-    // drop rate; rafDelay = scheduling starvation; age = pending-wait; decode =
-    // base64 cost. All averages per SHOWN frame except recv (per second).
-    const now = Date.now();
-    if (now - this.statLastLog >= 2000) {
-      const secs = (now - (this.statLastLog || now - 2000)) / 1000;
-      const shown = Math.max(1, this.statShown);
-      const lagN = Math.max(1, this.statLagN);
-      console.log(
-        `[screenstat] recv/s=${(this.statRecv / secs).toFixed(1)} ` +
-        `shown/s=${(this.statShown / secs).toFixed(1)} ` +
-        `rafDelay=${(this.statRafDelayMs / shown).toFixed(0)}ms ` +
-        `age=${(this.statAgeMs / shown).toFixed(0)}ms ` +
-        `decode=${(this.statDecodeMs / shown).toFixed(0)}ms ` +
-        `lag=${(this.statLagMs / lagN).toFixed(0)}ms ` +
-        `lagMax=${this.statLagMax.toFixed(0)}ms ` +
-        `kb=${(data.byteLength / 1024).toFixed(0)}`);
-      this.statRecv = this.statShown = 0;
-      this.statDecodeMs = this.statRafDelayMs = this.statAgeMs = 0;
-      this.statLagMs = this.statLagMax = this.statLagN = 0;
-      this.statLastLog = now;
-    }
     // Frames that arrived while decoding overwrote pendingFrame — take the
     // freshest on the next tick (again just one; anything between is dropped).
     if (this.pendingFrame) this.scheduleDecode();

--- a/app/lib/screenstream.ts
+++ b/app/lib/screenstream.ts
@@ -41,6 +41,15 @@ export class ScreenStreamClient {
   private connectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private backoffIdx = 0;
+  // Newest-only DECODE: onmessage stores the freshest raw frame here (cheap) and
+  // a per-render-tick job base64-decodes just that one, dropping any that piled
+  // up undecoded. Without this, the phone decodes every frame the native WS
+  // hands it — and hardware jpeg on the box out-produces the JS decode on high
+  // motion, so a backlog serializes into seconds of DISPLAY lag (input is on a
+  // separate socket and stays instant).
+  private pendingFrame: ArrayBuffer | null = null;
+  private decodeScheduled = false;
+  private rafId: ReturnType<typeof requestAnimationFrame> | null = null;
 
   onFrame(cb: ((uri: string) => void) | null): void {
     this.frameCb = cb;
@@ -119,8 +128,12 @@ export class ScreenStreamClient {
       const data = ev.data as unknown;
       if (!(data instanceof ArrayBuffer)) return; // ignore text / stray frames
       if (!isUsableBodySize(data.byteLength)) return;
-      // Newest-only: decode + surface immediately, no queue.
-      this.frameCb?.(`data:image/jpeg;base64,${base64FromArrayBuffer(data)}`);
+      // Store the newest raw frame and decode on the next tick — do NOT decode
+      // here. Decoding every frame the native WS delivers serializes a backlog
+      // into display lag; overwriting keeps only the freshest and the piled-up
+      // older frames are dropped UNDECODED.
+      this.pendingFrame = data;
+      this.scheduleDecode();
     };
     ws.onerror = () => {
       if (ws !== this.ws) return;
@@ -163,8 +176,37 @@ export class ScreenStreamClient {
     }
   }
 
+  // Decode at most one frame per render tick — the freshest — and drop the rest.
+  private scheduleDecode(): void {
+    if (this.decodeScheduled) return;
+    this.decodeScheduled = true;
+    this.rafId = requestAnimationFrame(() => this.decodePending());
+  }
+
+  private decodePending(): void {
+    this.decodeScheduled = false;
+    this.rafId = null;
+    const data = this.pendingFrame;
+    this.pendingFrame = null;
+    if (!data) return;
+    this.frameCb?.(`data:image/jpeg;base64,${base64FromArrayBuffer(data)}`);
+    // Frames that arrived while decoding overwrote pendingFrame — take the
+    // freshest on the next tick (again just one; anything between is dropped).
+    if (this.pendingFrame) this.scheduleDecode();
+  }
+
+  private clearDecode(): void {
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+    this.decodeScheduled = false;
+    this.pendingFrame = null;
+  }
+
   private teardownSocket(): void {
     this.clearConnectTimer();
+    this.clearDecode();
     const ws = this.ws;
     this.ws = null;
     if (ws) {

--- a/app/lib/screenstream.ts
+++ b/app/lib/screenstream.ts
@@ -50,6 +50,18 @@ export class ScreenStreamClient {
   private pendingFrame: ArrayBuffer | null = null;
   private decodeScheduled = false;
   private rafId: ReturnType<typeof requestAnimationFrame> | null = null;
+  // TEMP instrumentation (remove before ship): where does display latency live?
+  private statRecv = 0;         // frames received from the WS
+  private statShown = 0;        // frames actually decoded + surfaced
+  private statDecodeMs = 0;     // total ms spent in base64 decode
+  private statRafDelayMs = 0;   // total ms between schedule and rAF firing
+  private statPendingAt = 0;    // when the currently-pending frame arrived
+  private statAgeMs = 0;        // total ms frames sat pending before decode
+  private statLastLog = 0;
+  private statBoxTs = 0;        // box wall-clock from the ts text frame
+  private statLagMs = 0;        // total (phone_now - box_ts) at binary arrival
+  private statLagMax = 0;       // worst single-frame transit lag this interval
+  private statLagN = 0;
 
   onFrame(cb: ((uri: string) => void) | null): void {
     this.frameCb = cb;
@@ -126,12 +138,34 @@ export class ScreenStreamClient {
     ws.onmessage = (ev: WebSocketMessageEvent) => {
       if (ws !== this.ws) return;
       const data = ev.data as unknown;
-      if (!(data instanceof ArrayBuffer)) return; // ignore text / stray frames
+      // TEMP instrumentation: the agent sends {"t":"ts","ms":<box clock>} as a
+      // text frame right before each binary frame; (phone_now - ms) exposes how
+      // long the frame spent in transit/buffers upstream of JS. Clock skew makes
+      // the absolute value approximate — the TREND is what matters.
+      if (typeof data === 'string') {
+        if (data.length < 64 && data.includes('"ts"')) {
+          try {
+            const m = JSON.parse(data) as { t?: string; ms?: number };
+            if (m.t === 'ts' && typeof m.ms === 'number') this.statBoxTs = m.ms;
+          } catch { /* not ours */ }
+        }
+        return;
+      }
+      if (!(data instanceof ArrayBuffer)) return; // ignore stray frames
       if (!isUsableBodySize(data.byteLength)) return;
+      if (this.statBoxTs > 0) {
+        const lag = Date.now() - this.statBoxTs;
+        this.statLagMs += lag;
+        this.statLagN++;
+        if (lag > this.statLagMax) this.statLagMax = lag;
+        this.statBoxTs = 0;
+      }
       // Store the newest raw frame and decode on the next tick — do NOT decode
       // here. Decoding every frame the native WS delivers serializes a backlog
       // into display lag; overwriting keeps only the freshest and the piled-up
       // older frames are dropped UNDECODED.
+      this.statRecv++;
+      this.statPendingAt = Date.now();
       this.pendingFrame = data;
       this.scheduleDecode();
     };
@@ -180,7 +214,11 @@ export class ScreenStreamClient {
   private scheduleDecode(): void {
     if (this.decodeScheduled) return;
     this.decodeScheduled = true;
-    this.rafId = requestAnimationFrame(() => this.decodePending());
+    const scheduledAt = Date.now();
+    this.rafId = requestAnimationFrame(() => {
+      this.statRafDelayMs += Date.now() - scheduledAt;
+      this.decodePending();
+    });
   }
 
   private decodePending(): void {
@@ -189,7 +227,34 @@ export class ScreenStreamClient {
     const data = this.pendingFrame;
     this.pendingFrame = null;
     if (!data) return;
-    this.frameCb?.(`data:image/jpeg;base64,${base64FromArrayBuffer(data)}`);
+    const t0 = Date.now();
+    this.statAgeMs += t0 - this.statPendingAt;
+    const uri = `data:image/jpeg;base64,${base64FromArrayBuffer(data)}`;
+    this.statDecodeMs += Date.now() - t0;
+    this.statShown++;
+    this.frameCb?.(uri);
+    // TEMP instrumentation: once per ~2s, log where time goes. recv vs shown =
+    // drop rate; rafDelay = scheduling starvation; age = pending-wait; decode =
+    // base64 cost. All averages per SHOWN frame except recv (per second).
+    const now = Date.now();
+    if (now - this.statLastLog >= 2000) {
+      const secs = (now - (this.statLastLog || now - 2000)) / 1000;
+      const shown = Math.max(1, this.statShown);
+      const lagN = Math.max(1, this.statLagN);
+      console.log(
+        `[screenstat] recv/s=${(this.statRecv / secs).toFixed(1)} ` +
+        `shown/s=${(this.statShown / secs).toFixed(1)} ` +
+        `rafDelay=${(this.statRafDelayMs / shown).toFixed(0)}ms ` +
+        `age=${(this.statAgeMs / shown).toFixed(0)}ms ` +
+        `decode=${(this.statDecodeMs / shown).toFixed(0)}ms ` +
+        `lag=${(this.statLagMs / lagN).toFixed(0)}ms ` +
+        `lagMax=${this.statLagMax.toFixed(0)}ms ` +
+        `kb=${(data.byteLength / 1024).toFixed(0)}`);
+      this.statRecv = this.statShown = 0;
+      this.statDecodeMs = this.statRafDelayMs = this.statAgeMs = 0;
+      this.statLagMs = this.statLagMax = this.statLagN = 0;
+      this.statLastLog = now;
+    }
     // Frames that arrived while decoding overwrote pendingFrame — take the
     // freshest on the next tick (again just one; anything between is dropped).
     if (this.pendingFrame) this.scheduleDecode();

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -297,12 +297,15 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // capsEqual) and the cap never persists, so the desktop view can never latch onto
   // the fluid stream and re-probes forever.
   const screenstream = bool('screenstream');
+  // P4b: same module, its H.264/WebRTC tier. Same optional-cap drop trap — it MUST
+  // appear in the RETURN object below or it never persists and the app re-probes.
+  const screenstream_h264 = bool('screenstream_h264');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
-    steaminstall, utilities, screenstream,
+    steaminstall, utilities, screenstream, screenstream_h264,
   };
 }
 

--- a/app/lib/webrtcstream.native.ts
+++ b/app/lib/webrtcstream.native.ts
@@ -1,0 +1,244 @@
+/**
+ * Native WebRTC client for the Couchside H.264 screen stream (remote-desktop
+ * P4b P0). Endpoint: ws://<host>:<port>/ws/webrtc?token=<token>&profile=<id>.
+ *
+ * The BOX offers (sendonly H.264); this side answers and renders the remote
+ * track with <RTCView> (hardware decode — VideoToolbox on iOS, MediaCodec on
+ * Android). The agent's /ws/webrtc is a dumb JSON relay to the portal helper's
+ * webrtcbin; we exchange only offer/answer/ice/bye/error. LAN-only ICE: no STUN,
+ * no TURN — host candidates + peer-reflexive (proven to pair with libnice over
+ * WiFi in B0).
+ *
+ * ONE-SHOT, not the reconnect loop that lib/screenstream.ts runs: a WebRTC
+ * session is expensive (it re-pops the box's consent), so on any hard failure we
+ * report 'error' ONCE and stop — the desktop route then falls back to the MJPEG
+ * stream (caps.screenstream), which owns its own reconnect. Two timeouts guard
+ * that: a connect watchdog (WS stuck opening) and a post-answer negotiation
+ * timeout. There is deliberately NO timeout while waiting for the offer, because
+ * that window is the user walking to the box to click Approve.
+ */
+import { RTCIceCandidate, RTCPeerConnection, RTCSessionDescription } from 'react-native-webrtc';
+
+import { resolveEffectiveHost, type ConnSettings } from './api';
+import type {
+  IWebRtcStreamClient, WebRtcProfile, WebRtcStatus,
+} from './webrtcstreamTypes';
+
+export const webrtcSupported: boolean = true;
+
+// A dead target leaves the WS CONNECTING with no error; cut it short.
+const CONNECT_TIMEOUT_MS = 8000;
+// After we send the answer, how long to wait for ICE to actually connect before
+// giving up and falling back to MJPEG. On a LAN this is a second or two; be
+// generous for WiFi. This does NOT cover the consent wait (that is pre-offer).
+const NEGOTIATE_TIMEOUT_MS = 12000;
+
+export class WebRtcStreamClient implements IWebRtcStreamClient {
+  private ws: WebSocket | null = null;
+  private pc: RTCPeerConnection | null = null;
+  private settings: ConnSettings | null = null;
+  private profile: WebRtcProfile = '720p60';
+  private active = false;
+  private streamCb: ((url: string | null) => void) | null = null;
+  private statusCb: ((s: WebRtcStatus) => void) | null = null;
+  private status: WebRtcStatus = 'closed';
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
+  private negotiateTimer: ReturnType<typeof setTimeout> | null = null;
+
+  onStream(cb: ((url: string | null) => void) | null): void {
+    this.streamCb = cb;
+  }
+
+  onStatus(cb: ((s: WebRtcStatus) => void) | null): void {
+    this.statusCb = cb;
+    if (cb) cb(this.status);
+  }
+
+  start(settings: ConnSettings, profile: WebRtcProfile = '720p60'): void {
+    this.settings = settings;
+    this.profile = profile;
+    this.active = true;
+    this.open();
+  }
+
+  stop(): void {
+    this.active = false;
+    this.teardown();
+    this.setStatus('closed');
+  }
+
+  private setStatus(s: WebRtcStatus): void {
+    if (this.status === s) return;
+    this.status = s;
+    this.statusCb?.(s);
+  }
+
+  private fail(): void {
+    // Hard, terminal failure -> report once and stop (no reconnect); the caller
+    // falls back to MJPEG. Guarded by `active` so stop() stays quiet.
+    if (!this.active) return;
+    this.teardown();
+    this.setStatus('error');
+  }
+
+  private open(): void {
+    if (!this.active || !this.settings) return;
+    this.setStatus('connecting');
+    const host = resolveEffectiveHost(this.settings);
+    const { port, token } = this.settings;
+    if (!host || !port) {
+      this.fail();
+      return;
+    }
+    const url =
+      `ws://${host}:${port}/ws/webrtc?token=${encodeURIComponent(token)}` +
+      `&profile=${this.profile}`;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(url);
+    } catch {
+      this.fail();
+      return;
+    }
+    this.ws = ws;
+
+    this.connectTimer = setTimeout(() => {
+      this.connectTimer = null;
+      if (ws !== this.ws || ws.readyState !== 0 /* CONNECTING */) return;
+      this.fail();
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      if (ws !== this.ws) return;
+      this.clearTimer('connect');
+      this.setupPeer();          // ready to answer once the offer arrives
+    };
+    ws.onmessage = (ev: WebSocketMessageEvent) => {
+      if (ws !== this.ws) return;
+      if (typeof ev.data !== 'string') return;
+      this.onSignal(ev.data);
+    };
+    ws.onerror = () => {
+      if (ws !== this.ws) return;
+      this.fail();               // onclose may follow; fail() is idempotent-ish
+    };
+    ws.onclose = () => {
+      if (ws !== this.ws) return;
+      // A box without a working H.264 path (or Game Mode) closes right away ->
+      // fall back. If we were already connected+streaming, a close is also the
+      // end of the session.
+      this.fail();
+    };
+  }
+
+  private send(obj: unknown): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== 1 /* OPEN */) return;
+    try {
+      ws.send(JSON.stringify(obj));
+    } catch {
+      this.fail();
+    }
+  }
+
+  private setupPeer(): void {
+    // LAN-only: no ICE servers (host candidates + peer-reflexive).
+    const pc = new RTCPeerConnection({ iceServers: [] });
+    this.pc = pc;
+    // react-native-webrtc exposes events via on* setters over a vendored
+    // event-target-shim; the payloads are loosely typed, so read them via `any`.
+    pc.ontrack = (e: any) => {
+      const stream = e?.streams?.[0] as { toURL?: () => string } | undefined;
+      const toURL = stream?.toURL;
+      if (toURL) this.streamCb?.(toURL.call(stream));
+    };
+    pc.onicecandidate = (e: any) => {
+      const c = e?.candidate as
+        { candidate?: string; sdpMLineIndex?: number | null } | null | undefined;
+      if (c && typeof c.candidate === 'string' && c.candidate) {
+        this.send({
+          t: 'ice',
+          candidate: c.candidate,
+          sdpMLineIndex: typeof c.sdpMLineIndex === 'number' ? c.sdpMLineIndex : 0,
+        });
+      }
+    };
+    pc.onconnectionstatechange = () => {
+      const st = this.pc?.connectionState;
+      if (st === 'connected') {
+        this.clearTimer('negotiate');
+        this.setStatus('connected');
+      } else if (st === 'failed' || st === 'closed') {
+        this.fail();
+      }
+    };
+  }
+
+  private async onSignal(text: string): Promise<void> {
+    let msg: { t?: string; sdp?: string; candidate?: string; sdpMLineIndex?: number };
+    try {
+      msg = JSON.parse(text);
+    } catch {
+      return;
+    }
+    const pc = this.pc;
+    if (!pc) return;
+    try {
+      if (msg.t === 'offer' && typeof msg.sdp === 'string') {
+        await pc.setRemoteDescription(
+          new RTCSessionDescription({ type: 'offer', sdp: msg.sdp }));
+        const answer = await pc.createAnswer();
+        await pc.setLocalDescription(answer);
+        this.send({ t: 'answer', sdp: answer.sdp });
+        // Media should flow within seconds now; arm the fallback timeout.
+        this.armNegotiateTimeout();
+      } else if (msg.t === 'ice' && typeof msg.candidate === 'string') {
+        await pc.addIceCandidate(new RTCIceCandidate({
+          candidate: msg.candidate,
+          sdpMLineIndex: typeof msg.sdpMLineIndex === 'number' ? msg.sdpMLineIndex : 0,
+        }));
+      } else if (msg.t === 'bye' || msg.t === 'error') {
+        this.fail();
+      }
+    } catch {
+      this.fail();
+    }
+  }
+
+  private armNegotiateTimeout(): void {
+    this.clearTimer('negotiate');
+    this.negotiateTimer = setTimeout(() => {
+      this.negotiateTimer = null;
+      if (this.status !== 'connected') this.fail();
+    }, NEGOTIATE_TIMEOUT_MS);
+  }
+
+  private clearTimer(which: 'connect' | 'negotiate'): void {
+    const ref = which === 'connect' ? this.connectTimer : this.negotiateTimer;
+    if (ref != null) {
+      clearTimeout(ref);
+      if (which === 'connect') this.connectTimer = null;
+      else this.negotiateTimer = null;
+    }
+  }
+
+  private teardown(): void {
+    this.clearTimer('connect');
+    this.clearTimer('negotiate');
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      try { ws.close(); } catch { /* already closed */ }
+    }
+    const pc = this.pc;
+    this.pc = null;
+    if (pc) {
+      try { pc.close(); } catch { /* already closed */ }
+    }
+    this.streamCb?.(null);
+  }
+}

--- a/app/lib/webrtcstream.native.ts
+++ b/app/lib/webrtcstream.native.ts
@@ -73,10 +73,11 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     this.statusCb?.(s);
   }
 
-  private fail(): void {
+  private fail(reason?: string): void {
     // Hard, terminal failure -> report once and stop (no reconnect); the caller
     // falls back to MJPEG. Guarded by `active` so stop() stays quiet.
     if (!this.active) return;
+    console.log('[webrtc] FAIL:', reason ?? '(unknown)');
     this.teardown();
     this.setStatus('error');
   }
@@ -93,11 +94,12 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     const url =
       `ws://${host}:${port}/ws/webrtc?token=${encodeURIComponent(token)}` +
       `&profile=${this.profile}`;
+    console.log('[webrtc] connecting', host, port, this.profile);
     let ws: WebSocket;
     try {
       ws = new WebSocket(url);
-    } catch {
-      this.fail();
+    } catch (e) {
+      this.fail('WebSocket ctor threw ' + String(e));
       return;
     }
     this.ws = ws;
@@ -105,11 +107,12 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     this.connectTimer = setTimeout(() => {
       this.connectTimer = null;
       if (ws !== this.ws || ws.readyState !== 0 /* CONNECTING */) return;
-      this.fail();
+      this.fail('connect watchdog (WS stuck CONNECTING)');
     }, CONNECT_TIMEOUT_MS);
 
     ws.onopen = () => {
       if (ws !== this.ws) return;
+      console.log('[webrtc] ws open');
       this.clearTimer('connect');
       this.setupPeer();          // ready to answer once the offer arrives
     };
@@ -118,16 +121,15 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
       if (typeof ev.data !== 'string') return;
       this.onSignal(ev.data);
     };
-    ws.onerror = () => {
+    ws.onerror = (e: unknown) => {
       if (ws !== this.ws) return;
-      this.fail();               // onclose may follow; fail() is idempotent-ish
+      this.fail('ws onerror ' + String((e as { message?: string })?.message ?? ''));
     };
-    ws.onclose = () => {
+    ws.onclose = (e: unknown) => {
       if (ws !== this.ws) return;
       // A box without a working H.264 path (or Game Mode) closes right away ->
-      // fall back. If we were already connected+streaming, a close is also the
-      // end of the session.
-      this.fail();
+      // fall back. If we were already connected+streaming, a close is also the end.
+      this.fail('ws onclose code=' + String((e as { code?: number })?.code ?? '?'));
     };
   }
 
@@ -150,7 +152,14 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     pc.ontrack = (e: any) => {
       const stream = e?.streams?.[0] as { toURL?: () => string } | undefined;
       const toURL = stream?.toURL;
+      console.log('[webrtc] ontrack, hasStream=', !!toURL);
       if (toURL) this.streamCb?.(toURL.call(stream));
+    };
+    (pc as any).oniceconnectionstatechange = () => {
+      console.log('[webrtc] iceConnectionState=', (this.pc as any)?.iceConnectionState);
+    };
+    (pc as any).onicegatheringstatechange = () => {
+      console.log('[webrtc] iceGatheringState=', (this.pc as any)?.iceGatheringState);
     };
     pc.onicecandidate = (e: any) => {
       const c = e?.candidate as
@@ -165,11 +174,12 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     };
     pc.onconnectionstatechange = () => {
       const st = this.pc?.connectionState;
+      console.log('[webrtc] connectionState=', st);
       if (st === 'connected') {
         this.clearTimer('negotiate');
         this.setStatus('connected');
       } else if (st === 'failed' || st === 'closed') {
-        this.fail();
+        this.fail('connectionState=' + st);
       }
     };
   }
@@ -183,13 +193,17 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     }
     const pc = this.pc;
     if (!pc) return;
+    console.log('[webrtc] <-', msg.t, msg.t === 'offer' ? '(sdp ' + (msg.sdp?.length ?? 0) + ')' : '');
     try {
       if (msg.t === 'offer' && typeof msg.sdp === 'string') {
         await pc.setRemoteDescription(
           new RTCSessionDescription({ type: 'offer', sdp: msg.sdp }));
+        console.log('[webrtc] setRemote done, creating answer');
         const answer = await pc.createAnswer();
+        console.log('[webrtc] answer created, setting local');
         await pc.setLocalDescription(answer);
         this.send({ t: 'answer', sdp: answer.sdp });
+        console.log('[webrtc] answer sent');
         // Media should flow within seconds now; arm the fallback timeout.
         this.armNegotiateTimeout();
       } else if (msg.t === 'ice' && typeof msg.candidate === 'string') {
@@ -198,10 +212,10 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
           sdpMLineIndex: typeof msg.sdpMLineIndex === 'number' ? msg.sdpMLineIndex : 0,
         }));
       } else if (msg.t === 'bye' || msg.t === 'error') {
-        this.fail();
+        this.fail('box sent ' + msg.t);
       }
-    } catch {
-      this.fail();
+    } catch (e) {
+      this.fail('onSignal ' + msg.t + ' threw ' + String(e));
     }
   }
 
@@ -209,7 +223,7 @@ export class WebRtcStreamClient implements IWebRtcStreamClient {
     this.clearTimer('negotiate');
     this.negotiateTimer = setTimeout(() => {
       this.negotiateTimer = null;
-      if (this.status !== 'connected') this.fail();
+      if (this.status !== 'connected') this.fail('negotiate timeout (ICE never connected)');
     }, NEGOTIATE_TIMEOUT_MS);
   }
 

--- a/app/lib/webrtcstream.ts
+++ b/app/lib/webrtcstream.ts
@@ -1,0 +1,30 @@
+/**
+ * WEB / no-native-module fallback for the WebRTC screen stream (P4b P0).
+ *
+ * react-native-webrtc is native-only. Metro resolves this `.ts` on web (and any
+ * build without the native module); the real client lives in
+ * `webrtcstream.native.ts`, which Metro picks on iOS/Android. Because the native
+ * dep is referenced ONLY from the `.native` file, it is never pulled into the web
+ * bundle. `webrtcSupported` is the runtime feature flag the desktop route gates
+ * on, so an unsupported build cleanly falls back to MJPEG (caps.screenstream)
+ * then the still-frame poller.
+ */
+import type { ConnSettings } from './api';
+import type {
+  IWebRtcStreamClient, WebRtcProfile, WebRtcStatus,
+} from './webrtcstreamTypes';
+
+// Typed `boolean` (not the literal `false`) so consumers don't dead-code the
+// WebRTC branch at compile time — the native override flips it to true.
+export const webrtcSupported: boolean = false;
+
+export class WebRtcStreamClient implements IWebRtcStreamClient {
+  onStream(_cb: ((url: string | null) => void) | null): void {}
+  onStatus(cb: ((s: WebRtcStatus) => void) | null): void {
+    // Report closed immediately so a caller that somehow reaches here (it never
+    // should — webrtcSupported is false) falls back rather than hanging.
+    if (cb) cb('closed');
+  }
+  start(_settings: ConnSettings, _profile?: WebRtcProfile): void {}
+  stop(): void {}
+}

--- a/app/lib/webrtcstreamTypes.ts
+++ b/app/lib/webrtcstreamTypes.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared, PLATFORM-AGNOSTIC types for the WebRTC H.264 screen stream (P4b P0).
+ * Kept in their own file (no react-native-webrtc import) so both the native
+ * client (lib/webrtcstream.native.ts) and the web stub (lib/webrtcstream.ts)
+ * implement the same interface, and consumers type against one source.
+ */
+import type { ConnSettings } from './api';
+
+export type WebRtcStatus = 'connecting' | 'connected' | 'error' | 'closed';
+
+// Must mirror the agent's _WEBRTC_PROFILES / helper _H264_PROFILES.
+export type WebRtcProfile = '720p30' | '720p60' | '1080p30' | '1080p60';
+
+export interface IWebRtcStreamClient {
+  /** The RTCView streamURL for the remote video, or null when there is none. */
+  onStream(cb: ((url: string | null) => void) | null): void;
+  onStatus(cb: ((s: WebRtcStatus) => void) | null): void;
+  start(settings: ConnSettings, profile?: WebRtcProfile): void;
+  stop(): void;
+}

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "1.0.0",
       "dependencies": {
+        "@config-plugins/react-native-webrtc": "^15.0.1",
         "@expo/metro-runtime": "~57.0.6",
         "@expo/vector-icons": "^15.0.2",
         "buffer": "^6.0.3",
@@ -46,6 +47,7 @@
         "react-native-udp": "^4.1.7",
         "react-native-volume-manager": "^2.0.8",
         "react-native-web": "~0.21.0",
+        "react-native-webrtc": "^124.0.8",
         "react-native-worklets": "0.10.0"
       },
       "devDependencies": {
@@ -932,38 +934,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
-      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
-      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.29.7.tgz",
@@ -971,22 +941,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.29.7",
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
@@ -1152,6 +1106,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@config-plugins/react-native-webrtc": {
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/@config-plugins/react-native-webrtc/-/react-native-webrtc-15.0.1.tgz",
+      "integrity": "sha512-1/RSRnMOWPqHmEJCGEhElzFvkXUiNkGYsbAIxJl/3+t9OW2l26Qsjo8Ei7v/OMJ7g0Ek6qnKkjCxYrrLSfJi2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "^56"
       }
     },
     "node_modules/@expo-google-fonts/material-symbols": {
@@ -2658,54 +2621,6 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
-    "node_modules/@react-native/babel-preset": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.86.0.tgz",
-      "integrity": "sha512-bYQcWiPySNvF4dns9Ls9gMmwgq66ohvM9Fwc/Kn8r85t66UNHxch3p1QwPiSorDelFauZwJbgo9+ReibTgvpbA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.25.2",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-        "@babel/plugin-transform-regenerator": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@react-native/babel-plugin-codegen": "0.86.0",
-        "babel-plugin-syntax-hermes-parser": "0.36.0",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
     "node_modules/@react-native/codegen": {
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.86.0.tgz",
@@ -2833,41 +2748,6 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
-    "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.86.0.tgz",
-      "integrity": "sha512-SjKej3E5qIahqo/G+rSOrmJUQM44RyKtWtO+VfmKAAMoJWkBFomM22hTLKCIS5cdbIAJ9COAmU+KAi2wVSO0wQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.86.0",
-        "hermes-parser": "0.36.0",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
-      }
-    },
-    "node_modules/@react-native/metro-config": {
-      "version": "0.86.0",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.86.0.tgz",
-      "integrity": "sha512-7v+xbTeEci9ZcQ/Z1OqI4RXcqN69wSMDYL5BAMvOReZ7U04+aDQ0/SQhClYPn6x2/RxM4WzMKSAuNyLKqvYVtw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@react-native/js-polyfills": "0.86.0",
-        "@react-native/metro-babel-transformer": "0.86.0",
-        "metro-config": "^0.84.3",
-        "metro-runtime": "^0.84.3"
-      },
-      "engines": {
-        "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
-      }
-    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.86.0.tgz",
@@ -2902,61 +2782,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "license": "MIT"
-    },
-    "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
-      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -2995,13 +2820,6 @@
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
       }
-    },
-    "node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@types/emscripten": {
       "version": "1.41.5",
@@ -3066,19 +2884,10 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/react-test-renderer": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
-      "integrity": "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -3922,6 +3731,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -4034,13 +3844,6 @@
       "resolved": "https://registry.npmjs.org/dnssd-advertise/-/dnssd-advertise-1.1.6.tgz",
       "integrity": "sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==",
       "license": "MIT"
-    },
-    "node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
-      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5932,16 +5735,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/lz-string": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
-      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -7207,21 +7000,6 @@
         "react-native-reanimated": ">= 2.0.0"
       }
     },
-    "node_modules/react-native-gesture-handler": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-3.0.2.tgz",
-      "integrity": "sha512-XBTgmvr2jh/xrMwlHTV2Z1x6IFUl3zfLxyaCAnvj3GSXK5YlY3ZmiIs57hniPmh3I7RtjPFxtGdRr0i+PzyBrg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/react-test-renderer": "^19.1.0",
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-get-random-values": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
@@ -7410,6 +7188,42 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
+    "node_modules/react-native-webrtc": {
+      "version": "124.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.8.tgz",
+      "integrity": "sha512-uuQxvmk+mvnk5U0tr+1N42sKZqgm41fJrBA+fmCvML9J9P4roSh2So82t5RHAlu/vE9vxu5AKgivAiH61clCBg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {
@@ -8260,7 +8074,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -18,6 +18,7 @@
         "expo-camera": "~57.0.3",
         "expo-clipboard": "~57.0.1",
         "expo-constants": "~57.0.2",
+        "expo-dev-client": "~57.0.11",
         "expo-document-picker": "~57.0.1",
         "expo-file-system": "~57.0.1",
         "expo-font": "~57.0.0",
@@ -4106,6 +4107,59 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "57.0.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-57.0.11.tgz",
+      "integrity": "sha512-IHatS97Vl0eQT8IG1Tsc10qDoyItxwjOw9AXLAbub+3uU7KljcqnXiCWRlhsI5KTjWV9/Dboc8psgiRb7oXXQw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "~57.0.11",
+        "expo-dev-menu": "~57.0.11",
+        "expo-dev-menu-interface": "~57.0.0",
+        "expo-manifests": "~57.0.1",
+        "expo-updates-interface": "~57.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "57.0.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-57.0.11.tgz",
+      "integrity": "sha512-PpYoSmtMkvLYG9xVVHv8ZDMMsHR0D5ax9lFTgy+e6WT98NLUTwTexlObOkjCB80cfiGaKfmOZEKyXRiec3Lgag==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/schema-utils": "^57.0.2",
+        "expo-dev-menu": "~57.0.11",
+        "expo-manifests": "~57.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "57.0.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-57.0.11.tgz",
+      "integrity": "sha512-XY+rT7JALQAMBVYLLGfTwZ/E9igLDtUnyCPox1xxWaH6n7T3LJyxVb5unoORYhF4HzHQoxxeeHd6hg5P4AfyrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "~57.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "57.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-57.0.0.tgz",
+      "integrity": "sha512-F47VdzOHYc19FhI/jBgctpO8a5UskTIxG6a1E5t3W5gF8VImuvBQffdXXfLHhsuCl7dS3v3U0R45cleeVXO1Zg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-document-picker": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-57.0.1.tgz",
@@ -4170,6 +4224,12 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-57.0.1.tgz",
+      "integrity": "sha512-cgTe1NqzQdYs/WN+3nIY5IZg8s0pb0xaTUbhYvxQDn137GbwRfHoGM2se3m3Vsl4Qu+B9G4RPEK5WJDEU2Do7g==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "57.0.1",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-57.0.1.tgz",
@@ -4192,6 +4252,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-57.0.1.tgz",
+      "integrity": "sha512-qB/mDG2dYdl+EvUeQuqP8KFYCFgFCQjJYdWIHo8SFBgDzMYmdF286DFY2M1M9Okr99wkb5M4tgA3aCcwv3aEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-json-utils": "~57.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -4400,6 +4472,15 @@
         "expo-font": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-57.0.1.tgz",
+      "integrity": "sha512-+LUWwJ0gf/TEKMVdQAw/Gjih4dvrk+URgy24X9qEGKuuMDZqjBRm9T4yQyBVALGL5TTdPUaB6ILxx3lshm3pwQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-web-browser": {

--- a/app/package.json
+++ b/app/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@config-plugins/react-native-webrtc": "^15.0.1",
     "@expo/metro-runtime": "~57.0.6",
     "@expo/vector-icons": "^15.0.2",
     "buffer": "^6.0.3",
@@ -41,6 +42,7 @@
     "react-native-udp": "^4.1.7",
     "react-native-volume-manager": "^2.0.8",
     "react-native-web": "~0.21.0",
+    "react-native-webrtc": "^124.0.8",
     "react-native-worklets": "0.10.0"
   },
   "devDependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -13,6 +13,7 @@
     "expo-camera": "~57.0.3",
     "expo-clipboard": "~57.0.1",
     "expo-constants": "~57.0.2",
+    "expo-dev-client": "~57.0.11",
     "expo-document-picker": "~57.0.1",
     "expo-file-system": "~57.0.1",
     "expo-font": "~57.0.0",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -186,7 +186,8 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   "Control input devices"). So **P2 (absolute input) + P4a (fluid capture) are ONE opt-in portal module.** The
   portal driver needs `gi`/`Gio` (third-party) → lives in a session-scoped helper (user, not root); the agent
   stays pure-stdlib. Consent is per-session on this box's (older) KDE (no persist checkbox); newer KDE persists.
-  Full unified spec: **`docs/memory/project_remote-desktop.md`**. gamescope Game Mode is OUT (no portal desktop).
+  Full unified spec: **`docs/memory/project_remote-desktop.md`**. gamescope Game Mode is OUT *for the portal path* —
+  BUT hardware-probed 2026-08-11 and menu-nav is DOABLE via a DIFFERENT stack (see the game-mode sub-entry below).
 - **Phased plan:**
   - **P1 (low, app-only, ship-now): Fullscreen control mode.** Screen frame as a live background +
     a RemoteView-style trackpad + button overlay + `immersive.ts` chrome-hide + landscape. Reuses the
@@ -222,18 +223,29 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
         native H264 player) into EVERY app build (bloat + iOS build surface) even for non-users.
     - gamescope continuous capture still unproven (gamescopectl is one-shot); may be desktop-session-only.
       New stream endpoint = a new "video of your screen" data flow → security pass (token-authed, LAN-only).
-- **Next step (updated 2026-08-10):** P1 SHIPPED (#433). Portal cursor + capture PROVEN; spec rewritten around
-  the portal (P2+P4a unified). **Build not started — it is now mechanical plumbing over mapped anchors:**
-  (1) `couchside-portal` helper (session mgmt + absolute-input verbs + gstreamer capture, runs as user);
-  (2) agent `/ws/screen` (mirrors `/ws/gamepad`) + additive `{t:'ma',x,y}` + `screenstream` cap (six sites);
-  (3) app `lib/screenstream.ts` MJPEG consumer + absolute-tap overlay on `app/app/desktop.tsx`;
-  (4) signed-channel install (deps + user unit) + uninstall. Capture = **gstreamer** (box ffmpeg lacks
-  pipewiregrab). `project_screenstream-module.md` is SUPERSEDED (transport detail only). Older P4b (H264 →
-  `react-native-webrtc` app-wide) stays deferred.
-  <!-- legacy note (kept per §7): P4a was earlier spec'd standalone in project_screenstream-module.md as
-  opt-in MJPEG: KDE-desktop PipeWire/wlr capture → ffmpeg MJPEG → /ws/screen, caps.screenstream gating,
-  `<Image>` decode = no app native dep; gamescope Game Mode out of scope. -->
-  Note: input isn't the bottleneck — video is.
+- **STATUS 2026-08-11 (marathon): P4a MJPEG remote-desktop SHIPPED (MERGED #435) + a big polish/keyboard/latency
+  pass ON PR #436 (branch `claude/remote-desktop-p4b-h264`, ~26 commits, pushed, NOT merged).** Desktop-mode MJPEG
+  control is now GOOD (owner "working great"). Done this pass: persistent per-session encoder (killed the stale/
+  black/laggy-reopen bug) + newest-only pump/decode + 20s zombie-socket timeout (latency solved); idle-TTL teardown;
+  CONTROL button gated to desktop mode; poller fallback (no infinite "Approve…" spin); precise ring+dot cursor;
+  landscape fullscreen "Remote Desktop" surface + double-tap window-drag; a FULL KEYBOARD (portrait iOS system kbd +
+  a landscape custom translucent floating QWERTY, both via the uinput `{t:'kt'}/{t:'k'}` path — portal keyboard
+  probed + REJECTED as dead on this kwin); install.sh refreshes the opt-in helper on agent update; Console SCREEN
+  card moved up + hold-to-edit reorder/hide ([[console-hold-to-edit-cards]]). **Full detail: auto-memory
+  [[remote-desktop-and-screen-capture]].** BEFORE MERGE: strip the TEMP `[screenstat]` latency instrumentation.
+- **P4b (H.264/WebRTC) = SHELVED:** box side (B1 helper webrtc + A0 agent /ws/webrtc relay + caps.screenstream_h264)
+  all PROVEN, BUT `react-native-webrtc@124` is INCOMPATIBLE with RN 0.86 (RTCView crash + 14s setRemoteDescription
+  → the tier is `WEBRTC_TIER_ENABLED=false`). Re-enable when the lib supports RN 0.86.
+- **📋 SUB-ENTRY — Game-mode (gamescope) MENU navigation (owner ask 2026-08-11; PROVEN doable, NOT built).** Owner
+  narrowed scope to "just menu nav, not control while a game runs." Hardware-probed on lenovodesktop (gamescope
+  1.4.10): **VIEW already works** — the agent's existing gamescopectl still-frame reads the real scanout buffer, so
+  Big-Picture menus come through non-black (~1.4fps, fine for menus). **INPUT proven** — xdotool on gamescope's
+  Xwayland `:0` moved the pointer to exact coords (routes XTEST→gamescope EIS→wlserver); libei socket present. Portal
+  is dead in game mode (irrelevant here). The fluid pipewire node (`node.name=gamescope`, ~75fps) is BLACK for
+  fullscreen apps (direct-scanout) — needs `--force-composition`; NOT needed for menu nav. **Build (small, ~1–2
+  sessions):** un-gate the CONTROL button in game mode (or a game-mode variant); view = existing still-frame; input =
+  a new allowlisted agent verb driving xdotool/libei on `:0` OR reuse the uinput gamepad for D-pad+A. **Owner UX pref:
+  game mode defaults to TOUCH (tap-to-point), Mouse as a toggle.** Detail in [[remote-desktop-and-screen-capture]].
 
 ## 📋 Planned
 

--- a/install.sh
+++ b/install.sh
@@ -580,6 +580,17 @@ case "${COUCHSIDE_PLAYER:-ask}" in
        fi ;;
 esac
 
+# Opt-in remote-desktop module (couchside-portal.py): REFRESH its helper when
+# an agent update runs, but ONLY on a box that already installed it — the base
+# install NEVER opts a box in here (that stays scripts/portal-module.sh / the
+# app's setup). This carries the module's own fixes to boxes that chose it,
+# instead of stranding them on the helper version they first installed. PRESERVE,
+# never opt in: presence of the installed helper is the whole gate.
+REFRESH_PORTAL=0
+if [ -f "$INSTALL_DIR/couchside-portal.py" ]; then
+    REFRESH_PORTAL=1
+fi
+
 SCRIPT_DIR=""
 if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]:-}" ]; then
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -598,6 +609,12 @@ if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/agent/couchsided.py" ]; then
     for f in couchside-helper.py couchside-helper.socket couchside-helper.service; do
         [ -f "$SCRIPT_DIR/agent/$f" ] && cp "$SCRIPT_DIR/agent/$f" "$WORK_DIR/$f"
     done
+    # Remote-desktop module helper + unit — ONLY when already installed (refresh).
+    if [ "$REFRESH_PORTAL" = 1 ]; then
+        for f in couchside-portal.py couchside-portal.service; do
+            [ -f "$SCRIPT_DIR/agent/$f" ] && cp "$SCRIPT_DIR/agent/$f" "$WORK_DIR/$f"
+        done
+    fi
     # Optional Couchside Player tile + its branded art, only when wanted.
     if [ "$WANT_PLAYER" = 1 ]; then
         [ -f "$SCRIPT_DIR/agent/couchside-player.sh" ] && \
@@ -642,6 +659,16 @@ else
         rm -f "$WORK_DIR/couchside-helper.py" \
               "$WORK_DIR/couchside-helper.socket" \
               "$WORK_DIR/couchside-helper.service"
+    fi
+    # Remote-desktop module helper + unit — fetched ONLY to refresh a box that
+    # already installed it. Signed like the privileged helper (gated below); a
+    # partial fetch drops the pair so a stale unit never points at a missing file.
+    if [ "$REFRESH_PORTAL" = 1 ]; then
+        curl -fsSL "${AGENT_BASE}/couchside-portal.py" -o "$WORK_DIR/couchside-portal.py" 2>/dev/null || true
+        curl -fsSL "${AGENT_BASE}/couchside-portal.service" -o "$WORK_DIR/couchside-portal.service" 2>/dev/null || true
+        if [ ! -s "$WORK_DIR/couchside-portal.py" ] || [ ! -s "$WORK_DIR/couchside-portal.service" ]; then
+            rm -f "$WORK_DIR/couchside-portal.py" "$WORK_DIR/couchside-portal.service"
+        fi
     fi
     # Optional Couchside Player tile + art, same policy. The tile is CODE, so it
     # goes through the same signature + checksum gate as everything else below;
@@ -731,6 +758,23 @@ if [ -f "$WORK_DIR/couchside-helper.py" ]; then
     python3 -m py_compile "$WORK_DIR/couchside-helper.py" \
         || die "downloaded couchside-helper.py does not compile, aborting."
 fi
+# The remote-desktop module helper gets the SAME strict rule: present-but-not in
+# the signed manifest means DON'T refresh it (leave the working one in place),
+# never install unverified. A local checkout skips the crypto, same as the agent.
+if [ -f "$WORK_DIR/couchside-portal.py" ]; then
+    if [ -f "$WORK_DIR/SHA256SUMS" ] && \
+       ! grep -qF ' couchside-portal.py' "$WORK_DIR/SHA256SUMS"; then
+        note "remote-desktop module not in the signed manifest; keeping the installed helper."
+        rm -f "$WORK_DIR"/couchside-portal.py "$WORK_DIR"/couchside-portal.service
+    elif [ ! -f "$WORK_DIR/SHA256SUMS" ] && [ -z "$SCRIPT_DIR" ]; then
+        note "remote-desktop module present but no signed manifest; keeping the installed helper."
+        rm -f "$WORK_DIR"/couchside-portal.py "$WORK_DIR"/couchside-portal.service
+    fi
+fi
+if [ -f "$WORK_DIR/couchside-portal.py" ]; then
+    python3 -m py_compile "$WORK_DIR/couchside-portal.py" \
+        || die "downloaded couchside-portal.py does not compile, aborting."
+fi
 # Secondary sanity gate: even a correctly-signed file must actually parse (a
 # git-checkout install skips the crypto above, and this catches a bad local
 # tree too). py_compile also rejects a truncated read or an HTML error page.
@@ -747,6 +791,30 @@ fi
 say "Installing daemon to $INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 install -m 0755 "$WORK_DIR/couchsided.py" "$INSTALL_DIR/couchsided.py"
+# Refresh the opt-in remote-desktop module helper (only reached when the box
+# already had it — REFRESH_PORTAL, and only if it survived the signed-manifest
+# gate above). Same install dir + __PORTAL__ unit substitution scripts/
+# portal-module.sh uses. The base install NEVER lands this file.
+if [ -f "$WORK_DIR/couchside-portal.py" ]; then
+    install -m 0755 "$WORK_DIR/couchside-portal.py" "$INSTALL_DIR/couchside-portal.py"
+    if [ -f "$WORK_DIR/couchside-portal.service" ]; then
+        mkdir -p "$HOME/.config/systemd/user"
+        sed "s#__PORTAL__#$INSTALL_DIR/couchside-portal.py#g" \
+            "$WORK_DIR/couchside-portal.service" > "$HOME/.config/systemd/user/couchside-portal.service"
+    fi
+    # Best-effort restart so the fix takes effect now. It is a USER unit; an
+    # update fired from the headless service context may have no reachable user
+    # systemd instance — then the new file simply loads on the next graphical
+    # login instead (the running old helper keeps serving until then). Never
+    # fatal: the file is already in place.
+    _cs_xrd="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+    if XDG_RUNTIME_DIR="$_cs_xrd" systemctl --user daemon-reload 2>/dev/null \
+       && XDG_RUNTIME_DIR="$_cs_xrd" systemctl --user restart couchside-portal.service 2>/dev/null; then
+        note "remote-desktop module refreshed + restarted."
+    else
+        note "remote-desktop module file refreshed; restart deferred to next login."
+    fi
+fi
 # OpenPuck firmware (optional OFFLINE seed): install ONLY if the fetched .uf2
 # matches the sha256 PINNED in this installer. It comes straight from the fork, not
 # via the signed manifest, so this pin is its integrity gate — fail closed: no

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -186,6 +186,7 @@
       "gaming",
       "player",
       "screenstream",
+      "screenstream_h264",
       "session_default",
       "steaminstall",
       "steamlink",

--- a/tests/test_protocol_parity.py
+++ b/tests/test_protocol_parity.py
@@ -257,13 +257,15 @@ def _app_caps_sites():
     fixed window -- truncation is what produced the earlier false finding."""
     api = open(os.path.join(ROOT, "app", "lib", "api.ts")).read()
     st = open(os.path.join(ROOT, "app", "lib", "settings.ts")).read()
+    # cap names may contain DIGITS (e.g. screenstream_h264); [a-z0-9_]+ or a
+    # digit-bearing name is silently unparseable and reads as a missing site.
     m = re.search(r"export type BoxCaps = \{(.*?)\n\};", api, re.S)
-    box = set(re.findall(r"^\s{2}([a-z_]+)\??:", m.group(1), re.M)) if m else set()
+    box = set(re.findall(r"^\s{2}([a-z0-9_]+)\??:", m.group(1), re.M)) if m else set()
     i = api.find("capsEqual")
-    equal = set(re.findall(r"a\.([a-z_]+) === b\.", api[i:i + 2000])) if i >= 0 else set()
+    equal = set(re.findall(r"a\.([a-z0-9_]+) === b\.", api[i:i + 2000])) if i >= 0 else set()
     j = st.find("normalizeCaps")
     k = st.find("\n}", j)
-    norm = set(re.findall(r"bool\('([a-z_]+)'\)", st[j:k])) if j >= 0 else set()
+    norm = set(re.findall(r"bool\('([a-z0-9_]+)'\)", st[j:k])) if j >= 0 else set()
     return {"BoxCaps": box, "normalizeCaps": norm, "capsEqual": equal}
 
 

--- a/tests/test_webrtc_relay.py
+++ b/tests/test_webrtc_relay.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Agent side of the P4b H.264/WebRTC signaling relay (/ws/webrtc).
+
+Run: python3 tests/test_webrtc_relay.py
+
+Pins the §6 requirements for the new surface, all pure-stdlib (no box, no gi):
+  1. screenstream_h264_available(): reachable + ok + h264 -> True; ok but NO
+     h264 -> False; absent -> False (degrade closed).
+  2. _portal_webrtc(): PRESENT helper -> a socket carrying the `webrtc` verb;
+     ABSENT -> None (the "fall back to MJPEG/poller" case).
+  3. _webrtc_app_msg(): the app->box allowlist boundary (§3). Only answer/ice/bye
+     with well-typed fields forward; unknown types, malformed args, and extra
+     client fields are DROPPED/stripped -- no arbitrary client JSON reaches the
+     helper (and thus never reaches webrtcbin/gst).
+  4. /ws/webrtc: auth FAILURE (bad/absent token -> 401, no session); bad Upgrade
+     -> 400; an UNKNOWN ?profile is replaced by the DEFAULT (never a client
+     string reaches the helper); a KNOWN profile passes through; and over the
+     concurrency cap the socket is closed with NO portal session opened.
+"""
+import importlib.util
+import json
+import os
+import socket
+import sys
+import tempfile
+import threading
+from urllib.parse import urlparse
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def fake_portal(replies):
+    """A one-shot portal helper: serves len(replies) JSON connections then stops.
+    Returns (socket_path, seen_requests)."""
+    d = tempfile.mkdtemp()
+    path = os.path.join(d, "portal.sock")
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    srv.bind(path)
+    srv.listen(4)
+    seen = []
+
+    def serve():
+        for reply in replies:
+            try:
+                conn, _ = srv.accept()
+            except OSError:
+                return
+            buf = b""
+            while b"\n" not in buf:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+            try:
+                seen.append(json.loads(buf.split(b"\n", 1)[0].decode()))
+            except ValueError:
+                seen.append(None)
+            conn.sendall(json.dumps(reply).encode() + b"\n")
+            conn.close()
+
+    threading.Thread(target=serve, daemon=True).start()
+    return path, seen
+
+
+saved_portal_socket = cs.PORTAL_SOCKET
+try:
+    # --- 1. screenstream_h264_available() -----------------------------------
+    print("1. screenstream_h264_available: needs ok AND h264")
+    path, _ = fake_portal([{"ok": True, "h264": True, "h264_profiles": []}])
+    cs.PORTAL_SOCKET = path
+    check("reachable + h264 -> True", cs.screenstream_h264_available(), True)
+    path, _ = fake_portal([{"ok": True, "h264": False}])
+    cs.PORTAL_SOCKET = path
+    check("ok but NO h264 -> False (honest cap)", cs.screenstream_h264_available(), False)
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    check("absent helper -> False (degrade closed)", cs.screenstream_h264_available(), False)
+
+    # --- 2. _portal_webrtc() ------------------------------------------------
+    print()
+    print("2. _portal_webrtc: sends the `webrtc` verb, absent -> None")
+    path, seen = fake_portal([{"ignored": True}])   # helper never JSON-replies here
+    cs.PORTAL_SOCKET = path
+    s = cs._portal_webrtc("720p60")
+    check("present helper -> a socket", s is not None, True)
+    if s is not None:
+        # give the fake helper a moment to read the verb line
+        s.settimeout(1.0)
+        for _ in range(50):
+            if seen:
+                break
+            threading.Event().wait(0.02)
+        check("helper saw verb=webrtc", seen and seen[0].get("verb"), "webrtc")
+        check("helper saw the profile", seen and seen[0].get("arg"), {"profile": "720p60"})
+        try:
+            s.close()
+        except OSError:
+            pass
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    check("absent helper -> None", cs._portal_webrtc("720p60"), None)
+
+    # --- 3. _webrtc_app_msg(): the app->box allowlist boundary (§3) ----------
+    print()
+    print("3. _webrtc_app_msg: allowlist + field discipline")
+    check("answer with sdp forwards {t,sdp} only",
+          cs._webrtc_app_msg({"t": "answer", "sdp": "v=0...", "evil": 1}),
+          {"t": "answer", "sdp": "v=0..."})
+    check("ice with candidate+mline forwards known fields",
+          cs._webrtc_app_msg({"t": "ice", "candidate": "cand", "sdpMLineIndex": 0, "x": 9}),
+          {"t": "ice", "candidate": "cand", "sdpMLineIndex": 0})
+    check("bye forwards {t:bye}", cs._webrtc_app_msg({"t": "bye"}), {"t": "bye"})
+    check("unknown type dropped", cs._webrtc_app_msg({"t": "offer", "sdp": "x"}), None)
+    check("hello (box-drives-nego) dropped", cs._webrtc_app_msg({"t": "hello"}), None)
+    check("answer without sdp dropped", cs._webrtc_app_msg({"t": "answer"}), None)
+    check("answer with non-string sdp dropped",
+          cs._webrtc_app_msg({"t": "answer", "sdp": 123}), None)
+    check("ice without candidate dropped",
+          cs._webrtc_app_msg({"t": "ice", "sdpMLineIndex": 0}), None)
+    check("ice with non-int mline dropped",
+          cs._webrtc_app_msg({"t": "ice", "candidate": "c", "sdpMLineIndex": "0"}), None)
+    check("non-dict dropped", cs._webrtc_app_msg("bye"), None)
+    check("missing t dropped", cs._webrtc_app_msg({"sdp": "x"}), None)
+
+    # --- 4. /ws/webrtc auth + profile allowlist + cap ------------------------
+    print()
+    print("4. /ws/webrtc: auth failure + profile allowlist + concurrency cap")
+
+    class _WSStub:
+        token = "s3cr3t"
+        close_connection = False
+
+        def __init__(self, headers):
+            self.headers = headers
+            self.sent = None
+            self.session_profile = "UNSET"
+            self._sendall = []
+
+        _handle_webrtc_ws = cs.Handler._handle_webrtc_ws
+        _webrtc_relay_session = cs.Handler._webrtc_relay_session  # real (cap test)
+
+        def _send(self, code, body, started, extra_headers=None):
+            self.sent = code
+
+        def _log(self, code, started):
+            pass
+
+        class _Conn:
+            def __init__(self, out):
+                self.out = out
+
+            def sendall(self, b):
+                self.out.append(b)
+
+        def _relay_stub(self, profile):
+            self.session_profile = profile
+
+    def ws_stub(headers, stub_relay=True):
+        st = _WSStub(headers)
+        st.connection = _WSStub._Conn(st._sendall)
+        if stub_relay:
+            st._webrtc_relay_session = st._relay_stub
+        return st
+
+    # (a) absent token -> 401, no session
+    st = ws_stub({})
+    st._handle_webrtc_ws(urlparse("/ws/webrtc"), 0.0)
+    check("no token -> 401", st.sent, 401)
+    check("no token -> no session", st.session_profile, "UNSET")
+
+    # (b) wrong token -> 401
+    st = ws_stub({})
+    st._handle_webrtc_ws(urlparse("/ws/webrtc?token=WRONG"), 0.0)
+    check("wrong token -> 401", st.sent, 401)
+
+    # (c) right token, no Upgrade header -> 400
+    st = ws_stub({})
+    st._handle_webrtc_ws(urlparse("/ws/webrtc?token=s3cr3t"), 0.0)
+    check("valid token, no upgrade -> 400", st.sent, 400)
+
+    # (d) valid handshake + BOGUS profile -> the DEFAULT, never the client string
+    st = ws_stub({"Sec-WebSocket-Key": "dGhlIHNhbXBsZQ==", "Upgrade": "websocket"})
+    st._handle_webrtc_ws(urlparse("/ws/webrtc?token=s3cr3t&profile=rm -rf"), 0.0)
+    check("bogus profile replaced by default", st.session_profile, cs._WEBRTC_DEFAULT)
+    check("default profile is in the allowlist",
+          cs._WEBRTC_DEFAULT in cs._WEBRTC_PROFILES, True)
+
+    # (e) valid handshake + KNOWN profile -> passed through
+    st = ws_stub({"Sec-WebSocket-Key": "dGhlIHNhbXBsZQ==", "Upgrade": "websocket"})
+    st._handle_webrtc_ws(urlparse("/ws/webrtc?token=s3cr3t&profile=1080p60"), 0.0)
+    check("known profile passed through", st.session_profile, "1080p60")
+
+    # (f) over the concurrency cap -> the socket is CLOSED and NO session opens.
+    #     Exhaust the sema, point PORTAL at a recorder, run the REAL relay.
+    portal_calls = []
+    real_portal_call = cs._portal_call
+    cs._portal_call = lambda verb, arg=None, timeout=10: portal_calls.append(verb)
+    acquired = cs._webrtc_sema.acquire(blocking=False)
+    try:
+        st = ws_stub({}, stub_relay=False)          # real _webrtc_relay_session
+        st._webrtc_relay_session(cs._WEBRTC_DEFAULT)
+        check("over cap -> nothing sent to the portal (no ensure)", portal_calls, [])
+        check("over cap -> a WS frame was sent (CLOSE, app falls back)",
+              len(st._sendall) >= 1, True)
+    finally:
+        if acquired:
+            cs._webrtc_sema.release()
+        cs._portal_call = real_portal_call
+
+finally:
+    cs.PORTAL_SOCKET = saved_portal_socket
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all webrtc-relay tests passed")


### PR DESCRIPTION
Remote-desktop P4b work + the landscape "Remote Desktop" surface + this session's polish and bug fixes. The H.264/WebRTC tier is fully scaffolded (box + app) but **DISABLED** — react-native-webrtc@124 is broken on RN 0.86 (RTCView crash, 10–14s setRemoteDescription then abort). The live product path is **MJPEG /ws/screen**.

## What's in here
- **P4b box side (B1 + A0):** helper `webrtc` verb (in-process webrtcbin, H264-only, libnice-gated) + agent `/ws/webrtc` dumb relay + `caps.screenstream_h264` (all six sites) + `tests/test_webrtc_relay.py`. Proven box→Chrome ~70–92fps; kept for when the app lib catches up.
- **P0 app WebRTC tier:** platform-split so react-native-webrtc stays OUT of the web bundle; **disabled** behind `WEBRTC_TIER_ENABLED=false`.
- **Landscape fullscreen "Remote Desktop" surface** (`DesktopFullscreen.tsx`): whole screen is the input; Mouse (local cursor + absolute portal) / Touch (tap-to-point); floating toolbar.
- **Polish:** hardware `vajpegenc` + coalesced cursor sends (latency); precise ring+dot cursor (hotspot == click point); native `buffer` base64 (faster per-frame).
- **CONTROL button gated to desktop-mode sessions** — hidden in gamescope Game Mode (no portal RemoteDesktop there). App-only; consumes the live `session` field `/api/screen` already returns.
- **Reopen-wedge fixes (this session's headline):**
  - *Box/helper:* serialize streams — the portal pipewire node allows ONE gst consumer; a new stream now **preempts** the stale one (an abrupt background left the old gst alive → the reopened stream failed "Buffer allocation failed"). Verified on hardware.
  - *App:* still-frame **poller fallback** so a silent fluid stream can't spin "Approve…" forever — the desktop stays visible (poller uses spectacle/gamescopectl, not the portal), and fluid takes back over the instant it delivers.
  - *Earlier:* reuse ONE PipeWire remote per session; stable stream-hook deps (was recreating the peer connection per poll and crashing).

## Verified
- Agents compile; `test_portal_module`, `test_webrtc_relay`, `test_protocol_parity` pass; full app `tsc` clean.
- CONTROL gate: web harness, both states (session mock↔gamescope) — shown vs hidden.
- Poller fallback: web harness (`/ws` unproxied = the silent-stream case) — poller `<img>` renders, spinner gone.
- Stream preempt: hardware overlap test on lenovodesktop — B preempts A, one gst, B streams a valid JPEG, A EOFs. Deployed to the box + re-tested green.
- On-device (earlier, build 171 dev-client + Metro): MJPEG stream + tap-to-point + landscape cursor work; owner confirmed "remote control works ok" and, post-latency-pass, "way better responsiveness."

## NOT verified
- WebRTC/H.264 tier on-device (disabled — RN 0.86 gap).
- CONTROL-hidden on a REAL desktop↔game switch (harness-proven only; no gamescope box on hand).
- Helper preempt has no CI unit test (the helper binds gi/the session bus at import → not importable in CI); hardware-verified per the testing policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)