### PR TITLE
release(agent): 2.9.79 — game-mode menu nav reaches boxes

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,14 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.79
+
+**Steer your Steam Big Picture menus from the phone.** With the remote-desktop
+module installed, the Control screen now works in Game Mode too: tap a Big
+Picture menu item on your phone and it selects there, with a D-pad + Select on the
+toolbar as a fallback. (On the desktop it stays the full remote desktop.) Boxes
+without the module, or in Game Mode without it, are unaffected.
+
 ## 2.9.78
 
 **"Switch to Game Mode" works on the newest SteamOS.** On a Steam Machine, a

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.78"
+VERSION = "2.9.79"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 


### PR DESCRIPTION
Version bump so boxes pull the game-mode `{t:'gm'}` pointer verb from #438 (device-verified on a Steam Machine — touch tap-to-point lands correctly in Big Picture). 2.9.78 → 2.9.79 (a same-version republish reaches nobody). Changelog section added.

VERSION string + CHANGELOG only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)