### PR TITLE
Remote desktop: game-mode (Big Picture) menu nav + portrait cursor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,14 @@ jobs:
       - name: Unit tests (remote-desktop WebRTC relay)
         run: python3 tests/test_webrtc_relay.py
 
+      # Game-mode (gamescope / Big Picture) pointer input: the {t:'gm'} verb.
+      # The portal is absent in Game Mode, so absolute menu nav rides an xdotool
+      # ARGV LIST. Same security class as {t:'ma'}: holder gate + range-validated
+      # coords + a looked-up button (the client string never reaches argv) +
+      # degrade-closed when xdotool / a live gamescope session is missing.
+      - name: Unit tests (game-mode pointer input)
+        run: python3 tests/test_gamemode_input.py
+
       # Who is OFFERED Couch Mode. The gate used to grep /etc/os-release for
       # "steamos"/"bazzite", so a CachyOS deckify box with every tool, both
       # sessions and a connected panel was refused by its NAME — hiding the

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -11840,6 +11840,82 @@ def _screen_env(live=None):
     return env
 
 
+# Game-mode (gamescope) pointer button -> the xdotool button NUMBER. A client
+# names one of these keys; anything else falls back to left. LOOKED UP, never
+# interpolated -- the §3 analogue of Handler._PORTAL_BTNS.
+_XDO_BTN = {"l": "1", "m": "2", "r": "3"}
+
+# gamescope's Xwayland geometry, cached briefly: plugging in a TV re-probes, but
+# a stream of taps must not each spawn xdotool just to read the display size.
+_GS_GEOM = {"wh": None, "at": 0.0}
+_GS_GEOM_TTL_S = 10.0
+
+
+def _gamescope_geometry():
+    """(width, height) of gamescope's Xwayland via `xdotool getdisplaygeometry`,
+    or None. Cached ~10s. Degrades closed (§3.7): absent tool / non-zero exit /
+    unparseable output / timeout all return None, and the caller then does nothing."""
+    now = time.monotonic()
+    if _GS_GEOM["wh"] is not None and now - _GS_GEOM["at"] < _GS_GEOM_TTL_S:
+        return _GS_GEOM["wh"]
+    if shutil.which("xdotool") is None:
+        return None
+    try:
+        r = subprocess.run(["xdotool", "getdisplaygeometry"],
+                           env=_screen_env(_screen_live()), timeout=2,
+                           capture_output=True, text=True)
+    except Exception:
+        return None
+    if r.returncode != 0:
+        return None
+    try:
+        w, h = (int(v) for v in r.stdout.split())
+    except (ValueError, TypeError):
+        return None
+    if w <= 0 or h <= 0:
+        return None
+    _GS_GEOM["wh"] = (w, h)
+    _GS_GEOM["at"] = now
+    return (w, h)
+
+
+def _gamescope_pointer(nx, ny, click=False, btn_key=None):
+    """Move gamescope's Xwayland pointer to normalized (nx,ny) in 0..1 and
+    optionally click, via an xdotool ARGV LIST (never a shell string). The
+    xdg-desktop-portal is absent in Game Mode, so this is how the phone drives
+    Big Picture menus (proven on hardware 2026-08-11: `xdotool mousemove` on
+    DISPLAY=:0 routes XTEST -> gamescope EIS -> wlserver).
+
+    Degrades closed at every step: no xdotool, no live gamescope socket, or
+    unreadable geometry -> nothing runs, the session stays alive.
+
+    §3: the binary and every subcommand ('mousemove'/'click') are agent
+    CONSTANTS; the only client inputs are (nx,ny) -- already range-checked by the
+    caller, re-clamped here to integer pixels inside the display, emitted as
+    pure-digit str() tokens -- and btn_key, LOOKED UP in _XDO_BTN (unknown ->
+    default '1', the client string never reaches argv). shell=False throughout."""
+    if shutil.which("xdotool") is None:
+        return
+    # Defense in depth: a stray {t:'gm'} in desktop mode is a clean no-op (desktop
+    # drives the portal 'ma'/'mbp' path). Only act when a gamescope session lives.
+    if not any(s.startswith("gamescope-") for s in _wayland_display_sockets()):
+        return
+    geo = _gamescope_geometry()
+    if not geo:
+        return
+    w, h = geo
+    px = min(max(int(nx * w), 0), w - 1)
+    py = min(max(int(ny * h), 0), h - 1)
+    argv = ["xdotool", "mousemove", str(px), str(py)]
+    if click:
+        argv += ["click", _XDO_BTN.get(btn_key, "1")]
+    try:
+        subprocess.run(argv, env=_screen_env(_screen_live()), timeout=2,
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        return
+
+
 def _image_complete(path):
     """True when a captured image is FULLY written: >=100 bytes and carrying its
     format's end marker -- PNG's IEND chunk or JPEG's EOI (FFD9).
@@ -19267,6 +19343,21 @@ class Handler(BaseHTTPRequestHandler):
             return
         _portal_call("button", {"button": name, "state": v}, timeout=5)
 
+    def _handle_gamemode_abs(self, entry, msg):
+        """{t:'gm',x,y[,click,k]} -> gamescope Xwayland pointer (x,y normalized
+        0..1), optional click at a looked-up button. Range-validates x,y EXACTLY
+        like _handle_portal_abs; _gamescope_pointer degrades closed if xdotool or a
+        live gamescope session is missing. Best-effort: bad input is dropped, the
+        session stays alive. This is the Game-Mode counterpart of {t:'ma'} — the
+        portal is absent in gamescope, so Big Picture menu nav rides xdotool."""
+        x, y = msg.get("x"), msg.get("y")
+        if not (isinstance(x, (int, float)) and isinstance(y, (int, float))):
+            return
+        if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+            return
+        _gamescope_pointer(float(x), float(y),
+                           click=bool(msg.get("click")), btn_key=msg.get("k"))
+
     # Control frames (holder handoff) — handled regardless of hold state.
     _CONTROL_TYPES = frozenset(("grant", "deny", "request", "force"))
 
@@ -19353,6 +19444,13 @@ class Handler(BaseHTTPRequestHandler):
             return True
         if t == "mbp":
             self._handle_portal_btn(entry, msg)
+            return True
+        if t == "gm":
+            # Game-mode absolute pointer (Big Picture / gamescope menu nav). The
+            # portal is absent in Game Mode, so this drives gamescope's Xwayland
+            # via xdotool instead. Additive + tolerant like 'ma': bad coords or an
+            # absent tool are a no-op, never closing the session.
+            self._handle_gamemode_abs(entry, msg)
             return True
         if t == "kt":
             # Text passthrough is handled here, BEFORE the decode table, so it

--- a/app/app/desktop.tsx
+++ b/app/app/desktop.tsx
@@ -28,10 +28,10 @@
  * keeps the relative-mouse model honest (tap-a-spot-on-the-frame is P2/absolute).
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { Stack, router } from 'expo-router';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  ActivityIndicator, Image, Pressable, StyleSheet, Text, View,
+  ActivityIndicator, Animated, Image, Pressable, StyleSheet, Text, View,
   useWindowDimensions, type GestureResponderEvent,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -73,6 +73,13 @@ export default function DesktopControlScreen() {
   const insets = useSafeAreaInsets();
   const { settings, ready } = useSettings();
   const configured = settings.host.trim().length > 0;
+  // GAME MODE (gamescope / Big Picture): the xdg-desktop-portal is absent, so
+  // input rides the {t:'gm'} xdotool path and the view stays on the still-frame
+  // poller. `session` is a snapshot passed by the Console card at navigation time
+  // (a mid-control desktop<->game flip just needs a reopen). Consumed only as a
+  // boolean flag — never interpolated into anything.
+  const { session } = useLocalSearchParams<{ session?: string }>();
+  const gameMode = session === 'gamescope';
   // THREE tiers, best-first (all hooks run — hooks rules — only the active one
   // connects):
   //   1. WebRTC H.264 (fluid, 30–60fps): app built WITH react-native-webrtc AND
@@ -83,11 +90,19 @@ export default function DesktopControlScreen() {
   //   3. P1 still-frame poller (~1.4fps): always available.
   // Tiers 1 & 2 both get tap-to-point (the portal's absolute pointer).
   const [webrtcGaveUp, setWebrtcGaveUp] = useState(false);
+  // The fluid (portal) tiers are OFF in game mode — the portal doesn't exist
+  // there, so gating them off keeps the view on the poller and avoids a dead
+  // "Approve…" spinner.
   const webrtcMode =
-    WEBRTC_TIER_ENABLED && webrtcSupported
+    !gameMode && WEBRTC_TIER_ENABLED && webrtcSupported
     && settings.caps?.screenstream_h264 === true && !webrtcGaveUp;
-  const streamMode = !webrtcMode && settings.caps?.screenstream === true;
+  const streamMode = !gameMode && !webrtcMode && settings.caps?.screenstream === true;
   const fluidMode = webrtcMode || streamMode;
+  // The absolute-pointer flag both the portal (fluid) and game-mode (xdotool)
+  // paths share: tap-to-point + the local cursor render, and the trackpad drives
+  // an ABSOLUTE cursor rather than a relative one. Which wire verb it uses is
+  // chosen per-send by `gameMode` ({t:'gm'} vs {t:'ma'}).
+  const absoluteInput = fluidMode || gameMode;
   const live = ready && configured;
   const streamed = useScreenStream(settings, live && streamMode);
   const webrtc = useWebRtcStream(settings, live && webrtcMode);
@@ -172,38 +187,113 @@ export default function DesktopControlScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ready, configured]);
 
-  const leftClick = useCallback(() => {
+  // ── Portrait local cursor (absolute mode: portal OR game) ──────────────────
+  // The frame carries the box's own (tiny) cursor, but portrait otherwise draws
+  // nothing — so next to landscape's ring+dot it read as "no cursor". Give
+  // portrait the same local sprite: the trackpad drives a cursor inside the 16:9
+  // stage and sends an ABSOLUTE position, so the sprite is visible AND the box
+  // cursor locks to it. The wire verb is portal {t:'ma'} on desktop, xdotool
+  // {t:'gm'} in game mode. Relative mode (no portal, no game) keeps the plain
+  // trackpad — it never knows the box's absolute position, so a sprite would drift.
+  const SEND_MS = 25; // coalesce abs-move sends to ~40/s (box round-trip cap)
+  const stageSize = useRef({ w: 0, h: 0 });
+  const cur = useRef({ x: 0, y: 0 });                 // stage px
+  const curXY = useRef(new Animated.ValueXY({ x: 0, y: 0 })).current;
+  const curReady = useRef(false);
+  const sendAbs = useRef<{ x: number; y: number } | null>(null);
+  const sendAbsAt = useRef(0);
+  const sendAbsTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushAbs = () => {
+    sendAbsTimer.current = null;
+    const p = sendAbs.current;
+    if (!p) return;
+    sendAbs.current = null;
+    sendAbsAt.current = Date.now();
+    if (gameMode) client.sendGameMove(p.x, p.y);
+    else client.sendMouseAbs(p.x, p.y);
+  };
+  const queueAbs = (nx: number, ny: number) => {
+    sendAbs.current = { x: nx, y: ny };
+    const dt = Date.now() - sendAbsAt.current;
+    if (dt >= SEND_MS) { flushAbs(); return; }
+    if (sendAbsTimer.current == null) sendAbsTimer.current = setTimeout(flushAbs, SEND_MS - dt);
+  };
+  // Move the sprite to a stage-px point; `send` also pushes its normalized position.
+  const cursorToPx = (px: number, py: number, send = true) => {
+    const { w, h } = stageSize.current;
+    if (w <= 0 || h <= 0) return;
+    const x = Math.max(0, Math.min(w, px));
+    const y = Math.max(0, Math.min(h, py));
+    cur.current = { x, y };
+    curXY.setValue({ x, y });
+    if (send) queueAbs(x / w, y / h);
+  };
+  useEffect(() => () => {
+    if (sendAbsTimer.current) clearTimeout(sendAbsTimer.current);
+  }, []);
+
+  // In fluid mode a click rides the PORTAL button (at the portal's absolute
+  // position, where the sprite is); in game mode it is an atomic xdotool tap at
+  // the sprite; relative mode uses the uinput button.
+  const clickAt = useCallback((btn: 'l' | 'r') => {
     hapticLight();
-    client.sendMouseButton('l', 1);
-    setTimeout(() => client.sendMouseButton('l', 0), 40);
-  }, [client]);
-  const rightClick = useCallback(() => {
-    hapticLight();
-    client.sendMouseButton('r', 1);
-    setTimeout(() => client.sendMouseButton('r', 0), 40);
-  }, [client]);
+    if (gameMode) {
+      // Game mode has no separate button down/up — a click is a move+click at the
+      // current cursor. Only left is meaningful for Big Picture menus.
+      const { w, h } = stageSize.current;
+      if (btn === 'l' && w > 0 && h > 0) {
+        client.tapGame(cur.current.x / w, cur.current.y / h);
+      }
+    } else if (fluidMode) {
+      client.sendMouseButtonPortal(btn, 1);
+      setTimeout(() => client.sendMouseButtonPortal(btn, 0), 40);
+    } else {
+      client.sendMouseButton(btn, 1);
+      setTimeout(() => client.sendMouseButton(btn, 0), 40);
+    }
+  }, [client, fluidMode, gameMode]);
+  const leftClick = useCallback(() => clickAt('l'), [clickAt]);
+  const rightClick = useCallback(() => clickAt('r'), [clickAt]);
 
   const pad = useTrackpad({
-    onMove: (dx, dy) => client.sendMouseMove(dx, dy),
+    onMove: (dx, dy) => {
+      if (absoluteInput) cursorToPx(cur.current.x + dx, cur.current.y + dy);
+      else client.sendMouseMove(dx, dy);
+    },
     onLeftClick: leftClick,
     onRightClick: rightClick,
     onScroll: (notches) => client.sendWheel(notches),
-    onDragStart: () => { hapticLight(); client.sendMouseButton('l', 1); },
-    onDragEnd: () => client.sendMouseButton('l', 0),
+    onDragStart: () => {
+      hapticLight();
+      // Game mode has no held-button drag (the {t:'gm'} verb is an atomic
+      // move+click), so a drag there just moves the cursor — no button hold.
+      if (gameMode) return;
+      if (fluidMode) client.sendMouseButtonPortal('l', 1);
+      else client.sendMouseButton('l', 1);
+    },
+    onDragEnd: () => {
+      if (gameMode) return;
+      if (fluidMode) client.sendMouseButtonPortal('l', 0);
+      else client.sendMouseButton('l', 0);
+    },
   });
 
   // Tap-to-point (P2, fluid mode only): the tap's location within the frame maps
   // to a normalized 0..1 coordinate for the portal's absolute pointer. The stage
   // is 16:9 and the stream is 16:9, so there is no `contain` letterbox — the map
-  // is just location / measured size. (A non-16:9 source would need letterbox math.)
-  const stageSize = useRef({ w: 0, h: 0 });
+  // is just location / measured size. The local sprite jumps to the tap too, so
+  // it stays where the click lands.
   const onTapFrame = useCallback((e: GestureResponderEvent) => {
     const { w, h } = stageSize.current;
     if (w <= 0 || h <= 0) return;
     hapticLight();
-    // q01 on the client clamps to 0..1, so an edge tap past the bounds is fine.
-    client.tapAbs(e.nativeEvent.locationX / w, e.nativeEvent.locationY / h);
-  }, [client]);
+    const px = e.nativeEvent.locationX;
+    const py = e.nativeEvent.locationY;
+    cursorToPx(px, py, false);          // sprite jumps; the tap does the send + click
+    if (gameMode) client.tapGame(px / w, py / h);
+    else client.tapAbs(px / w, py / h); // q01 clamps to 0..1 (an edge tap is fine)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, gameMode]);
 
   const exit = useCallback(() => { hapticMedium(); router.back(); }, []);
 
@@ -221,7 +311,9 @@ export default function DesktopControlScreen() {
           status={status}
           failed={failed}
           configured={configured}
-          absoluteInput={fluidMode}
+          absoluteInput={absoluteInput}
+          pointerChannel={gameMode ? 'game' : 'portal'}
+          preferTouch={gameMode}
           onExit={exit}
           keyboard={kb}
         />
@@ -252,14 +344,30 @@ export default function DesktopControlScreen() {
         )}
         {/* Tap-to-point overlay (fluid tiers only): tapping the frame moves the
             real cursor there and clicks, via the portal's absolute pointer. */}
-        {fluidMode && hasVisual && (
+        {absoluteInput && hasVisual && (
           <Pressable
             style={StyleSheet.absoluteFill}
             onLayout={(e) => {
-              stageSize.current = { w: e.nativeEvent.layout.width, h: e.nativeEvent.layout.height };
+              const { width, height } = e.nativeEvent.layout;
+              stageSize.current = { w: width, h: height };
+              if (!curReady.current && width > 0 && height > 0) {
+                curReady.current = true;
+                cur.current = { x: width / 2, y: height / 2 };
+                curXY.setValue({ x: width / 2, y: height / 2 });
+              }
             }}
             onPress={onTapFrame}
             accessibilityLabel="Tap the screen to click there" />
+        )}
+        {/* Local cursor sprite (fluid mode): ring + center dot; the DOT is the
+            exact click point — same as the landscape surface. */}
+        {absoluteInput && hasVisual && (
+          <Animated.View
+            pointerEvents="none"
+            style={[styles.cursor, { transform: curXY.getTranslateTransform() }]}>
+            <View style={styles.cursorRing} />
+            <View style={styles.cursorDot} />
+          </Animated.View>
         )}
         {status !== 'connected' && (
           <View style={[styles.pill, { top: 6 }]} pointerEvents="none">
@@ -279,7 +387,7 @@ export default function DesktopControlScreen() {
       <View style={styles.trackpad} {...pad.panHandlers} accessibilityLabel="Desktop trackpad">
         <Ionicons name="move-outline" size={22} color={t.textFaint} />
         <Text style={styles.trackpadHint}>
-          {fluidMode
+          {absoluteInput
             ? 'tap the screen to point · drag here to move · two-finger scroll'
             : 'drag to move · tap to click · two-finger scroll'}
         </Text>
@@ -287,11 +395,32 @@ export default function DesktopControlScreen() {
 
       <View style={[styles.bar, { paddingBottom: insets.bottom + 8 }]}>
         <BarBtn t={t} styles={styles} icon="close" label="Exit" onPress={exit} />
-        <BarBtn t={t} styles={styles} icon="radio-button-on" label="Left" onPress={leftClick} />
-        <BarBtn t={t} styles={styles} icon="ellipsis-horizontal" label="Right" onPress={rightClick} />
-        <BarBtn t={t} styles={styles} icon="apps" label="Start"
-          onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
-        <BarBtn t={t} styles={styles} icon="keypad-outline" label="Keys" onPress={kb.toggle} />
+        {gameMode ? (
+          // Game Mode: the D-pad + Select ride the KEYBOARD path Steam Big Picture
+          // reads (arrows/enter). The uinput MOUSE is not grabbed in Game Mode, so
+          // this is the proven fallback alongside tap-to-point. The phone keyboard
+          // still auto-raises on a Steam text field via the {t:'osk'} subscription.
+          <>
+            <BarBtn t={t} styles={styles} icon="chevron-back" label="Left"
+              onPress={() => { hapticLight(); client.sendKey('left'); }} />
+            <BarBtn t={t} styles={styles} icon="chevron-up" label="Up"
+              onPress={() => { hapticLight(); client.sendKey('up'); }} />
+            <BarBtn t={t} styles={styles} icon="chevron-down" label="Down"
+              onPress={() => { hapticLight(); client.sendKey('down'); }} />
+            <BarBtn t={t} styles={styles} icon="chevron-forward" label="Right"
+              onPress={() => { hapticLight(); client.sendKey('right'); }} />
+            <BarBtn t={t} styles={styles} icon="checkmark-circle" label="Select"
+              onPress={() => { hapticLight(); client.sendKey('enter'); }} />
+          </>
+        ) : (
+          <>
+            <BarBtn t={t} styles={styles} icon="radio-button-on" label="Left" onPress={leftClick} />
+            <BarBtn t={t} styles={styles} icon="ellipsis-horizontal" label="Right" onPress={rightClick} />
+            <BarBtn t={t} styles={styles} icon="apps" label="Start"
+              onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+            <BarBtn t={t} styles={styles} icon="keypad-outline" label="Keys" onPress={kb.toggle} />
+          </>
+        )}
         <BarBtn t={t} styles={styles} icon="arrow-undo" label="Esc"
           onPress={() => { hapticLight(); client.sendKey('esc'); }} />
       </View>
@@ -342,4 +471,17 @@ const makeStyles = (t: Palette) =>
     },
     barBtn: { alignItems: 'center', justifyContent: 'center', gap: 3, paddingHorizontal: 10, paddingVertical: 4, minWidth: 56 },
     barLabel: { color: t.textDim, fontSize: 11, fontWeight: '600' },
+    cursor: {
+      position: 'absolute', left: -11, top: -11, width: 22, height: 22,
+      alignItems: 'center', justifyContent: 'center',
+    },
+    cursorRing: {
+      position: 'absolute', width: 18, height: 18, borderRadius: 9,
+      borderWidth: 1.5, borderColor: 'rgba(255,255,255,0.95)',
+      shadowColor: '#000', shadowOpacity: 0.85, shadowRadius: 2,
+    },
+    cursorDot: {
+      width: 4, height: 4, borderRadius: 2, backgroundColor: '#fff',
+      shadowColor: '#000', shadowOpacity: 0.9, shadowRadius: 1.5,
+    },
   });

--- a/app/components/DesktopFullscreen.tsx
+++ b/app/components/DesktopFullscreen.tsx
@@ -41,8 +41,8 @@ const DOUBLE_TAP_MS = 300;
 const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
 
 export function DesktopFullscreen({
-  client, streamURL, frame, status, failed, configured, absoluteInput, onExit,
-  keyboard,
+  client, streamURL, frame, status, failed, configured, absoluteInput,
+  pointerChannel = 'portal', preferTouch = false, onExit, keyboard,
 }: {
   client: GamepadClient;
   streamURL: string | null;
@@ -51,6 +51,11 @@ export function DesktopFullscreen({
   failed: boolean;
   configured: boolean;
   absoluteInput: boolean;
+  /** Which absolute-pointer wire path to drive: 'portal' ({t:'ma'}/{t:'mbp'}) on
+   *  the desktop, 'game' ({t:'gm'}, xdotool) in gamescope Game Mode. */
+  pointerChannel?: 'portal' | 'game';
+  /** Default the touch mode to direct tap-to-point (the Game Mode default). */
+  preferTouch?: boolean;
   onExit: () => void;
   /** From useDesktopKeyboard (owned by the parent so one instance serves both
    *  orientations): toolbar Keys button calls toggle; bar renders here. */
@@ -59,7 +64,7 @@ export function DesktopFullscreen({
   const t = useTheme();
   const { width, height } = useWindowDimensions();
   const insets = useSafeAreaInsets();
-  const [mode, setMode] = useState<Mode>(absoluteInput ? 'mouse' : 'mouse');
+  const [mode, setMode] = useState<Mode>(preferTouch ? 'touch' : 'mouse');
   const [barOpen, setBarOpen] = useState(true);
 
   // 16:9 content rect, contain-fit + centered (letterbox on the wider phone).
@@ -88,7 +93,8 @@ export function DesktopFullscreen({
     if (!p) return;
     send.current = null;
     sendAt.current = Date.now();
-    client.sendMouseAbs(p.x, p.y);
+    if (pointerChannel === 'game') client.sendGameMove(p.x, p.y);
+    else client.sendMouseAbs(p.x, p.y);
   };
   const queueSend = (nx: number, ny: number) => {
     send.current = { x: nx, y: ny };
@@ -114,16 +120,30 @@ export function DesktopFullscreen({
   });
 
   // Left button down/up, held across a drag (portal abs vs uinput relative).
+  // Game Mode has no separate button down/up (the {t:'gm'} verb is an atomic
+  // move+click), so down/up are no-ops there and a click becomes a tap at the
+  // current cursor. Portal + relative keep their real down/up (drag/marquee).
   const mouseDown = (btn: 'l' | 'r') => {
+    if (pointerChannel === 'game') return;
     if (absoluteInput) client.sendMouseButtonPortal(btn, 1);
     else client.sendMouseButton(btn, 1);
   };
   const mouseUp = (btn: 'l' | 'r') => {
+    if (pointerChannel === 'game') return;
     if (absoluteInput) client.sendMouseButtonPortal(btn, 0);
     else client.sendMouseButton(btn, 0);
   };
-  const leftClick = () => { mouseDown('l'); setTimeout(() => mouseUp('l'), 40); };
-  const rightClick = () => { mouseDown('r'); setTimeout(() => mouseUp('r'), 40); };
+  const tapAtCursor = () => {
+    client.tapGame((cur.current.x - rect.x) / rect.w, (cur.current.y - rect.y) / rect.h);
+  };
+  const leftClick = () => {
+    if (pointerChannel === 'game') { tapAtCursor(); return; }
+    mouseDown('l'); setTimeout(() => mouseUp('l'), 40);
+  };
+  const rightClick = () => {
+    if (pointerChannel === 'game') return; // right-click isn't meaningful in Big Picture
+    mouseDown('r'); setTimeout(() => mouseUp('r'), 40);
+  };
 
   const pan = useMemo(
     () =>
@@ -234,6 +254,7 @@ export function DesktopFullscreen({
           <View style={[StyleSheet.absoluteFill, styles.center]}>
             <Text style={styles.dim}>
               {!configured ? 'Connect a box first.'
+                : pointerChannel === 'game' ? 'Waiting for the screen…'
                 : 'Approve remote control on your box…'}
             </Text>
           </View>
@@ -264,12 +285,32 @@ export function DesktopFullscreen({
             label={mode === 'mouse' ? 'Mouse' : 'Touch'} styles={styles} t={t}
             active
             onPress={() => { hapticLight(); setMode((m) => (m === 'mouse' ? 'touch' : 'mouse')); }} />
-          <TB icon="radio-button-on" label="Left" styles={styles} t={t}
-            onPress={() => { hapticLight(); leftClick(); }} />
-          <TB icon="ellipsis-horizontal" label="Right" styles={styles} t={t}
-            onPress={() => { hapticLight(); rightClick(); }} />
-          <TB icon="apps" label="Start" styles={styles} t={t}
-            onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+          {pointerChannel === 'game' ? (
+            // Game Mode: the D-pad + Select ride the keyboard path Steam Big
+            // Picture reads (the uinput mouse is not grabbed there), alongside
+            // tap-to-point.
+            <>
+              <TB icon="chevron-back" label="Left" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendKey('left'); }} />
+              <TB icon="chevron-up" label="Up" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendKey('up'); }} />
+              <TB icon="chevron-down" label="Down" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendKey('down'); }} />
+              <TB icon="chevron-forward" label="Right" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendKey('right'); }} />
+              <TB icon="checkmark-circle" label="Select" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendKey('enter'); }} />
+            </>
+          ) : (
+            <>
+              <TB icon="radio-button-on" label="Left" styles={styles} t={t}
+                onPress={() => { hapticLight(); leftClick(); }} />
+              <TB icon="ellipsis-horizontal" label="Right" styles={styles} t={t}
+                onPress={() => { hapticLight(); rightClick(); }} />
+              <TB icon="apps" label="Start" styles={styles} t={t}
+                onPress={() => { hapticLight(); client.sendDesktopKey('meta'); }} />
+            </>
+          )}
           {keyboard && (
             <TB icon="keypad-outline" label="Keys" styles={styles} t={t}
               active={keyboard.open} onPress={keyboard.toggle} />

--- a/app/components/ScreenPreview.tsx
+++ b/app/components/ScreenPreview.tsx
@@ -54,16 +54,18 @@ export function ScreenPreview() {
   }
   if (probe.data && probe.dataKey === boxKey) everSupported.current = true;
   const supported = probe.data != null;
-  // CONTROL (portal remote-desktop: absolute cursor + input) is DESKTOP-ONLY.
-  // gamescope Game Mode has no xdg-desktop-portal RemoteDesktop path, so a
-  // Control button there leads to a dead surface — hide it (degrade closed).
-  // START PREVIEW stays available in both: gamescopectl grabs game-mode frames.
-  // 'mock' = dev harness. Live + non-sticky (reads probe.data, not the sticky
-  // ref), so a desktop<->game switch flips this within one probe (~30s) rather
-  // than needing an agent restart. `session` is recomputed per /api/screen call
-  // agent-side from the live wayland socket, so it never goes stale.
+  // CONTROL is offered on DESKTOP (portal absolute cursor + input) AND in
+  // gamescope GAME MODE (Big Picture menu nav — the portal is absent there, so
+  // input rides the {t:'gm'} xdotool path instead; the route reads the `session`
+  // param to pick that path and default to Touch). START PREVIEW works in both:
+  // gamescopectl grabs game-mode frames. 'mock' = dev harness. Live + non-sticky
+  // (reads probe.data, not the sticky ref), so a desktop<->game switch flips this
+  // within one probe (~30s), no agent restart. `session` is recomputed per
+  // /api/screen call from the live wayland socket, so it never goes stale.
+  // Degrade closed: session===null (agent couldn't read the socket) stays off.
   const controllable =
-    probe.data?.session === 'desktop' || probe.data?.session === 'mock';
+    probe.data?.session === 'desktop' || probe.data?.session === 'mock'
+    || probe.data?.session === 'gamescope';
 
   const [active, setActive] = useState(false);
   const [frame, setFrame] = useState<string | null>(null);
@@ -168,7 +170,10 @@ export function ScreenPreview() {
           <View style={styles.headerBtns}>
             {controllable && (
               <Pressable
-                onPress={() => { hapticLight(); router.push('/desktop'); }}
+                onPress={() => {
+                  hapticLight();
+                  router.push({ pathname: '/desktop', params: { session: probe.data?.session ?? '' } });
+                }}
                 accessibilityRole="button"
                 accessibilityLabel="Control the desktop"
                 style={({ pressed }) => [styles.pill, pressed && styles.pressed]}>

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -850,6 +850,21 @@ export class GamepadClient {
     setTimeout(() => this.sendMouseButtonPortal('l', 0), 40);
   }
 
+  /** GAME-MODE absolute pointer move: x/y normalized 0..1 of the frame. Routes to
+   *  the {t:'gm'} verb, which drives gamescope's Xwayland via xdotool — the
+   *  xdg-desktop-portal is absent in Game Mode. An agent without game-mode support
+   *  drops it, so it is safe to send unconditionally. */
+  sendGameMove(x: number, y: number): void {
+    this.sendRaw({ t: 'gm', x: q01(x), y: q01(y) });
+  }
+
+  /** GAME-MODE tap-to-point: move to (x,y) 0..1 AND left-click, atomically, in a
+   *  single {t:'gm'} frame (xdotool moves + clicks in one spawn — Game Mode has no
+   *  separate button down/up, so a tap is the whole select gesture). */
+  tapGame(x: number, y: number): void {
+    this.sendRaw({ t: 'gm', x: q01(x), y: q01(y), click: true, k: 'l' });
+  }
+
   // ---------- keyboard (v2) ----------
 
   /**

--- a/tests/test_gamemode_input.py
+++ b/tests/test_gamemode_input.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Game-mode (gamescope / Big Picture) pointer input: the {t:'gm'} verb.
+
+Run: python3 tests/test_gamemode_input.py
+
+The portal (xdg-desktop-portal RemoteDesktop) is absent in Game Mode, so
+absolute menu navigation rides `xdotool` on gamescope's Xwayland instead. This
+pins the §6 requirements for that new, security-critical surface — all
+pure-stdlib, no box, no xdotool actually run:
+
+  1. DISPATCH ({t:'gm'} on /ws/gamepad, mirroring {t:'ma'}):
+       - a NON-HOLDER's frame is DROPPED (the holder gate) — nothing runs;
+       - out-of-range / non-numeric / missing coords are DROPPED (nothing runs);
+       - a good frame forwards the validated coords + looked-up button;
+       - the session stays alive across all of them.
+  2. POINTER (_gamescope_pointer -> the xdotool argv):
+       - the exact argv is agent-chosen constants + pure-digit clamped coords;
+       - an UNKNOWN button key never reaches argv (looked up, default '1');
+       - coords are CLAMPED inside the display (a known-answer control);
+       - degrade-closed: absent xdotool OR no live gamescope socket -> nothing runs
+         (two-directional: fires in game mode, no-ops in desktop mode).
+"""
+import importlib.util
+import json
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# Save everything we monkeypatch so a failure can't leak into another test file
+# (these are module globals on the shared couchsided module).
+_saved = {
+    "which": cs.shutil.which,
+    "run": cs.subprocess.run,
+    "socks": cs._wayland_display_sockets,
+    "geom": cs._gamescope_geometry,
+    "wsend_json": cs._wsend_json,
+    "wsend_op": cs._wsend_op,
+    "pointer": cs._gamescope_pointer,
+}
+
+try:
+    # --- 1. DISPATCH: holder gate + coord validation + tolerance --------------
+    print("1. {t:'gm'}: holder gate + coord validation")
+    cs._wsend_json = lambda entry, obj: None
+    cs._wsend_op = lambda entry, op, payload=b"": None
+    PTR = []
+    cs._gamescope_pointer = (
+        lambda nx, ny, click=False, btn_key=None: PTR.append((nx, ny, click, btn_key)))
+
+    class _Stub:
+        mock = True
+        _MOUSE_TYPES = cs.Handler._MOUSE_TYPES
+        _KEYBOARD_TYPES = cs.Handler._KEYBOARD_TYPES
+        _CONTROL_TYPES = cs.Handler._CONTROL_TYPES
+        _PORTAL_BTNS = cs.Handler._PORTAL_BTNS
+        _handle_portal_abs = cs.Handler._handle_portal_abs
+        _handle_portal_btn = cs.Handler._handle_portal_btn
+        _handle_gamemode_abs = cs.Handler._handle_gamemode_abs
+        _handle_kt = cs.Handler._handle_kt
+        _gamepad_message = cs.Handler._gamepad_message
+
+    def feed(entry, msg):
+        PTR.clear()
+        return _Stub()._gamepad_message(None, entry, json.dumps(msg).encode())
+
+    held = {"held": True}
+    waiter = {"held": False}
+
+    # holder gate: a non-holder's frame reaches xdotool never
+    feed(waiter, {"t": "gm", "x": 0.5, "y": 0.5})
+    check("non-holder {gm} dropped (nothing runs)", PTR, [])
+
+    # good move-only forwards the coords, no click
+    feed(held, {"t": "gm", "x": 0.25, "y": 0.75})
+    check("holder {gm} forwards move", PTR, [(0.25, 0.75, False, None)])
+
+    # good tap forwards click + looked-up button key
+    feed(held, {"t": "gm", "x": 0.5, "y": 0.5, "click": True, "k": "l"})
+    check("holder {gm} tap forwards click+key", PTR, [(0.5, 0.5, True, "l")])
+
+    # out-of-range / non-numeric / missing coords are all dropped
+    feed(held, {"t": "gm", "x": 1.5, "y": 0.5})
+    check("out-of-range x dropped", PTR, [])
+    feed(held, {"t": "gm", "x": "0.5", "y": 0.5})
+    check("string x dropped", PTR, [])
+    feed(held, {"t": "gm", "y": 0.5})
+    check("missing x dropped", PTR, [])
+    feed(held, {"t": "gm", "x": -0.1, "y": 0.5})
+    check("negative x dropped", PTR, [])
+
+    # the session stays alive across all of these (returns True, never closes)
+    check("{gm} keeps the session alive",
+          feed(held, {"t": "gm", "x": 0.1, "y": 0.1}), True)
+
+    # --- 2. POINTER: the xdotool argv + degrade-closed ------------------------
+    print()
+    print("2. _gamescope_pointer: argv correctness + degrade closed")
+    cs._gamescope_pointer = _saved["pointer"]   # section 1 stubbed it; use the real one
+    RUN = []
+    cs.subprocess.run = lambda argv, **kw: RUN.append(list(argv))
+    cs.shutil.which = lambda name: "/usr/bin/xdotool"
+    cs._wayland_display_sockets = lambda: ["gamescope-0", "gamescope-0-ei"]
+    cs._gamescope_geometry = lambda: (1920, 1080)
+
+    def run_ptr(*a, **k):
+        RUN.clear()
+        cs._gamescope_pointer(*a, **k)
+        return RUN
+
+    # happy path: exact argv, agent constants + pure-digit clamped coords
+    check("move+click argv exact",
+          run_ptr(0.5, 0.5, click=True, btn_key="l"),
+          [["xdotool", "mousemove", "960", "540", "click", "1"]])
+
+    # move-only: no click subcommand
+    check("move-only argv (no click)",
+          run_ptr(0.0, 1.0), [["xdotool", "mousemove", "0", "1079"]])
+
+    # UNKNOWN button key never reaches argv — looked up, default '1'
+    got = run_ptr(0.5, 0.5, click=True, btn_key="pwn; rm -rf /")
+    check("unknown button -> default '1'", got, [["xdotool", "mousemove", "960", "540", "click", "1"]])
+    check("client button string never in argv",
+          any("pwn" in tok for tok in got[0]), False)
+
+    # right/middle map to 3/2
+    check("right button -> 3",
+          run_ptr(0.5, 0.5, click=True, btn_key="r")[0][-1], "3")
+    check("middle button -> 2",
+          run_ptr(0.5, 0.5, click=True, btn_key="m")[0][-1], "2")
+
+    # clamp control: an answer we already know — 0.999999*1920 = 1919.998 -> 1919,
+    # never 1920 (off the display).
+    check("clamp: 0.999999 x 1920 -> 1919, not 1920",
+          run_ptr(0.999999, 0.0)[0][2], "1919")
+
+    # degrade closed: absent xdotool -> nothing runs
+    cs.shutil.which = lambda name: None
+    check("absent xdotool -> nothing runs", run_ptr(0.5, 0.5, click=True), [])
+    cs.shutil.which = lambda name: "/usr/bin/xdotool"
+
+    # degrade closed: DESKTOP mode (no gamescope-* socket) -> nothing runs
+    cs._wayland_display_sockets = lambda: ["wayland-0"]
+    check("desktop mode (no gamescope socket) -> nothing runs",
+          run_ptr(0.5, 0.5, click=True), [])
+    cs._wayland_display_sockets = lambda: ["gamescope-0"]
+
+    # degrade closed: unreadable geometry -> nothing runs
+    cs._gamescope_geometry = lambda: None
+    check("no geometry -> nothing runs", run_ptr(0.5, 0.5, click=True), [])
+
+finally:
+    cs.shutil.which = _saved["which"]
+    cs.subprocess.run = _saved["run"]
+    cs._wayland_display_sockets = _saved["socks"]
+    cs._gamescope_geometry = _saved["geom"]
+    cs._wsend_json = _saved["wsend_json"]
+    cs._wsend_op = _saved["wsend_op"]
+    cs._gamescope_pointer = _saved["pointer"]
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all game-mode input tests passed")


### PR DESCRIPTION
Two remote-desktop follow-ups (both **device-verification pending** — WS/gamescope paths the harness can't drive).

## Game-mode menu navigation
Control Steam Big Picture / gamescope menus from the Control screen. VIEW already worked (still-frame poller). The missing half was INPUT: the xdg-desktop-portal is absent in Game Mode, so a **new allowlisted agent verb `{t:'gm'}`** drives gamescope's Xwayland via an **xdotool argv list** (`_gamescope_pointer`), mirroring the portal `{t:'ma'}` precedent.

**§3-clean by construction:** string-equality verb behind the holder gate · coords range-validated 0..1 then int-clamped to display px · button looked up in `_XDO_BTN` (client string never reaches argv) · `subprocess.run` argv list, `shell=False` · degrade-closed (no xdotool / no live gamescope socket / no geometry → nothing runs). No new cap (session-driven); additive/tolerant so an old agent drops it.

App: un-gate CONTROL in game mode + pass the live `session`; `desktop.tsx` routes input to `{t:'gm'}`, defaults to **Touch** (tap-to-point), keeps the proven **D-pad+Select** keyboard fallback (the uinput mouse isn't grabbed in Game Mode; arrows/enter are).

Tests: `tests/test_gamemode_input.py` — holder gate, range-validation, **exact argv**, unknown-button `"pwn; rm -rf"` → never in argv, clamp control, degrade-closed both directions. Wired into CI.

## Portrait cursor
The landscape ring+dot local cursor now renders in **portrait** absolute mode too — the trackpad drives it via absolute positioning so it's visible and the box cursor locks to it. Relative mode keeps the plain trackpad (no absolute position to pin a sprite to).

## Not verified (box/device-only)
- xdotool click **landing** where you tap in Big Picture (geometry/click-accept — the one open geometry claim)
- portrait cursor feel on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)