### PR TITLE
feat: audio output switcher — pick the box's sink from the phone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
       - name: Unit tests (audio sink restore)
         run: python3 tests/test_audio_sink_restore.py
 
+      # Audio OUTPUT switcher (GET /api/audio, POST /api/audio/default). The one
+      # that matters is the allowlist: the sink a client names is looked up in the
+      # set pactl itself reported and refused otherwise, reaching subprocess only
+      # as a single argv element. Proves an unknown/empty/injection name runs
+      # nothing, and that the --mock switch is observable (default moves).
+      - name: Unit tests (audio output switcher)
+        run: python3 tests/test_audio_switch.py
+
       # Which filesystems the dashboard reports. A Deck owner was shown
       # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
       # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,14 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.80
+
+**Switch your audio output from the couch.** A new AUDIO OUTPUT card on the
+Console tab lists the devices your box can play through — the TV over HDMI, a
+Bluetooth speaker, the built-in output — and one tap moves the sound there,
+including whatever is already playing. LAN-only like everything else; boxes
+without PipeWire/PulseAudio simply don't show the card.
+
 ## 2.9.79
 
 **Steer your Steam Big Picture menus from the phone.** With the remote-desktop

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.79"
+VERSION = "2.9.80"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1583,7 +1583,7 @@ def set_caps(mock):
                  "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player", "screenstream",
-                 "screenstream_h264")}
+                 "screenstream_h264", "audioswitch")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1625,6 +1625,10 @@ def set_caps(mock):
         # libnice + a VA encoder). Linux-only, additive; absent -> the app uses
         # MJPEG (caps.screenstream) then the poller. /ws/webrtc re-checks live.
         "screenstream_h264": safe(screenstream_h264_available),
+        # Choose the box's default audio output (TV/HDMI <-> Bluetooth <-> analog)
+        # from the phone. Linux-only: pactl. A deliberate user pick, so unlike the
+        # Couch Mode audio move it never guesses a sink to restore.
+        "audioswitch": safe(audioswitch_available),
     }
 
 
@@ -3860,10 +3864,12 @@ def _couch_run(cmd, timeout=25, max_out=1500):
 
 
 def _pactl_sinks():
-    """Parse `pactl list sinks` into [{name, hdmi, available}]. `available` is
-    True only when a port on the sink reports availability 'available' (an
+    """Parse `pactl list sinks` into [{name, desc, hdmi, available}]. `available`
+    is True only when a port on the sink reports availability 'available' (an
     HDMI/DP output with a live display), so the TV's audio sink is the one that's
-    both hdmi and available. [] when pactl is missing or errors."""
+    both hdmi and available. `desc` is the human "Description:" ("LG TV", "Built-in
+    Audio Analog Stereo") for the switcher UI, "" when pactl omitted it. [] when
+    pactl is missing or errors."""
     if not shutil.which("pactl"):
         return []
     r = _couch_run(["pactl", "list", "sinks"], timeout=8, max_out=None)
@@ -3874,8 +3880,10 @@ def _pactl_sinks():
         s = raw.strip()
         if s.startswith("Name:"):
             cur = {"name": s.split(":", 1)[1].strip(),
-                   "hdmi": False, "available": False}
+                   "desc": "", "hdmi": False, "available": False}
             sinks.append(cur)
+        elif cur is not None and s.startswith("Description:"):
+            cur["desc"] = s.split(":", 1)[1].strip()
         elif cur is not None and "type: HDMI" in s:
             cur["hdmi"] = True
             # port line ends "..., available)" vs "..., not available)"
@@ -3957,6 +3965,100 @@ def _restore_default_sink():
     if _current_default_sink() == want:
         return {"skipped": True, "reason": "already the default"}
     return _couch_run(["pactl", "set-default-sink", want])
+
+
+# ---- Audio output switcher (cap: audioswitch) -----------------------------
+# Choose which sink the box plays through -- TV/HDMI, a Bluetooth speaker, the
+# built-in analog out -- from the phone. DISTINCT from the Couch Mode audio move
+# above: that AUTO-moves audio to the TV and remembers the prior sink to restore
+# it, which is where "guessing a sink cost a user their audio" came from (see the
+# _PRIOR_DEFAULT_SINK note). This is a DELIBERATE user pick with no restore -- the
+# user names the exact device they want -- so it carries none of that hazard.
+
+# The off-box contract the app develops against (--mock). Shapes mirror a real
+# `pactl list sinks`: a TV on HDMI, a Bluetooth speaker, the built-in analog out.
+MOCK_SINKS = [
+    {"name": "alsa_output.pci-0000_00_1f.3.hdmi-stereo",
+     "desc": "LG TV (HDMI)", "hdmi": True, "available": True},
+    {"name": "bluez_output.AC_12_34_56_78_9A.1",
+     "desc": "Soundcore Motion+ (Bluetooth)", "hdmi": False, "available": True},
+    {"name": "alsa_output.pci-0000_00_1f.3.analog-stereo",
+     "desc": "Built-in Audio Analog Stereo", "hdmi": False, "available": True},
+]
+
+# Remembered across --mock requests so a harness tap on a sink actually MOVES the
+# default (observe both states, CLAUDE.md §11) instead of snapping back to the
+# first one. Mock-only; the real path reads pactl's live default every call.
+_MOCK_DEFAULT_SINK = None
+
+
+def set_mock_default_sink(name):
+    global _MOCK_DEFAULT_SINK
+    _MOCK_DEFAULT_SINK = name
+
+
+def audioswitch_available():
+    """True when the box can enumerate and set the default audio sink, i.e. pactl
+    is on PATH. Read-only probe; degrades closed (no pactl -> False, never raises)."""
+    return shutil.which("pactl") is not None
+
+
+def audio_state(mock):
+    """Payload for GET /api/audio: the sinks the box can play through, each tagged
+    with whether it is the current default. Read-only. In --mock, the fixed
+    MOCK_SINKS with the remembered (or first) sink marked default so the harness
+    can exercise the switch off-box and SEE it land."""
+    src = MOCK_SINKS if mock else _pactl_sinks()
+    if not mock and not audioswitch_available():
+        return {"available": False, "default": None, "sinks": []}
+    if mock:
+        default = _MOCK_DEFAULT_SINK or (src[0]["name"] if src else None)
+    else:
+        default = _current_default_sink()
+    sinks = [{"name": s["name"], "desc": s.get("desc", ""), "hdmi": s["hdmi"],
+              "available": s["available"], "default": s["name"] == default}
+             for s in src]
+    return {"available": True, "default": default, "sinks": sinks}
+
+
+def _move_sink_inputs(name):
+    """Best-effort: move every currently-playing stream onto `name` so the switch
+    takes effect on audio that is ALREADY playing, not just the next app to start.
+    Each input id comes from pactl's OWN `list sink-inputs short` output -- never
+    from the client -- and is passed as one argv element. Failures are swallowed:
+    a stream that refuses to move must not fail the switch."""
+    r = _couch_run(["pactl", "list", "sink-inputs", "short"], timeout=8)
+    if not r["ok"]:
+        return
+    for line in (r["stdout"] or "").splitlines():
+        sid = line.split("\t", 1)[0].strip()
+        if sid.isdigit():
+            _couch_run(["pactl", "move-sink-input", sid, name])
+
+
+def set_audio_default(name):
+    """Make `name` the box's default audio sink.
+
+    ALLOWLIST (CLAUDE.md §3.1/§3.2): `name` must be a sink pactl ITSELF just
+    reported -- it is looked up in the live `_pactl_sinks()` set, never
+    interpolated. An unknown name returns None and NOTHING runs; the caller maps
+    that to 404. The name only ever reaches subprocess as a single argv element of
+    a fixed `pactl set-default-sink` command -- no shell, no format string.
+
+    No remember/restore: the user chose this device explicitly, so there is no
+    sink to guess on the way back (the hazard the _PRIOR_DEFAULT_SINK note above
+    documents). Returns the new state on success, {"ok": False, "error": ...} on a
+    pactl failure, or None when `name` is not a current sink."""
+    if not isinstance(name, str) or name not in [s["name"] for s in _pactl_sinks()]:
+        return None
+    r = _couch_run(["pactl", "set-default-sink", name])
+    if not r["ok"]:
+        return {"ok": False,
+                "error": (r.get("stderr") or "").strip() or "set-default-sink failed"}
+    # Move audio that is already playing, too -- otherwise the change only applies
+    # to the next app to open a stream, which reads as "nothing happened".
+    _move_sink_inputs(name)
+    return {"ok": True, "default": _current_default_sink() or name}
 
 
 def _couch_run_first(cmds):
@@ -17284,6 +17386,13 @@ class Handler(BaseHTTPRequestHandler):
                 # note above display_info() for what each name may claim.
                 data = mock_display_payload() if self.mock else display_payload()
                 self._send(200, data, started)
+            elif path == "/api/audio":
+                # READ-ONLY: the audio sinks this box can play through + which is
+                # the current default, for the output switcher (cap `audioswitch`).
+                # Always 200 with `available` (like /api/display-info): the app
+                # tells "agent too old" (404) apart from "no pactl here"
+                # (available:false). The set is POST /api/audio/default.
+                self._send(200, audio_state(self.mock), started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app
@@ -17734,6 +17843,37 @@ class Handler(BaseHTTPRequestHandler):
                 ok = open_steam_menu(menu_id)
                 self._send(200 if ok else 500,
                            {"ok": ok, "id": menu_id}, started)
+                return
+            if path == "/api/audio/default":
+                # Set the box's default audio sink. Same allowlist shape as
+                # /api/steam/menus: the client `sink` is LOOKED UP in the live set
+                # of sinks pactl itself reports (mock: MOCK_SINKS) and 404s if it
+                # is not one of them -- never interpolated into a command. On a
+                # match, set_audio_default() passes it as a single argv element.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"},
+                               started)
+                    return
+                sink = req.get("sink")
+                if self.mock:
+                    if not isinstance(sink, str) or sink not in [
+                            s["name"] for s in MOCK_SINKS]:
+                        self._send(404, {"error": "unknown sink"}, started)
+                        return
+                    # Remember it so the next GET /api/audio shows the move (the
+                    # harness needs to SEE the default change, not snap back).
+                    set_mock_default_sink(sink)
+                    self._send(200, {"ok": True, "default": sink}, started)
+                    return
+                res = set_audio_default(sink)
+                if res is None:
+                    self._send(404, {"error": "unknown sink"}, started)
+                    return
+                self._send(200 if res.get("ok") else 500, res, started)
                 return
 
             prefix = "/api/actions/"

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -6,6 +6,7 @@ import { Gated } from '@/components/Gated';
 import { TourAnchor } from '@/components/TourAnchor';
 import { registerScroller } from '@/hooks/useTourAnchor';
 import { DisplayAudioCard } from '@/components/DisplayAudioCard';
+import { AudioOutputCard } from '@/components/AudioOutputCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
@@ -137,7 +138,7 @@ function ConsoleScreen() {
 
   // --- Console card layout: hold-to-edit reorder + hide (persisted) --------
   const CARD_ORDER_CANON = [
-    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'units', 'filedrop',
+    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'units', 'filedrop',
   ];
   const cardLayout = useConsoleLayout();
   const [editingCards, setEditingCards] = useState(false);
@@ -287,6 +288,7 @@ function ConsoleScreen() {
         <DisplayAudioCard />
       </TourAnchor>
     ),
+    audio: <AudioOutputCard />,
     units: configured ? (
       <Card title="UNITS" index={5}>
         {units.error != null && !units.data ? (

--- a/app/components/AudioOutputCard.tsx
+++ b/app/components/AudioOutputCard.tsx
@@ -1,0 +1,185 @@
+/**
+ * AUDIO OUTPUT (Console tab) — pick which device the box plays through: the TV
+ * over HDMI, a Bluetooth speaker, the built-in analog out. The read-only sibling
+ * DisplayAudioCard SHOWS the current default; this one CHANGES it.
+ *
+ * Probe-and-appear, the DisplayAudioCard shape exactly: a 404 (agent too old),
+ * `available: false` (no pactl on this box), or an empty sink list renders
+ * NOTHING — no placeholder, so a box that can't switch audio shows no dead card.
+ *
+ * Tapping a row asks the box to switch, then RE-READS /api/audio rather than
+ * trusting the POST's echo (CLAUDE.md §11: observe the real state). The radio
+ * that moves is the box telling us it moved, not the app assuming it did.
+ *
+ * The sink `name` sent back is one the box itself listed; the agent looks it up
+ * in its live set and refuses anything else, so this control can only ever point
+ * audio at a device the box offered.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, type AudioSink, type AudioState } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { useSkinKit } from '@/lib/skin';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** Audio devices come and go (a Bluetooth speaker connects) but not second by
+ *  second; the switch itself refreshes immediately, so this is just a backstop. */
+const POLL_MS = 15000;
+
+/** A short, dim kind tag from what we can tell about the sink, or null. Derived
+ *  from the pactl node name, which is stable ("bluez_output…", "…hdmi…"). */
+function kindTag(s: AudioSink): string | null {
+  if (s.hdmi) return 'HDMI';
+  if (s.name.startsWith('bluez')) return 'BLUETOOTH';
+  if (s.name.includes('usb')) return 'USB';
+  if (s.name.includes('analog')) return 'ANALOG';
+  return null;
+}
+
+export function AudioOutputCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  // The sink name currently being switched to (disables the list + shows a
+  // spinner on that row) so a double-tap can't fire two switches at once.
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const poll = usePoll<AudioState | null>(
+    () => api.audio(settings), POLL_MS, ready && configured, hostKey(settings));
+
+  const d = poll.data;
+  // Old agent, no pactl, or nothing to switch between -> render nothing at all.
+  if (!d || !d.available || d.sinks.length === 0) return null;
+
+  const onPick = async (s: AudioSink) => {
+    if (busy || s.default) return; // already the default, or a switch in flight
+    hapticLight();
+    setBusy(s.name);
+    try {
+      await api.setAudioDefault(settings, s.name);
+    } finally {
+      // Re-read the box's real default whether or not the POST claimed success.
+      await poll.refresh();
+      setBusy(null);
+    }
+  };
+
+  return (
+    <Card index={6}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>AUDIO OUTPUT</Text>
+        <Pressable
+          onPress={() => {
+            hapticLight();
+            poll.refresh();
+          }}
+          hitSlop={10}
+          accessibilityRole="button"
+          accessibilityLabel="Refresh audio outputs"
+          style={({ pressed }) => [styles.refreshBtn, pressed && styles.pressed]}>
+          <Ionicons name="refresh" size={13} color={t.textDim} />
+        </Pressable>
+      </View>
+
+      <View style={styles.list}>
+        {d.sinks.map((s) => {
+          const tag = kindTag(s);
+          const switching = busy === s.name;
+          return (
+            <Pressable
+              key={s.name}
+              onPress={() => onPick(s)}
+              disabled={!!busy}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: s.default, disabled: !!busy }}
+              accessibilityLabel={`${s.desc || s.name}${s.default ? ', current output' : ''}`}
+              style={({ pressed }) => [styles.row, pressed && !busy && styles.rowPressed]}>
+              {switching ? (
+                <ActivityIndicator size="small" color={t.blue} style={styles.icon} />
+              ) : (
+                <Ionicons
+                  name={s.default ? 'radio-button-on' : 'radio-button-off'}
+                  size={18}
+                  color={s.default ? t.blue : t.textFaint}
+                  style={styles.icon}
+                />
+              )}
+              <Text
+                style={[styles.rowLabel, s.default && styles.rowLabelOn]}
+                numberOfLines={1}>
+                {s.desc || s.name}
+              </Text>
+              {tag ? <Text style={styles.tag}>{tag}</Text> : null}
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Text style={styles.hint}>Tap a device to send the box’s audio there.</Text>
+    </Card>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 10,
+    },
+    cardTitle: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+    refreshBtn: {
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingVertical: 4,
+      paddingHorizontal: 9,
+    },
+    pressed: { opacity: 0.7 },
+
+    list: { gap: 2 },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      paddingVertical: 9,
+    },
+    rowPressed: { opacity: 0.6 },
+    icon: { width: 20, textAlign: 'center' },
+    // flex so a long device name shrinks inside the row instead of shoving the
+    // kind tag off the right edge.
+    rowLabel: {
+      color: t.text,
+      fontSize: 14,
+      fontFamily: mono,
+      flex: 1,
+    },
+    rowLabelOn: { color: t.text, fontWeight: '700' },
+    tag: {
+      color: t.textFaint,
+      fontSize: 10,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+    hint: {
+      color: t.textFaint,
+      fontSize: 11,
+      fontFamily: mono,
+      marginTop: 8,
+    },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -224,6 +224,14 @@ export type BoxCaps = {
    * built with react-native-webrtc, else it falls back to screenstream (MJPEG).
    */
   screenstream_h264?: boolean;
+  /**
+   * Audio output switcher (agent >= 2.9.80): the box can enumerate its audio
+   * sinks and set the default from the phone (TV/HDMI ↔ Bluetooth ↔ analog).
+   * Linux-only — it drives pactl. Gates the Console-tab "AUDIO OUTPUT" card.
+   * Optional: absent on older agents and on Windows, so undefined reads as
+   * "unknown, probe" — only an explicit false (no pactl) hides the card.
+   */
+  audioswitch?: boolean;
 };
 
 /** One Setup → Utilities helper + its live state, from GET /api/utilities.
@@ -402,6 +410,26 @@ export type DisplayInfo = {
         sink, so the two are separate fields and both are shown. */
     input?: string;
   };
+};
+
+/** One audio output the box can play through, from GET /api/audio (agent >= 2.9.80,
+    cap `audioswitch`). `name` is the pactl node id the switch POSTs back verbatim;
+    `desc` is the human label shown in the row. */
+export type AudioSink = {
+  name: string;
+  desc: string;
+  hdmi: boolean;
+  available: boolean;
+  /** True for the sink pactl currently reports as the default. */
+  default: boolean;
+};
+
+/** GET /api/audio: the box's audio outputs + which is the current default.
+    `available: false` = no pactl on this box (the card hides). */
+export type AudioState = {
+  available: boolean;
+  default: string | null;
+  sinks: AudioSink[];
 };
 
 /** One stage of the Couch Mode ceremony (GET /api/couch-mode/status, agent
@@ -1201,7 +1229,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.steaminstall === b.steaminstall &&
     a.utilities === b.utilities &&
     a.screenstream === b.screenstream &&
-    a.screenstream_h264 === b.screenstream_h264
+    a.screenstream_h264 === b.screenstream_h264 &&
+    a.audioswitch === b.audioswitch
   );
 }
 
@@ -2435,6 +2464,35 @@ export const api = {
   ): Promise<DisplayInfo | null> {
     return probeGated(caps?.display_info, () =>
       probeOrNull(request<DisplayInfo>(settings, '/api/display-info')));
+  },
+
+  /**
+   * The box's audio outputs + the current default (agent >= 2.9.80, cap
+   * `audioswitch`). Probe-and-appear: null on a 404 (older agent) so the AUDIO
+   * OUTPUT card hides; an `available: false` payload (no pactl) hides it too.
+   */
+  audio(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<AudioState | null> {
+    return probeGated(caps?.audioswitch, () =>
+      probeOrNull(request<AudioState>(settings, '/api/audio')));
+  },
+
+  /**
+   * Make `sink` the box's default output. `sink` is a `name` the box itself sent
+   * in audio()'s sink list — the agent looks it up in its live set and 404s an
+   * unknown one, so this can never point audio at something the box didn't offer.
+   * Resolves false on any failure; the caller re-reads /api/audio to show the REAL
+   * default rather than trusting this return (CLAUDE.md §11: observe the state).
+   */
+  setAudioDefault(settings: ConnSettings, sink: string): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/audio/default', {
+      method: 'POST',
+      body: { sink },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
   },
 
   /** Enter Couch Mode: fling Game Mode onto `output` (HDR optional). */

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -300,12 +300,16 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // P4b: same module, its H.264/WebRTC tier. Same optional-cap drop trap — it MUST
   // appear in the RETURN object below or it never persists and the app re-probes.
   const screenstream_h264 = bool('screenstream_h264');
+  // audioswitch = the audio output switcher (agent >= 2.9.80). Same optional-cap
+  // drop trap: omit it from the RETURN object below (or from capsEqual) and the
+  // cap never persists, so the AUDIO OUTPUT card re-probes /api/audio every launch.
+  const audioswitch = bool('audioswitch');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
-    steaminstall, utilities, screenstream, screenstream_h264,
+    steaminstall, utilities, screenstream, screenstream_h264, audioswitch,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,24 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Audio output switcher — pick the box's sink from the phone (user ask 2026-08-12)
+- **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
+- **BUILT (agent 2.9.80, branch `claude/audio-output-switcher`).** Console-tab AUDIO OUTPUT
+  card: lists the box's audio sinks and one tap sets the default (TV/HDMI ↔ Bluetooth ↔
+  analog), moving already-playing streams too.
+- **Allowlist:** the client `sink` is looked up in the LIVE set `_pactl_sinks()` reported and
+  404s otherwise; only ever reaches subprocess as one argv element of `pactl set-default-sink`.
+  Distinct from Couch Mode's audio move — a deliberate user pick, so no guess-to-restore
+  (the hazard the `_PRIOR_DEFAULT_SINK` note documents).
+- **Cap:** new `audioswitch` (all six sites; parity green). `GET /api/audio`,
+  `POST /api/audio/default`. `MOCK_SINKS` + remembered mock default so the switch is
+  observable off-box.
+- **Verified:** agent proven end-to-end vs `--mock` (GET lists, 401 no-token, POST moves the
+  default HDMI→BT, unknown/injection → 404); `tests/test_audio_switch.py` + protocol parity.
+  App: typecheck clean, harness tap = the last step before merge.
+- **NOT yet:** on-box against real pactl (multi-sink box with HDMI + a BT device); native row
+  overflow for long device descriptions (harness can't judge, §6).
+
 ### Setup → Utilities menu — extensible one-click hardware/setup helpers (owner ask 2026-08-08)
 - **priority:** P2 · **risk:** medium-high (agent runs hardware-touching flashes + signed
   setups; must stay strictly allowlisted) · **affects:** agent + app · **depends_on:** nothing

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -179,6 +179,7 @@
       "linux"
     ],
     "keys": [
+      "audioswitch",
       "bigpicture",
       "boxbattery",
       "display_info",

--- a/tests/test_audio_switch.py
+++ b/tests/test_audio_switch.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Tests for the audio output switcher (GET /api/audio, POST /api/audio/default).
+
+Run: python3 tests/test_audio_switch.py
+
+The property that matters is the allowlist one: the sink a client names is
+LOOKED UP in the set pactl itself just reported and refused otherwise, and it
+only ever reaches subprocess as a single argv element of a fixed command. A hole
+here would let a LAN client point `pactl set-default-sink` at an arbitrary
+string, so the regression below proves an unknown / empty / injection-shaped name
+runs NOTHING.
+
+Pure stdlib, no pytest — same style as the other agent tests.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def test_state_payload_mock():
+    print("mock state payload")
+    p = cs.audio_state(True)
+    check(p.get("available") is True, "available: true in mock")
+    sinks = p.get("sinks")
+    check(isinstance(sinks, list) and sinks, "returns a non-empty sinks list")
+    check(all(set(s) == {"name", "desc", "hdmi", "available", "default"} for s in sinks),
+          "every sink is exactly {name,desc,hdmi,available,default}")
+    defaults = [s for s in sinks if s["default"]]
+    check(len(defaults) == 1, "exactly one sink is marked default")
+    check(p["default"] == defaults[0]["name"],
+          "top-level default matches the flagged sink")
+
+
+def test_available_gate():
+    print("caps gate")
+    orig = cs.shutil.which
+    try:
+        cs.shutil.which = lambda _b: None
+        check(cs.audioswitch_available() is False, "no pactl -> unavailable")
+        cs.shutil.which = lambda _b: "/usr/bin/pactl"
+        check(cs.audioswitch_available() is True, "pactl present -> available")
+    finally:
+        cs.shutil.which = orig
+
+
+# A live sink set the box "reported", for the allowlist test. Only these names
+# are legal targets; anything else must be refused.
+_LIVE = [
+    {"name": "alsa_output.hdmi-stereo", "desc": "TV", "hdmi": True, "available": True},
+    {"name": "bluez_output.AA_BB.1", "desc": "Speaker", "hdmi": False, "available": True},
+]
+
+
+def test_allowlist_is_enforced():
+    print("allowlist (the regression that matters)")
+    calls = []
+    orig_sinks = cs._pactl_sinks
+    orig_run = cs._couch_run
+    cs._pactl_sinks = lambda: list(_LIVE)
+    cs._couch_run = lambda cmd, **k: calls.append(cmd) or {
+        "ok": True, "exit_code": 0, "stdout": "", "stderr": ""}
+    try:
+        for bad in ("not-a-real-sink", "", "../../etc/passwd",
+                    "hdmi-stereo; rm -rf /", None, 123):
+            check(cs.set_audio_default(bad) is None,
+                  "refused: %r" % (bad,))
+        check(not calls, "nothing was run for any refused sink")
+
+        res = cs.set_audio_default("bluez_output.AA_BB.1")
+        check(isinstance(res, dict) and res.get("ok") is True, "known sink accepted")
+        check(calls and calls[0] == ["pactl", "set-default-sink", "bluez_output.AA_BB.1"],
+              "first call is a set-default-sink argv LIST built from the allowlisted name")
+        check(all(isinstance(c, list) for c in calls),
+              "every subprocess call is an argv list (no shell string)")
+    finally:
+        cs._pactl_sinks = orig_sinks
+        cs._couch_run = orig_run
+
+
+def test_mock_switch_is_observable():
+    print("mock switch moves the default (observe both states)")
+    orig = cs._MOCK_DEFAULT_SINK
+    try:
+        cs.set_mock_default_sink(None)
+        first = cs.audio_state(True)["default"]
+        target = next(s["name"] for s in cs.MOCK_SINKS if s["name"] != first)
+        cs.set_mock_default_sink(target)
+        moved = cs.audio_state(True)
+        check(moved["default"] == target, "GET reflects the switched-to sink")
+        check(sum(1 for s in moved["sinks"] if s["default"]) == 1,
+              "still exactly one default after the switch")
+    finally:
+        cs.set_mock_default_sink(orig)
+
+
+def test_caps_key_registered():
+    print("caps key (six-edit-site rule, agent half)")
+    src = open(AGENT).read()
+    check('"audioswitch")' in src or '"audioswitch",' in src,
+          "audioswitch present in the mock all-true caps tuple")
+    check('"audioswitch": safe(audioswitch_available)' in src,
+          "audioswitch wired into the real CAPS dict")
+
+
+if __name__ == "__main__":
+    test_state_payload_mock()
+    test_available_gate()
+    test_allowlist_is_enforced()
+    test_mock_switch_is_observable()
+    test_caps_key_registered()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all audio-switch tests passed")


### PR DESCRIPTION
## What

A new **AUDIO OUTPUT** card on the Console tab lists the audio devices the box can play through and switches the default with one tap — TV/HDMI ↔ Bluetooth speaker ↔ built-in analog — moving already-playing streams too. From a user feature request.

Sits directly under the read-only **DISPLAY / AUDIO** card: that one *shows* the default, this one *changes* it.

## Allowlist (the part that matters)

`POST /api/audio/default {sink}` — the client's `sink` is **looked up in the live set `_pactl_sinks()` reported** (mock: `MOCK_SINKS`) and **404s** otherwise. It is never interpolated; it reaches `subprocess` only as a single argv element of a fixed `pactl set-default-sink`. `set_audio_default()` returns `None` (→404) for any name that isn't currently a sink. The move ids for already-playing streams come from pactl's own output, never the client.

No remember/restore — a **deliberate user pick**, unlike Couch Mode's auto audio move (which is where "guessing a sink cost a user their audio" came from; that hazard doesn't apply here).

## Endpoints / cap

- `GET /api/audio` → `{available, default, sinks:[{name,desc,hdmi,available,default}]}` (read-only; `available:false` when no pactl).
- `POST /api/audio/default` → switch.
- New Linux-only cap **`audioswitch`** wired at all six sites (agent real+mock, app BoxCaps+normalizeCaps+capsEqual, protocol.json). Parity green.

## Tests / verification

- `tests/test_audio_switch.py` (+ CI step): allowlist refuses unknown / empty / injection-shaped names with **nothing run**, argv is a list, and the `--mock` switch is observable. Protocol parity + CHANGELOG updated.
- **Agent** proven end-to-end vs `--mock` over curl: authed GET lists sinks, no-token → 401, POST moves the default **HDMI → Bluetooth** (both states), unknown/injection sink → **404**.
- **App** driven in the web harness — *pressed the Bluetooth row*, "current output" moved LG TV → Bluetooth, network showed `POST /api/audio/default` 200 + the refresh GET, and steady-state poll cadence held (no tight loop).

### Not verified
- On a real box against live `pactl` (a machine with HDMI **and** a connected Bluetooth sink).
- Native row overflow for very long sink descriptions — the web harness can't judge row layout (RN gives `<Text>` free flex-shrink on web only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)