### PR TITLE
chore(release): 2.9.45 store notes + shipped build numbers + agent 2.9.81 changelog

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -20,12 +20,26 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.81
 
+Three things land here if you're coming from an older agent.
+
+**Fluid remote desktop.** When your box has a hardware H.264 video encoder, the
+Control screen now streams smooth, hardware-decoded video instead of the older
+frame-by-frame picture — much closer to sitting at the machine, with the same
+trackpad, tap-to-point, keyboard and landscape mode. Boxes without an encoder
+keep the existing view automatically. LAN-only, and it uses the same remote-
+desktop module you already opted into.
+
+**Switch your audio output from the couch.** A new AUDIO OUTPUT card on the
+Console tab lists the devices your box can play through — the TV over HDMI, a
+Bluetooth speaker, the built-in output — and one tap moves the sound there,
+including whatever is already playing. Boxes without PipeWire/PulseAudio simply
+don't show the card.
+
 **Set your box's light from the phone.** If your machine has a controllable
-front RGB or status LED, a new LIGHT card on the Console tab lets you pick a
-colour and brightness (or turn it off) with a tap. LAN-only like everything else.
-Boxes with no controllable LED simply don't show the card — and note that on many
-machines the LED files are locked to the system account, so this needs a one-time
-permission grant (coming in the installer) before it can take effect.
+front RGB or status LED, a new LIGHT card lets you pick a colour and brightness
+(or turn it off) with a tap. Boxes with no controllable LED don't show the card —
+and note that on many machines the LED files are locked to the system account, so
+this needs a one-time permission grant before it can take effect.
 
 ## 2.9.80
 

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "172",
+      "buildNumber": "173",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 92
+      "versionCode": 93
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,7 +1,9 @@
-Flash an OpenPuck receiver from the couch: turn a cheap nRF52840 board into a Steam Controller 2 wireless dongle, right from your phone.
+Remote desktop, now fluid. See and control your box's whole desktop from your phone, with smooth hardware-accelerated H.264 video. Move the cursor with a trackpad or just tap where you want to click, type with a full keyboard, and flip to a full-screen landscape mode.
 
-Your whole library, instantly — browse games you own but haven't installed, and install them on the box from the couch.
+Navigate Steam's Big Picture from the couch — point and tap your way through Game Mode menus.
 
-Game ratings on your library: Metacritic, Steam reviews, and Steam Deck/Proton compatibility, plus Open in Steam.
+Switch the box's audio output from your phone: speakers, headphones, or HDMI, without getting up.
 
-New Playlog: queue and reorder the games you want to play next.
+Set the colour of your box's front light bar right in the app.
+
+Also new: a quick note scratchpad on the controller. Plus fixes and polish.

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,3 +1,3 @@
-35 controller themes. The Setup theme picker now offers a big library — Dark Gothic, Bonk, Cyberpunk Rain, Toxic Slime Lab and many more — each with its own full-screen backdrop behind the buttons.
+Remote desktop, now fluid: see and control your box's desktop from your phone with smooth, hardware-accelerated H.264 video. Move the cursor with a trackpad or tap where you want to click, use a full keyboard, and flip to a full-screen landscape mode.
 
-New: a palette button inside the full-screen MOVE controller switches themes on the fly, no trip to Setup. Auto matches Vampire Survivors and Megabonk to a fitting look. Plus the one-handed MOVE mode and fixes.
+Navigate Steam Big Picture from the couch. Switch the box's audio output from your phone. Set your front light-bar colour in the app. Plus a note scratchpad on the controller, and the usual fixes.


### PR DESCRIPTION
Post-release housekeeping for the 2.9.45 store release (already shipped: agent 2.9.81 on GitHub, iOS build 173 in App Store review, Android vc93 on Play). Records the shipped build numbers so the next autoIncrement is correct, the store release notes, and the agent 2.9.81 changelog covering the full delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)