### PR TITLE
release(agent): 2.9.78 — SteamOS Game Mode fix + remote-desktop polish

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,20 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.78
+
+**"Switch to Game Mode" works on the newest SteamOS.** On a Steam Machine, a
+Legion Go S, or any box running a recent SteamOS build, the Couch button now
+hands the box to Game Mode correctly instead of falling back to Big Picture (or
+failing with an "Unable to open a connection to X" error). Your box's Game Mode
+session is now recognised by the name current SteamOS ships it under.
+
+**Smoother remote desktop (opt-in module).** For boxes with the remote-desktop
+module installed, controlling the desktop from your phone is markedly more fluid:
+reopening the view is instant, the picture stays low-latency under motion,
+there's an on-screen keyboard, and a full-screen landscape "Remote Desktop" mode.
+Boxes without the module are unaffected.
+
 ## 2.9.77
 
 **OpenPuck firmware now comes straight from the source.** Flashing an OpenPuck

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.77"
+VERSION = "2.9.78"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 


### PR DESCRIPTION
Bumps the agent version so boxes actually pull the fix.

The published agent (2.9.77, on release v2.9.43) predated:
- **#432** — couch-mode/Game Mode detection for the current SteamOS session name (`gamescope-wayland.desktop`). Confirmed on a real Steam Machine + verified fixing `couchmode_available()` False→True.
- **#435/#436** — the opt-in remote-desktop portal module + fluid MJPEG/keyboard/landscape polish.

A same-version republish reaches nobody (boxes compare `agent-version.txt`), so 2.9.77 → **2.9.78**. Changelog section added (release-agent.sh publishes it as the update card's "What's new").

No code change beyond the VERSION string + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)