### PR TITLE
fix(remote-desktop): portal helper — preempt on codec switch + non-blocking status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,14 @@ jobs:
       - name: Unit tests (remote-desktop H.264 stream relay)
         run: python3 tests/test_h264_stream.py
 
+      # Portal helper stream-path fixes (a fake `gi` shim makes it importable):
+      # verb_status must NOT block on _SLOCK (a pending consent held it and
+      # deadlocked the agent's 2s caps probe -> caps read False -> no fluid tier),
+      # and stream() must PREEMPT a different-codec encoder on a MJPEG->H.264
+      # switch instead of refusing (a refusal wedged the app back on MJPEG).
+      - name: Unit tests (remote-desktop portal helper logic)
+        run: python3 tests/test_portal_helper_logic.py
+
       # Game-mode (gamescope / Big Picture) pointer input: the {t:'gm'} verb.
       # The portal is absent in Game Mode, so absolute menu nav rides an xdotool
       # ARGV LIST. Same security class as {t:'ma'}: holder gate + range-validated

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -266,8 +266,15 @@ def _open_pipewire_fd():
 
 def verb_status():
     h264 = _h264_available()
-    with _SLOCK:
-        sess = _SESSION
+    # Read the session WITHOUT taking _SLOCK. _ensure_session holds _SLOCK for its
+    # ENTIRE run, including the Start call that BLOCKS on the user's consent (up to
+    # _CONSENT_TIMEOUT_S). The agent probes this verb on a ~2s budget to fill
+    # caps.screenstream[_h264]; blocking on _SLOCK made that probe time out whenever
+    # a consent dialog was pending, so caps read False and the app never offered the
+    # fluid tiers. A single-pointer read needs no lock: _ensure_session publishes
+    # `_SESSION = {...}` as its last step and _close_session sets it to None, both
+    # atomic under the GIL, so a reader sees either None or a fully-built dict.
+    sess = _SESSION
     base = {"ok": True, "h264": h264, "h264_profiles": sorted(_H264_PROFILES)}
     if sess is None:
         base["session"] = False
@@ -639,6 +646,30 @@ def _stream_reader(proc, codec):
         _close_session()
 
 
+def _spawn_encoder(profile, codec):
+    """Spawn the persistent gst encoder for `codec` + start its reader thread, and
+    register it in _STREAM. CALLER MUST HOLD _STREAM_LOCK. Returns the proc, or
+    None on failure. The pwfd is a dup of the session's cached PipeWire remote."""
+    with _SLOCK:
+        node = _SESSION["node"]
+    pwfd = _open_pipewire_fd()
+    if pwfd is None:
+        return None
+    argv = (_stream_h264_argv(profile, pwfd, node) if codec == "h264"
+            else _stream_argv(profile, pwfd, node))
+    try:
+        proc = subprocess.Popen(argv, stdout=subprocess.PIPE,
+                                stderr=subprocess.DEVNULL, pass_fds=(pwfd,))
+    finally:
+        try:
+            os.close(pwfd)                           # the child holds it now
+        except OSError:
+            pass
+    _STREAM.update(proc=proc, profile=profile, codec=codec)
+    threading.Thread(target=_stream_reader, args=(proc, codec), daemon=True).start()
+    return proc
+
+
 def stream(profile, conn, codec):
     """Subscribe `conn` to the session's persistent encoder for `codec` ("mjpeg"
     or "h264"), spawning it on first use, then block until the subscription ends —
@@ -647,43 +678,58 @@ def stream(profile, conn, codec):
 
     MJPEG and H.264 are MUTUALLY EXCLUSIVE — one encoder per session (they can't
     both read the single portal ScreenCast node). If an encoder of the OTHER codec
-    is already running we REFUSE (return without subscribing); the agent then
-    closes the socket and the app degrades to its fallback. The app commits to one
-    tier per box (caps-driven), so a codec clash only happens when two clients
-    disagree — rare, and it self-heals once the running encoder hits its idle
-    TTL and the session tears down. We do NOT preempt by killing the running gst:
-    two gsts briefly sharing the node fail 'not-negotiated (-4)' (proven), and a
-    kill-then-respawn re-encodes stale keepalive buffers (also proven)."""
+    is already running we PREEMPT it (last-opener wins across codecs): this happens
+    when the app moves MJPEG->H.264 after the box gains a VA encoder, and REFUSING
+    left the app wedged on the old codec (the /ws/h264 socket closed and it demoted
+    straight back to MJPEG). Preempt safely: detach the old encoder under the lock,
+    then terminate it and WAIT for it to fully exit OUTSIDE the lock, so two gsts
+    never briefly share the node (the proven 'not-negotiated (-4)' / stale-keepalive
+    trap) — a fully-exited gst releases the node's buffer pool before the new one
+    opens it."""
     if _ensure_session() is None:
         return
+    # 1. Detect a codec switch under the lock + DETACH the old encoder (don't reap
+    #    while holding the lock — the wait would block the reader).
+    preempt = old_sub2 = old_done2 = None
     with _STREAM_LOCK:
         proc = _STREAM["proc"]
         if proc is not None and proc.poll() is not None:
             proc = None                              # crashed: allow respawn
             _STREAM.update(proc=None, profile=None, codec=None)
         if proc is not None and _STREAM["codec"] != codec:
-            return                                   # other codec live -> refuse
-        if proc is None:
-            with _SLOCK:
-                node = _SESSION["node"]
-            pwfd = _open_pipewire_fd()
-            if pwfd is None:
-                return
-            argv = (_stream_h264_argv(profile, pwfd, node) if codec == "h264"
-                    else _stream_argv(profile, pwfd, node))
+            preempt = proc
+            old_sub2, old_done2 = _STREAM["sub"], _STREAM["done"]
+            _STREAM.update(proc=None, profile=None, codec=None,
+                           sub=None, done=None, idle_since=None)
+    # 2. Reap the preempted encoder OUTSIDE the lock: wake its subscriber, then
+    #    terminate + wait for it to fully exit before we spawn the new codec.
+    if preempt is not None:
+        if old_done2 is not None:
+            old_done2.set()
+        if old_sub2 is not None:
             try:
-                proc = subprocess.Popen(
-                    argv,
-                    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-                    pass_fds=(pwfd,))
-            finally:
-                try:
-                    os.close(pwfd)                   # the child holds it now
-                except OSError:
-                    pass
-            _STREAM.update(proc=proc, profile=profile, codec=codec)
-            threading.Thread(target=_stream_reader, args=(proc, codec),
-                             daemon=True).start()
+                old_sub2.close()
+            except OSError:
+                pass
+        try:
+            preempt.terminate()
+            preempt.wait(timeout=5)
+        except Exception:
+            try:
+                preempt.kill()
+            except Exception:
+                pass
+    # 3. Spawn the new codec (if needed) + subscribe.
+    with _STREAM_LOCK:
+        proc = _STREAM["proc"]
+        if proc is not None and proc.poll() is not None:
+            proc = None
+            _STREAM.update(proc=None, profile=None, codec=None)
+        if proc is not None and _STREAM["codec"] != codec:
+            return                                   # a racing switch won; bail
+        if proc is None:
+            if _spawn_encoder(profile, codec) is None:
+                return
         # Subscribe, last-opener wins: kick + close any current subscriber.
         conn.settimeout(10)                          # a wedged peer can't block the reader
         done = threading.Event()

--- a/tests/test_portal_helper_logic.py
+++ b/tests/test_portal_helper_logic.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Pure-logic tests for two fixes in the remote-desktop portal helper
+(agent/couchside-portal.py), the concurrency-sensitive stream path.
+
+Run: python3 tests/test_portal_helper_logic.py
+
+The helper binds Gio at IMPORT (module-level `_con = Gio.bus_get_sync(...)`), so
+it can't be imported in CI as-is. This shims a minimal fake `gi` so the module
+loads, then tests the two fixes WITHOUT any real portal / gst / D-Bus:
+
+  1. verb_status() is NON-BLOCKING. `_ensure_session` holds `_SLOCK` for its whole
+     run — including the Start call that blocks on the user's consent (up to
+     _CONSENT_TIMEOUT_S). The agent probes status on a ~2s budget to fill
+     caps.screenstream[_h264]; the old `with _SLOCK: sess = _SESSION` made that
+     probe DEADLOCK behind a pending consent, so caps read False and the app never
+     offered the fluid tiers. status must return immediately even while _SLOCK is
+     held elsewhere.
+
+  2. stream() PREEMPTS on a codec switch instead of refusing. When the app moves
+     MJPEG->H.264 (box just gained a VA encoder), a leftover MJPEG encoder used to
+     make the helper REFUSE -> the /ws/h264 socket closed -> the app demoted back
+     to MJPEG. Now it terminates + waits for the old encoder, then spawns the new
+     one (last-opener wins across codecs).
+"""
+import os
+import sys
+import threading
+import time
+import types
+
+# --- shim a minimal `gi` so couchside-portal.py imports without a real bus -----
+_fake_gi = types.ModuleType("gi")
+_fake_gi.require_version = lambda *a, **k: None
+
+
+class _FakeConn:
+    def get_unique_name(self):
+        return ":1.999"
+
+    def call_sync(self, *a, **k):
+        return None
+
+
+class _Gio:
+    class BusType:
+        SESSION = 0
+
+    class DBusCallFlags:
+        NONE = 0
+
+    class DBusSignalFlags:
+        NONE = 0
+
+    class VariantType:
+        @staticmethod
+        def new(*a, **k):
+            return None
+
+    @staticmethod
+    def bus_get_sync(*a, **k):
+        return _FakeConn()
+
+
+class _GLib:
+    @staticmethod
+    def Variant(*a, **k):
+        return None
+
+    class VariantType:
+        @staticmethod
+        def new(*a, **k):
+            return None
+
+
+_repo = types.ModuleType("gi.repository")
+_repo.Gio = _Gio
+_repo.GLib = _GLib
+_fake_gi.repository = _repo
+sys.modules["gi"] = _fake_gi
+sys.modules["gi.repository"] = _repo
+
+import importlib.util  # noqa: E402
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "cs_portal", os.path.join(ROOT, "agent", "couchside-portal.py"))
+ph = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(ph)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# --- 1. verb_status() is non-blocking while _SLOCK is held --------------------
+print("1. verb_status() does not block on _SLOCK (the consent-deadlock fix)")
+holding = threading.Event()
+release = threading.Event()
+
+
+def _hold_slock():
+    with ph._SLOCK:            # mimic _ensure_session holding the lock over consent
+        holding.set()
+        release.wait(5)
+
+
+t = threading.Thread(target=_hold_slock, daemon=True)
+t.start()
+holding.wait(2)                # ensure the lock is held before we probe
+t0 = time.time()
+res = ph.verb_status()
+elapsed = time.time() - t0
+release.set()
+t.join(2)
+check("status returned while _SLOCK held", isinstance(res, dict) and res.get("ok"), True)
+check("status did NOT block (< 0.5s)", elapsed < 0.5, True)
+check("status reports session False (none open)", res.get("session"), False)
+
+
+# --- 2. stream() preempts a different-codec encoder ---------------------------
+print()
+print("2. stream() preempts on a codec switch (MJPEG encoder -> H.264 request)")
+
+
+class _FakeProc:
+    def __init__(self):
+        self.terminated = False
+        self.waited = False
+
+    def poll(self):
+        return None            # still running
+
+    def terminate(self):
+        self.terminated = True
+
+    def wait(self, timeout=None):
+        self.waited = True
+        return 0
+
+
+class _FakeConnSock:
+    def __init__(self):
+        self.closed = False
+
+    def settimeout(self, _t):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+old_proc = _FakeProc()
+old_sub = _FakeConnSock()
+old_done = threading.Event()
+# A live MJPEG encoder is running for this session.
+ph._STREAM.update(proc=old_proc, profile="720p20", codec="mjpeg",
+                  sub=old_sub, done=old_done, idle_since=None)
+
+spawned = {}
+new_proc = _FakeProc()
+
+
+def _fake_spawn(profile, codec):
+    spawned["profile"] = profile
+    spawned["codec"] = codec
+    ph._STREAM.update(proc=new_proc, profile=profile, codec=codec)
+    return new_proc
+
+
+saved_ensure = ph._ensure_session
+saved_spawn = ph._spawn_encoder
+ph._ensure_session = lambda: {"node": 7, "w": 1280, "h": 720}
+ph._spawn_encoder = _fake_spawn
+
+new_conn = _FakeConnSock()
+
+
+def _run_stream():
+    ph.stream("720p60", new_conn, "h264")            # blocks on done.wait()
+
+
+try:
+    st = threading.Thread(target=_run_stream, daemon=True)
+    st.start()
+    # Wait until the H.264 subscriber is installed, then release the blocking wait.
+    for _ in range(200):
+        if ph._STREAM.get("sub") is new_conn:
+            break
+        time.sleep(0.01)
+    done_evt = ph._STREAM.get("done")
+    if isinstance(done_evt, threading.Event):
+        done_evt.set()                               # unblock stream()'s done.wait()
+    st.join(2)
+
+    check("old MJPEG encoder was terminated", old_proc.terminated, True)
+    check("old encoder was waited on (fully reaped)", old_proc.waited, True)
+    check("old subscriber was kicked", old_sub.closed, True)
+    check("a new encoder was spawned", spawned.get("codec"), "h264")
+    check("new encoder used the requested profile", spawned.get("profile"), "720p60")
+    check("new H.264 conn is the current subscriber", ph._STREAM.get("sub") is new_conn, True)
+    check("codec is now h264", ph._STREAM.get("codec"), "h264")
+finally:
+    ph._ensure_session = saved_ensure
+    ph._spawn_encoder = saved_spawn
+    ph._STREAM.update(proc=None, profile=None, codec=None, sub=None, done=None,
+                      idle_since=None)
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all portal-helper-logic tests passed")


### PR DESCRIPTION
Two concurrency bugs in the Stage B portal helper, found testing the H.264 tier live.

## 1. Codec-switch refuse -> app wedged on MJPEG
The single-codec persistent encoder made `stream()` REFUSE a MJPEG->H.264 switch (leftover MJPEG encoder), so `/ws/h264` closed (1006/1005) and the app demoted back to the flickery MJPEG and stayed. Now it PREEMPTS: detach under the lock, terminate + wait-for-exit OUTSIDE the lock (so two gsts never share the portal node), then spawn the new codec.

## 2. `verb_status` deadlock on `_SLOCK`
`_ensure_session` holds `_SLOCK` through the consent wait; `verb_status`'s `with _SLOCK` made the agent's 2s caps probe time out during a pending consent -> caps read False -> no fluid tier offered. Now reads `_SESSION` lock-free.

## Tests
`tests/test_portal_helper_logic.py` (10 checks, CI-wired) — fake-`gi` shim; verifies status is non-blocking under a held `_SLOCK`, and that a codec switch terminates+reaps the old encoder and spawns the new one.

## NOT verified
The codec switch + status-under-consent on a real box (the live test box's KDE portal was too wedged for a clean run). Verify on a stable box, then cut the agent release (2.9.82) that ships the fixed helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)