### PR TITLE
feat: front light-bar / status-LED control from the phone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,16 @@ jobs:
       - name: Unit tests (audio output switcher)
         run: python3 tests/test_audio_switch.py
 
+      # Front light-bar / status-LED control (GET /api/leds, POST /api/leds/set).
+      # The one that matters is the allowlist: the LED a client names is looked up
+      # in the live os.listdir(/sys/class/leds) set and must be writable, else
+      # NOTHING is written; attribute paths are fixed literals; trigger is only
+      # ever 'none'. Proves unknown/traversal/non-writable ids write nothing,
+      # colour is written in the device's own channel order, and the --mock switch
+      # is observable.
+      - name: Unit tests (led control)
+        run: python3 tests/test_led_control.py
+
       # Which filesystems the dashboard reports. A Deck owner was shown
       # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
       # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.81
+
+**Set your box's light from the phone.** If your machine has a controllable
+front RGB or status LED, a new LIGHT card on the Console tab lets you pick a
+colour and brightness (or turn it off) with a tap. LAN-only like everything else.
+Boxes with no controllable LED simply don't show the card — and note that on many
+machines the LED files are locked to the system account, so this needs a one-time
+permission grant (coming in the installer) before it can take effect.
+
 ## 2.9.80
 
 **Switch your audio output from the couch.** A new AUDIO OUTPUT card on the

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.80"
+VERSION = "2.9.81"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1583,7 +1583,7 @@ def set_caps(mock):
                  "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player", "screenstream",
-                 "screenstream_h264", "audioswitch")}
+                 "screenstream_h264", "audioswitch", "ledcontrol")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1629,6 +1629,10 @@ def set_caps(mock):
         # from the phone. Linux-only: pactl. A deliberate user pick, so unlike the
         # Couch Mode audio move it never guesses a sink to restore.
         "audioswitch": safe(audioswitch_available),
+        # Set the box's front RGB / status LED (colour + brightness) from the
+        # phone via /sys/class/leds. Linux-only. False on a stock box (files are
+        # root-owned) until an install-time udev grant makes an LED writable.
+        "ledcontrol": safe(ledcontrol_available),
     }
 
 
@@ -4059,6 +4063,327 @@ def set_audio_default(name):
     # to the next app to open a stream, which reads as "nothing happened".
     _move_sink_inputs(name)
     return {"ok": True, "default": _current_default_sink() or name}
+
+
+# ---- Front light-bar / status-LED control (cap: ledcontrol) ----------------
+# Set the box's front RGB / status LED (color + brightness) from the phone via
+# the Linux LED class, /sys/class/leds. Same shape as the audio switcher: the
+# live-enumerated set of LED names IS the allowlist -- a POST id is honoured only
+# if it is an EXACT member of os.listdir(_LEDS_ROOT) and writable (else 404, and
+# NOTHING is written). Attribute file names are always fixed literals joined onto
+# the contained per-LED dir; client input only ever selects WHICH enumerated LED.
+#
+# Colour model (kernel multicolor LED class): `multi_intensity` carries the hue
+# (one value per channel, in `multi_index` order), `brightness` is the master
+# dimmer; the driver emits brightness * intensity / max_brightness per channel.
+# So a swatch sets multi_intensity and a level button sets brightness -- they
+# multiply, which is exactly the two-control app UI.
+#
+# HARDWARE-UNVERIFIED (see the PR): the write path is validated against the
+# kernel ABI + the mock only, never observed lighting a real LED, and on a stock
+# box the sysfs files are root-owned (writable:false -> the card hides) until an
+# install-time udev grant is added and proven on real hardware.
+_LEDS_ROOT = "/sys/class/leds"
+
+# Presentation-only classifier. NEVER gates authorization -- the agent honours a
+# POST to any enumerated *writable* LED regardless of this; it only decides what
+# the app SHOWS and whether the cap is advertised (don't offer a "lights" card
+# whose only targets are keyboard indicators).
+_LED_NOISE = ("capslock", "numlock", "scrolllock", "compose", "kana", "shift")
+_LED_POSITIVE = ("rgb", "chassis", "status", "joystick_ring", "logo", "bar", "light")
+
+# The off-box contract the app develops against (--mock): one RGB "front bar"
+# (swatches + brightness), one mono status LED (brightness only), one keyboard
+# indicator (writable but notable:false -> proves the app filters noise out).
+MOCK_LEDS = [
+    {"name": "multicolor:chassis", "desc": "Chassis RGB", "rgb": True,
+     "notable": True, "writable": True, "max_brightness": 255,
+     "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+     "brightness": 255, "color": {"r": 0, "g": 200, "b": 255}},
+    {"name": "steamdeck::status", "desc": "Status LED", "rgb": False,
+     "notable": True, "writable": True, "max_brightness": 100,
+     "index": [], "maxint": [], "brightness": 60, "color": None},
+    {"name": "input3::capslock", "desc": "Caps Lock", "rgb": False,
+     "notable": False, "writable": True, "max_brightness": 1,
+     "index": [], "maxint": [], "brightness": 0, "color": None},
+]
+# name -> {"brightness": <device units>, "color": {r,g,b}}, remembered across
+# --mock requests so a harness swatch/level tap MOVES the value and the next GET
+# shows it (observe both states, CLAUDE.md §11). Mock-only.
+_MOCK_LED_STATE = {}
+
+
+def set_mock_led(name, brightness=None, color=None):
+    base = next((l for l in MOCK_LEDS if l["name"] == name), None)
+    if base is None:
+        return
+    st = dict(_MOCK_LED_STATE.get(name, {}))
+    if brightness is not None:
+        # Round half up (see set_led): keep the mock faithful to the device path.
+        st["brightness"] = int(brightness / 100 * base["max_brightness"] + 0.5)
+    if color is not None:
+        st["color"] = color
+    _MOCK_LED_STATE[name] = st
+
+
+def _led_notable(name, rgb):
+    """Presentation/cap hint only (see the section note). rgb LEDs are always
+    notable; a mono LED is notable if its name looks like a front/status light and
+    not like a keyboard/storage/wifi indicator."""
+    low = name.lower()
+    if any(n in low for n in _LED_NOISE):
+        return False
+    if low.startswith(("input", "mmc")) or (low.startswith("phy") and "led" in low):
+        return False
+    if rgb:
+        return True
+    return any(p in low for p in _LED_POSITIVE)
+
+
+def _led_int(s):
+    try:
+        return int((s or "").strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _led_access_w(name, attr):
+    try:
+        return os.access(os.path.join(_LEDS_ROOT, name, attr), os.W_OK)
+    except OSError:
+        return False
+
+
+def _led_read_attr(name, attr):
+    """Read one fixed-literal attribute file fresh (sysfs is one-shot per open).
+    `attr` is NEVER client input. None when missing/unreadable (degrade closed)."""
+    try:
+        with open(os.path.join(_LEDS_ROOT, name, attr)) as f:
+            return f.read().strip()
+    except OSError:
+        return None
+
+
+def _led_chmax(maxint, i, maxb):
+    """Per-channel intensity max for channel i: multi_max_intensity[i] when the
+    driver publishes it, else the LED's max_brightness (the kernel bounds each
+    multi_intensity value by max_brightness). ONE fallback used by BOTH the colour
+    read and write so the 0-255 <-> device round-trip is consistent -- a mismatch
+    here corrupts the colour on any LED whose max_brightness isn't 255."""
+    if i < len(maxint) and maxint[i] > 0:
+        return maxint[i]
+    return maxb or 255
+
+
+def _led_color_from_intensity(mi, index, maxint, maxb):
+    """Reverse-map multi_intensity (device order) to canonical {r,g,b} 0-255, or
+    None if unparseable. Only red/green/blue channels are mapped."""
+    try:
+        vals = [int(x) for x in (mi or "").split()]
+    except ValueError:
+        return None
+    if not vals or len(vals) != len(index):
+        return None
+    out = {"r": 0, "g": 0, "b": 0}
+    for i, ch in enumerate(index):
+        key = {"red": "r", "green": "g", "blue": "b"}.get(ch)
+        if key is None:
+            continue
+        chmax = _led_chmax(maxint, i, maxb)
+        out[key] = max(0, min(255, round(vals[i] * 255 / chmax)))
+    return out
+
+
+def _read_led_raw(name):
+    """Read /sys/class/leds/<name> into a full dict (incl. internal `index`/
+    `maxint` used by the writer), or None if max_brightness can't be read. `name`
+    is a bare dir name from _list_led_names(), never client-derived here."""
+    maxb = _led_int(_led_read_attr(name, "max_brightness"))
+    if maxb is None or maxb <= 0:
+        return None
+    cur = _led_int(_led_read_attr(name, "brightness")) or 0
+    mi = _led_read_attr(name, "multi_intensity")
+    idx_s = _led_read_attr(name, "multi_index")
+    index = idx_s.split() if idx_s is not None else []
+    # Treat as an RGB LED only when the multicolor channels are exactly the
+    # red/green/blue ones the colour path can read AND write. An amber/white or
+    # RGBW LED (or an empty index) is offered as brightness-only instead -- else
+    # its colour reads back as black and a swatch tap writes 0 to its real
+    # channels, turning it OFF.
+    rgb = (mi is not None and bool(index)
+           and set(index).issubset({"red", "green", "blue"}))
+    maxint = [int(x) for x in (_led_read_attr(name, "multi_max_intensity") or "").split()
+              if x.strip().isdigit()] if rgb else []
+    color = _led_color_from_intensity(mi, index, maxint, maxb) if rgb else None
+    writable = _led_access_w(name, "brightness") and (
+        (not rgb) or _led_access_w(name, "multi_intensity"))
+    return {"name": name, "desc": name, "rgb": rgb,
+            "notable": _led_notable(name, rgb), "writable": writable,
+            "max_brightness": maxb, "brightness": cur, "index": index,
+            "maxint": maxint, "color": color}
+
+
+def _led_public(raw):
+    """Project a raw LED dict to the API fields (drops internal index/maxint)."""
+    maxb = raw["max_brightness"]
+    return {"name": raw["name"], "desc": raw["desc"], "rgb": raw["rgb"],
+            "notable": raw["notable"], "writable": raw["writable"],
+            "max_brightness": maxb, "brightness": raw["brightness"],
+            "brightness_pct": round(raw["brightness"] / maxb * 100) if maxb else 0,
+            "color": raw["color"]}
+
+
+def _list_led_names():
+    """The live LED-name allowlist: bare child dirs of /sys/class/leds. [] when
+    the tree is absent/unreadable (degrade closed)."""
+    try:
+        return sorted(n for n in os.listdir(_LEDS_ROOT)
+                      if os.path.isdir(os.path.join(_LEDS_ROOT, n)))
+    except OSError:
+        return []
+
+
+def _mock_led_public(name):
+    base = next(l for l in MOCK_LEDS if l["name"] == name)
+    st = _MOCK_LED_STATE.get(name, {})
+    maxb = base["max_brightness"]
+    brightness = st.get("brightness", base["brightness"])
+    color = st.get("color", base.get("color"))
+    return {"name": name, "desc": base["desc"], "rgb": base["rgb"],
+            "notable": base["notable"], "writable": base["writable"],
+            "max_brightness": maxb, "brightness": brightness,
+            "brightness_pct": round(brightness / maxb * 100) if maxb else 0,
+            "color": color}
+
+
+def ledcontrol_available():
+    """True when at least one enumerated LED is BOTH writable by us and 'notable'
+    (a front/status/RGB light, not a keyboard indicator). Read-only; degrades
+    closed. On a stock box the sysfs files are root-owned, so this is False until
+    an install-time udev grant lands -- and the card then stays hidden."""
+    for name in _list_led_names():
+        raw = _read_led_raw(name)
+        if raw and raw["writable"] and raw["notable"]:
+            return True
+    return False
+
+
+def leds_state(mock):
+    """Payload for GET /api/leds: the writable LEDs the box exposes + their state,
+    each tagged `notable` so the app renders the front/status lights and ignores
+    keyboard indicators. Read-only. --mock returns MOCK_LEDS merged with the
+    remembered mock state so the harness can observe a change."""
+    if mock:
+        pubs = [_mock_led_public(l["name"]) for l in MOCK_LEDS if l["writable"]]
+        return {"available": any(p["notable"] for p in pubs), "leds": pubs}
+    raws = [_read_led_raw(n) for n in _list_led_names()]
+    pubs = [_led_public(r) for r in raws if r and r["writable"]]
+    return {"available": any(p["notable"] for p in pubs), "leds": pubs}
+
+
+def _led_realpath_ok(name):
+    """The per-LED dir must resolve under /sys (the node is usually a symlink into
+    /sys/devices, so we contain under /sys, not /sys/class/leds -- the listdir
+    membership + fixed literal attr names are the real guard)."""
+    try:
+        rp = os.path.realpath(os.path.join(_LEDS_ROOT, name))
+    except OSError:
+        return False
+    return rp == "/sys" or rp.startswith("/sys/")
+
+
+def _led_write(name, attr, value):
+    """Write to the FIXED-literal attribute `attr` of LED `name`. attr is NEVER
+    client input -- only 'brightness', 'multi_intensity', 'trigger' are ever
+    passed by set_led()."""
+    with open(os.path.join(_LEDS_ROOT, name, attr), "w") as f:
+        f.write(value)
+
+
+def _led_clear_trigger(name):
+    """Set the LED's trigger to 'none' (the ONLY trigger string we ever write) so
+    a live heartbeat/timer can't keep overwriting our static value. No-op when the
+    trigger is already none/absent. Non-fatal."""
+    cur = _led_read_attr(name, "trigger")
+    if cur is None or "[none]" in cur or "[" not in cur:
+        return
+    try:
+        _led_write(name, "trigger", "none")
+    except OSError:
+        pass
+
+
+def _led_write_color(name, raw, color):
+    """Write client {r,g,b} (0-255) to multi_intensity in the DEVICE's channel
+    order (raw['index']), scaled to each channel's max, whole array at once (the
+    kernel needs every element in one write)."""
+    canon = {"red": color["r"], "green": color["g"], "blue": color["b"]}
+    maxint = raw["maxint"]
+    maxb = raw["max_brightness"]
+    vals = []
+    for i, ch in enumerate(raw["index"]):
+        v = canon.get(ch, 0)
+        chmax = _led_chmax(maxint, i, maxb)
+        vals.append(str(max(0, min(chmax, round(v * chmax / 255)))))
+    _led_write(name, "multi_intensity", " ".join(vals))
+
+
+def set_led(name, brightness, color):
+    """Apply brightness (0-100) and/or color ({r,g,b} 0-255) to LED `name`.
+
+    ALLOWLIST (CLAUDE.md §3): `name` must be an EXACT member of the freshly
+    re-read os.listdir(_LEDS_ROOT) set AND writable -- else None (caller -> 404)
+    and NOTHING is written. Attribute paths use fixed literal names on the
+    contained per-LED dir; the client never names a path. Body shape is validated
+    by the caller; here we reject `color` on a mono LED. Returns
+    {"ok":True,...} | {"ok":False,"status":400|500,"error":..} | None."""
+    if not isinstance(name, str) or "/" in name or ".." in name or "\x00" in name:
+        return None
+    if name not in _list_led_names() or not _led_realpath_ok(name):
+        return None
+    raw = _read_led_raw(name)
+    if raw is None or not raw["writable"]:
+        return None
+    if color is not None and not raw["rgb"]:
+        return {"ok": False, "status": 400, "error": "led has no colour channels"}
+    try:
+        _led_clear_trigger(name)
+        if color is not None:
+            _led_write_color(name, raw, color)
+        if brightness is not None:
+            # Round half UP, not Python's banker's rounding: on a 2-state LED
+            # (max_brightness == 1) round(0.5) is 0, so tapping 50% would turn it
+            # OFF. int(x + 0.5) sends the midpoint to ON.
+            _led_write(name, "brightness",
+                       str(int(brightness / 100 * raw["max_brightness"] + 0.5)))
+    except OSError as e:
+        return {"ok": False, "status": 500,
+                "error": (str(e) or "led write failed")}
+    fresh = _read_led_raw(name) or raw
+    pub = _led_public(fresh)
+    return {"ok": True, "led": name,
+            "brightness_pct": pub["brightness_pct"], "color": pub["color"]}
+
+
+def _validate_led_body(req):
+    """Shared shape check for POST /api/leds/set. Returns
+    (brightness|None, color|None, error|None); error -> 400. Rejects (never
+    sanitises) anything that isn't an int 0-100 brightness or a {r,g,b} 0-255
+    colour. Booleans are excluded (JSON true == 1 in Python)."""
+    brightness = req.get("brightness")
+    color = req.get("color")
+    if brightness is None and color is None:
+        return None, None, "need brightness or color"
+    if brightness is not None and not (
+            isinstance(brightness, int) and not isinstance(brightness, bool)
+            and 0 <= brightness <= 100):
+        return None, None, "brightness must be an int 0-100"
+    if color is not None and not (
+            isinstance(color, dict) and set(color) == {"r", "g", "b"}
+            and all(isinstance(color[c], int) and not isinstance(color[c], bool)
+                    and 0 <= color[c] <= 255 for c in ("r", "g", "b"))):
+        return None, None, "color must be {r,g,b} ints 0-255"
+    return brightness, color, None
 
 
 def _couch_run_first(cmds):
@@ -17393,6 +17718,13 @@ class Handler(BaseHTTPRequestHandler):
                 # tells "agent too old" (404) apart from "no pactl here"
                 # (available:false). The set is POST /api/audio/default.
                 self._send(200, audio_state(self.mock), started)
+            elif path == "/api/leds":
+                # READ-ONLY: the writable front/status/RGB LEDs this box exposes +
+                # their state, for the light-bar card (cap `ledcontrol`). Always
+                # 200 with `available` (like /api/audio): 404 = agent too old,
+                # available:false = nothing controllable here. Set = POST
+                # /api/leds/set.
+                self._send(200, leds_state(self.mock), started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app
@@ -17874,6 +18206,47 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(404, {"error": "unknown sink"}, started)
                     return
                 self._send(200 if res.get("ok") else 500, res, started)
+                return
+            if path == "/api/leds/set":
+                # Set an LED's colour/brightness. Same allowlist shape as
+                # /api/audio/default: the client `led` is LOOKED UP in the live
+                # os.listdir(/sys/class/leds) set (mock: MOCK_LEDS) and 404s if it
+                # is not a writable member -- never interpolated into a path.
+                # Attribute file names are fixed literals inside set_led().
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"},
+                               started)
+                    return
+                led_name = req.get("led")
+                brightness, color, verr = _validate_led_body(req)
+                if verr is not None:
+                    self._send(400, {"error": verr}, started)
+                    return
+                if self.mock:
+                    match = next((l for l in MOCK_LEDS
+                                  if l["name"] == led_name), None)
+                    if not isinstance(led_name, str) or match is None:
+                        self._send(404, {"error": "unknown led"}, started)
+                        return
+                    if color is not None and not match["rgb"]:
+                        self._send(400, {"error": "led has no colour channels"},
+                                   started)
+                        return
+                    # Remember it so the next GET /api/leds shows the change.
+                    set_mock_led(led_name, brightness, color)
+                    self._send(200, dict({"ok": True},
+                                         **_mock_led_public(led_name)), started)
+                    return
+                res = set_led(led_name, brightness, color)
+                if res is None:
+                    self._send(404, {"error": "unknown led"}, started)
+                    return
+                self._send(res.get("status", 200) if not res.get("ok") else 200,
+                           res, started)
                 return
 
             prefix = "/api/actions/"

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -7,6 +7,7 @@ import { TourAnchor } from '@/components/TourAnchor';
 import { registerScroller } from '@/hooks/useTourAnchor';
 import { DisplayAudioCard } from '@/components/DisplayAudioCard';
 import { AudioOutputCard } from '@/components/AudioOutputCard';
+import { RgbLedCard } from '@/components/RgbLedCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
@@ -138,7 +139,7 @@ function ConsoleScreen() {
 
   // --- Console card layout: hold-to-edit reorder + hide (persisted) --------
   const CARD_ORDER_CANON = [
-    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'units', 'filedrop',
+    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'leds', 'units', 'filedrop',
   ];
   const cardLayout = useConsoleLayout();
   const [editingCards, setEditingCards] = useState(false);
@@ -289,6 +290,7 @@ function ConsoleScreen() {
       </TourAnchor>
     ),
     audio: <AudioOutputCard />,
+    leds: <RgbLedCard />,
     units: configured ? (
       <Card title="UNITS" index={5}>
         {units.error != null && !units.data ? (

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -1,0 +1,327 @@
+/**
+ * LIGHT (Console tab) — set the box's front RGB / status LED colour + brightness
+ * from the phone. The read-only siblings show state; this one changes it.
+ *
+ * Probe-and-appear, the AudioOutputCard shape exactly: a 404 (agent too old),
+ * `available: false` (no controllable/writable LED), or zero *notable* LEDs
+ * renders NOTHING — no dead card. On a stock box the LED sysfs files are
+ * root-owned, so nothing is writable until an install-time udev grant lands, and
+ * the card correctly stays hidden until then.
+ *
+ * Tap-only by design (colour swatches + discrete brightness levels), because
+ * drag gestures aren't verifiable in the web harness. Every tap fires one POST
+ * then RE-READS /api/leds rather than trusting the echo (CLAUDE.md §11: observe
+ * the real state) — the ring that moves is the box telling us it moved.
+ *
+ * The LED `name` sent back is one the box itself listed; the agent looks it up in
+ * its live /sys/class/leds set and refuses anything else, so this control can
+ * only ever aim at an LED the box offered.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, type LedInfo, type LedsState, type Rgb } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { useSkinKit } from '@/lib/skin';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** LEDs don't change on their own second-by-second; the taps refresh immediately,
+ *  so this is just a backstop (e.g. another app changed the colour). */
+const POLL_MS = 15000;
+
+/** Frozen preset colours (0–255 per channel), sent verbatim; the agent
+ *  range-checks each triple. Tap-testable: one swatch = one POST. */
+const PRESETS: { label: string; rgb: Rgb }[] = [
+  { label: 'Red', rgb: { r: 255, g: 0, b: 0 } },
+  { label: 'Orange', rgb: { r: 255, g: 120, b: 0 } },
+  { label: 'Yellow', rgb: { r: 255, g: 220, b: 0 } },
+  { label: 'Green', rgb: { r: 0, g: 200, b: 0 } },
+  { label: 'Cyan', rgb: { r: 0, g: 200, b: 255 } },
+  { label: 'Blue', rgb: { r: 0, g: 80, b: 255 } },
+  { label: 'Purple', rgb: { r: 160, g: 0, b: 255 } },
+  { label: 'Pink', rgb: { r: 255, g: 0, b: 150 } },
+  { label: 'White', rgb: { r: 255, g: 255, b: 255 } },
+  { label: 'Warm', rgb: { r: 255, g: 170, b: 90 } },
+];
+
+const LEVELS = [0, 25, 50, 75, 100];
+
+const css = (c: Rgb) => `rgb(${c.r}, ${c.g}, ${c.b})`;
+
+/** A colour round-trips through device scaling, so match within a small
+ *  tolerance rather than requiring exact equality. */
+function sameColor(a: Rgb | null, b: Rgb): boolean {
+  if (!a) return false;
+  return Math.abs(a.r - b.r) <= 3 && Math.abs(a.g - b.g) <= 3 && Math.abs(a.b - b.b) <= 3;
+}
+
+/** The level button (from the rendered set) that best matches the reported
+ *  brightness, so exactly one lights up. */
+function nearestLevel(pct: number, levels: number[]): number {
+  return levels.reduce((best, lv) =>
+    Math.abs(lv - pct) < Math.abs(best - pct) ? lv : best, levels[0]);
+}
+
+export function RgbLedCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  // Which LED is being written (disables the controls + shows a spinner) so a
+  // double-tap can't fire two writes at once.
+  const [busy, setBusy] = useState(false);
+  // When several notable LEDs exist, which one the controls act on.
+  const [selName, setSelName] = useState<string | null>(null);
+
+  const poll = usePoll<LedsState | null>(
+    () => api.leds(settings), POLL_MS, ready && configured, hostKey(settings));
+
+  const d = poll.data;
+  const leds = (d?.leds ?? []).filter((l) => l.notable && l.writable);
+  // Old agent, no writable LED, or nothing notable -> render nothing at all.
+  if (!d || !d.available || leds.length === 0) return null;
+
+  const led: LedInfo = leds.find((l) => l.name === selName) ?? leds[0];
+  const off = led.brightness_pct === 0;
+  // An rgb LED gets its "off" from the OFF swatch, so drop the duplicate level-0
+  // button (otherwise both light up when off). A mono LED keeps it — it has no
+  // swatch. When off, no level highlights (the OFF swatch shows the state).
+  const levels = led.rgb ? LEVELS.filter((l) => l > 0) : LEVELS;
+  const activeLevel = off ? -1 : nearestLevel(led.brightness_pct, levels);
+
+  const apply = async (patch: { brightness?: number; color?: Rgb }) => {
+    if (busy) return;
+    hapticLight();
+    setBusy(true);
+    try {
+      await api.setLed(settings, led.name, patch);
+    } finally {
+      await poll.refresh();
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card index={6}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>LIGHT</Text>
+        <View style={styles.headerRight}>
+          {/* One spinner for the whole card while a write is in flight — the
+              swatch/level that lands is shown by the ring after the re-read, so
+              a per-control spinner (which would sit on stale state) is wrong. */}
+          {busy ? <ActivityIndicator size="small" color={t.blue} /> : null}
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              poll.refresh();
+            }}
+            hitSlop={10}
+            accessibilityRole="button"
+            accessibilityLabel="Refresh lights"
+            style={({ pressed }) => [styles.refreshBtn, pressed && styles.pressed]}>
+            <Ionicons name="refresh" size={13} color={t.textDim} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* LED picker — only when the box exposes more than one controllable light. */}
+      {leds.length > 1 && (
+        <View style={styles.ledRow}>
+          {leds.map((l) => {
+            const on = l.name === led.name;
+            return (
+              <Pressable
+                key={l.name}
+                onPress={() => { hapticLight(); setSelName(l.name); }}
+                disabled={busy}
+                accessibilityRole="button"
+                accessibilityState={{ selected: on }}
+                accessibilityLabel={`Control ${l.desc}`}
+                style={({ pressed }) => [
+                  styles.ledChip, on && styles.ledChipOn, pressed && styles.pressed]}>
+                <Text style={[styles.ledChipText, on && styles.ledChipTextOn]} numberOfLines={1}>
+                  {l.desc}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+
+      {/* Colour swatches (rgb LEDs only). */}
+      {led.rgb && (
+        <>
+          <Text style={styles.sectionLabel}>COLOUR</Text>
+          <View style={styles.swatchGrid}>
+            {PRESETS.map((p) => {
+              const on = !off && sameColor(led.color, p.rgb);
+              return (
+                <Pressable
+                  key={p.label}
+                  onPress={() => apply({
+                    color: p.rgb,
+                    brightness: led.brightness_pct > 0 ? led.brightness_pct : 100,
+                  })}
+                  disabled={busy}
+                  accessibilityRole="radio"
+                  accessibilityState={{ selected: on, disabled: busy }}
+                  accessibilityLabel={`Set light to ${p.label}`}
+                  style={({ pressed }) => [
+                    styles.swatch,
+                    { backgroundColor: css(p.rgb) },
+                    on && styles.swatchOn,
+                    pressed && !busy && styles.pressed,
+                  ]}>
+                  {on ? (
+                    <Ionicons
+                      name="checkmark"
+                      size={16}
+                      color={p.rgb.r + p.rgb.g + p.rgb.b > 480 ? '#000' : '#fff'}
+                    />
+                  ) : null}
+                </Pressable>
+              );
+            })}
+            {/* Off — turns the light out (brightness 0), rendered as an inset chip. */}
+            <Pressable
+              onPress={() => apply({ brightness: 0 })}
+              disabled={busy}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: off, disabled: busy }}
+              accessibilityLabel="Turn the light off"
+              style={({ pressed }) => [
+                styles.swatch, styles.offSwatch, off && styles.swatchOn,
+                pressed && !busy && styles.pressed]}>
+              <Text style={styles.offText}>OFF</Text>
+            </Pressable>
+          </View>
+        </>
+      )}
+
+      {/* Brightness levels (every LED). */}
+      <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
+      <View style={styles.levelRow}>
+        {levels.map((lv) => {
+          const on = activeLevel === lv;
+          return (
+            <Pressable
+              key={lv}
+              onPress={() => apply({ brightness: lv })}
+              disabled={busy}
+              accessibilityRole="button"
+              accessibilityState={{ selected: on, disabled: busy }}
+              accessibilityLabel={lv === 0 ? 'Brightness off' : `Brightness ${lv} percent`}
+              style={({ pressed }) => [
+                styles.level, on && styles.levelOn, pressed && !busy && styles.pressed]}>
+              <Text style={[styles.levelText, on && styles.levelTextOn]}>
+                {lv === 0 ? 'Off' : `${lv}`}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Text style={styles.hint}>
+        {led.rgb ? 'Tap a colour, then a brightness.' : 'Tap a brightness level.'}
+      </Text>
+    </Card>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      marginBottom: 10,
+    },
+    headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    cardTitle: {
+      color: t.textDim,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+    refreshBtn: {
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingVertical: 4,
+      paddingHorizontal: 9,
+    },
+    pressed: { opacity: 0.6 },
+
+    sectionLabel: {
+      color: t.textFaint,
+      fontSize: 10,
+      fontWeight: '700',
+      letterSpacing: 1.2,
+      fontFamily: mono,
+      marginTop: 12,
+      marginBottom: 8,
+    },
+
+    ledRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+    ledChip: {
+      borderColor: t.cardBorder,
+      borderWidth: 1,
+      borderRadius: 999,
+      paddingVertical: 5,
+      paddingHorizontal: 11,
+    },
+    ledChipOn: { borderColor: t.text },
+    ledChipText: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    ledChipTextOn: { color: t.text, fontWeight: '700' },
+
+    swatchGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
+    // A 2px transparent border is ALWAYS present so selecting shifts no layout.
+    swatch: {
+      width: 44,
+      height: 44,
+      borderRadius: 10,
+      borderWidth: 2,
+      borderColor: 'transparent',
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    swatchOn: { borderColor: t.text },
+    offSwatch: {
+      backgroundColor: t.card,
+      borderColor: t.cardBorder,
+    },
+    offText: {
+      color: t.textDim,
+      fontSize: 10,
+      fontWeight: '700',
+      letterSpacing: 1,
+      fontFamily: mono,
+    },
+
+    levelRow: { flexDirection: 'row', gap: 6 },
+    level: {
+      flex: 1,
+      height: 38,
+      borderRadius: 8,
+      borderWidth: 1,
+      borderColor: t.cardBorder,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    levelOn: { borderColor: t.blue, backgroundColor: t.card },
+    levelText: { color: t.textDim, fontSize: 13, fontFamily: mono },
+    levelTextOn: { color: t.text, fontWeight: '700' },
+
+    hint: {
+      color: t.textFaint,
+      fontSize: 11,
+      fontFamily: mono,
+      marginTop: 10,
+    },
+  });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -232,6 +232,16 @@ export type BoxCaps = {
    * "unknown, probe" — only an explicit false (no pactl) hides the card.
    */
   audioswitch?: boolean;
+  /**
+   * Front light-bar / status-LED control (agent >= 2.9.81): the box can set an
+   * RGB or mono LED's colour + brightness from the phone (via /sys/class/leds).
+   * Linux-only. Gates the Console-tab "LIGHT" card. Optional: absent on older
+   * agents and on Windows, so undefined reads as "unknown, probe" — and an
+   * explicit false (no controllable/writable LED) hides the card. NOTE: on a
+   * stock box the sysfs files are root-owned, so this is false until an
+   * install-time udev grant makes an LED writable.
+   */
+  ledcontrol?: boolean;
 };
 
 /** One Setup → Utilities helper + its live state, from GET /api/utilities.
@@ -430,6 +440,37 @@ export type AudioState = {
   available: boolean;
   default: string | null;
   sinks: AudioSink[];
+};
+
+/** An 8-bit RGB colour, as the app and agent both speak it (0–255 per channel,
+    device-independent — the agent scales to the LED's own range). */
+export type Rgb = { r: number; g: number; b: number };
+
+/** One controllable LED from GET /api/leds (agent >= 2.9.81, cap `ledcontrol`).
+    `name` is the /sys/class/leds node id the setter POSTs back verbatim. */
+export type LedInfo = {
+  name: string;
+  desc: string;
+  /** True for a multicolour LED (has colour swatches); false = brightness only. */
+  rgb: boolean;
+  /** Presentation hint from the agent: a front/status/RGB light vs a keyboard
+      indicator. The app renders only notable LEDs. */
+  notable: boolean;
+  /** The agent can write this LED as the desktop user (else it isn't returned). */
+  writable: boolean;
+  max_brightness: number;
+  brightness: number;
+  /** 0–100, so the app can light the matching level button. */
+  brightness_pct: number;
+  /** Current colour for an rgb LED, or null (mono, or the box couldn't tell). */
+  color: Rgb | null;
+};
+
+/** GET /api/leds: the writable LEDs the box exposes + their state.
+    `available: false` = nothing controllable here (the card hides). */
+export type LedsState = {
+  available: boolean;
+  leds: LedInfo[];
 };
 
 /** One stage of the Couch Mode ceremony (GET /api/couch-mode/status, agent
@@ -1230,7 +1271,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.utilities === b.utilities &&
     a.screenstream === b.screenstream &&
     a.screenstream_h264 === b.screenstream_h264 &&
-    a.audioswitch === b.audioswitch
+    a.audioswitch === b.audioswitch &&
+    a.ledcontrol === b.ledcontrol
   );
 }
 
@@ -2490,6 +2532,40 @@ export const api = {
     return request<{ ok: boolean }>(settings, '/api/audio/default', {
       method: 'POST',
       body: { sink },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
+  /**
+   * The box's controllable LEDs + their state (agent >= 2.9.81, cap
+   * `ledcontrol`). Probe-and-appear: null on a 404 (older agent) so the LIGHT
+   * card hides; an `available: false` payload (no writable LED) hides it too.
+   */
+  leds(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<LedsState | null> {
+    return probeGated(caps?.ledcontrol, () =>
+      probeOrNull(request<LedsState>(settings, '/api/leds')));
+  },
+
+  /**
+   * Set an LED's colour and/or brightness. `led` is a `name` the box itself sent
+   * in leds()'s list — the agent looks it up in its live /sys/class/leds set and
+   * 404s an unknown one, so this can never aim a write anywhere the box didn't
+   * offer. `brightness` is 0–100; `color` is 0–255 per channel. Resolves false on
+   * any failure; the caller re-reads /api/leds to show the REAL state rather than
+   * trusting this return (CLAUDE.md §11: observe the state).
+   */
+  setLed(
+    settings: ConnSettings,
+    led: string,
+    patch: { brightness?: number; color?: Rgb },
+  ): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/leds/set', {
+      method: 'POST',
+      body: { led, ...patch },
     })
       .then((r) => !!r?.ok)
       .catch(() => false);

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -304,12 +304,18 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // drop trap: omit it from the RETURN object below (or from capsEqual) and the
   // cap never persists, so the AUDIO OUTPUT card re-probes /api/audio every launch.
   const audioswitch = bool('audioswitch');
+  // ledcontrol = the front light-bar / status-LED control (agent >= 2.9.81). Same
+  // optional-cap drop trap: omit it from the RETURN object below (or from
+  // capsEqual) and the cap never persists, so the LIGHT card re-probes /api/leds
+  // every launch.
+  const ledcontrol = bool('ledcontrol');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
     steaminstall, utilities, screenstream, screenstream_h264, audioswitch,
+    ledcontrol,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,36 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### Front light-bar / status-LED control (owner ask 2026-08-12)
+- **priority:** P2 · **risk:** medium (writes a hardware sysfs path; strictly allowlisted +
+  validated) · **affects:** agent + app · **depends_on:** an install-time udev grant (below)
+- **BUILT (agent 2.9.81, branch `claude/lightbar-led`).** Console-tab LIGHT card: pick an
+  LED's colour (preset swatches) + brightness (Off/25/50/75/100) with a tap. `GET /api/leds`
+  enumerates the writable LEDs; `POST /api/leds/set {led,brightness?,color?}` writes. Cap
+  `ledcontrol` (six sites, parity green). Mirrors [[the audio switcher]] (`audioswitch`).
+- **Allowlist:** the client `led` must be an EXACT member of the live
+  `os.listdir(/sys/class/leds)` set AND writable → else 404, **nothing written**. Attribute
+  files are fixed literals (`brightness`/`multi_intensity`/`trigger`); trigger is only ever
+  `none`; colour is reordered into the device's `multi_index` order + scaled; brightness/colour
+  range-checked (reject, don't sanitise); path contained under `/sys`. `notable` name-heuristic
+  is presentation-only, NEVER gates authorization. Built from a research pass on the kernel
+  multicolor-LED ABI + a 4-lens adversarial review of the diff.
+- **Verified:** `tests/test_led_control.py` (refused/traversal/non-writable ids write NOTHING;
+  colour reordered to device channel order; trigger only `none`; validation rejects bad
+  colour/brightness; mock observable) + protocol parity + CI step. Agent end-to-end vs `--mock`
+  over curl (401 no/wrong-token, 404 unknown, 400 colour-on-mono/bad-brightness, colour moves).
+  App in the harness: pressed a swatch and a level, box state moved to green @ 50%, ring
+  followed the re-read (observe both states, §11).
+- **NOT verified / the real gate:** no real LED hardware lit. On a stock box the sysfs files
+  are **root-owned**, so `writable:false` → the card **hides** until an **install-time udev
+  grant** makes a specific LED writable — that rule is **not written yet**, must be scoped to
+  the target LED (don't blanket-open every LED), and proven on the home Legion Go S / an
+  AYANEO before this is "done". Also unverified: which node exists per box, write contention
+  with Steam/InputPlumber, AYN `led_mode` gotcha, reported-colour accuracy. Classifier tested
+  only on SYNTHETIC names (no `/sys/class/leds` fixtures yet). OpenRGB fallback: deferred.
+- **Follow-ups:** the scoped udev rule + hardware pass; real sysfs fixtures for the classifier;
+  effects (breathe/rainbow) once a device is in hand.
+
 ### Audio output switcher — pick the box's sink from the phone (user ask 2026-08-12)
 - **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none
 - **BUILT (agent 2.9.80, branch `claude/audio-output-switcher`).** Console-tab AUDIO OUTPUT
@@ -274,37 +304,6 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   game mode defaults to TOUCH (tap-to-point), Mouse as a toggle.** Detail in [[remote-desktop-and-screen-capture]].
 
 ## 📋 Planned
-
-### Front light-bar / RGB LED customization (owner ask 2026-08-12)
-- **priority:** P2 · **risk:** medium (writes to a hardware LED path; must stay strictly
-  allowlisted + validated) · **affects:** agent + app · **depends_on:** nothing
-- **Owner:** "customize the Steam machine's front light bar LED." Set the box's front
-  RGB/status LED — color, brightness, and maybe a small set of effects — from the phone.
-- **Mechanism (stays pure-stdlib, no bundled deps):** the Linux **LED class** under
-  `/sys/class/leds/*` — `brightness` + `max_brightness`, and `multi_intensity` +
-  `multi_index` for RGB/multicolor LEDs — written as plain files, exactly the "resolve then
-  contain" pattern uploads already use. Handheld front LEDs are exposed by platform drivers
-  (`ayaneo-platform`, `ayn-platform`, `oxp-platform`; ASUS via `asusctl` if present); the new
-  Valve Steam Machine has a front status LED. If a tool like OpenRGB is *installed*, shell out
-  to it via the allowlist like we do `pactl`/`wpctl` — never bundle it (agent stays stdlib).
-- **Allowlist plan (the load-bearing part):**
-  - **Enumerate** controllable LEDs read-only from sysfs (probe-and-appear). A box with no
-    writable front LED → cap absent, no card. Degrade closed.
-  - **Set** is token-gated. The target LED is an **id looked up in the enumerated set**, never
-    interpolated into a path. Color is parsed to validated 0–255 ints; brightness clamped to
-    `[0, max_brightness]`; any effect id must be in a **frozen set**. Reject, don't sanitise.
-    Contain the resolved sysfs path under `/sys/class/leds` before writing (§3.5).
-  - New cap **`lightbar`** → all SIX edit sites (§4). `GET /api/lightbar` (state) +
-    `POST /api/lightbar` (set). `MOCK_*` LEDs so the switch is harness-observable, like
-    [[the audio switcher]] (`audioswitch`, PR #441) — this feature is that one's sibling and
-    should mirror its shape (enumerate → look-up-not-interpolate → argv/file write → mock).
-- **The hard part = device diversity.** The controllable LED, its path, and RGB vs single-color
-  differ per machine; parse real sysfs fixtures copied VERBATIM from hardware (§6). Start with
-  the generic LED-class multicolor path + one or two known handhelds, degrade closed everywhere
-  else. **If the build plan reaches 3+ phases, move it to `docs/memory/project_lightbar-led.md`
-  and leave a pointer here** (§10).
-- **NOT yet designed:** effect set (static / breathe / off?), whether brightness rides the
-  existing vitals signal, per-box persistence. Capture on build, not now.
 
 ### Apple Watch + desktop widgets — quick actions (owner ask 2026-08-10)
 - **priority:** P2 · **risk:** medium-high (NEW native surfaces: WidgetKit + watchOS;

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -185,6 +185,7 @@
       "display_info",
       "file_upload",
       "gaming",
+      "ledcontrol",
       "player",
       "screenstream",
       "screenstream_h264",

--- a/tests/test_led_control.py
+++ b/tests/test_led_control.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Tests for front light-bar / status-LED control (GET /api/leds, POST
+/api/leds/set).
+
+Run: python3 tests/test_led_control.py
+
+The property that matters is the allowlist one: the LED a client names is LOOKED
+UP in the live os.listdir(/sys/class/leds) set (and must be writable) -- else
+NOTHING is written -- and it only ever reaches the filesystem as a bare directory
+name joined with FIXED literal attribute file names ('brightness',
+'multi_intensity', 'trigger'). A hole here would let a LAN client aim a sysfs
+write at an arbitrary path, so the regression below proves an unknown /
+traversal-shaped / non-writable id writes nothing, that the trigger write is only
+ever the literal 'none', and that colour is written in the device's own channel
+order.
+
+NOTE: the notable-vs-noise classifier is tested against SYNTHETIC LED names only
+-- we do not yet have /sys/class/leds fixtures copied verbatim from real hardware
+(CLAUDE.md §6). That, and the fact the write path has never lit a real LED, are
+called out in the PR.
+
+Pure stdlib, no pytest -- same style as the other agent tests.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def test_state_payload_mock():
+    print("mock state payload")
+    st = cs.leds_state(True)
+    check(st.get("available") is True, "available: true in mock")
+    leds = st.get("leds")
+    fields = {"name", "desc", "rgb", "notable", "writable",
+              "max_brightness", "brightness", "brightness_pct", "color"}
+    check(isinstance(leds, list) and leds, "non-empty leds list")
+    check(all(set(l) == fields for l in leds),
+          "every led carries exactly the public field set")
+    rgb = [l for l in leds if l["rgb"]]
+    check(rgb and all(isinstance(l["color"], dict) for l in rgb),
+          "rgb leds report a {r,g,b} color")
+    check(any(l["notable"] for l in leds) and any(not l["notable"] for l in leds),
+          "payload includes both a notable light and a filtered-out noise led")
+
+
+def test_notable_classifier():
+    print("notable classifier (SYNTHETIC names -- no hw fixtures yet)")
+    notable = ["multicolor:chassis", "asus::rgb:logo", "phys0:rgb:joystick_rings",
+               "steamdeck::status"]
+    noise = ["input3::capslock", "input5::numlock", "mmc1::", "phy0-led",
+             "input0::scrolllock"]
+    check(all(cs._led_notable(n, "rgb" in n or "multicolor" in n) for n in notable),
+          "front/status/rgb names are notable")
+    check(all(not cs._led_notable(n, False) for n in noise),
+          "keyboard/storage/wifi indicator names are filtered out")
+    check(cs._led_notable("some_obscure_led", True) is True,
+          "ANY rgb led is notable regardless of name")
+
+
+def test_validate_body():
+    print("body validation (reject, don't sanitise)")
+    ok = [({"brightness": 0}, (0, None)), ({"brightness": 100}, (100, None)),
+          ({"color": {"r": 1, "g": 2, "b": 3}}, (None, {"r": 1, "g": 2, "b": 3}))]
+    for body, want in ok:
+        b, c, err = cs._validate_led_body(body)
+        check(err is None and (b, c) == want, "accepts %s" % body)
+    bad = [{}, {"brightness": 150}, {"brightness": -1}, {"brightness": 1.0},
+           {"brightness": True}, {"color": {"r": 256, "g": 0, "b": 0}},
+           {"color": {"r": -1, "g": 0, "b": 0}}, {"color": {"r": 1, "g": 2}},
+           {"color": {"r": 1, "g": 2, "b": 3, "w": 4}}, {"color": [1, 2, 3]},
+           {"color": {"r": True, "g": 0, "b": 0}}]
+    for body in bad:
+        b, c, err = cs._validate_led_body(body)
+        check(err is not None, "rejects %s" % body)
+
+
+# A fake /sys/class/leds. `blue red green` channel order on the RGB LED proves
+# the writer reorders client r,g,b into the DEVICE order, not a hard-coded one.
+_FAKE = {
+    "multicolor:front": {"name": "multicolor:front", "desc": "multicolor:front",
+        "rgb": True, "notable": True, "writable": True, "max_brightness": 255,
+        "index": ["blue", "red", "green"], "maxint": [255, 255, 255],
+        "brightness": 255, "color": {"r": 0, "g": 0, "b": 0}},
+    "steamdeck::status": {"name": "steamdeck::status", "desc": "steamdeck::status",
+        "rgb": False, "notable": True, "writable": True, "max_brightness": 100,
+        "index": [], "maxint": [], "brightness": 60, "color": None},
+    "input3::capslock": {"name": "input3::capslock", "desc": "input3::capslock",
+        "rgb": False, "notable": False, "writable": True, "max_brightness": 1,
+        "index": [], "maxint": [], "brightness": 0, "color": None},
+    "locked::led": {"name": "locked::led", "desc": "locked::led", "rgb": True,
+        "notable": True, "writable": False, "max_brightness": 255,
+        "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+        "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}},
+}
+
+
+def _install_fake(writes, trigger="[heartbeat] none"):
+    cs._list_led_names = lambda: list(_FAKE)
+    cs._read_led_raw = lambda n: dict(_FAKE[n]) if n in _FAKE else None
+    cs._led_realpath_ok = lambda n: True
+    cs._led_read_attr = lambda name, attr: trigger if attr == "trigger" else None
+    cs._led_write = lambda name, attr, value: writes.append((name, attr, value))
+
+
+def test_allowlist_write():
+    print("allowlist + write path (the regression that matters)")
+    saved = {k: getattr(cs, k) for k in
+             ("_list_led_names", "_read_led_raw", "_led_realpath_ok",
+              "_led_read_attr", "_led_write")}
+    writes = []
+    _install_fake(writes)
+    try:
+        for bad in ("not-a-real-led", "", "../../etc/passwd",
+                    "multicolor:front/../x", "locked::led", None, 123):
+            writes.clear()
+            res = cs.set_led(bad, 50, None)
+            check(res is None, "refused: %r" % (bad,))
+            check(not writes, "nothing written for %r" % (bad,))
+
+        # colour on a mono LED -> 400, nothing written
+        writes.clear()
+        res = cs.set_led("steamdeck::status", None, {"r": 1, "g": 2, "b": 3})
+        check(isinstance(res, dict) and res.get("status") == 400,
+              "colour on a mono led -> 400")
+        check(not writes, "nothing written when colour rejected on mono led")
+
+        # known rgb led: colour reordered into device order (blue,red,green),
+        # trigger cleared to 'none' first, then brightness mapped pct->device.
+        writes.clear()
+        res = cs.set_led("multicolor:front", 50, {"r": 10, "g": 20, "b": 30})
+        check(res and res.get("ok") is True, "known writable rgb led accepted")
+        check(("multicolor:front", "trigger", "none") in writes,
+              "trigger written exactly 'none' (never any other trigger)")
+        check(("multicolor:front", "multi_intensity", "30 10 20") in writes,
+              "colour written in DEVICE channel order blue,red,green -> '30 10 20'")
+        check(("multicolor:front", "brightness", "128") in writes,
+              "brightness 50%% of 255 -> 128")
+        check(all(w[1] in ("trigger", "multi_intensity", "brightness")
+                  for w in writes),
+              "only ever wrote the three fixed-literal attributes")
+
+        # mono led brightness maps against ITS max (100), no colour write
+        writes.clear()
+        cs.set_led("steamdeck::status", 25, None)
+        check(("steamdeck::status", "brightness", "25") in writes,
+              "mono brightness 25%% of 100 -> 25")
+        check(not any(w[1] == "multi_intensity" for w in writes),
+              "no colour write for a mono led")
+    finally:
+        for k, v in saved.items():
+            setattr(cs, k, v)
+
+
+def test_color_roundtrip_scaling():
+    print("colour round-trip is consistent across max_brightness (fallback asymmetry)")
+    # rgb LED, max_brightness=64, NO multi_max_intensity — the mainline ABI path
+    # where the read and write fallbacks used to disagree and corrupt the colour.
+    raw = {"index": ["red", "green", "blue"], "maxint": [], "max_brightness": 64}
+    writes = []
+    saved = cs._led_write
+    cs._led_write = lambda name, attr, value: writes.append((attr, value))
+    try:
+        cs._led_write_color("x", raw, {"r": 0, "g": 200, "b": 0})
+    finally:
+        cs._led_write = saved
+    mi = dict(writes)["multi_intensity"]
+    back = cs._led_color_from_intensity(mi, raw["index"], raw["maxint"], raw["max_brightness"])
+    check(back["r"] == 0 and back["b"] == 0 and abs(back["g"] - 200) <= 3,
+          "green 200 on a max_brightness=64 LED round-trips within tolerance "
+          "(wrote '%s', read back %s)" % (mi, back))
+
+
+def test_non_rgb_multicolor_is_not_rgb():
+    print("amber/white multicolor LED is brightness-only, not colour")
+    saved = cs._led_read_attr
+    cs._led_read_attr = lambda name, attr: {
+        "max_brightness": "255", "brightness": "200",
+        "multi_intensity": "128 64", "multi_index": "amber white"}.get(attr)
+    try:
+        raw = cs._read_led_raw("amber:led")
+        check(raw is not None and raw["rgb"] is False,
+              "amber/white channels -> rgb False (no colour swatches to darken it)")
+        check(raw["color"] is None, "no colour reported for a non-rgb multicolor LED")
+    finally:
+        cs._led_read_attr = saved
+
+
+def test_brightness_round_half_up():
+    print("50%% of a 2-state (max_brightness=1) LED turns it ON, not off")
+    raw = {"name": "on-off", "desc": "on-off", "rgb": False, "notable": True,
+           "writable": True, "max_brightness": 1, "brightness": 0,
+           "index": [], "maxint": [], "color": None}
+    writes = []
+    saved = {k: getattr(cs, k) for k in
+             ("_list_led_names", "_read_led_raw", "_led_realpath_ok",
+              "_led_read_attr", "_led_write")}
+    cs._list_led_names = lambda: ["on-off"]
+    cs._read_led_raw = lambda n: dict(raw) if n == "on-off" else None
+    cs._led_realpath_ok = lambda n: True
+    cs._led_read_attr = lambda name, attr: None
+    cs._led_write = lambda name, attr, value: writes.append((attr, value))
+    try:
+        cs.set_led("on-off", 50, None)
+        check(("brightness", "1") in writes,
+              "brightness 50%% of max 1 -> '1' (ON), not '0'")
+        writes.clear()
+        cs.set_led("on-off", 25, None)
+        check(("brightness", "0") in writes,
+              "brightness 25%% of max 1 -> '0' (still OFF below the midpoint)")
+    finally:
+        for k, v in saved.items():
+            setattr(cs, k, v)
+
+
+def test_mock_switch_is_observable():
+    print("mock switch moves state (observe both states)")
+    saved = dict(cs._MOCK_LED_STATE)
+    try:
+        cs._MOCK_LED_STATE.clear()
+        cs.set_mock_led("multicolor:chassis", None, {"r": 255, "g": 0, "b": 0})
+        cs.set_mock_led("steamdeck::status", 25, None)
+        st = {l["name"]: l for l in cs.leds_state(True)["leds"]}
+        check(st["multicolor:chassis"]["color"] == {"r": 255, "g": 0, "b": 0},
+              "GET reflects the switched-to colour")
+        check(st["steamdeck::status"]["brightness_pct"] == 25,
+              "GET reflects the dimmed brightness")
+    finally:
+        cs._MOCK_LED_STATE.clear()
+        cs._MOCK_LED_STATE.update(saved)
+
+
+def test_caps_key_registered():
+    print("caps key (six-edit-site rule, agent half)")
+    src = open(AGENT).read()
+    check('"ledcontrol")' in src or '"ledcontrol",' in src,
+          "ledcontrol present in the mock all-true caps tuple")
+    check('"ledcontrol": safe(ledcontrol_available)' in src,
+          "ledcontrol wired into the real CAPS dict")
+
+
+if __name__ == "__main__":
+    test_state_payload_mock()
+    test_notable_classifier()
+    test_validate_body()
+    test_allowlist_write()
+    test_color_roundtrip_scaling()
+    test_non_rgb_multicolor_is_not_rgb()
+    test_brightness_round_half_up()
+    test_mock_switch_is_observable()
+    test_caps_key_registered()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all led-control tests passed")


### PR DESCRIPTION
## What

A new **LIGHT** card on the Console tab sets the box's front RGB or status LED — pick a colour (preset swatches) and a brightness level (Off/25/50/75/100), or turn it off, with a tap. Via the Linux LED class (`/sys/class/leds`). From a user feature request; sibling to the [audio switcher](https://github.com/emerytech/couchside/pull/441).

Built from a research fan-out (kernel multicolor-LED ABI + real Steam-machine LED layouts + OpenRGB + tap-testable UX) and a **4-lens adversarial review** of the diff.

## Allowlist (the part that matters)

`POST /api/leds/set {led, brightness?, color?}` — the client `led` must be an **exact member of the live `os.listdir("/sys/class/leds")` set AND writable** → else **404, nothing written**. `led` with `/`/`..`/NUL is rejected first; attribute files are **fixed literals** (`brightness`/`multi_intensity`/`trigger`); `trigger` is only ever written `none`; colour is reordered into the device's `multi_index` order + scaled; brightness/colour are range-checked (reject, don't sanitise); the per-LED dir realpath is contained under `/sys`. The `notable` name-heuristic is **presentation + cap-advertisement only and never gates authorization**.

The security lens of the adversarial review found **zero** allowlist/containment issues.

## Endpoints / cap

- `GET /api/leds` → `{available, leds:[{name,desc,rgb,notable,writable,max_brightness,brightness,brightness_pct,color}]}` (read-only; `available:false` when nothing controllable).
- `POST /api/leds/set` → write.
- New Linux-only cap **`ledcontrol`** at all six sites (parity green). `MOCK_LEDS` + remembered mock state so a harness tap is observable.

## Adversarial-review fixes (all 5 confirmed findings; all correctness/UX, no security)

- **Colour round-trip** — shared `_led_chmax` so the read and write agree when `multi_max_intensity` is absent (the mainline-ABI path); was corrupting colour on any LED with `max_brightness != 255`.
- **Non-RGB multicolor** — classify `rgb` only when channels ⊆ {red,green,blue}; an amber/white/RGBW/empty-index LED is now brightness-only instead of shown-as-black / darkened by a swatch tap.
- **Round-half-up** brightness so 50% of a 2-state LED turns it **on** (Python `round()` is banker's rounding).
- **App:** one header spinner while a write is in flight (the per-level spinner sat on stale state); dropped the duplicate level-0 "Off" on rgb LEDs (the OFF swatch owns off).

## Tests / verification

- `tests/test_led_control.py` (+ CI step): refused / traversal / non-writable ids write **nothing**; colour reordered to device channel order; `trigger` only `none`; colour round-trips within tolerance at `max_brightness != 255`; amber LED → brightness-only; 50% of a 2-state LED → on; validation rejects bad colour/brightness; mock observable. Protocol parity + CHANGELOG.
- **Agent** vs `--mock` over curl: `401` no/wrong-token (direct on the agent — the dev proxy backfills the token), `404` unknown, `400` colour-on-mono / bad-brightness, colour moves.
- **App** in the web harness: pressed a colour swatch and a brightness level → box state moved to **green @ 50%**, the ring followed the re-read; the mono LED shows Off/25/50/75/100 with no swatches; the rgb LED shows a single off control.

### Not verified — the real gate before this is "done"
- **No real LED hardware lit.** On a stock box the `/sys/class/leds` files are **root-owned**, so `writable:false` → the card **hides** until an **install-time udev grant** makes a specific LED writable. That rule is **not written yet**, must be **scoped to the target LED** (don't blanket-open), and proven on the home Legion Go S / an AYANEO. Also unverified: which node exists per box, write contention with Steam/InputPlumber, the AYN `led_mode` gotcha, reported-colour accuracy.
- The notable classifier is tested only on **synthetic** names (no real `/sys/class/leds` fixtures yet).
- OpenRGB fallback + effects (breathe/rainbow): deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)