### PR TITLE
fix(pairing): show the pairing PIN full-screen on desktop-session boxes (agent 2.9.83)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,13 @@ jobs:
       - name: Unit tests (remote-desktop portal helper logic)
         run: python3 tests/test_portal_helper_logic.py
 
+      # Pairing PIN full-screen launch resolver. A desktop-session box is a system
+      # service with a partial env, so a bare xdg-open failed and the PIN never
+      # showed (a hard stop for pairing). Pins the browser->--kiosk argv mapping
+      # (flatpak vs system browser, known browsers only, url passed verbatim).
+      - name: Unit tests (pairing PIN kiosk launch)
+        run: python3 tests/test_pair_kiosk.py
+
       # Game-mode (gamescope / Big Picture) pointer input: the {t:'gm'} verb.
       # The portal is absent in Game Mode, so absolute menu nav rides an xdotool
       # ARGV LIST. Same security class as {t:'ma'}: holder gate + range-validated

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,25 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.83
+
+**Pairing now works on desktop-session boxes.** On a box sitting at the Linux
+desktop (not Game Mode), the pairing PIN could fail to appear on the box's screen
+— a hard stop, since you can't finish setup without it. The box now reliably shows
+the PIN full-screen. (Game Mode was unaffected.) Everything from the last update is
+here too:
+
+**Fluid remote desktop.** When your box has a hardware H.264 encoder, the Control
+screen streams smooth, hardware-decoded video — trackpad, tap-to-point, keyboard,
+landscape — much closer to sitting at the machine. Boxes without an encoder keep
+the existing view.
+
+**Switch your audio output from the couch.** A new AUDIO OUTPUT card moves the
+box's sound to the TV, a speaker, or its built-in output with one tap.
+
+**Set your box's light from the phone.** A new LIGHT card sets a controllable front
+RGB/status LED's colour and brightness, or turns it off.
+
 ## 2.9.82
 
 Three features, now with a more reliable fluid remote desktop.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.82"
+VERSION = "2.9.83"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -16978,22 +16978,93 @@ def pair_show_on_box(port):
     pair_show_on_box_url("http://localhost:%d/pair" % port)
 
 
+_PIN_KIOSK_BROWSERS = ("firefox", "chromium", "chrome", "brave", "edge", "vivaldi")
+
+
+def _pin_kiosk_argv(url, default_browser, have=None):
+    """FULLSCREEN launch argv for `default_browser` (an `xdg-settings get
+    default-web-browser` .desktop id) on `url`, or None to fall back to windowed.
+
+    Firefox and every Chromium-family browser take --kiosk. A flatpak default
+    browser has a reverse-DNS .desktop id (e.g. org.mozilla.firefox.desktop) ->
+    `flatpak run <id> --kiosk`; a system browser -> its binary --kiosk. `have` is
+    the presence check (shutil.which), injectable for tests. No client input:
+    `url` is agent-built, the browser id comes from the box's own settings."""
+    if have is None:
+        have = shutil.which
+    app = default_browser[:-len(".desktop")] if default_browser.endswith(
+        ".desktop") else default_browser
+    dl = app.lower()
+    if not any(b in dl for b in _PIN_KIOSK_BROWSERS):
+        return None
+    if "." in app and have("flatpak"):                  # flatpak reverse-DNS id
+        return ["flatpak", "run", app, "--kiosk", url]
+    for b in ("firefox", "chromium", "chromium-browser", "google-chrome",
+              "google-chrome-stable", "brave-browser", "microsoft-edge",
+              "vivaldi-stable"):
+        if b in dl and have(b):
+            return [b, "--kiosk", url]
+    return None
+
+
 def pair_show_on_box_url(url):
     """Open a LOOPBACK url on the box's own screen. Game Mode -> Steam's
-    built-in browser (steam://openurl); desktop -> xdg-open. Best-effort,
-    detached, never blocks the request.
+    built-in browser (steam://openurl); desktop -> a FULLSCREEN (kiosk) browser
+    launched inside the user's systemd session. Best-effort, detached, never
+    blocks the request.
 
     Shared by the pairing PIN page and the update progress page. Callers pass a
     url this module built; nothing here comes from a client."""
     gamescope = _couchmode_session() == "gamescope"
+
+    # The agent is a SYSTEM service. It runs as the desktop user but inherits only
+    # a partial session env (XDG_RUNTIME_DIR yes; DISPLAY/WAYLAND_DISPLAY/
+    # DBUS_SESSION_BUS_ADDRESS no), so a BARE `xdg-open` has no display to draw on
+    # and — with a flatpak browser as the default — silently fails or hangs. The
+    # PIN then NEVER appears on a desktop-session box, a hard stop for pairing.
+    # Measured on a live Bazzite desktop 2026-08-12: bare xdg-open hung (rc 124, no
+    # browser); `systemd-run --user xdg-open <url>` opened Firefox on the /pair page
+    # (it runs inside the user's systemd manager, which carries the full graphical
+    # session env). Set DBUS_SESSION_BUS_ADDRESS so systemd-run can reach that
+    # manager. Game Mode is unchanged: Steam's own browser via steam://openurl.
+    def _desktop_env():
+        uid = os.getuid()
+        rt = os.environ.get("XDG_RUNTIME_DIR") or ("/run/user/%d" % uid)
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", rt)
+        env.setdefault("DBUS_SESSION_BUS_ADDRESS", "unix:path=%s/bus" % rt)
+        return env
+
+    def _kiosk_argv():
+        try:
+            d = subprocess.run(["xdg-settings", "get", "default-web-browser"],
+                               capture_output=True, text=True, timeout=5,
+                               env=_desktop_env()).stdout.strip()
+        except Exception:
+            d = ""
+        return _pin_kiosk_argv(url, d)
 
     def go():
         try:
             if gamescope:
                 subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
                                timeout=10)
-            elif shutil.which("xdg-open"):
-                subprocess.run(["xdg-open", url], timeout=10)
+                return
+            # Desktop: run inside the user's systemd manager (full session env),
+            # FULLSCREEN via the browser's --kiosk when we can resolve it, else a
+            # windowed xdg-open (the PIN still shows, just not fullscreen).
+            if shutil.which("systemd-run"):
+                launch = _kiosk_argv()
+                if launch is None and shutil.which("xdg-open"):
+                    launch = ["xdg-open", url]
+                if launch is not None:
+                    subprocess.run(
+                        ["systemd-run", "--user", "--collect"] + launch,
+                        timeout=10, env=_desktop_env(),
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                    return
+            if shutil.which("xdg-open"):
+                subprocess.run(["xdg-open", url], timeout=10, env=_desktop_env())
             elif shutil.which("steam"):
                 subprocess.run(["steam", "-ifrunning", "steam://openurl/" + url],
                                timeout=10)

--- a/tests/test_pair_kiosk.py
+++ b/tests/test_pair_kiosk.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fullscreen pairing-PIN launch resolver (_pin_kiosk_argv).
+
+Run: python3 tests/test_pair_kiosk.py
+
+The pairing PIN page must open FULLSCREEN on the box so a user can read the code
+off a TV. On a desktop-session box the agent is a system service with only a
+partial session env, so a bare xdg-open silently failed and the PIN never showed
+— a hard stop for pairing (fixed by launching a --kiosk browser inside the user's
+systemd session). This pins the browser->argv mapping: a flatpak default browser
+(reverse-DNS .desktop id) -> `flatpak run <id> --kiosk`, a system browser -> its
+binary --kiosk, and anything that isn't a known browser -> None (fall back to a
+windowed xdg-open; the PIN still shows). The actual launch is hardware-verified.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+URL = "http://localhost:8787/pair"
+
+
+def have_all(_x):
+    return True
+
+
+def have_none(_x):
+    return False
+
+
+def have_set(names):
+    return lambda x: x in names
+
+
+# flatpak default browser (reverse-DNS id) -> flatpak run <id> --kiosk
+check("flatpak firefox -> flatpak run --kiosk",
+      cs._pin_kiosk_argv(URL, "org.mozilla.firefox.desktop", have=have_set({"flatpak"})),
+      ["flatpak", "run", "org.mozilla.firefox", "--kiosk", URL])
+check("flatpak chromium -> flatpak run --kiosk",
+      cs._pin_kiosk_argv(URL, "org.chromium.Chromium.desktop", have=have_set({"flatpak"})),
+      ["flatpak", "run", "org.chromium.Chromium", "--kiosk", URL])
+
+# system browser (plain id) -> <binary> --kiosk
+check("system firefox -> firefox --kiosk",
+      cs._pin_kiosk_argv(URL, "firefox.desktop", have=have_set({"firefox"})),
+      ["firefox", "--kiosk", URL])
+check("google-chrome -> google-chrome --kiosk",
+      cs._pin_kiosk_argv(URL, "google-chrome.desktop", have=have_set({"google-chrome"})),
+      ["google-chrome", "--kiosk", URL])
+check("brave -> brave-browser --kiosk",
+      cs._pin_kiosk_argv(URL, "brave-browser.desktop", have=have_set({"brave-browser"})),
+      ["brave-browser", "--kiosk", URL])
+
+# a flatpak id but flatpak binary absent -> None (fall through, no bad argv)
+check("flatpak firefox but no flatpak binary -> None",
+      cs._pin_kiosk_argv(URL, "org.mozilla.firefox.desktop", have=have_none),
+      None)
+
+# not a browser at all -> None (windowed fallback)
+check("non-browser default (kate) -> None",
+      cs._pin_kiosk_argv(URL, "org.kde.kate.desktop", have=have_all), None)
+check("empty default -> None", cs._pin_kiosk_argv(URL, "", have=have_all), None)
+
+# a known browser name but its binary isn't present -> None (no unlaunchable argv)
+check("system firefox but binary missing -> None",
+      cs._pin_kiosk_argv(URL, "firefox.desktop", have=have_none), None)
+
+# url is passed through verbatim (agent-built, never interpolated into a shell)
+weird = "http://localhost:8787/pair"
+check("url is the last argv element, verbatim",
+      cs._pin_kiosk_argv(weird, "firefox.desktop", have=have_set({"firefox"}))[-1], weird)
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all pair-kiosk tests passed")


### PR DESCRIPTION
**Critical / hard stop.** On a desktop-session box (not Game Mode), the pairing PIN never appeared on the box's screen, so a new user couldn't finish setup.

**Cause** (measured on live Bazzite desktop): the agent is a system service with only a partial session env (XDG_RUNTIME_DIR yes; DISPLAY/WAYLAND_DISPLAY/DBUS_SESSION_BUS_ADDRESS no), so a bare `xdg-open` had no display and — with a flatpak default browser — silently hung.

**Fix:** launch the /pair page inside the user's systemd manager (`systemd-run --user`, full session env) and full-screen it via the browser's `--kiosk`. `_pin_kiosk_argv` resolves the default browser to a launch (flatpak vs system binary), else falls back to windowed xdg-open. Game Mode unchanged.

Hardware-verified on live Bazzite desktop (PIN shows full-screen). `tests/test_pair_kiosk.py` (10 checks, CI-wired) pins the argv mapping. Bumps agent to 2.9.83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)