### PR TITLE
LED Studio — editor, presets, effects, persistence, OpenRGB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,22 @@ jobs:
       - name: Unit tests (led control)
         run: python3 tests/test_led_control.py
 
+      # LED effect engine + persistence (POST /api/leds/effect, the effects/active
+      # fields on GET /api/leds, reboot restore). Proves an unknown effect id or an
+      # unknown/traversal/non-writable LED starts + writes NOTHING, that the render
+      # thread only ever writes the three fixed-literal attrs, that persistence
+      # round-trips and is REVALIDATED on restore, and that --mock is observable.
+      - name: Unit tests (led effects)
+        run: python3 tests/test_led_effects.py
+
+      # OpenRGB backend (GET /api/openrgb, POST /api/openrgb/set) + the hand-rolled
+      # SDK client. No OpenRGB hardware in CI, so the wire format is proven against
+      # an in-process mock OpenRGB server (handshake, controller-data parse, per-LED
+      # UPDATE_LEDS frames). Proves an out-of-range device index or unknown effect
+      # writes NOTHING, colours round-trip, and --mock is observable.
+      - name: Unit tests (openrgb)
+        run: python3 tests/test_openrgb.py
+
       # Which filesystems the dashboard reports. A Deck owner was shown
       # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
       # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,15 @@ jobs:
       - name: Unit tests (openrgb)
         run: python3 tests/test_openrgb.py
 
+      # Addressable LED strip + hardware effects (valve-leds). The allowlist one:
+      # the client sends a strip PREFIX, members come from the live listdir, and
+      # the `effect` VALUE written must be one the device itself publishes in
+      # effect_index. Proves an unknown prefix writes nothing, an unpublished
+      # firmware effect is never written, and only fixed-literal attrs on the
+      # strip's own members are touched.
+      - name: Unit tests (led strip)
+        run: python3 tests/test_led_strip.py
+
       # Which filesystems the dashboard reports. A Deck owner was shown
       # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
       # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.84"
+VERSION = "2.9.85"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4115,6 +4115,23 @@ MOCK_LEDS = [
      "notable": False, "writable": True, "max_brightness": 1,
      "index": [], "maxint": [], "brightness": 0, "color": None},
 ]
+# A mock ADDRESSABLE STRIP (Steam-Machine-style valve-leds) so the app can build
+# + drive the strip UI off-box: 8 RGB nodes named valve-leds[0..7].
+MOCK_LEDS += [
+    {"name": "valve-leds[%d]" % i, "desc": "valve-leds[%d]" % i, "rgb": True,
+     "notable": True, "writable": True, "max_brightness": 255,
+     "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+     "brightness": 120, "color": {"r": 0, "g": 200, "b": 255}}
+    for i in range(8)
+]
+# Firmware effects the mock strip advertises (mirrors a real valve-leds device).
+_MOCK_STRIP_HW = ["patrol", "breath", "factory", "normal", "off", "rainbow",
+                  "demo", "manual"]
+
+
+def _mock_strip_public(prefix, members):
+    return {"prefix": prefix, "count": len(members), "rgb": True,
+            "hw_effects": list(_MOCK_STRIP_HW)}
 # name -> {"brightness": <device units>, "color": {r,g,b}}, remembered across
 # --mock requests so a harness swatch/level tap MOVES the value and the next GET
 # shows it (observe both states, CLAUDE.md §11). Mock-only.
@@ -4283,13 +4300,18 @@ def leds_state(mock):
     remembered mock state so the harness can observe a change."""
     if mock:
         pubs = [_mock_led_public(l["name"]) for l in MOCK_LEDS if l["writable"]]
+        strips = _led_strips([l["name"] for l in MOCK_LEDS if l["writable"]])
         return {"available": any(p["notable"] for p in pubs), "leds": pubs,
                 "effects": list(_LED_EFFECTS),
-                "active": {k: dict(v) for k, v in _MOCK_FX.items()}}
-    raws = [_read_led_raw(n) for n in _list_led_names()]
+                "active": {k: dict(v) for k, v in _MOCK_FX.items()},
+                "strips": [_mock_strip_public(p, m) for p, m in strips.items()]}
+    names = _list_led_names()
+    raws = [_read_led_raw(n) for n in names]
     pubs = [_led_public(r) for r in raws if r and r["writable"]]
+    strips = _led_strips(names)
     return {"available": any(p["notable"] for p in pubs), "leds": pubs,
-            "effects": list(_LED_EFFECTS), "active": _led_active_map()}
+            "effects": list(_LED_EFFECTS), "active": _led_active_map(),
+            "strips": [_strip_public(p, m) for p, m in strips.items()]}
 
 
 def _led_realpath_ok(name):
@@ -4305,8 +4327,10 @@ def _led_realpath_ok(name):
 
 def _led_write(name, attr, value):
     """Write to the FIXED-literal attribute `attr` of LED `name`. attr is NEVER
-    client input -- only 'brightness', 'multi_intensity', 'trigger' are ever
-    passed by set_led()."""
+    client input -- the only literals ever passed are 'brightness',
+    'multi_intensity', 'trigger' (set_led) and 'effect', 'enabled', 'delay'
+    (the valve-leds hardware-effect strip path). The effect VALUE is validated
+    against the device's own effect_index before it reaches here."""
     with open(os.path.join(_LEDS_ROOT, name, attr), "w") as f:
         f.write(value)
 
@@ -4651,9 +4675,11 @@ def _led_restore():
     """Re-apply the persisted effect/colour to each LED still present + writable.
     Revalidates EVERY field (never trusts the file); a vanished/locked LED or a
     junk record is skipped. Best-effort."""
-    live = set(_list_led_names())
+    names = _list_led_names()
+    live = set(names)
+    strips = _led_strips(names)
     for name, st in _led_state_load().items():
-        if name not in live or not isinstance(st, dict):
+        if not isinstance(st, dict):
             continue
         effect = st.get("effect")
         if effect not in _LED_EFFECTS:
@@ -4662,7 +4688,14 @@ def _led_restore():
         speed = st.get("speed") if _is_pct(st.get("speed"), 1) else 50
         brightness = st.get("brightness") if _is_pct(st.get("brightness")) else 100
         try:
-            apply_led_effect(name, effect, color, speed, brightness)
+            if name.startswith("strip:"):
+                # A persisted strip (firmware effect): re-arm the whole strip so a
+                # reboot brings back the night-rider without the phone.
+                prefix = name[len("strip:"):]
+                if prefix in strips:
+                    apply_strip_effect(prefix, effect, color, speed, brightness)
+            elif name in live:
+                apply_led_effect(name, effect, color, speed, brightness)
         except OSError:
             pass
 
@@ -4678,6 +4711,148 @@ def _led_restore_worker():
                 return
         except OSError:
             pass
+
+
+# ---- Addressable LED STRIP + hardware effects (valve-leds) -------------------
+# A Steam Deck / Steam Machine exposes its front strip as N kernel LED nodes
+# `valve-leds[0]` .. `valve-leds[16]`, and the driver runs animations IN FIRMWARE
+# via an `effect` attribute whose allowed values it publishes in `effect_index`
+# (patrol/breath/rainbow/normal/off/manual/...). So the box owns the animation:
+# set `effect=patrol` once and the strip does a real night-rider sweep with the
+# phone closed, backgrounded, or gone -- and it survives reboot via our restore.
+#
+# ALLOWLIST (CLAUDE.md §3): the client sends a strip PREFIX; members come from the
+# live os.listdir(/sys/class/leds) filtered by `prefix[<n>]`, never interpolated.
+# The `effect` attr name is a fixed literal; the VALUE written must be an EXACT
+# member of the device's own `effect_index` set (looked up, not trusted); `delay`
+# is range-checked against the device's `delay_range`; colour/brightness are the
+# same validated writers set_led() uses.
+_STRIP_RE = re.compile(r"^(.*)\[(\d+)\]$")
+
+# our effect id -> the firmware effect name we try (only used if the device's
+# effect_index actually offers it; else we fall back to a per-LED manual paint).
+_STRIP_HW_MAP = {"scanner": "patrol", "breathe": "breath", "rainbow": "rainbow",
+                 "pulse": "breath", "strobe": "breath", "solid": "manual",
+                 "off": "off"}
+# effects whose look depends on the picked colour (set multi_intensity first).
+_STRIP_COLOUR_FX = ("scanner", "breathe", "pulse", "strobe", "solid")
+
+
+def _led_strips(names=None):
+    """Group live LEDs into strips: {prefix: [member names sorted by index]} for
+    any `prefix[N]` family with >= 3 members. Members are bare listdir names."""
+    groups = {}
+    for name in (names if names is not None else _list_led_names()):
+        m = _STRIP_RE.match(name)
+        if m:
+            groups.setdefault(m.group(1), []).append(name)
+    return {p: sorted(ns, key=lambda n: int(_STRIP_RE.match(n).group(2)))
+            for p, ns in groups.items() if len(ns) >= 3}
+
+
+def _strip_hw_effects(member):
+    """The firmware effect names the device publishes for this node
+    (`effect_index`, space-separated), or [] for a plain strip with no hardware
+    effects. Read-only."""
+    raw = _led_read_attr(member, "effect_index")
+    return raw.split() if raw else []
+
+
+def _strip_delay(member, speed):
+    """Map speed 1-100 -> the device's `delay` value (higher speed = smaller
+    delay = faster), clamped to the node's own `delay_range` (e.g. '0-20'). None
+    when the node has no delay control."""
+    rng = _led_read_attr(member, "delay_range")
+    if not rng or "-" not in rng:
+        return None
+    try:
+        lo, hi = (int(x) for x in rng.split("-")[:2])
+    except (ValueError, TypeError):
+        return None
+    s = speed if _is_pct(speed, 1) else 50
+    return max(lo, min(hi, round(hi - (s / 100.0) * (hi - lo))))
+
+
+def _strip_public(prefix, members):
+    """API view of a strip for GET /api/leds `strips`."""
+    raw0 = _read_led_raw(members[0])
+    return {"prefix": prefix, "count": len(members),
+            "rgb": bool(raw0 and raw0["rgb"]),
+            "hw_effects": _strip_hw_effects(members[0])}
+
+
+def apply_strip_effect(prefix, effect, color, speed, brightness):
+    """Set an addressable strip to a FIRMWARE effect (or a manual solid/off).
+
+    Returns {"ok":True,"active":..} | {"ok":False,"status":..} | None(->404).
+    The heavy lifting is the driver's: for a hardware effect we set the base
+    colour/brightness then write `effect`=<firmware name> + `delay`, and the strip
+    animates itself. `solid` paints every LED (effect=manual); `off` zeroes them."""
+    if effect not in _LED_EFFECTS:
+        return {"ok": False, "status": 400, "error": "unknown effect"}
+    if not isinstance(prefix, str):
+        return None
+    members = _led_strips().get(prefix)
+    if not members:
+        return None
+    raws = {n: _read_led_raw(n) for n in members}
+    if not all(r and r["writable"] for r in raws.values()):
+        return None
+    avail = _strip_hw_effects(members[0])
+    hw = _STRIP_HW_MAP.get(effect)
+    b = brightness if _is_pct(brightness) else 100
+    sp = speed if _is_pct(speed, 1) else 50
+    col = color or ({"r": 255, "g": 0, "b": 0} if effect == "scanner"
+                    else {"r": 255, "g": 255, "b": 255})
+
+    def _bval(raw):
+        return str(int(b / 100 * raw["max_brightness"] + 0.5))
+
+    try:
+        if effect == "off":
+            for n in members:
+                if "off" in avail:
+                    _led_write(n, "effect", "off")
+                _led_write(n, "brightness", "0")
+        elif hw and hw in avail and hw != "manual":
+            # FIRMWARE effect. Set the base colour (for colour-driven effects) +
+            # brightness, then flip the mode + speed; the driver animates.
+            for n in members:
+                if effect in _STRIP_COLOUR_FX and raws[n]["rgb"]:
+                    _led_write_color(n, raws[n], col)
+                _led_write(n, "brightness", _bval(raws[n]))
+            for n in members:
+                _led_write(n, "effect", hw)
+                try:
+                    _led_write(n, "enabled", "1")
+                except OSError:
+                    pass
+                d = _strip_delay(n, sp)
+                if d is not None:
+                    try:
+                        _led_write(n, "delay", str(d))
+                    except OSError:
+                        pass
+        else:
+            # No matching firmware effect (or `solid`): manual per-LED paint.
+            for n in members:
+                if "manual" in avail:
+                    try:
+                        _led_write(n, "effect", "manual")
+                    except OSError:
+                        pass
+                if raws[n]["rgb"]:
+                    _led_write_color(n, raws[n], col)
+                _led_write(n, "brightness", _bval(raws[n]))
+    except OSError as e:
+        return {"ok": False, "status": 500, "error": str(e) or "strip write failed"}
+
+    with _FX_LOCK:
+        _LED_PERSIST["strip:" + prefix] = {"effect": effect, "color": col,
+                                           "speed": sp, "brightness": b}
+    _led_state_save()
+    return {"ok": True, "strip": prefix,
+            "active": {"effect": effect, "color": col, "speed": sp, "brightness": b}}
 
 
 # ---- OpenRGB backend (cap: openrgb) -----------------------------------------
@@ -19166,6 +19341,38 @@ class Handler(BaseHTTPRequestHandler):
                 if verr is not None:
                     self._send(400, {"error": verr}, started)
                     return
+
+                # STRIP target: the client sends a `strip` PREFIX; the agent drives
+                # the whole valve-leds[*] family (firmware effect on the box, so it
+                # survives the phone closing). Same allowlist: prefix members come
+                # from the live listdir, effect id is frozen, params range-checked.
+                strip_name = req.get("strip")
+                if strip_name is not None:
+                    if self.mock:
+                        ms = _led_strips([l["name"] for l in MOCK_LEDS if l["writable"]])
+                        if not isinstance(strip_name, str) or strip_name not in ms:
+                            self._send(404, {"error": "unknown strip"}, started)
+                            return
+                        key = "strip:" + strip_name
+                        if effect in _LED_STATIC:
+                            _MOCK_FX.pop(key, None)
+                        else:
+                            _MOCK_FX[key] = {
+                                "effect": effect,
+                                "color": color if color is not None else {"r": 255, "g": 0, "b": 0},
+                                "speed": speed if speed is not None else 50,
+                                "brightness": brightness if brightness is not None else 100}
+                        self._send(200, {"ok": True, "strip": strip_name,
+                                         "active": _MOCK_FX.get(key)}, started)
+                        return
+                    res = apply_strip_effect(strip_name, effect, color, speed, brightness)
+                    if res is None:
+                        self._send(404, {"error": "unknown strip"}, started)
+                        return
+                    self._send(res.get("status", 200) if not res.get("ok") else 200,
+                               res, started)
+                    return
+
                 if self.mock:
                     match = next((l for l in MOCK_LEDS
                                   if l["name"] == led_name), None)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -4383,6 +4383,16 @@ def set_led(name, brightness, color):
         return {"ok": False, "status": 400, "error": "led has no colour channels"}
     try:
         _led_clear_trigger(name)
+        # If this LED is a firmware-effect strip node (valve-leds[N]), a running
+        # effect (patrol/breath/…) would overwrite a static paint -- put just this
+        # node into manual mode first so the colour STICKS. 'manual' is written
+        # only when the device itself lists it in effect_index (looked up, not
+        # trusted); this is what makes per-LED painting a real customizer.
+        if _STRIP_RE.match(name) and "manual" in _strip_hw_effects(name):
+            try:
+                _led_write(name, "effect", "manual")
+            except OSError:
+                pass
         if color is not None:
             _led_write_color(name, raw, color)
         if brightness is not None:
@@ -4448,7 +4458,8 @@ _LED_STATE_CONF = os.path.expanduser("~/.config/couchside/leds.json")
 
 # Frozen allowlist of effect ids (looked up, never interpolated). 'solid'/'off'
 # are one-shot (no animation); the rest animate on the render thread.
-_LED_EFFECTS = ("solid", "off", "breathe", "pulse", "rainbow", "strobe", "scanner")
+_LED_EFFECTS = ("solid", "off", "breathe", "pulse", "rainbow", "strobe",
+                "scanner", "manual")
 _LED_STATIC = frozenset(("solid", "off"))
 
 _FX_TICK = 0.033                 # ~30 fps render cadence
@@ -4625,7 +4636,8 @@ def apply_led_effect(name, effect, color, speed, brightness):
     raw = _read_led_raw(name)
     if raw is None or not raw["writable"]:
         return None
-    if effect in _LED_STATIC:
+    # `manual` is a strip concept; on a single LED it's just a static paint.
+    if effect in _LED_STATIC or effect == "manual":
         res = set_led(name, 0 if effect == "off" else brightness,
                       None if effect == "off" else color)
         if res is None:
@@ -4733,7 +4745,7 @@ _STRIP_RE = re.compile(r"^(.*)\[(\d+)\]$")
 # effect_index actually offers it; else we fall back to a per-LED manual paint).
 _STRIP_HW_MAP = {"scanner": "patrol", "breathe": "breath", "rainbow": "rainbow",
                  "pulse": "breath", "strobe": "breath", "solid": "manual",
-                 "off": "off"}
+                 "manual": "manual", "off": "off"}
 # effects whose look depends on the picked colour (set multi_intensity first).
 _STRIP_COLOUR_FX = ("scanner", "breathe", "pulse", "strobe", "solid")
 
@@ -4833,6 +4845,14 @@ def apply_strip_effect(prefix, effect, color, speed, brightness):
                         _led_write(n, "delay", str(d))
                     except OSError:
                         pass
+        elif effect == "manual":
+            # Enter manual mode strip-wide (stops any running firmware effect) but
+            # PRESERVE each LED's colour, so the phone can paint a per-LED pattern
+            # (via /api/leds/set) that sticks instead of being overwritten.
+            for n in members:
+                if "manual" in avail:
+                    _led_write(n, "effect", "manual")
+                _led_write(n, "brightness", _bval(raws[n]))
         else:
             # No matching firmware effect (or `solid`): manual per-LED paint.
             for n in members:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -14,11 +14,13 @@ defaults.
 import argparse
 import base64
 import calendar
+import colorsys
 import errno
 import glob
 import hashlib
 import hmac
 import json
+import math
 import os
 import random
 import re
@@ -46,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.83"
+VERSION = "2.9.84"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1583,7 +1585,8 @@ def set_caps(mock):
                  "steamlink", "gaming", "steaminstall", "utilities",
                  "streamhost", "steammenus", "boxbattery", "file_upload",
                  "session_default", "display_info", "player", "screenstream",
-                 "screenstream_h264", "audioswitch", "ledcontrol")}
+                 "screenstream_h264", "audioswitch", "ledcontrol",
+                 "openrgb")}
         return
     CAPS = {
         "gamepad": _uinput_writable(),
@@ -1633,6 +1636,11 @@ def set_caps(mock):
         # phone via /sys/class/leds. Linux-only. False on a stock box (files are
         # root-owned) until an install-time udev grant makes an LED writable.
         "ledcontrol": safe(ledcontrol_available),
+        # Whole-system / addressable RGB via a local OpenRGB SDK server
+        # (127.0.0.1:6742) -> motherboard/RAM/GPU/strip control + a real
+        # multi-zone scanner. Absent unless the user installed OpenRGB and its
+        # server answers on loopback (degrade closed).
+        "openrgb": safe(openrgb_available),
     }
 
 
@@ -4275,10 +4283,13 @@ def leds_state(mock):
     remembered mock state so the harness can observe a change."""
     if mock:
         pubs = [_mock_led_public(l["name"]) for l in MOCK_LEDS if l["writable"]]
-        return {"available": any(p["notable"] for p in pubs), "leds": pubs}
+        return {"available": any(p["notable"] for p in pubs), "leds": pubs,
+                "effects": list(_LED_EFFECTS),
+                "active": {k: dict(v) for k, v in _MOCK_FX.items()}}
     raws = [_read_led_raw(n) for n in _list_led_names()]
     pubs = [_led_public(r) for r in raws if r and r["writable"]]
-    return {"available": any(p["notable"] for p in pubs), "leds": pubs}
+    return {"available": any(p["notable"] for p in pubs), "leds": pubs,
+            "effects": list(_LED_EFFECTS), "active": _led_active_map()}
 
 
 def _led_realpath_ok(name):
@@ -4365,6 +4376,20 @@ def set_led(name, brightness, color):
             "brightness_pct": pub["brightness_pct"], "color": pub["color"]}
 
 
+def _is_rgb_triple(c):
+    """True iff `c` is exactly {r,g,b} of ints 0-255. Booleans are excluded
+    (JSON true == 1 in Python). Shared by every LED colour validator so the
+    accept/reject rule is defined once."""
+    return (isinstance(c, dict) and set(c) == {"r", "g", "b"}
+            and all(isinstance(c[k], int) and not isinstance(c[k], bool)
+                    and 0 <= c[k] <= 255 for k in ("r", "g", "b")))
+
+
+def _is_pct(v, lo=0):
+    """True iff `v` is an int lo..100 (not a bool)."""
+    return isinstance(v, int) and not isinstance(v, bool) and lo <= v <= 100
+
+
 def _validate_led_body(req):
     """Shared shape check for POST /api/leds/set. Returns
     (brightness|None, color|None, error|None); error -> 400. Rejects (never
@@ -4374,16 +4399,753 @@ def _validate_led_body(req):
     color = req.get("color")
     if brightness is None and color is None:
         return None, None, "need brightness or color"
-    if brightness is not None and not (
-            isinstance(brightness, int) and not isinstance(brightness, bool)
-            and 0 <= brightness <= 100):
+    if brightness is not None and not _is_pct(brightness):
         return None, None, "brightness must be an int 0-100"
-    if color is not None and not (
-            isinstance(color, dict) and set(color) == {"r", "g", "b"}
-            and all(isinstance(color[c], int) and not isinstance(color[c], bool)
-                    and 0 <= color[c] <= 255 for c in ("r", "g", "b"))):
+    if color is not None and not _is_rgb_triple(color):
         return None, None, "color must be {r,g,b} ints 0-255"
     return brightness, color, None
+
+
+# ---- LED effect engine + persistence (rides on the `ledcontrol` cap) --------
+# Animates the kernel LEDs the LIGHT card already controls: breathe / pulse /
+# rainbow / strobe (and `scanner`, which really wants MULTIPLE LEDs -> the
+# OpenRGB backend; on a single kernel LED it degrades to a bounce-pulse). ONE
+# daemon thread renders every ACTIVE effect ~30x/s by calling the SAME validated
+# writers set_led() uses -- a client only ever selects an ALLOWLISTED effect id
+# + range-checked params + an LED looked up in the live /sys/class/leds set when
+# the effect starts. Nothing client-supplied reaches a path per-frame; no new
+# raw write path is exposed (CLAUDE.md §3).
+#
+# The active effect (and a plain solid colour) is persisted to
+# ~/.config/couchside/leds.json and re-applied at startup, so a reboot restores
+# it instead of reverting to the firmware default -- the agent is a systemd
+# *user* service, so the restore runs on login.
+_LED_STATE_CONF = os.path.expanduser("~/.config/couchside/leds.json")
+
+# Frozen allowlist of effect ids (looked up, never interpolated). 'solid'/'off'
+# are one-shot (no animation); the rest animate on the render thread.
+_LED_EFFECTS = ("solid", "off", "breathe", "pulse", "rainbow", "strobe", "scanner")
+_LED_STATIC = frozenset(("solid", "off"))
+
+_FX_TICK = 0.033                 # ~30 fps render cadence
+_FX_LOCK = threading.RLock()
+_FX_ACTIVE = {}                  # led name -> params dict {effect,color,speed,brightness}
+_FX_RAW = {}                     # led name -> cached raw LED dict (index/maxint/maxb)
+_LED_PERSIST = {}                # led name -> last-applied state (statics too), for restore
+_FX_THREAD = [None]              # the single render thread (mutable cell)
+_FX_STOP = threading.Event()     # set only on full shutdown; single stops just pop _FX_ACTIVE
+_MOCK_FX = {}                    # --mock: animated effect the harness last selected, per LED
+
+
+def _fx_period(speed):
+    """Map speed (int 1..100) to an effect period in seconds -- higher = faster.
+    100 -> ~0.5s, 50 -> ~2.75s, 1 -> ~6s. Clamped so speed 1 isn't absurd."""
+    s = speed if _is_pct(speed, 1) else 50
+    return 6.0 - (s / 100.0) * 5.5
+
+
+def _fx_frame(effect, params, t):
+    """(color|None, brightness_pct) for `effect` at elapsed time t seconds.
+    color None -> leave the LED's colour, drive brightness only."""
+    target = params.get("brightness")
+    target = 100 if not _is_pct(target) else target
+    color = params.get("color")
+    period = _fx_period(params.get("speed"))
+    if effect == "breathe":
+        frac = (math.sin(2 * math.pi * (t / period) - math.pi / 2) + 1) / 2
+        return color, int(round(target * frac))
+    if effect == "pulse":
+        frac = 1.0 - (t % period) / period          # sharp on, linear fade
+        return color, int(round(target * frac))
+    if effect == "strobe":
+        return color, (target if (t % period) < period / 2 else 0)
+    if effect == "rainbow":
+        r, g, b = colorsys.hsv_to_rgb((t / period) % 1.0, 1.0, 1.0)
+        return ({"r": int(r * 255), "g": int(g * 255), "b": int(b * 255)}, target)
+    if effect == "scanner":
+        frac = abs(1.0 - 2.0 * ((t % period) / period))   # triangle 1->0->1 bounce
+        return color, int(round(target * frac))
+    return color, target
+
+
+def _fx_write(name, raw, color, brightness_pct):
+    """Write one animation frame via the SAME fixed-literal writers set_led()
+    uses. `name`/`raw` were validated when the effect started; nothing here is
+    client-derived. A transient sysfs error must not kill the render loop."""
+    try:
+        if color is not None and raw.get("rgb"):
+            _led_write_color(name, raw, color)
+        if brightness_pct is not None:
+            maxb = raw["max_brightness"]
+            _led_write(name, "brightness",
+                       str(int(brightness_pct / 100 * maxb + 0.5)))
+    except OSError:
+        pass
+
+
+def _fx_loop():
+    """Render every active animated effect until none remain (or shutdown)."""
+    start = time.monotonic()
+    with _FX_LOCK:
+        for name in list(_FX_ACTIVE):
+            _led_clear_trigger(name)          # a kernel heartbeat can't fight us
+    while not _FX_STOP.is_set():
+        with _FX_LOCK:
+            items = [(n, dict(p), _FX_RAW.get(n)) for n, p in _FX_ACTIVE.items()]
+        if not items:
+            break
+        now = time.monotonic() - start
+        for name, params, raw in items:
+            if raw is None:
+                continue
+            color, b = _fx_frame(params["effect"], params, now)
+            _fx_write(name, raw, color, b)
+        _FX_STOP.wait(_FX_TICK)
+    with _FX_LOCK:
+        _FX_THREAD[0] = None
+
+
+def _fx_ensure_thread():
+    with _FX_LOCK:
+        th = _FX_THREAD[0]
+        if th is None or not th.is_alive():
+            _FX_STOP.clear()
+            th = threading.Thread(target=_fx_loop, daemon=True, name="led-fx")
+            _FX_THREAD[0] = th
+            th.start()
+
+
+def _fx_start(name, raw, effect, params):
+    """Register/replace an animated effect on already-validated LED `name`."""
+    with _FX_LOCK:
+        _FX_RAW[name] = raw
+        _FX_ACTIVE[name] = dict(params, effect=effect)
+    _fx_ensure_thread()
+
+
+def _fx_stop(name):
+    """Stop any animation on `name` (leaves whatever frame it last wrote)."""
+    with _FX_LOCK:
+        _FX_ACTIVE.pop(name, None)
+        _FX_RAW.pop(name, None)
+
+
+def _fx_note_static(name, res):
+    """After a solid/off write (via set_led): stop any animation on `name` and
+    persist it as a solid so a reboot restores the colour."""
+    _fx_stop(name)
+    with _FX_LOCK:
+        _LED_PERSIST[name] = {"effect": "solid", "color": res.get("color"),
+                              "brightness": res.get("brightness_pct"), "speed": 50}
+    _led_state_save()
+
+
+def _led_state_save():
+    """Atomically persist _LED_PERSIST to ~/.config/couchside/leds.json. Best
+    effort -- a save failure never breaks a live LED write."""
+    with _FX_LOCK:
+        data = {"version": 1, "leds": {k: dict(v) for k, v in _LED_PERSIST.items()}}
+    d = os.path.dirname(_LED_STATE_CONF)
+    try:
+        os.makedirs(d, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".couchside-leds-", dir=d)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, _LED_STATE_CONF)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def _led_state_load():
+    """Read the persisted led map (name -> state dict), or {} on any problem.
+    Never trusts the contents -- callers revalidate every field."""
+    try:
+        with open(_LED_STATE_CONF) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    leds = data.get("leds") if isinstance(data, dict) else None
+    return leds if isinstance(leds, dict) else {}
+
+
+def _led_active_map():
+    """The animated-effect state per LED for GET /api/leds `active` (statics are
+    already reflected in each led's colour/brightness_pct, so they're omitted)."""
+    with _FX_LOCK:
+        return {n: dict(s) for n, s in _LED_PERSIST.items()
+                if s.get("effect") not in _LED_STATIC}
+
+
+def apply_led_effect(name, effect, color, speed, brightness):
+    """Start/replace an effect (or a solid/off) on LED `name`.
+
+    ALLOWLIST (CLAUDE.md §3): `name` must be an EXACT writable member of the
+    freshly re-read /sys/class/leds set -- else None (caller -> 404) and nothing
+    is touched. Effect id is checked against the frozen _LED_EFFECTS; params were
+    range-checked by the caller. Returns {"ok":True,"active":..} |
+    {"ok":False,"status":..,"error":..} | None."""
+    if effect not in _LED_EFFECTS:
+        return {"ok": False, "status": 400, "error": "unknown effect"}
+    if (not isinstance(name, str) or "/" in name or ".." in name
+            or "\x00" in name or name not in _list_led_names()
+            or not _led_realpath_ok(name)):
+        return None
+    raw = _read_led_raw(name)
+    if raw is None or not raw["writable"]:
+        return None
+    if effect in _LED_STATIC:
+        res = set_led(name, 0 if effect == "off" else brightness,
+                      None if effect == "off" else color)
+        if res is None:
+            return None
+        if not res.get("ok"):
+            return res
+        _fx_note_static(name, res)
+        return {"ok": True, "active": None, "led": name,
+                "brightness_pct": res.get("brightness_pct"), "color": res.get("color")}
+    # animated effect
+    params = {"color": color,
+              "speed": speed if _is_pct(speed, 1) else 50,
+              "brightness": brightness if _is_pct(brightness) else 100}
+    if raw["rgb"] and params["color"] is None:
+        params["color"] = raw["color"] or (
+            {"r": 255, "g": 0, "b": 0} if effect == "scanner"
+            else {"r": 255, "g": 255, "b": 255})
+    _fx_start(name, raw, effect, params)
+    with _FX_LOCK:
+        _LED_PERSIST[name] = dict(params, effect=effect)
+    _led_state_save()
+    return {"ok": True, "led": name,
+            "active": {"effect": effect, "color": params["color"],
+                       "speed": params["speed"], "brightness": params["brightness"]}}
+
+
+def _validate_effect_body(req):
+    """Shape check for POST /api/leds/effect. Returns
+    (effect, color|None, speed|None, brightness|None, error|None). Rejects, never
+    sanitises."""
+    effect = req.get("effect")
+    if effect not in _LED_EFFECTS:
+        return None, None, None, None, "unknown effect"
+    color = req.get("color")
+    if color is not None and not _is_rgb_triple(color):
+        return None, None, None, None, "color must be {r,g,b} ints 0-255"
+    speed = req.get("speed")
+    if speed is not None and not _is_pct(speed, 1):
+        return None, None, None, None, "speed must be an int 1-100"
+    brightness = req.get("brightness")
+    if brightness is not None and not _is_pct(brightness):
+        return None, None, None, None, "brightness must be an int 0-100"
+    return effect, color, speed, brightness, None
+
+
+def _led_restore():
+    """Re-apply the persisted effect/colour to each LED still present + writable.
+    Revalidates EVERY field (never trusts the file); a vanished/locked LED or a
+    junk record is skipped. Best-effort."""
+    live = set(_list_led_names())
+    for name, st in _led_state_load().items():
+        if name not in live or not isinstance(st, dict):
+            continue
+        effect = st.get("effect")
+        if effect not in _LED_EFFECTS:
+            continue
+        color = st.get("color") if _is_rgb_triple(st.get("color")) else None
+        speed = st.get("speed") if _is_pct(st.get("speed"), 1) else 50
+        brightness = st.get("brightness") if _is_pct(st.get("brightness")) else 100
+        try:
+            apply_led_effect(name, effect, color, speed, brightness)
+        except OSError:
+            pass
+
+
+def _led_restore_worker():
+    """Startup thread: wait for the OS/Steam to finish its own LED init, then
+    restore. One retry covers the boot race where the LED node appears late."""
+    for delay in (2.0, 6.0):
+        time.sleep(delay)
+        try:
+            if _list_led_names():
+                _led_restore()
+                return
+        except OSError:
+            pass
+
+
+# ---- OpenRGB backend (cap: openrgb) -----------------------------------------
+# Whole-system / addressable RGB via a LOCAL OpenRGB SDK server on
+# 127.0.0.1:6742 (the phone keypad spelling of "ORGB"). This is what makes a real
+# KITT scanner possible: OpenRGB exposes per-LED control of motherboard / RAM /
+# GPU / strip zones, and the agent drives a lit dot across them frame-by-frame.
+#
+# Hand-rolled stdlib client (socket + struct) -- the agent must stay pure stdlib,
+# so no openrgb-python import. LOOPBACK ONLY: the OpenRGB SDK has no auth, so we
+# connect only to 127.0.0.1 and never expose a socket/host/command to the client.
+# A client request only ever selects WHICH enumerated device index (looked up
+# against the live controller count -> 404 otherwise) + an ALLOWLISTED effect id
+# + range-checked colour/speed/brightness. Degrade closed: if the server isn't
+# running, the cap is absent and the whole surface hides.
+#
+# HARDWARE-UNVERIFIED (see the PR): the wire format is validated against the
+# documented protocol + an in-process mock OpenRGB server in the tests, never
+# against a real OpenRGB daemon. Protocol drift across installs is handled by
+# version negotiation + defensive parsing, but real hardware is the final gate.
+_ORGB_HOST = "127.0.0.1"
+_ORGB_PORT = 6742
+_ORGB_MAGIC = b"ORGB"
+_ORGB_CLIENT_PROTOCOL = 3          # negotiated down to the server's if older
+# packet ids (NetworkProtocol.h)
+_ORGB_REQUEST_CONTROLLER_COUNT = 0
+_ORGB_REQUEST_CONTROLLER_DATA = 1
+_ORGB_REQUEST_PROTOCOL_VERSION = 40
+_ORGB_SET_CLIENT_NAME = 50
+_ORGB_UPDATE_LEDS = 1050
+_ORGB_SET_CUSTOM_MODE = 1100
+
+_ORGB_STATE_CONF = os.path.expanduser("~/.config/couchside/openrgb.json")
+
+
+def _orgb_header(dev_idx, pkt_id, size):
+    return _ORGB_MAGIC + struct.pack("<III", dev_idx & 0xFFFFFFFF, pkt_id, size)
+
+
+def _orgb_recv_exact(s, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = s.recv(n - len(buf))
+        if not chunk:
+            raise OSError("openrgb server closed the connection")
+        buf += chunk
+    return buf
+
+
+def _orgb_recv_packet(s):
+    hdr = _orgb_recv_exact(s, 16)
+    if hdr[:4] != _ORGB_MAGIC:
+        raise OSError("bad openrgb packet magic")
+    dev_idx, pkt_id, size = struct.unpack("<III", hdr[4:16])
+    body = _orgb_recv_exact(s, size) if size else b""
+    return dev_idx, pkt_id, body
+
+
+class _ORGBCursor:
+    """Little-endian reader for an OpenRGB controller-data blob."""
+    def __init__(self, data):
+        self.d = data
+        self.i = 0
+
+    def u16(self):
+        v = struct.unpack_from("<H", self.d, self.i)[0]
+        self.i += 2
+        return v
+
+    def i32(self):
+        v = struct.unpack_from("<i", self.d, self.i)[0]
+        self.i += 4
+        return v
+
+    def u32(self):
+        v = struct.unpack_from("<I", self.d, self.i)[0]
+        self.i += 4
+        return v
+
+    def skip(self, n):
+        self.i += n
+
+    def bstr(self):
+        n = self.u16()
+        s = self.d[self.i:self.i + max(0, n - 1)].decode("utf-8", "replace")
+        self.i += n
+        return s
+
+
+class _OpenRGBClient:
+    """Persistent loopback client to the OpenRGB SDK server. Thread-safe; a dead
+    socket is dropped + reconnected on the next call."""
+    def __init__(self):
+        self._sock = None
+        self._proto = _ORGB_CLIENT_PROTOCOL
+        self._lock = threading.RLock()
+
+    def _connect(self):
+        s = socket.create_connection((_ORGB_HOST, _ORGB_PORT), timeout=1.0)
+        s.settimeout(2.0)
+        name = b"Couchside"
+        s.sendall(_orgb_header(0, _ORGB_SET_CLIENT_NAME, len(name) + 1) + name + b"\x00")
+        # negotiate protocol: send our version, server replies with the min.
+        s.sendall(_orgb_header(0, _ORGB_REQUEST_PROTOCOL_VERSION, 4)
+                  + struct.pack("<I", _ORGB_CLIENT_PROTOCOL))
+        try:
+            _, _, body = _orgb_recv_packet(s)
+            self._proto = min(_ORGB_CLIENT_PROTOCOL, struct.unpack("<I", body[:4])[0])
+        except (OSError, struct.error):
+            # a very old server that doesn't answer version -> assume 0-era layout
+            self._proto = 0
+        self._sock = s
+        return s
+
+    def _ensure(self):
+        if self._sock is None:
+            return self._connect()
+        return self._sock
+
+    def _drop(self):
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+    def _parse_controller(self, idx, data):
+        """Parse just what we need: name + zones (name + led count). The device's
+        total LED count is the SUM of its zone counts, so we can stop before the
+        per-LED section. Version-aware (brightness fields exist only on proto>=3;
+        segments on proto>=4, which we never negotiate up to)."""
+        c = _ORGBCursor(data)
+        c.u32()               # data_size
+        c.i32()               # device type
+        name = c.bstr()
+        c.bstr()              # description
+        c.bstr()              # version
+        c.bstr()              # serial
+        c.bstr()              # location
+        num_modes = c.u16()
+        c.i32()               # active mode
+        for _ in range(num_modes):
+            c.bstr()          # mode name
+            c.i32()           # value
+            c.u32()           # flags
+            c.u32(); c.u32()  # speed_min, speed_max
+            if self._proto >= 3:
+                c.u32(); c.u32()  # brightness_min, brightness_max
+            c.u32(); c.u32()  # colors_min, colors_max
+            c.u32()           # speed
+            if self._proto >= 3:
+                c.u32()       # brightness
+            c.u32()           # direction
+            c.u32()           # color_mode
+            c.skip(c.u16() * 4)   # mode colors
+        num_zones = c.u16()
+        zones = []
+        total = 0
+        for _ in range(num_zones):
+            zname = c.bstr()
+            c.i32()           # zone type
+            c.u32()           # leds_min
+            c.u32()           # leds_max
+            zleds = c.u32()   # leds_count
+            mlen = c.u16()
+            if mlen > 0:
+                h = c.u32(); w = c.u32()
+                c.skip(h * w * 4)
+            zones.append({"name": zname, "leds": zleds})
+            total += zleds
+        return {"index": idx, "name": name, "zones": zones, "led_count": total}
+
+    def controllers(self):
+        """Enumerate all controllers. Reconnects once on a stale socket."""
+        with self._lock:
+            for attempt in (1, 2):
+                try:
+                    s = self._ensure()
+                    s.sendall(_orgb_header(0, _ORGB_REQUEST_CONTROLLER_COUNT, 0))
+                    _, _, body = _orgb_recv_packet(s)
+                    count = struct.unpack("<I", body[:4])[0]
+                    out = []
+                    for i in range(count):
+                        s.sendall(_orgb_header(i, _ORGB_REQUEST_CONTROLLER_DATA, 4)
+                                  + struct.pack("<I", self._proto))
+                        _, _, data = _orgb_recv_packet(s)
+                        out.append(self._parse_controller(i, data))
+                    return out
+                except (OSError, struct.error):
+                    self._drop()
+                    if attempt == 2:
+                        raise
+            return []
+
+    def _update_leds(self, s, idx, colors):
+        body = struct.pack("<H", len(colors))
+        for c in colors:
+            body += struct.pack("<BBBx", c["r"] & 0xFF, c["g"] & 0xFF, c["b"] & 0xFF)
+        body = struct.pack("<I", len(body) + 4) + body
+        s.sendall(_orgb_header(idx, _ORGB_UPDATE_LEDS, len(body)) + body)
+
+    def set_frame(self, idx, colors):
+        """Write one full-device frame (a list of {r,g,b}). Puts the device in
+        its custom/direct mode first so the colours stick."""
+        with self._lock:
+            for attempt in (1, 2):
+                try:
+                    s = self._ensure()
+                    s.sendall(_orgb_header(idx, _ORGB_SET_CUSTOM_MODE, 0))
+                    self._update_leds(s, idx, colors)
+                    return True
+                except OSError:
+                    self._drop()
+                    if attempt == 2:
+                        return False
+            return False
+
+
+_ORGB = _OpenRGBClient()
+
+# Cached controller list (enumeration opens a socket + reads every device, so we
+# don't do it per request). name -> ... ; refreshed on a short TTL / on writes.
+_ORGB_CACHE = {"at": 0.0, "ctrls": []}
+_ORGB_CACHE_TTL = 5.0
+
+
+def _orgb_list(force=False):
+    now = time.monotonic()
+    if not force and _ORGB_CACHE["ctrls"] and (now - _ORGB_CACHE["at"]) < _ORGB_CACHE_TTL:
+        return _ORGB_CACHE["ctrls"]
+    try:
+        ctrls = _ORGB.controllers()
+    except (OSError, struct.error):
+        ctrls = []
+    _ORGB_CACHE["ctrls"] = ctrls
+    _ORGB_CACHE["at"] = now
+    return ctrls
+
+
+def openrgb_available():
+    """True when the OpenRGB SDK server answers on loopback AND reports at least
+    one controller. Read-only; degrades closed."""
+    try:
+        return bool(_ORGB.controllers())
+    except (OSError, struct.error):
+        return False
+
+
+# OpenRGB effect engine: a dedicated render thread (separate from the kernel
+# _fx engine, which drives single sysfs LEDs) that streams per-LED frames over
+# the socket. Same allowlist/param rules.
+_ORGB_FX_LOCK = threading.RLock()
+_ORGB_FX_ACTIVE = {}        # device index -> {effect,color,speed,brightness,led_count}
+_ORGB_PERSIST = {}          # device index (str) -> last-applied state, for restore
+_ORGB_FX_THREAD = [None]
+_ORGB_FX_STOP = threading.Event()
+_MOCK_ORGB_FX = {}          # --mock observable active effects
+
+
+def _hsv255(h):
+    r, g, b = colorsys.hsv_to_rgb(h % 1.0, 1.0, 1.0)
+    return {"r": int(r * 255), "g": int(g * 255), "b": int(b * 255)}
+
+
+def _orgb_frame(effect, n, color, t, speed):
+    """A list of n {r,g,b} for `effect` at elapsed time t. `scanner` is the real
+    KITT sweep -- a lit dot bouncing across the strip with a short fading tail."""
+    n = max(1, n)
+    period = _fx_period(speed)
+    if effect == "rainbow":
+        base = t / period
+        return [_hsv255(base + i / n) for i in range(n)]
+    if effect == "scanner":
+        pos = (n - 1) * abs(1.0 - 2.0 * ((t % period) / period))
+        out = []
+        for i in range(n):
+            f = max(0.0, 1.0 - abs(i - pos) / 2.5)   # ~2-3 LED tail
+            out.append({"r": int(color["r"] * f), "g": int(color["g"] * f),
+                        "b": int(color["b"] * f)})
+        return out
+    if effect in ("breathe", "pulse", "strobe"):
+        _, b = _fx_frame(effect, {"color": color, "speed": speed, "brightness": 100}, t)
+        f = (b or 0) / 100.0
+        return [{"r": int(color["r"] * f), "g": int(color["g"] * f),
+                 "b": int(color["b"] * f)}] * n
+    return [dict(color)] * n       # solid
+
+
+def _orgb_fx_loop():
+    start = time.monotonic()
+    while not _ORGB_FX_STOP.is_set():
+        with _ORGB_FX_LOCK:
+            items = [(i, dict(p)) for i, p in _ORGB_FX_ACTIVE.items()]
+        if not items:
+            break
+        t = time.monotonic() - start
+        for idx, p in items:
+            frame = _orgb_frame(p["effect"], p["led_count"], p["color"], t, p["speed"])
+            bf = (p.get("brightness", 100)) / 100.0
+            if bf < 1.0:
+                frame = [{"r": int(c["r"] * bf), "g": int(c["g"] * bf),
+                          "b": int(c["b"] * bf)} for c in frame]
+            try:
+                _ORGB.set_frame(idx, frame)
+            except OSError:
+                pass
+        _ORGB_FX_STOP.wait(_FX_TICK)
+    with _ORGB_FX_LOCK:
+        _ORGB_FX_THREAD[0] = None
+
+
+def _orgb_fx_ensure():
+    with _ORGB_FX_LOCK:
+        th = _ORGB_FX_THREAD[0]
+        if th is None or not th.is_alive():
+            _ORGB_FX_STOP.clear()
+            th = threading.Thread(target=_orgb_fx_loop, daemon=True, name="orgb-fx")
+            _ORGB_FX_THREAD[0] = th
+            th.start()
+
+
+def _orgb_fx_start(idx, effect, color, speed, brightness, led_count):
+    with _ORGB_FX_LOCK:
+        _ORGB_FX_ACTIVE[idx] = {"effect": effect, "color": color, "speed": speed,
+                                "brightness": brightness, "led_count": led_count}
+    _orgb_fx_ensure()
+
+
+def _orgb_fx_stop(idx):
+    with _ORGB_FX_LOCK:
+        _ORGB_FX_ACTIVE.pop(idx, None)
+
+
+def _orgb_state_save():
+    with _ORGB_FX_LOCK:
+        data = {"version": 1, "devices": {k: dict(v) for k, v in _ORGB_PERSIST.items()}}
+    d = os.path.dirname(_ORGB_STATE_CONF)
+    try:
+        os.makedirs(d, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(prefix=".couchside-orgb-", dir=d)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, _ORGB_STATE_CONF)
+        except OSError:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+    except OSError:
+        pass
+
+
+def _orgb_state_load():
+    try:
+        with open(_ORGB_STATE_CONF) as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {}
+    devs = data.get("devices") if isinstance(data, dict) else None
+    return devs if isinstance(devs, dict) else {}
+
+
+def openrgb_state(mock):
+    """Payload for GET /api/openrgb: controllers + their running effect."""
+    if mock:
+        return {"available": bool(MOCK_ORGB), "server": "%s:%d" % (_ORGB_HOST, _ORGB_PORT),
+                "controllers": [dict(c) for c in MOCK_ORGB],
+                "effects": list(_LED_EFFECTS),
+                "active": {str(k): dict(v) for k, v in _MOCK_ORGB_FX.items()}}
+    ctrls = _orgb_list()
+    with _ORGB_FX_LOCK:
+        active = {str(i): dict(p) for i, p in _ORGB_FX_ACTIVE.items()}
+    return {"available": bool(ctrls), "server": ("%s:%d" % (_ORGB_HOST, _ORGB_PORT)) if ctrls else None,
+            "controllers": [{"index": c["index"], "name": c["name"],
+                             "led_count": c["led_count"], "zones": c["zones"]} for c in ctrls],
+            "effects": list(_LED_EFFECTS), "active": active}
+
+
+def apply_openrgb(device, effect, color, speed, brightness):
+    """Set an OpenRGB device to a solid colour or an animated effect.
+
+    ALLOWLIST: `device` must be an int index present in the LIVE controller list
+    -- else None (caller -> 404). `effect` is checked against _LED_EFFECTS; params
+    were range-checked by the caller. Returns {"ok":True,...} | {"ok":False,...} |
+    None."""
+    if effect not in _LED_EFFECTS:
+        return {"ok": False, "status": 400, "error": "unknown effect"}
+    if not isinstance(device, int) or isinstance(device, bool):
+        return None
+    ctrls = _orgb_list(force=True)
+    match = next((c for c in ctrls if c["index"] == device), None)
+    if match is None:
+        return None
+    n = match["led_count"]
+    col = color or {"r": 255, "g": 0, "b": 0}
+    b = brightness if _is_pct(brightness) else 100
+    sp = speed if _is_pct(speed, 1) else 50
+    if effect in _LED_STATIC:
+        _orgb_fx_stop(device)
+        frame = [{"r": 0, "g": 0, "b": 0}] * max(1, n) if effect == "off" else \
+                [{"r": int(col["r"] * b / 100), "g": int(col["g"] * b / 100),
+                  "b": int(col["b"] * b / 100)}] * max(1, n)
+        ok = _ORGB.set_frame(device, frame)
+        if not ok:
+            return {"ok": False, "status": 502, "error": "openrgb write failed"}
+        with _ORGB_FX_LOCK:
+            _ORGB_PERSIST[str(device)] = {"effect": "solid", "color": col,
+                                          "brightness": b, "speed": sp}
+        _orgb_state_save()
+        return {"ok": True, "device": device, "active": None}
+    _orgb_fx_start(device, effect, col, sp, b, n)
+    with _ORGB_FX_LOCK:
+        _ORGB_PERSIST[str(device)] = {"effect": effect, "color": col,
+                                      "brightness": b, "speed": sp}
+    _orgb_state_save()
+    return {"ok": True, "device": device,
+            "active": {"effect": effect, "color": col, "speed": sp, "brightness": b}}
+
+
+def _orgb_restore():
+    """Re-apply persisted OpenRGB effects after a reboot. Revalidates every field;
+    a device index that no longer exists is skipped."""
+    saved = _orgb_state_load()
+    if not saved:
+        return
+    live = {c["index"] for c in _orgb_list(force=True)}
+    for k, st in saved.items():
+        try:
+            idx = int(k)
+        except (TypeError, ValueError):
+            continue
+        if idx not in live or not isinstance(st, dict):
+            continue
+        effect = st.get("effect")
+        if effect not in _LED_EFFECTS:
+            continue
+        color = st.get("color") if _is_rgb_triple(st.get("color")) else None
+        speed = st.get("speed") if _is_pct(st.get("speed"), 1) else 50
+        brightness = st.get("brightness") if _is_pct(st.get("brightness")) else 100
+        try:
+            apply_openrgb(idx, effect, color, speed, brightness)
+        except OSError:
+            pass
+
+
+def _orgb_restore_worker():
+    for delay in (3.0, 8.0):
+        time.sleep(delay)
+        try:
+            if _orgb_list(force=True):
+                _orgb_restore()
+                return
+        except (OSError, struct.error):
+            pass
+
+
+# The off-box contract the app develops against (--mock): two controllers with
+# addressable zones so the scanner + zone UI have something to render.
+MOCK_ORGB = [
+    {"index": 0, "name": "ASUS Aura Motherboard", "led_count": 12,
+     "zones": [{"name": "Addressable 1", "leds": 8}, {"name": "Onboard", "leds": 4}]},
+    {"index": 1, "name": "Corsair Vengeance RGB", "led_count": 20,
+     "zones": [{"name": "DIMM 1", "leds": 10}, {"name": "DIMM 2", "leds": 10}]},
+]
 
 
 def _couch_run_first(cmds):
@@ -17848,6 +18610,12 @@ class Handler(BaseHTTPRequestHandler):
                 # available:false = nothing controllable here. Set = POST
                 # /api/leds/set.
                 self._send(200, leds_state(self.mock), started)
+            elif path == "/api/openrgb":
+                # READ-ONLY: OpenRGB controllers (whole-system / addressable RGB)
+                # + their running effect, for the OpenRGB card (cap `openrgb`).
+                # available:false = no OpenRGB server on loopback. Set = POST
+                # /api/openrgb/set.
+                self._send(200, openrgb_state(self.mock), started)
             elif path == "/api/displays":
                 # Probe-and-appear: 404 unless this box can do the desktop->TV
                 # Game Mode handoff (SteamOS/Bazzite, 2+ outputs), so the app
@@ -18360,13 +19128,116 @@ class Handler(BaseHTTPRequestHandler):
                                    started)
                         return
                     # Remember it so the next GET /api/leds shows the change.
+                    # A solid tap also stops any animation the harness started.
                     set_mock_led(led_name, brightness, color)
+                    _MOCK_FX.pop(led_name, None)
                     self._send(200, dict({"ok": True},
                                          **_mock_led_public(led_name)), started)
                     return
                 res = set_led(led_name, brightness, color)
                 if res is None:
                     self._send(404, {"error": "unknown led"}, started)
+                    return
+                # A plain colour/brightness write is a "solid": stop any running
+                # effect on this LED and persist it so a reboot restores it.
+                if res.get("ok"):
+                    _fx_note_static(led_name, res)
+                self._send(res.get("status", 200) if not res.get("ok") else 200,
+                           res, started)
+                return
+
+            if path == "/api/leds/effect":
+                # Start/replace an animated effect (breathe/pulse/rainbow/strobe/
+                # scanner) or a solid/off on an LED. SAME allowlist shape as
+                # /api/leds/set: the client `led` is LOOKED UP in the live
+                # /sys/class/leds set (mock: MOCK_LEDS) and 404s otherwise; the
+                # effect id is checked against the frozen _LED_EFFECTS; params are
+                # range-checked (reject, don't sanitise).
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"},
+                               started)
+                    return
+                led_name = req.get("led")
+                effect, color, speed, brightness, verr = _validate_effect_body(req)
+                if verr is not None:
+                    self._send(400, {"error": verr}, started)
+                    return
+                if self.mock:
+                    match = next((l for l in MOCK_LEDS
+                                  if l["name"] == led_name), None)
+                    if not isinstance(led_name, str) or match is None:
+                        self._send(404, {"error": "unknown led"}, started)
+                        return
+                    if effect in _LED_STATIC:
+                        # solid/off moves colour/brightness like /set; no anim.
+                        _MOCK_FX.pop(led_name, None)
+                        set_mock_led(led_name,
+                                     0 if effect == "off" else brightness,
+                                     None if effect == "off" else color)
+                    else:
+                        if color is not None and not match["rgb"]:
+                            self._send(400, {"error":
+                                             "led has no colour channels"}, started)
+                            return
+                        _MOCK_FX[led_name] = {
+                            "effect": effect, "color": color,
+                            "speed": speed if speed is not None else 50,
+                            "brightness": brightness if brightness is not None else 100}
+                    self._send(200, {"ok": True, "led": led_name,
+                                     "active": _MOCK_FX.get(led_name)}, started)
+                    return
+                res = apply_led_effect(led_name, effect, color, speed, brightness)
+                if res is None:
+                    self._send(404, {"error": "unknown led"}, started)
+                    return
+                self._send(res.get("status", 200) if not res.get("ok") else 200,
+                           res, started)
+                return
+
+            if path == "/api/openrgb/set":
+                # Set an OpenRGB device to a solid colour or an animated effect
+                # (real multi-zone scanner). ALLOWLIST: the client `device` is an
+                # int index LOOKED UP in the live controller list (mock:
+                # MOCK_ORGB) and 404s if absent -- never a socket/host/command.
+                # `effect` is checked against _LED_EFFECTS; params range-checked.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"},
+                               started)
+                    return
+                device = req.get("device")
+                effect, color, speed, brightness, verr = _validate_effect_body(req)
+                if verr is not None:
+                    self._send(400, {"error": verr}, started)
+                    return
+                if self.mock:
+                    match = next((c for c in MOCK_ORGB
+                                  if c["index"] == device), None)
+                    if not isinstance(device, int) or isinstance(device, bool) \
+                            or match is None:
+                        self._send(404, {"error": "unknown device"}, started)
+                        return
+                    if effect in _LED_STATIC:
+                        _MOCK_ORGB_FX.pop(device, None)
+                    else:
+                        _MOCK_ORGB_FX[device] = {
+                            "effect": effect,
+                            "color": color if color is not None else {"r": 255, "g": 0, "b": 0},
+                            "speed": speed if speed is not None else 50,
+                            "brightness": brightness if brightness is not None else 100}
+                    self._send(200, {"ok": True, "device": device,
+                                     "active": _MOCK_ORGB_FX.get(device)}, started)
+                    return
+                res = apply_openrgb(device, effect, color, speed, brightness)
+                if res is None:
+                    self._send(404, {"error": "unknown device"}, started)
                     return
                 self._send(res.get("status", 200) if not res.get("ok") else 200,
                            res, started)
@@ -20370,6 +21241,15 @@ def main():
     # the session alive even while the app's own JS keepalive timer is frozen (iOS).
     threading.Thread(target=_gamepad_keepalive_loop,
                      daemon=True, name="gp-keepalive").start()
+    # Restore the persisted LED colour/effect after a reboot so the front bar
+    # comes back the way the user left it instead of the firmware default. Real
+    # hardware only; waits for the OS/Steam to finish its own LED init first.
+    if not args.mock:
+        threading.Thread(target=_led_restore_worker,
+                         daemon=True, name="led-restore").start()
+        # Same for OpenRGB devices, when an OpenRGB server is present.
+        threading.Thread(target=_orgb_restore_worker,
+                         daemon=True, name="orgb-restore").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "174",
+      "buildNumber": "175",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.45",
+    "version": "2.9.46",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "173",
+      "buildNumber": "174",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { registerScroller } from '@/hooks/useTourAnchor';
 import { DisplayAudioCard } from '@/components/DisplayAudioCard';
 import { AudioOutputCard } from '@/components/AudioOutputCard';
 import { RgbLedCard } from '@/components/RgbLedCard';
+import { StripLightCard } from '@/components/StripLightCard';
 import { OpenRgbCard } from '@/components/OpenRgbCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
@@ -140,7 +141,7 @@ function ConsoleScreen() {
 
   // --- Console card layout: hold-to-edit reorder + hide (persisted) --------
   const CARD_ORDER_CANON = [
-    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'leds', 'openrgb', 'units', 'filedrop',
+    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'leds', 'stripleds', 'openrgb', 'units', 'filedrop',
   ];
   const cardLayout = useConsoleLayout();
   const [editingCards, setEditingCards] = useState(false);
@@ -292,6 +293,7 @@ function ConsoleScreen() {
     ),
     audio: <AudioOutputCard />,
     leds: <RgbLedCard />,
+    stripleds: <StripLightCard />,
     openrgb: <OpenRgbCard />,
     units: configured ? (
       <Card title="UNITS" index={5}>

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -8,6 +8,7 @@ import { registerScroller } from '@/hooks/useTourAnchor';
 import { DisplayAudioCard } from '@/components/DisplayAudioCard';
 import { AudioOutputCard } from '@/components/AudioOutputCard';
 import { RgbLedCard } from '@/components/RgbLedCard';
+import { OpenRgbCard } from '@/components/OpenRgbCard';
 import { FileDropCard } from '@/components/FileDropCard';
 import { GamingCard } from '@/components/GamingCard';
 import { NowPlayingCard } from '@/components/NowPlayingCard';
@@ -139,7 +140,7 @@ function ConsoleScreen() {
 
   // --- Console card layout: hold-to-edit reorder + hide (persisted) --------
   const CARD_ORDER_CANON = [
-    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'leds', 'units', 'filedrop',
+    'nowplaying', 'streamhost', 'gaming', 'vitals', 'screen', 'display', 'audio', 'leds', 'openrgb', 'units', 'filedrop',
   ];
   const cardLayout = useConsoleLayout();
   const [editingCards, setEditingCards] = useState(false);
@@ -291,6 +292,7 @@ function ConsoleScreen() {
     ),
     audio: <AudioOutputCard />,
     leds: <RgbLedCard />,
+    openrgb: <OpenRgbCard />,
     units: configured ? (
       <Card title="UNITS" index={5}>
         {units.error != null && !units.data ? (

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { DarkTheme, DefaultTheme, Stack, ThemeProvider } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useMemo } from 'react';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 
 import { ReviewPrompt } from '@/components/ReviewPrompt';
@@ -44,6 +45,7 @@ export default function RootLayout() {
   }, [t, scheme]);
 
   return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
     <SettingsProvider>
       <EntitlementProvider>
         <ThemeProvider value={navTheme}>
@@ -111,5 +113,6 @@ export default function RootLayout() {
         </ThemeProvider>
       </EntitlementProvider>
     </SettingsProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/app/components/OpenRgbCard.tsx
+++ b/app/components/OpenRgbCard.tsx
@@ -1,0 +1,320 @@
+/**
+ * SYSTEM RGB (Console tab) — whole-system / addressable RGB via OpenRGB, from the
+ * phone. Owner ask 2026-08-13: "make it OpenRGB-compatible … configure system
+ * LEDs straight from the phone", with a real "night rider" sweep across the LEDs.
+ *
+ * Sibling of the LIGHT card (RgbLedCard): the LIGHT card drives the single kernel
+ * front bar; this drives motherboard / RAM / GPU / strip controllers that OpenRGB
+ * exposes, which is what makes a REAL multi-zone SCANNER possible (a lit dot
+ * sweeping across the strip). The agent renders the sweep frame-by-frame.
+ *
+ * Probe-and-appear: null on a 404 (older agent) or `available: false` (no OpenRGB
+ * server on the box) — no dead card. OpenRGB must be installed + its server
+ * running on the box, so most boxes won't show this at all.
+ *
+ * Controls: EFFECT + SPEED chips are TAPS (harness-verifiable, §6); HUE /
+ * BRIGHTNESS are the shared PanResponder sliders (drag = on-device proof). Every
+ * change POSTs then re-reads /api/openrgb (§11: observe the real state). The agent
+ * persists the choice, so a reboot restores it.
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { TrackSlider } from '@/components/TrackSlider';
+import { usePoll } from '@/hooks/usePoll';
+import {
+  api, hostKey, type LedEffect, type OpenRgbController, type OpenRgbState,
+} from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { cssRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
+import { useSkinKit } from '@/lib/skin';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+const POLL_MS = 15000;
+
+/** OpenRGB devices are always colour-capable, so every effect applies. */
+const EFFECTS: { id: LedEffect; label: string }[] = [
+  { id: 'solid', label: 'Solid' },
+  { id: 'off', label: 'Off' },
+  { id: 'breathe', label: 'Breathe' },
+  { id: 'pulse', label: 'Pulse' },
+  { id: 'rainbow', label: 'Rainbow' },
+  { id: 'strobe', label: 'Strobe' },
+  { id: 'scanner', label: 'Scanner' },
+];
+const SPEEDS = [
+  { label: 'Slow', value: 25 },
+  { label: 'Med', value: 55 },
+  { label: 'Fast', value: 90 },
+];
+
+export function OpenRgbCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+
+  const [busy, setBusy] = useState(false);
+  const [selIdx, setSelIdx] = useState<number | null>(null);
+  const [effect, setEffect] = useState<LedEffect>('solid');
+  const [hue, setHue] = useState(0);
+  const [bright, setBright] = useState(100);
+  const [speed, setSpeed] = useState(55);
+  const seeded = useRef<number | null>(null);
+
+  const poll = usePoll<OpenRgbState | null>(
+    () => api.openrgb(settings), POLL_MS, ready && configured, hostKey(settings));
+
+  const d = poll.data;
+  const ctrls = d?.controllers ?? [];
+  const dev: OpenRgbController | undefined =
+    ctrls.find((c) => c.index === selIdx) ?? ctrls[0];
+
+  useEffect(() => {
+    if (!dev || seeded.current === dev.index) return;
+    seeded.current = dev.index;
+    const a = d?.active?.[String(dev.index)];
+    setEffect(a?.effect ?? 'solid');
+    setSpeed(a?.speed ?? 55);
+    setBright(a?.brightness ?? 100);
+    setHue(a?.color ? rgbToHue(a.color) : 0);
+  }, [dev, d]);
+
+  if (!d || !d.available || !dev || ctrls.length === 0) return null;
+
+  const supported = d.effects ?? EFFECTS.map((e) => e.id);
+  const shown = EFFECTS.filter((e) => supported.includes(e.id));
+  const animated = effect !== 'solid' && effect !== 'off';
+  const color = hueToRgb(hue);
+
+  const send = async (over: Partial<{ effect: LedEffect; hue: number; bright: number; speed: number }>) => {
+    if (busy || !dev) return;
+    let eff = over.effect ?? effect;
+    if (over.effect === undefined && (over.hue !== undefined || over.bright !== undefined) && eff === 'off') {
+      eff = 'solid';
+      setEffect('solid');
+    }
+    const b = Math.round(over.bright ?? bright);
+    const sp = Math.round(over.speed ?? speed);
+    const col = hueToRgb(over.hue ?? hue);
+    hapticLight();
+    setBusy(true);
+    try {
+      if (eff === 'off') {
+        await api.openrgbSet(settings, dev.index, { effect: 'off' });
+      } else {
+        await api.openrgbSet(settings, dev.index, {
+          effect: eff, brightness: b,
+          ...(animated || eff !== 'solid' ? { speed: sp } : {}),
+          ...(eff === 'rainbow' ? {} : { color: col }),
+        });
+      }
+    } finally {
+      await poll.refresh();
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card index={7}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>SYSTEM RGB</Text>
+        <View style={styles.headerRight}>
+          {busy ? <ActivityIndicator size="small" color={t.blue} /> : null}
+          <Pressable
+            onPress={() => { hapticLight(); poll.refresh(); }}
+            hitSlop={10}
+            accessibilityRole="button"
+            accessibilityLabel="Refresh OpenRGB devices"
+            style={({ pressed }) => [styles.refreshBtn, pressed && styles.pressed]}>
+            <Ionicons name="refresh" size={13} color={t.textDim} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Device picker — only when the box exposes more than one controller. */}
+      {ctrls.length > 1 && (
+        <View style={styles.chipRow}>
+          {ctrls.map((c) => {
+            const on = c.index === dev.index;
+            return (
+              <Pressable
+                key={c.index}
+                onPress={() => { hapticLight(); setSelIdx(c.index); }}
+                disabled={busy}
+                accessibilityRole="button"
+                accessibilityState={{ selected: on }}
+                accessibilityLabel={`Control ${c.name}`}
+                style={({ pressed }) => [
+                  styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
+                <Text style={[styles.chipText, on && styles.chipTextOn]} numberOfLines={1}>
+                  {c.name}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      )}
+
+      <Text style={styles.deviceMeta}>
+        {dev.name} · {dev.led_count} LEDs · {dev.zones.map((z) => z.name).join(', ')}
+      </Text>
+
+      {/* EFFECT chips. */}
+      <Text style={styles.sectionLabel}>EFFECT</Text>
+      <View style={styles.chipRow}>
+        {shown.map((e) => {
+          const on = effect === e.id;
+          return (
+            <Pressable
+              key={e.id}
+              onPress={() => { setEffect(e.id); void send({ effect: e.id }); }}
+              disabled={busy}
+              accessibilityRole="button"
+              accessibilityState={{ selected: on, disabled: busy }}
+              accessibilityLabel={`Effect ${e.label}`}
+              style={({ pressed }) => [
+                styles.chip, on && styles.chipOn, pressed && !busy && styles.pressed]}>
+              <Text style={[styles.chipText, on && styles.chipTextOn]}>{e.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* SPEED — animated effects only. */}
+      {animated && (
+        <>
+          <Text style={styles.sectionLabel}>SPEED</Text>
+          <View style={styles.chipRow}>
+            {SPEEDS.map((s) => {
+              const on = Math.abs(speed - s.value) <= 15;
+              return (
+                <Pressable
+                  key={s.label}
+                  onPress={() => { setSpeed(s.value); void send({ speed: s.value }); }}
+                  disabled={busy}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: on, disabled: busy }}
+                  accessibilityLabel={`Speed ${s.label}`}
+                  style={({ pressed }) => [
+                    styles.chip, on && styles.chipOn, pressed && !busy && styles.pressed]}>
+                  <Text style={[styles.chipText, on && styles.chipTextOn]}>{s.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </>
+      )}
+
+      {/* COLOUR — hidden for rainbow (cycles its own) and off. */}
+      {effect !== 'rainbow' && effect !== 'off' && (
+        <>
+          <View style={styles.sliderHeader}>
+            <Text style={styles.sectionLabel}>COLOUR</Text>
+            <View style={[styles.swatchPreview, { backgroundColor: cssRgb(color) }]} />
+          </View>
+          <TrackSlider
+            value={hue}
+            min={0}
+            max={360}
+            disabled={busy}
+            onChange={setHue}
+            onCommit={(v) => void send({ hue: v })}
+            thumbColor={cssRgb(color)}
+            accessibilityLabel="System RGB colour hue"
+            renderTrack={() => (
+              <View style={styles.hueFill}>
+                {HUE_STOPS.map((c, i) => (
+                  <View key={i} style={{ flex: 1, backgroundColor: c }} />
+                ))}
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      {/* BRIGHTNESS — unless off. */}
+      {effect !== 'off' && (
+        <>
+          <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
+          <TrackSlider
+            value={bright}
+            min={0}
+            max={100}
+            disabled={busy}
+            onChange={setBright}
+            onCommit={(v) => void send({ bright: v })}
+            thumbColor={t.text}
+            accessibilityLabel="System RGB brightness"
+            renderTrack={(pct) => (
+              <View style={styles.brightTrack}>
+                <View style={[styles.brightFill,
+                  { width: `${pct * 100}%`, backgroundColor: cssRgb(color) }]} />
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      <Text style={styles.hint}>
+        Scanner sweeps a lit dot across the strip — a real night-rider.
+      </Text>
+    </Card>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    header: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+      marginBottom: 10,
+    },
+    headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    cardTitle: {
+      color: t.textDim, fontSize: 11, fontWeight: '700', letterSpacing: 1, fontFamily: mono,
+    },
+    refreshBtn: {
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 4, paddingHorizontal: 9,
+    },
+    pressed: { opacity: 0.6 },
+
+    deviceMeta: {
+      color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 10,
+    },
+    sectionLabel: {
+      color: t.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1.2,
+      fontFamily: mono, marginTop: 14, marginBottom: 8,
+    },
+    sliderHeader: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    },
+    swatchPreview: {
+      width: 22, height: 22, borderRadius: 6, borderWidth: 1, borderColor: t.cardBorder,
+      marginTop: 10,
+    },
+
+    chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+    chip: {
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 12,
+    },
+    chipOn: { borderColor: t.blue, backgroundColor: t.card },
+    chipText: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    chipTextOn: { color: t.text, fontWeight: '700' },
+
+    hueFill: {
+      flexDirection: 'row', height: 18, borderRadius: 9, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightTrack: {
+      height: 18, borderRadius: 9, backgroundColor: t.card, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightFill: { height: '100%', borderRadius: 9 },
+
+    hint: { color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 12 },
+  });

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -35,6 +35,7 @@ import {
 } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
+import { detectStrips } from '@/lib/ledStrip';
 import {
   addPreset, removePreset, useLedPresets, type LedPreset,
 } from '@/lib/ledPresets';
@@ -89,7 +90,12 @@ export function RgbLedCard() {
     () => api.leds(settings), POLL_MS, ready && configured, hostKey(settings));
 
   const d = poll.data;
-  const leds = (d?.leds ?? []).filter((l) => l.notable && l.writable);
+  // Addressable strips (valve-leds[0..N]) are owned by StripLightCard; this card
+  // keeps only the SINGLE lights (status LED, a lone front bar) so it isn't a
+  // wall of per-node chips.
+  const notable = (d?.leds ?? []).filter((l) => l.notable && l.writable);
+  const { strips, singles } = detectStrips(notable);
+  const leds = singles;
   const led: LedInfo | undefined = leds.find((l) => l.name === selName) ?? leds[0];
 
   useEffect(() => {
@@ -103,8 +109,14 @@ export function RgbLedCard() {
     setHue(c ? rgbToHue(c) : 0);
   }, [led, d]);
 
-  // Old agent, no writable LED, or nothing notable -> render nothing at all.
-  if (!d || !d.available || !led || leds.length === 0) return null;
+  // Render nothing when: old agent / no writable LED / nothing notable — OR when
+  // an addressable strip owns the box's lights and the only singles left are mono
+  // status LEDs (a lone status light isn't worth a card next to the STRIP card,
+  // which now carries the presets). Keep this card for a real RGB single (a
+  // chassis bar on non-strip hardware) or when there's no strip.
+  const onlyMonoSingles = leds.length > 0 && leds.every((l) => !l.rgb);
+  if (!d || !d.available || !led || leds.length === 0
+      || (strips.length > 0 && onlyMonoSingles)) return null;
 
   const supported: LedEffect[] = (d.effects ?? ['solid', 'off']).filter((e) =>
     led.rgb ? true : MONO_EFFECTS.includes(e));

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -1,69 +1,70 @@
 /**
- * LIGHT (Console tab) — set the box's front RGB / status LED colour + brightness
- * from the phone. The read-only siblings show state; this one changes it.
+ * LIGHT (Console tab) — the box's front RGB / status LED editor: colour, effects,
+ * and saved presets, from the phone. The read-only siblings show state; this one
+ * changes it. Owner ask 2026-08-13: "easier editor … save presets … automation
+ * (night rider) … survive reboot".
  *
- * Probe-and-appear, the AudioOutputCard shape exactly: a 404 (agent too old),
- * `available: false` (no controllable/writable LED), or zero *notable* LEDs
- * renders NOTHING — no dead card. On a stock box the LED sysfs files are
- * root-owned, so nothing is writable until an install-time udev grant lands, and
- * the card correctly stays hidden until then.
+ * Probe-and-appear (the AudioOutputCard shape): a 404 (agent too old),
+ * `available: false`, or zero *notable* LEDs renders NOTHING — no dead card. On a
+ * stock box the LED sysfs files are root-owned, so nothing is writable until an
+ * install-time udev grant lands, and the card correctly stays hidden until then.
  *
- * Tap-only by design (colour swatches + discrete brightness levels), because
- * drag gestures aren't verifiable in the web harness. Every tap fires one POST
- * then RE-READS /api/leds rather than trusting the echo (CLAUDE.md §11: observe
- * the real state) — the ring that moves is the box telling us it moved.
+ * Controls, and why each is testable:
+ *  - EFFECT chips + SPEED chips + PRESET chips are TAPS → verifiable in the web
+ *    harness (§6: press the control, don't just render it).
+ *  - HUE / BRIGHTNESS are PanResponder sliders. A drag feels native; a single TAP
+ *    on the track also sets the value (grant fires with the tap position), so the
+ *    harness can press them too. The *drag* itself is on-device-only proof.
+ *
+ * Every change fires one POST then RE-READS /api/leds rather than trusting the
+ * echo (§11: observe the real state). Effects/presets persist on the box, so a
+ * reboot restores them (agent >= 2.9.84); the preset *library* is per-phone
+ * (lib/ledPresets.ts) — applying one is just another setLedEffect call.
  *
  * The LED `name` sent back is one the box itself listed; the agent looks it up in
- * its live /sys/class/leds set and refuses anything else, so this control can
- * only ever aim at an LED the box offered.
+ * its live /sys/class/leds set and refuses anything else.
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
-import React, { useState } from 'react';
-import { ActivityIndicator, Pressable, StyleSheet, Text, View } from 'react-native';
+import React, { useEffect, useRef, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { TrackSlider } from '@/components/TrackSlider';
 import { usePoll } from '@/hooks/usePoll';
-import { api, hostKey, type LedInfo, type LedsState, type Rgb } from '@/lib/api';
+import {
+  api, hostKey, type LedEffect, type LedInfo, type LedsState, type Rgb,
+} from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
+import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
+import {
+  addPreset, removePreset, useLedPresets, type LedPreset,
+} from '@/lib/ledPresets';
 import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
-/** LEDs don't change on their own second-by-second; the taps refresh immediately,
- *  so this is just a backstop (e.g. another app changed the colour). */
+/** LEDs don't change on their own second-by-second; taps refresh immediately, so
+ *  this is just a backstop (e.g. another app changed the colour). */
 const POLL_MS = 15000;
 
-/** Frozen preset colours (0–255 per channel), sent verbatim; the agent
- *  range-checks each triple. Tap-testable: one swatch = one POST. */
-const PRESETS: { label: string; rgb: Rgb }[] = [
-  { label: 'Red', rgb: { r: 255, g: 0, b: 0 } },
-  { label: 'Orange', rgb: { r: 255, g: 120, b: 0 } },
-  { label: 'Yellow', rgb: { r: 255, g: 220, b: 0 } },
-  { label: 'Green', rgb: { r: 0, g: 200, b: 0 } },
-  { label: 'Cyan', rgb: { r: 0, g: 200, b: 255 } },
-  { label: 'Blue', rgb: { r: 0, g: 80, b: 255 } },
-  { label: 'Purple', rgb: { r: 160, g: 0, b: 255 } },
-  { label: 'Pink', rgb: { r: 255, g: 0, b: 150 } },
-  { label: 'White', rgb: { r: 255, g: 255, b: 255 } },
-  { label: 'Warm', rgb: { r: 255, g: 170, b: 90 } },
+/** Effect id → label + whether it drives a colour. `rainbow` cycles its own hue,
+ *  so we never send it a colour; the rest use the picked colour. */
+const EFFECT_META: Record<LedEffect, { label: string; usesColor: boolean }> = {
+  solid: { label: 'Solid', usesColor: true },
+  off: { label: 'Off', usesColor: false },
+  breathe: { label: 'Breathe', usesColor: true },
+  pulse: { label: 'Pulse', usesColor: true },
+  rainbow: { label: 'Rainbow', usesColor: false },
+  strobe: { label: 'Strobe', usesColor: true },
+  scanner: { label: 'Scanner', usesColor: true },
+};
+/** A mono LED can't show colour, so only these effects make sense on one. */
+const MONO_EFFECTS: LedEffect[] = ['solid', 'off', 'breathe', 'pulse', 'strobe'];
+
+const SPEEDS: { label: string; value: number }[] = [
+  { label: 'Slow', value: 25 },
+  { label: 'Med', value: 55 },
+  { label: 'Fast', value: 90 },
 ];
-
-const LEVELS = [0, 25, 50, 75, 100];
-
-const css = (c: Rgb) => `rgb(${c.r}, ${c.g}, ${c.b})`;
-
-/** A colour round-trips through device scaling, so match within a small
- *  tolerance rather than requiring exact equality. */
-function sameColor(a: Rgb | null, b: Rgb): boolean {
-  if (!a) return false;
-  return Math.abs(a.r - b.r) <= 3 && Math.abs(a.g - b.g) <= 3 && Math.abs(a.b - b.b) <= 3;
-}
-
-/** The level button (from the rendered set) that best matches the reported
- *  brightness, so exactly one lights up. */
-function nearestLevel(pct: number, levels: number[]): number {
-  return levels.reduce((best, lv) =>
-    Math.abs(lv - pct) < Math.abs(best - pct) ? lv : best, levels[0]);
-}
 
 export function RgbLedCard() {
   const t = useTheme();
@@ -71,55 +72,112 @@ export function RgbLedCard() {
   const { Card } = useSkinKit();
   const { settings, ready } = useSettings();
   const configured = !!settings.host && !!settings.token;
+  const presets = useLedPresets();
 
-  // Which LED is being written (disables the controls + shows a spinner) so a
-  // double-tap can't fire two writes at once.
   const [busy, setBusy] = useState(false);
-  // When several notable LEDs exist, which one the controls act on.
   const [selName, setSelName] = useState<string | null>(null);
+
+  // Local editor state; seeded from the box once per selected LED, then the
+  // user's edits drive the UI (poll is a backstop, not the source of truth).
+  const [effect, setEffect] = useState<LedEffect>('solid');
+  const [hue, setHue] = useState(0);
+  const [bright, setBright] = useState(100);
+  const [speed, setSpeed] = useState(55);
+  const seeded = useRef<string | null>(null);
 
   const poll = usePoll<LedsState | null>(
     () => api.leds(settings), POLL_MS, ready && configured, hostKey(settings));
 
   const d = poll.data;
   const leds = (d?.leds ?? []).filter((l) => l.notable && l.writable);
+  const led: LedInfo | undefined = leds.find((l) => l.name === selName) ?? leds[0];
+
+  useEffect(() => {
+    if (!led || seeded.current === led.name) return;
+    seeded.current = led.name;
+    const a = d?.active?.[led.name];
+    setEffect(a?.effect ?? 'solid');
+    setSpeed(a?.speed ?? 55);
+    setBright(a?.brightness ?? led.brightness_pct ?? 100);
+    const c = a?.color ?? led.color;
+    setHue(c ? rgbToHue(c) : 0);
+  }, [led, d]);
+
   // Old agent, no writable LED, or nothing notable -> render nothing at all.
-  if (!d || !d.available || leds.length === 0) return null;
+  if (!d || !d.available || !led || leds.length === 0) return null;
 
-  const led: LedInfo = leds.find((l) => l.name === selName) ?? leds[0];
-  const off = led.brightness_pct === 0;
-  // An rgb LED gets its "off" from the OFF swatch, so drop the duplicate level-0
-  // button (otherwise both light up when off). A mono LED keeps it — it has no
-  // swatch. When off, no level highlights (the OFF swatch shows the state).
-  const levels = led.rgb ? LEVELS.filter((l) => l > 0) : LEVELS;
-  const activeLevel = off ? -1 : nearestLevel(led.brightness_pct, levels);
+  const supported: LedEffect[] = (d.effects ?? ['solid', 'off']).filter((e) =>
+    led.rgb ? true : MONO_EFFECTS.includes(e));
+  const animated = effect !== 'solid' && effect !== 'off';
+  const color = hueToRgb(hue);
 
-  const apply = async (patch: { brightness?: number; color?: Rgb }) => {
-    if (busy) return;
+  /** One place that turns the current editor state into a box write, then
+   *  re-reads. `over` lets a control apply its brand-new value in the same tick
+   *  (setState is async). Editing colour/brightness while 'off' switches to solid. */
+  const send = async (over: Partial<{ effect: LedEffect; hue: number; bright: number; speed: number }>) => {
+    if (busy || !led) return;
+    let eff = over.effect ?? effect;
+    if (over.effect === undefined && (over.hue !== undefined || over.bright !== undefined) && eff === 'off') {
+      eff = 'solid';
+      setEffect('solid');
+    }
+    const h = over.hue ?? hue;
+    const b = Math.round(over.bright ?? bright);
+    const sp = Math.round(over.speed ?? speed);
+    const col = hueToRgb(h);
     hapticLight();
     setBusy(true);
     try {
-      await api.setLed(settings, led.name, patch);
+      if (eff === 'off') {
+        await api.setLedEffect(settings, led.name, { effect: 'off' });
+      } else if (eff === 'solid') {
+        await api.setLed(settings, led.name,
+          led.rgb ? { color: col, brightness: b } : { brightness: b });
+      } else {
+        await api.setLedEffect(settings, led.name, {
+          effect: eff, speed: sp, brightness: b,
+          ...(led.rgb && EFFECT_META[eff].usesColor ? { color: col } : {}),
+        });
+      }
     } finally {
       await poll.refresh();
       setBusy(false);
     }
   };
 
+  const applyPreset = (p: LedPreset) => {
+    const h = p.color ? rgbToHue(p.color) : hue;
+    setEffect(p.effect); setHue(h); setBright(p.brightness); setSpeed(p.speed);
+    void send({ effect: p.effect, hue: h, bright: p.brightness, speed: p.speed });
+  };
+
+  const saveCurrent = () => {
+    const label = EFFECT_META[effect].label +
+      (led.rgb && EFFECT_META[effect].usesColor ? ` ${hexRgb(color)}` : '');
+    void addPreset({
+      label,
+      effect,
+      color: led.rgb && EFFECT_META[effect].usesColor ? color : null,
+      speed: Math.round(speed),
+      brightness: Math.round(bright),
+    });
+    hapticLight();
+  };
+
+  const confirmDelete = (p: LedPreset) =>
+    Alert.alert('Delete preset', `Remove "${p.label}"?`, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: () => void removePreset(p.id) },
+    ]);
+
   return (
     <Card index={6}>
       <View style={styles.header}>
         <Text style={styles.cardTitle}>LIGHT</Text>
         <View style={styles.headerRight}>
-          {/* One spinner for the whole card while a write is in flight — the
-              swatch/level that lands is shown by the ring after the re-read, so
-              a per-control spinner (which would sit on stale state) is wrong. */}
           {busy ? <ActivityIndicator size="small" color={t.blue} /> : null}
           <Pressable
-            onPress={() => {
-              hapticLight();
-              poll.refresh();
-            }}
+            onPress={() => { hapticLight(); poll.refresh(); }}
             hitSlop={10}
             accessibilityRole="button"
             accessibilityLabel="Refresh lights"
@@ -131,7 +189,7 @@ export function RgbLedCard() {
 
       {/* LED picker — only when the box exposes more than one controllable light. */}
       {leds.length > 1 && (
-        <View style={styles.ledRow}>
+        <View style={styles.chipRow}>
           {leds.map((l) => {
             const on = l.name === led.name;
             return (
@@ -143,8 +201,8 @@ export function RgbLedCard() {
                 accessibilityState={{ selected: on }}
                 accessibilityLabel={`Control ${l.desc}`}
                 style={({ pressed }) => [
-                  styles.ledChip, on && styles.ledChipOn, pressed && styles.pressed]}>
-                <Text style={[styles.ledChipText, on && styles.ledChipTextOn]} numberOfLines={1}>
+                  styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
+                <Text style={[styles.chipText, on && styles.chipTextOn]} numberOfLines={1}>
                   {l.desc}
                 </Text>
               </Pressable>
@@ -153,82 +211,137 @@ export function RgbLedCard() {
         </View>
       )}
 
-      {/* Colour swatches (rgb LEDs only). */}
-      {led.rgb && (
+      {/* EFFECT chips (agent >= 2.9.84). */}
+      {supported.length > 0 && (
         <>
-          <Text style={styles.sectionLabel}>COLOUR</Text>
-          <View style={styles.swatchGrid}>
-            {PRESETS.map((p) => {
-              const on = !off && sameColor(led.color, p.rgb);
+          <Text style={styles.sectionLabel}>EFFECT</Text>
+          <View style={styles.chipRow}>
+            {supported.map((e) => {
+              const on = effect === e;
               return (
                 <Pressable
-                  key={p.label}
-                  onPress={() => apply({
-                    color: p.rgb,
-                    brightness: led.brightness_pct > 0 ? led.brightness_pct : 100,
-                  })}
+                  key={e}
+                  onPress={() => { setEffect(e); void send({ effect: e }); }}
                   disabled={busy}
-                  accessibilityRole="radio"
+                  accessibilityRole="button"
                   accessibilityState={{ selected: on, disabled: busy }}
-                  accessibilityLabel={`Set light to ${p.label}`}
+                  accessibilityLabel={`Effect ${EFFECT_META[e].label}`}
                   style={({ pressed }) => [
-                    styles.swatch,
-                    { backgroundColor: css(p.rgb) },
-                    on && styles.swatchOn,
-                    pressed && !busy && styles.pressed,
-                  ]}>
-                  {on ? (
-                    <Ionicons
-                      name="checkmark"
-                      size={16}
-                      color={p.rgb.r + p.rgb.g + p.rgb.b > 480 ? '#000' : '#fff'}
-                    />
-                  ) : null}
+                    styles.chip, on && styles.chipOn, pressed && !busy && styles.pressed]}>
+                  <Text style={[styles.chipText, on && styles.chipTextOn]}>
+                    {EFFECT_META[e].label}
+                  </Text>
                 </Pressable>
               );
             })}
-            {/* Off — turns the light out (brightness 0), rendered as an inset chip. */}
-            <Pressable
-              onPress={() => apply({ brightness: 0 })}
-              disabled={busy}
-              accessibilityRole="radio"
-              accessibilityState={{ selected: off, disabled: busy }}
-              accessibilityLabel="Turn the light off"
-              style={({ pressed }) => [
-                styles.swatch, styles.offSwatch, off && styles.swatchOn,
-                pressed && !busy && styles.pressed]}>
-              <Text style={styles.offText}>OFF</Text>
-            </Pressable>
           </View>
         </>
       )}
 
-      {/* Brightness levels (every LED). */}
-      <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
-      <View style={styles.levelRow}>
-        {levels.map((lv) => {
-          const on = activeLevel === lv;
-          return (
-            <Pressable
-              key={lv}
-              onPress={() => apply({ brightness: lv })}
-              disabled={busy}
-              accessibilityRole="button"
-              accessibilityState={{ selected: on, disabled: busy }}
-              accessibilityLabel={lv === 0 ? 'Brightness off' : `Brightness ${lv} percent`}
-              style={({ pressed }) => [
-                styles.level, on && styles.levelOn, pressed && !busy && styles.pressed]}>
-              <Text style={[styles.levelText, on && styles.levelTextOn]}>
-                {lv === 0 ? 'Off' : `${lv}`}
-              </Text>
-            </Pressable>
-          );
-        })}
+      {/* SPEED — only for an animated effect. */}
+      {animated && (
+        <>
+          <Text style={styles.sectionLabel}>SPEED</Text>
+          <View style={styles.chipRow}>
+            {SPEEDS.map((s) => {
+              const on = Math.abs(speed - s.value) <= 15;
+              return (
+                <Pressable
+                  key={s.label}
+                  onPress={() => { setSpeed(s.value); void send({ speed: s.value }); }}
+                  disabled={busy}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: on, disabled: busy }}
+                  accessibilityLabel={`Speed ${s.label}`}
+                  style={({ pressed }) => [
+                    styles.chip, on && styles.chipOn, pressed && !busy && styles.pressed]}>
+                  <Text style={[styles.chipText, on && styles.chipTextOn]}>{s.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </>
+      )}
+
+      {/* COLOUR — rgb LEDs only. Hue slider + a live swatch. */}
+      {led.rgb && effect !== 'rainbow' && effect !== 'off' && (
+        <>
+          <View style={styles.sliderHeader}>
+            <Text style={styles.sectionLabel}>COLOUR</Text>
+            <View style={[styles.swatchPreview, { backgroundColor: cssRgb(color) }]} />
+          </View>
+          <TrackSlider
+            value={hue}
+            min={0}
+            max={360}
+            disabled={busy}
+            onChange={setHue}
+            onCommit={(v) => void send({ hue: v })}
+            thumbColor={cssRgb(color)}
+            accessibilityLabel="Light colour hue"
+            renderTrack={() => (
+              <View style={styles.hueFill}>
+                {HUE_STOPS.map((c, i) => (
+                  <View key={i} style={{ flex: 1, backgroundColor: c }} />
+                ))}
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      {/* BRIGHTNESS — every LED, unless off. */}
+      {effect !== 'off' && (
+        <>
+          <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
+          <TrackSlider
+            value={bright}
+            min={0}
+            max={100}
+            disabled={busy}
+            onChange={setBright}
+            onCommit={(v) => void send({ bright: v })}
+            thumbColor={t.text}
+            accessibilityLabel="Light brightness"
+            renderTrack={(pct) => (
+              <View style={styles.brightTrack}>
+                <View style={[styles.brightFill,
+                  { width: `${pct * 100}%`, backgroundColor: led.rgb ? cssRgb(color) : t.text }]} />
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      {/* PRESETS — tap to apply, long-press to delete, + to save the current look. */}
+      <Text style={styles.sectionLabel}>PRESETS</Text>
+      <View style={styles.chipRow}>
+        {presets.map((p) => (
+          <Pressable
+            key={p.id}
+            onPress={() => applyPreset(p)}
+            onLongPress={() => confirmDelete(p)}
+            disabled={busy}
+            accessibilityRole="button"
+            accessibilityLabel={`Apply preset ${p.label}`}
+            style={({ pressed }) => [styles.presetChip, pressed && !busy && styles.pressed]}>
+            <View style={[styles.presetDot,
+              { backgroundColor: p.color ? cssRgb(p.color) : t.textDim }]} />
+            <Text style={styles.chipText} numberOfLines={1}>{p.label}</Text>
+          </Pressable>
+        ))}
+        <Pressable
+          onPress={saveCurrent}
+          disabled={busy}
+          accessibilityRole="button"
+          accessibilityLabel="Save current look as a preset"
+          style={({ pressed }) => [styles.savePreset, pressed && !busy && styles.pressed]}>
+          <Ionicons name="add" size={14} color={t.blue} />
+          <Text style={[styles.chipText, { color: t.blue }]}>Save</Text>
+        </Pressable>
       </View>
 
-      <Text style={styles.hint}>
-        {led.rgb ? 'Tap a colour, then a brightness.' : 'Tap a brightness level.'}
-      </Text>
+      <Text style={styles.hint}>Long-press a preset to delete it.</Text>
     </Card>
   );
 }
@@ -236,92 +349,63 @@ export function RgbLedCard() {
 const makeStyles = (t: Palette) =>
   StyleSheet.create({
     header: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
       marginBottom: 10,
     },
     headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
     cardTitle: {
-      color: t.textDim,
-      fontSize: 11,
-      fontWeight: '700',
-      letterSpacing: 1,
-      fontFamily: mono,
+      color: t.textDim, fontSize: 11, fontWeight: '700', letterSpacing: 1, fontFamily: mono,
     },
     refreshBtn: {
-      borderColor: t.cardBorder,
-      borderWidth: 1,
-      borderRadius: 999,
-      paddingVertical: 4,
-      paddingHorizontal: 9,
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 4, paddingHorizontal: 9,
     },
     pressed: { opacity: 0.6 },
 
     sectionLabel: {
-      color: t.textFaint,
-      fontSize: 10,
-      fontWeight: '700',
-      letterSpacing: 1.2,
-      fontFamily: mono,
-      marginTop: 12,
-      marginBottom: 8,
+      color: t.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1.2,
+      fontFamily: mono, marginTop: 14, marginBottom: 8,
     },
-
-    ledRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
-    ledChip: {
-      borderColor: t.cardBorder,
-      borderWidth: 1,
-      borderRadius: 999,
-      paddingVertical: 5,
-      paddingHorizontal: 11,
+    sliderHeader: {
+      flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
     },
-    ledChipOn: { borderColor: t.text },
-    ledChipText: { color: t.textDim, fontSize: 12, fontFamily: mono },
-    ledChipTextOn: { color: t.text, fontWeight: '700' },
-
-    swatchGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10 },
-    // A 2px transparent border is ALWAYS present so selecting shifts no layout.
-    swatch: {
-      width: 44,
-      height: 44,
-      borderRadius: 10,
-      borderWidth: 2,
-      borderColor: 'transparent',
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    swatchOn: { borderColor: t.text },
-    offSwatch: {
-      backgroundColor: t.card,
-      borderColor: t.cardBorder,
-    },
-    offText: {
-      color: t.textDim,
-      fontSize: 10,
-      fontWeight: '700',
-      letterSpacing: 1,
-      fontFamily: mono,
-    },
-
-    levelRow: { flexDirection: 'row', gap: 6 },
-    level: {
-      flex: 1,
-      height: 38,
-      borderRadius: 8,
-      borderWidth: 1,
-      borderColor: t.cardBorder,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    levelOn: { borderColor: t.blue, backgroundColor: t.card },
-    levelText: { color: t.textDim, fontSize: 13, fontFamily: mono },
-    levelTextOn: { color: t.text, fontWeight: '700' },
-
-    hint: {
-      color: t.textFaint,
-      fontSize: 11,
-      fontFamily: mono,
+    swatchPreview: {
+      width: 22, height: 22, borderRadius: 6, borderWidth: 1, borderColor: t.cardBorder,
       marginTop: 10,
     },
+
+    chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+    chip: {
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 12,
+    },
+    chipOn: { borderColor: t.blue, backgroundColor: t.card },
+    chipText: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    chipTextOn: { color: t.text, fontWeight: '700' },
+
+    // The hue/brightness slider bodies (the TrackSlider draws the tall touch
+    // target + thumb; these are the coloured fills it renders inside).
+    hueFill: {
+      flexDirection: 'row', height: 18, borderRadius: 9, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightTrack: {
+      height: 18, borderRadius: 9, backgroundColor: t.card, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightFill: { height: '100%', borderRadius: 9 },
+
+    presetChip: {
+      flexDirection: 'row', alignItems: 'center', gap: 6,
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 10,
+    },
+    presetDot: { width: 12, height: 12, borderRadius: 6 },
+    savePreset: {
+      flexDirection: 'row', alignItems: 'center', gap: 4,
+      borderColor: t.blue, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 10,
+    },
+
+    hint: { color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 10 },
   });

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -57,6 +57,8 @@ const EFFECT_META: Record<LedEffect, { label: string; usesColor: boolean }> = {
   rainbow: { label: 'Rainbow', usesColor: false },
   strobe: { label: 'Strobe', usesColor: true },
   scanner: { label: 'Scanner', usesColor: true },
+  // `manual` is a strip-only concept; filtered out of this single-LED card below.
+  manual: { label: 'Manual', usesColor: true },
 };
 /** A mono LED can't show colour, so only these effects make sense on one. */
 const MONO_EFFECTS: LedEffect[] = ['solid', 'off', 'breathe', 'pulse', 'strobe'];
@@ -118,8 +120,9 @@ export function RgbLedCard() {
   if (!d || !d.available || !led || leds.length === 0
       || (strips.length > 0 && onlyMonoSingles)) return null;
 
-  const supported: LedEffect[] = (d.effects ?? ['solid', 'off']).filter((e) =>
-    led.rgb ? true : MONO_EFFECTS.includes(e));
+  const supported: LedEffect[] = (d.effects ?? ['solid', 'off'])
+    .filter((e) => e !== 'manual') // `manual` is a strip painter, not a single-LED effect
+    .filter((e) => (led.rgb ? true : MONO_EFFECTS.includes(e)));
   const animated = effect !== 'solid' && effect !== 'off';
   const color = hueToRgb(hue);
 

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -1,0 +1,420 @@
+/**
+ * LIGHT STRIP (Console tab) — an ADDRESSABLE kernel-LED strip (e.g. the Steam
+ * Machine's `valve-leds[0..16]`), grouped into ONE target instead of a chip per
+ * node. Owner ask 2026-08-13: per-LED addressable but easy; a night-rider that
+ * actually sweeps AND keeps sweeping with the app closed.
+ *
+ * TWO drive modes:
+ *  - AGENT (agent >= 2.9.85 reports the strip in `strips`): effects run in the
+ *    box's FIRMWARE — one POST sets `scanner`→patrol / `rainbow` / `breathe`, and
+ *    the strip animates on its own, surviving app-close / phone-off / reboot. This
+ *    is the right architecture: the driver lives on the agent, the app controls it.
+ *  - APP fallback (older agent): the app sweeps the dot itself via /api/leds/set
+ *    (works, but throttles when backgrounded — the exact bug the agent path fixes).
+ *
+ * Solid/Off/paint go per-LED via /api/leds/set so a Solid strip is a paintable
+ * customizer. Renders nothing unless a strip is detected (lib/ledStrip).
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useEffect, useRef, useState } from 'react';
+import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { TrackSlider } from '@/components/TrackSlider';
+import { usePoll } from '@/hooks/usePoll';
+import { api, hostKey, type LedEffect, type LedsState, type Rgb } from '@/lib/api';
+import { hapticLight } from '@/lib/haptics';
+import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
+import { addPreset, removePreset, useLedPresets, type LedPreset } from '@/lib/ledPresets';
+import { detectStrips, type LedStrip } from '@/lib/ledStrip';
+import { useSkinKit } from '@/lib/skin';
+import { useSettings } from '@/lib/SettingsContext';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+const POLL_MS = 15000;
+
+type StripEffect = 'solid' | 'off' | 'scanner' | 'rainbow' | 'breathe';
+const EFFECTS: { id: StripEffect; label: string }[] = [
+  { id: 'solid', label: 'Solid' },
+  { id: 'off', label: 'Off' },
+  { id: 'scanner', label: 'Scanner' },
+  { id: 'rainbow', label: 'Rainbow' },
+  { id: 'breathe', label: 'Breathe' },
+];
+const SPEEDS = [
+  { label: 'Slow', pct: 25, ms: 150 },
+  { label: 'Med', pct: 55, ms: 90 },
+  { label: 'Fast', pct: 90, ms: 55 },
+];
+const scale = (c: Rgb, f: number): Rgb => ({
+  r: Math.round(c.r * f), g: Math.round(c.g * f), b: Math.round(c.b * f),
+});
+
+/** Friendly name for a known device so the customizer reads as "your box". */
+function stripDeviceLabel(prefix: string): string {
+  if (prefix.startsWith('valve-leds')) return 'Steam Machine strip';
+  return prefix.replace(/[:_-]+$/, '');
+}
+
+/** One frame of the APP-driven fallback animation (only used on old agents). */
+function computeFrame(effect: StripEffect, n: number, t: number, color: Rgb): (Rgb | null)[] {
+  const period = (n - 1) * 2 || 1;
+  const cyc = t % period;
+  const pos = cyc < n - 1 ? cyc : period - cyc;
+  return Array.from({ length: n }, (_, i) => {
+    const f = Math.max(0, 1 - Math.abs(i - pos) / 1.7);
+    return f > 0.06 ? scale(color, f) : null;
+  });
+}
+const sameCell = (a: Rgb | null, b: Rgb | null) =>
+  (!a && !b) || (!!a && !!b && a.r === b.r && a.g === b.g && a.b === b.b);
+
+export function StripLightCard() {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { Card } = useSkinKit();
+  const { settings, ready } = useSettings();
+  const configured = !!settings.host && !!settings.token;
+  const presets = useLedPresets();
+
+  const [selKey, setSelKey] = useState<string | null>(null);
+  const [effect, setEffect] = useState<StripEffect>('solid');
+  const [hue, setHue] = useState(0);
+  const [bright, setBright] = useState(100);
+  const [speedPct, setSpeedPct] = useState(55);
+  const [frame, setFrame] = useState<(Rgb | null)[]>([]);
+  const [busy, setBusy] = useState(false);
+
+  const poll = usePoll<LedsState | null>(
+    () => api.leds(settings), POLL_MS, ready && configured, hostKey(settings));
+
+  const leds = (poll.data?.leds ?? []).filter((l) => l.notable && l.writable);
+  const { strips } = detectStrips(leds);
+  const strip: LedStrip | undefined = strips.find((s) => s.key === selKey) ?? strips[0];
+  // Does the AGENT own this strip (firmware effects)? Match by prefix.
+  const agentStrip = strip
+    ? (poll.data?.strips ?? []).find((s) => strip.key === `strip:${s.prefix}`)
+    : undefined;
+  const agentMode = !!agentStrip;
+
+  const colorRef = useRef<Rgb>({ r: 255, g: 0, b: 0 });
+  const brightRef = useRef(100);
+  colorRef.current = hueToRgb(hue);
+  brightRef.current = bright;
+
+  const seeded = useRef<string | null>(null);
+  useEffect(() => {
+    if (!strip) return;
+    if (seeded.current === strip.key) return;
+    seeded.current = strip.key;
+    setFrame(strip.leds.map((l) => (l.brightness_pct > 0 ? l.color : null)));
+    const a = strip && poll.data?.active?.[`strip:${agentStrip?.prefix}`];
+    if (a) { setEffect(a.effect as StripEffect); setBright(a.brightness); if (a.color) setHue(rgbToHue(a.color)); }
+    else {
+      const lit = strip.leds.find((l) => l.color && l.brightness_pct > 0);
+      if (lit?.color) setHue(rgbToHue(lit.color));
+    }
+  }, [strip, agentStrip, poll.data]);
+
+  // APP-driven fallback animation (old agents only). No-op in agent mode.
+  useEffect(() => {
+    if (agentMode || !strip || (effect !== 'scanner')) return;
+    const n = strip.leds.length;
+    let tick = 0;
+    let first = true;
+    let last: (Rgb | null)[] = new Array(n).fill(null);
+    const ms = SPEEDS.find((s) => s.pct === speedPct)?.ms ?? 90;
+    const timer = setInterval(() => {
+      const next = computeFrame(effect, n, tick, colorRef.current);
+      const b = Math.round(brightRef.current);
+      for (let i = 0; i < n; i++) {
+        if (first || !sameCell(next[i], last[i])) {
+          const cell = next[i];
+          void api.setLed(settings, strip.leds[i].name, cell ? { color: cell, brightness: b } : { brightness: 0 });
+        }
+      }
+      setFrame(next); last = next; first = false; tick++;
+    }, ms);
+    return () => clearInterval(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agentMode, effect, strip?.key, speedPct]);
+
+  if (!poll.data || strips.length === 0 || !strip) return null;
+
+  const color = hueToRgb(hue);
+  const animated = effect === 'scanner' || effect === 'rainbow' || effect === 'breathe';
+  const shown = agentMode
+    ? EFFECTS
+    : EFFECTS.filter((e) => e.id === 'solid' || e.id === 'off' || e.id === 'scanner');
+
+  /** Apply an effect. Agent mode = one POST, the box animates. */
+  const applyEffect = async (e: StripEffect) => {
+    hapticLight();
+    setEffect(e);
+    if (agentMode && agentStrip) {
+      setBusy(true);
+      try {
+        await api.setStripEffect(settings, agentStrip.prefix, {
+          effect: e as LedEffect, brightness: Math.round(bright),
+          ...(animated || e !== 'off' ? { speed: Math.round(speedPct) } : {}),
+          ...(e === 'rainbow' ? {} : { color }),
+        });
+      } finally { await poll.refresh(); setBusy(false); }
+      return;
+    }
+    // App fallback: solid/off fill immediately; scanner runs the loop above.
+    if (e === 'solid' || e === 'off') {
+      const b = Math.round(bright);
+      strip.leds.forEach((l) => void api.setLed(settings, l.name, e === 'off' ? { brightness: 0 } : { color, brightness: b }));
+      setFrame(strip.leds.map(() => (e === 'off' ? null : color)));
+    }
+  };
+
+  /** Re-apply the current colour/brightness — for a solid strip, or to re-arm an
+   *  agent effect with the tweaked colour/speed (slider/speed commit). */
+  const reapply = () => {
+    if (agentMode && agentStrip && effect !== 'off') {
+      void api.setStripEffect(settings, agentStrip.prefix, {
+        effect: effect as LedEffect, brightness: Math.round(bright),
+        speed: Math.round(speedPct), ...(effect === 'rainbow' ? {} : { color }),
+      });
+      return;
+    }
+    if (effect === 'solid') {
+      const b = Math.round(bright);
+      strip.leds.forEach((l) => void api.setLed(settings, l.name, { color, brightness: b }));
+      setFrame(strip.leds.map(() => color));
+    }
+  };
+
+  /** Paint one cell — a per-LED customizer (best in Solid). */
+  const paintCell = (i: number) => {
+    hapticLight();
+    void api.setLed(settings, strip.leds[i].name, { color, brightness: Math.round(bright) });
+    setFrame((f) => { const c = f.slice(); c[i] = color; return c; });
+  };
+
+  /** Coerce any saved preset effect to one the strip runs. */
+  const toStripEffect = (e: LedEffect): StripEffect =>
+    (EFFECTS.some((x) => x.id === e) ? e : 'breathe') as StripEffect;
+  const nearestSpeed = (p: number) =>
+    SPEEDS.reduce((b, s) => (Math.abs(s.pct - p) < Math.abs(b - p) ? s.pct : b), 55);
+
+  const applyPreset = (p: LedPreset) => {
+    hapticLight();
+    const e = toStripEffect(p.effect);
+    const h = p.color ? rgbToHue(p.color) : hue;
+    setEffect(e); setHue(h); setBright(p.brightness); setSpeedPct(nearestSpeed(p.speed));
+    if (agentMode && agentStrip) {
+      void api.setStripEffect(settings, agentStrip.prefix, {
+        effect: e as LedEffect, brightness: p.brightness, speed: p.speed,
+        ...(e === 'rainbow' ? {} : { color: p.color ?? hueToRgb(h) }),
+      }).then(() => poll.refresh());
+    } else {
+      void applyEffect(e);
+    }
+  };
+
+  const saveCurrent = () => {
+    hapticLight();
+    const label = EFFECTS.find((x) => x.id === effect)?.label ?? 'Look';
+    const usesColor = effect !== 'rainbow' && effect !== 'off';
+    void addPreset({
+      label: label + (usesColor ? ` ${hexRgb(color)}` : ''),
+      effect: effect as LedEffect, color: usesColor ? color : null,
+      speed: Math.round(speedPct), brightness: Math.round(bright),
+    });
+  };
+
+  const confirmDelete = (p: LedPreset) =>
+    Alert.alert('Delete preset', `Remove "${p.label}"?`, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Delete', style: 'destructive', onPress: () => void removePreset(p.id) },
+    ]);
+
+  return (
+    <Card index={7}>
+      <View style={styles.header}>
+        <Text style={styles.cardTitle}>LIGHT STRIP</Text>
+        <View style={styles.headerRight}>
+          <Text style={styles.count}>{stripDeviceLabel(agentStrip?.prefix ?? strip.key)} · {strip.leds.length}</Text>
+          <Pressable
+            onPress={() => { hapticLight(); poll.refresh(); }}
+            hitSlop={10} accessibilityRole="button" accessibilityLabel="Refresh strip"
+            style={({ pressed }) => [styles.refreshBtn, pressed && styles.pressed]}>
+            <Ionicons name="refresh" size={13} color={t.textDim} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* The strip as ONE row (matches the single physical line) — tap a cell to
+          paint it. Cells flex to share the width so 17 fit without wrapping. */}
+      <View style={styles.strip}>
+        {strip.leds.map((l, i) => {
+          const c = frame[i] ?? null;
+          return (
+            <Pressable
+              key={l.name} onPress={() => paintCell(i)} style={styles.cellWrap}
+              accessibilityRole="button" accessibilityLabel={`Paint LED ${i}`}>
+              {({ pressed }) => (
+                <View style={[styles.cell, { backgroundColor: c ? cssRgb(c) : t.card },
+                  pressed && styles.pressed]} />
+              )}
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* EFFECT chips. */}
+      <Text style={styles.sectionLabel}>EFFECT</Text>
+      <View style={styles.chipRow}>
+        {shown.map((e) => {
+          const on = effect === e.id;
+          return (
+            <Pressable
+              key={e.id} onPress={() => void applyEffect(e.id)} disabled={busy}
+              accessibilityRole="button" accessibilityState={{ selected: on, disabled: busy }}
+              accessibilityLabel={`Effect ${e.label}`}
+              style={({ pressed }) => [styles.chip, on && styles.chipOn, pressed && !busy && styles.pressed]}>
+              <Text style={[styles.chipText, on && styles.chipTextOn]}>{e.label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* SPEED — animated effects only. */}
+      {animated && (
+        <>
+          <Text style={styles.sectionLabel}>SPEED</Text>
+          <View style={styles.chipRow}>
+            {SPEEDS.map((s) => {
+              const on = speedPct === s.pct;
+              return (
+                <Pressable
+                  key={s.label} onPress={() => { hapticLight(); setSpeedPct(s.pct); if (agentMode) reapply(); }}
+                  accessibilityRole="button" accessibilityState={{ selected: on }}
+                  accessibilityLabel={`Speed ${s.label}`}
+                  style={({ pressed }) => [styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
+                  <Text style={[styles.chipText, on && styles.chipTextOn]}>{s.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </>
+      )}
+
+      {/* COLOUR — hidden for rainbow (its own hues) and off. */}
+      {strip.rgb && effect !== 'rainbow' && effect !== 'off' && (
+        <>
+          <View style={styles.sliderHeader}>
+            <Text style={styles.sectionLabel}>COLOUR</Text>
+            <View style={[styles.swatchPreview, { backgroundColor: cssRgb(color) }]} />
+          </View>
+          <TrackSlider
+            value={hue} min={0} max={360} onChange={setHue} onCommit={reapply}
+            thumbColor={cssRgb(color)} accessibilityLabel="Strip colour hue"
+            renderTrack={() => (
+              <View style={styles.hueFill}>
+                {HUE_STOPS.map((c, i) => (<View key={i} style={{ flex: 1, backgroundColor: c }} />))}
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      {/* BRIGHTNESS — unless off. */}
+      {effect !== 'off' && (
+        <>
+          <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
+          <TrackSlider
+            value={bright} min={0} max={100} onChange={setBright} onCommit={reapply}
+            thumbColor={t.text} accessibilityLabel="Strip brightness"
+            renderTrack={(pct) => (
+              <View style={styles.brightTrack}>
+                <View style={[styles.brightFill, { width: `${pct * 100}%`, backgroundColor: cssRgb(color) }]} />
+              </View>
+            )}
+          />
+        </>
+      )}
+
+      {/* PRESETS — saved profiles, applied to the whole strip. */}
+      <Text style={styles.sectionLabel}>PRESETS</Text>
+      <View style={styles.chipRow}>
+        {presets.map((p) => (
+          <Pressable
+            key={p.id} onPress={() => applyPreset(p)} onLongPress={() => confirmDelete(p)}
+            accessibilityRole="button" accessibilityLabel={`Apply preset ${p.label}`}
+            style={({ pressed }) => [styles.presetChip, pressed && styles.pressed]}>
+            <View style={[styles.presetDot, { backgroundColor: p.color ? cssRgb(p.color) : t.textDim }]} />
+            <Text style={styles.chipText} numberOfLines={1}>{p.label}</Text>
+          </Pressable>
+        ))}
+        <Pressable
+          onPress={saveCurrent} accessibilityRole="button"
+          accessibilityLabel="Save current look as a preset"
+          style={({ pressed }) => [styles.savePreset, pressed && styles.pressed]}>
+          <Ionicons name="add" size={14} color={t.blue} />
+          <Text style={[styles.chipText, { color: t.blue }]}>Save</Text>
+        </Pressable>
+      </View>
+
+      <Text style={styles.hint}>
+        {agentMode
+          ? 'Effects run on the box — they keep going with the app closed. Long-press a preset to delete.'
+          : 'Tap a cell to paint it. Scanner sweeps a dot across the strip.'}
+      </Text>
+    </Card>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    header: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 10 },
+    headerRight: { flexDirection: 'row', alignItems: 'center', gap: 10 },
+    cardTitle: { color: t.textDim, fontSize: 11, fontWeight: '700', letterSpacing: 1, fontFamily: mono },
+    count: { color: t.textFaint, fontSize: 11, fontFamily: mono },
+    refreshBtn: { borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999, paddingVertical: 4, paddingHorizontal: 9 },
+    pressed: { opacity: 0.6 },
+
+    // One row: cells flex to share the width so all 17 fit on a single line.
+    strip: { flexDirection: 'row', gap: 3, marginBottom: 8, marginTop: 2 },
+    cellWrap: { flex: 1 },
+    cell: { width: '100%', height: 40, borderRadius: 4, borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder },
+
+    sectionLabel: {
+      color: t.textFaint, fontSize: 10, fontWeight: '700', letterSpacing: 1.2, fontFamily: mono,
+      marginTop: 14, marginBottom: 8,
+    },
+    sliderHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+    swatchPreview: { width: 22, height: 22, borderRadius: 6, borderWidth: 1, borderColor: t.cardBorder, marginTop: 10 },
+
+    chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6 },
+    chip: { borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999, paddingVertical: 6, paddingHorizontal: 12 },
+    chipOn: { borderColor: t.blue, backgroundColor: t.card },
+    chipText: { color: t.textDim, fontSize: 12, fontFamily: mono },
+    chipTextOn: { color: t.text, fontWeight: '700' },
+
+    hueFill: {
+      flexDirection: 'row', height: 18, borderRadius: 9, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightTrack: {
+      height: 18, borderRadius: 9, backgroundColor: t.card, overflow: 'hidden',
+      borderWidth: StyleSheet.hairlineWidth, borderColor: t.cardBorder,
+    },
+    brightFill: { height: '100%', borderRadius: 9 },
+
+    presetChip: {
+      flexDirection: 'row', alignItems: 'center', gap: 6,
+      borderColor: t.cardBorder, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 10,
+    },
+    presetDot: { width: 12, height: 12, borderRadius: 6 },
+    savePreset: {
+      flexDirection: 'row', alignItems: 'center', gap: 4,
+      borderColor: t.blue, borderWidth: 1, borderRadius: 999,
+      paddingVertical: 6, paddingHorizontal: 10,
+    },
+
+    hint: { color: t.textFaint, fontSize: 11, fontFamily: mono, marginTop: 10 },
+  });

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -32,9 +32,10 @@ import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const POLL_MS = 15000;
 
-type StripEffect = 'solid' | 'off' | 'scanner' | 'rainbow' | 'breathe';
+type StripEffect = 'solid' | 'off' | 'manual' | 'scanner' | 'rainbow' | 'breathe';
 const EFFECTS: { id: StripEffect; label: string }[] = [
   { id: 'solid', label: 'Solid' },
+  { id: 'manual', label: 'Manual' },
   { id: 'off', label: 'Off' },
   { id: 'scanner', label: 'Scanner' },
   { id: 'rainbow', label: 'Rainbow' },
@@ -201,6 +202,24 @@ export function StripLightCard() {
 
   const applyPreset = (p: LedPreset) => {
     hapticLight();
+    // A painted PATTERN preset: enter manual mode, then repaint every LED.
+    if (p.pattern && p.pattern.length) {
+      setEffect('manual'); setBright(p.brightness);
+      const pat = strip.leds.map((_, i) => p.pattern![i] ?? null);
+      setFrame(pat);
+      if (agentMode && agentStrip) {
+        void api.setStripEffect(settings, agentStrip.prefix, { effect: 'manual', brightness: p.brightness })
+          .then(() => Promise.all(strip.leds.map((l, i) =>
+            api.setLed(settings, l.name, pat[i]
+              ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) }
+              : { brightness: 0 }))))
+          .then(() => poll.refresh());
+      } else {
+        strip.leds.forEach((l, i) => void api.setLed(settings, l.name, pat[i]
+          ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) } : { brightness: 0 }));
+      }
+      return;
+    }
     const e = toStripEffect(p.effect);
     const h = p.color ? rgbToHue(p.color) : hue;
     setEffect(e); setHue(h); setBright(p.brightness); setSpeedPct(nearestSpeed(p.speed));
@@ -216,6 +235,15 @@ export function StripLightCard() {
 
   const saveCurrent = () => {
     hapticLight();
+    // In Manual mode, save the whole painted pattern (one colour per LED).
+    if (effect === 'manual') {
+      void addPreset({
+        label: `Custom ${strip.leds.length}`, effect: 'manual', color: null,
+        speed: Math.round(speedPct), brightness: Math.round(bright),
+        pattern: frame.map((c) => c ?? null),
+      });
+      return;
+    }
     const label = EFFECTS.find((x) => x.id === effect)?.label ?? 'Look';
     const usesColor = effect !== 'rainbow' && effect !== 'off';
     void addPreset({
@@ -359,9 +387,11 @@ export function StripLightCard() {
       </View>
 
       <Text style={styles.hint}>
-        {agentMode
-          ? 'Effects run on the box — they keep going with the app closed. Long-press a preset to delete.'
-          : 'Tap a cell to paint it. Scanner sweeps a dot across the strip.'}
+        {effect === 'manual'
+          ? 'Pick a colour, tap cells to paint them, then Save the pattern.'
+          : agentMode
+            ? 'Effects run on the box — they keep going with the app closed. Long-press a preset to delete.'
+            : 'Tap a cell to paint it. Scanner sweeps a dot across the strip.'}
       </Text>
     </Card>
   );

--- a/app/components/TrackSlider.tsx
+++ b/app/components/TrackSlider.tsx
@@ -1,0 +1,78 @@
+/**
+ * A PanResponder slider used by the LED editors. A DRAG feels native; a single
+ * TAP on the track also sets the value (the responder grant fires with the tap
+ * position), so the web harness can press it too (CLAUDE.md §6). `onChange` fires
+ * live for a preview; `onCommit` fires on release/tap — that's when the write
+ * goes to the box. The DRAG gesture is on-device-only proof.
+ */
+import React, { useRef } from 'react';
+import { PanResponder, StyleSheet, View } from 'react-native';
+
+import { clamp } from '@/lib/ledColor';
+import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function TrackSlider(props: {
+  value: number;
+  min: number;
+  max: number;
+  onChange: (v: number) => void;
+  onCommit: (v: number) => void;
+  renderTrack: (pct: number) => React.ReactNode;
+  thumbColor: string;
+  disabled?: boolean;
+  accessibilityLabel: string;
+}) {
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const { value, min, max, renderTrack, thumbColor, disabled, accessibilityLabel } = props;
+  const wRef = useRef(0);
+  // Latest props in a ref so the once-created responder never reads stale values.
+  const live = useRef(props);
+  live.current = props;
+
+  const emit = (locationX: number, commit: boolean) => {
+    const p = live.current;
+    const w = wRef.current || 1;
+    const frac = clamp(locationX, 0, w) / w;
+    const v = p.min + frac * (p.max - p.min);
+    p.onChange(v);
+    if (commit) p.onCommit(v);
+  };
+
+  const pan = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => !live.current.disabled,
+      onMoveShouldSetPanResponder: () => !live.current.disabled,
+      onPanResponderGrant: (e) => emit(e.nativeEvent.locationX, false),
+      onPanResponderMove: (e) => emit(e.nativeEvent.locationX, false),
+      onPanResponderRelease: (e) => emit(e.nativeEvent.locationX, true),
+    }),
+  ).current;
+
+  const pct = clamp((value - min) / (max - min), 0, 1);
+  return (
+    <View
+      onLayout={(e) => { wRef.current = e.nativeEvent.layout.width; }}
+      {...pan.panHandlers}
+      accessibilityRole="adjustable"
+      accessibilityLabel={accessibilityLabel}
+      accessibilityValue={{ min, max, now: Math.round(value) }}
+      style={[styles.track, disabled && styles.disabled]}>
+      {renderTrack(pct)}
+      <View style={[styles.thumb, { left: `${pct * 100}%`, borderColor: thumbColor }]} />
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    // Intentionally tall for a comfortable touch/drag target.
+    track: { height: 34, borderRadius: 10, justifyContent: 'center', overflow: 'visible' },
+    disabled: { opacity: 0.5 },
+    thumb: {
+      position: 'absolute', top: 3, width: 28, height: 28, borderRadius: 14,
+      marginLeft: -14, backgroundColor: t.text, borderWidth: 3,
+      shadowColor: '#000', shadowOpacity: 0.35, shadowRadius: 3,
+      shadowOffset: { width: 0, height: 1 }, elevation: 3,
+    },
+  });

--- a/app/components/TrackSlider.tsx
+++ b/app/components/TrackSlider.tsx
@@ -1,12 +1,20 @@
 /**
- * A PanResponder slider used by the LED editors. A DRAG feels native; a single
- * TAP on the track also sets the value (the responder grant fires with the tap
- * position), so the web harness can press it too (CLAUDE.md §6). `onChange` fires
- * live for a preview; `onCommit` fires on release/tap — that's when the write
- * goes to the box. The DRAG gesture is on-device-only proof.
+ * A slider used by the LED editors, built on react-native-gesture-handler so it
+ * arbitrates cleanly against the gestures around it:
+ *  - `activeOffsetX` claims a HORIZONTAL drag, so it wins over iOS's navigation
+ *    swipe (the `◀ App` back gesture) and the tab/stack swipe — the "slider
+ *    fights navigation" bug.
+ *  - `failOffsetY` yields a VERTICAL drag to the Console ScrollView, so a scroll
+ *    that happens to start on the track still scrolls the page.
+ * A tap sets the value too (so the web harness can press it, CLAUDE.md §6).
+ *
+ * Tracking is by ABSOLUTE touch X (gesture `absoluteX`) minus the track's
+ * measured window-left — not a child-relative coordinate, which jumps as the
+ * finger crosses the fill/thumb/hue segments.
  */
-import React, { useRef } from 'react';
-import { PanResponder, StyleSheet, View } from 'react-native';
+import React, { useMemo, useRef } from 'react';
+import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 import { clamp } from '@/lib/ledColor';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -25,48 +33,59 @@ export function TrackSlider(props: {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const { value, min, max, renderTrack, thumbColor, disabled, accessibilityLabel } = props;
-  const wRef = useRef(0);
-  // Latest props in a ref so the once-created responder never reads stale values.
+
+  const viewRef = useRef<View>(null);
+  const geom = useRef({ x: 0, w: 1 });
   const live = useRef(props);
   live.current = props;
 
-  const emit = (locationX: number, commit: boolean) => {
+  const measure = () =>
+    viewRef.current?.measureInWindow((x, _y, w) => { geom.current = { x, w: w || 1 }; });
+
+  const emit = (absX: number, commit: boolean) => {
     const p = live.current;
-    const w = wRef.current || 1;
-    const frac = clamp(locationX, 0, w) / w;
+    if (p.disabled) return;
+    const frac = clamp(absX - geom.current.x, 0, geom.current.w) / geom.current.w;
     const v = p.min + frac * (p.max - p.min);
     p.onChange(v);
     if (commit) p.onCommit(v);
   };
 
-  const pan = useRef(
-    PanResponder.create({
-      onStartShouldSetPanResponder: () => !live.current.disabled,
-      onMoveShouldSetPanResponder: () => !live.current.disabled,
-      onPanResponderGrant: (e) => emit(e.nativeEvent.locationX, false),
-      onPanResponderMove: (e) => emit(e.nativeEvent.locationX, false),
-      onPanResponderRelease: (e) => emit(e.nativeEvent.locationX, true),
-    }),
-  ).current;
+  const gesture = useMemo(() => {
+    const pan = Gesture.Pan()
+      .runOnJS(true)
+      .activeOffsetX([-8, 8])
+      .failOffsetY([-16, 16])
+      .onBegin(() => measure())
+      .onUpdate((e) => emit(e.absoluteX, false))
+      .onEnd((e) => emit(e.absoluteX, true));
+    const tap = Gesture.Tap()
+      .runOnJS(true)
+      .onEnd((e) => { measure(); emit(e.absoluteX, true); });
+    // Pan preferred (a drag); tap only if the pan never activated (a plain tap).
+    return Gesture.Exclusive(pan, tap);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const pct = clamp((value - min) / (max - min), 0, 1);
   return (
-    <View
-      onLayout={(e) => { wRef.current = e.nativeEvent.layout.width; }}
-      {...pan.panHandlers}
-      accessibilityRole="adjustable"
-      accessibilityLabel={accessibilityLabel}
-      accessibilityValue={{ min, max, now: Math.round(value) }}
-      style={[styles.track, disabled && styles.disabled]}>
-      {renderTrack(pct)}
-      <View style={[styles.thumb, { left: `${pct * 100}%`, borderColor: thumbColor }]} />
-    </View>
+    <GestureDetector gesture={gesture}>
+      <View
+        ref={viewRef}
+        onLayout={(_e: LayoutChangeEvent) => measure()}
+        accessibilityRole="adjustable"
+        accessibilityLabel={accessibilityLabel}
+        accessibilityValue={{ min, max, now: Math.round(value) }}
+        style={[styles.track, disabled && styles.disabled]}>
+        {renderTrack(pct)}
+        <View pointerEvents="none" style={[styles.thumb, { left: `${pct * 100}%`, borderColor: thumbColor }]} />
+      </View>
+    </GestureDetector>
   );
 }
 
 const makeStyles = (t: Palette) =>
   StyleSheet.create({
-    // Intentionally tall for a comfortable touch/drag target.
     track: { height: 34, borderRadius: 10, justifyContent: 'center', overflow: 'visible' },
     disabled: { opacity: 0.5 },
     thumb: {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -243,6 +243,13 @@ export type BoxCaps = {
    * install-time udev grant makes an LED writable.
    */
   ledcontrol?: boolean;
+  /**
+   * Whole-system / addressable RGB via a local OpenRGB SDK server (agent >=
+   * 2.9.84, cap `openrgb`). undefined = unknown/probe (older agent, Windows);
+   * false = no OpenRGB server on the box. Gates the OpenRGB card + the real
+   * multi-zone scanner.
+   */
+  openrgb?: boolean;
 };
 
 /** One Setup → Utilities helper + its live state, from GET /api/utilities.
@@ -467,11 +474,53 @@ export type LedInfo = {
   color: Rgb | null;
 };
 
+/** The animated LED effects the agent supports (agent >= 2.9.84). `solid` and
+    `off` are one-shot (no animation); the rest run on the box until changed.
+    `scanner` is the KITT sweep — real across multiple LEDs (OpenRGB), a
+    bounce-pulse on a single kernel LED. */
+export type LedEffect =
+  | 'solid' | 'off' | 'breathe' | 'pulse' | 'rainbow' | 'strobe' | 'scanner';
+
+/** The effect currently running on an LED (from GET /api/leds `active`). Absent
+    for an LED showing a plain solid colour (that's read from LedInfo instead). */
+export type LedActive = {
+  effect: LedEffect;
+  color: Rgb | null;
+  speed: number;
+  brightness: number;
+};
+
 /** GET /api/leds: the writable LEDs the box exposes + their state.
     `available: false` = nothing controllable here (the card hides). */
 export type LedsState = {
   available: boolean;
   leds: LedInfo[];
+  /** Supported effect ids (agent >= 2.9.84); absent on an older agent, in which
+      case the app shows colour/brightness only and hides the effect controls. */
+  effects?: LedEffect[];
+  /** Per-LED running animation, keyed by LED name (agent >= 2.9.84). */
+  active?: Record<string, LedActive>;
+};
+
+/** One OpenRGB controller from GET /api/openrgb (agent >= 2.9.84, cap `openrgb`).
+    `index` is what the setter POSTs back; `led_count` is the sum of its zones. */
+export type OpenRgbController = {
+  index: number;
+  name: string;
+  led_count: number;
+  zones: { name: string; leds: number }[];
+};
+
+/** GET /api/openrgb: the OpenRGB controllers the box exposes + their running
+    effect. `available: false` = no OpenRGB server on the box (card hides). */
+export type OpenRgbState = {
+  available: boolean;
+  /** "host:port" of the OpenRGB SDK server, or null when unavailable. */
+  server: string | null;
+  controllers: OpenRgbController[];
+  effects?: LedEffect[];
+  /** Per-device running animation, keyed by device index (as a string). */
+  active?: Record<string, LedActive>;
 };
 
 /** One stage of the Couch Mode ceremony (GET /api/couch-mode/status, agent
@@ -1273,7 +1322,8 @@ export function capsEqual(a?: BoxCaps, b?: BoxCaps): boolean {
     a.screenstream === b.screenstream &&
     a.screenstream_h264 === b.screenstream_h264 &&
     a.audioswitch === b.audioswitch &&
-    a.ledcontrol === b.ledcontrol
+    a.ledcontrol === b.ledcontrol &&
+    a.openrgb === b.openrgb
   );
 }
 
@@ -2567,6 +2617,62 @@ export const api = {
     return request<{ ok: boolean }>(settings, '/api/leds/set', {
       method: 'POST',
       body: { led, ...patch },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
+  /**
+   * Start (or replace) an animated effect on an LED — or a `solid`/`off`
+   * (agent >= 2.9.84). Same allowlist as setLed: `led` is a name the box sent,
+   * looked up in its live /sys/class/leds set (404 otherwise). `effect` must be
+   * one of the ids the box advertised in leds()'s `effects`; the agent
+   * range-checks `speed` (1–100) and `brightness` (0–100) and rejects anything
+   * else. The agent persists the choice so a reboot restores it. Resolves false
+   * on any failure; the caller re-reads /api/leds for the real state (§11).
+   */
+  setLedEffect(
+    settings: ConnSettings,
+    led: string,
+    patch: { effect: LedEffect; color?: Rgb; speed?: number; brightness?: number },
+  ): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/leds/effect', {
+      method: 'POST',
+      body: { led, ...patch },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
+  /**
+   * OpenRGB controllers (whole-system / addressable RGB) + their state (agent >=
+   * 2.9.84, cap `openrgb`). Probe-and-appear: null on a 404 (older agent) so the
+   * OpenRGB card hides; an `available: false` payload (no OpenRGB server on the
+   * box) hides it too.
+   */
+  openrgb(
+    settings: ConnSettings,
+    caps: BoxCaps | undefined = cachedCaps(settings),
+  ): Promise<OpenRgbState | null> {
+    return probeGated(caps?.openrgb, () =>
+      probeOrNull(request<OpenRgbState>(settings, '/api/openrgb')));
+  },
+
+  /**
+   * Set an OpenRGB device to a solid colour or an animated effect (the real
+   * multi-zone scanner). `device` is an int index the box itself sent in
+   * openrgb()'s list — the agent looks it up in its live controller list and
+   * 404s an unknown one, so this can never aim at a device the box didn't offer.
+   * Resolves false on any failure; the caller re-reads /api/openrgb (§11).
+   */
+  openrgbSet(
+    settings: ConnSettings,
+    device: number,
+    patch: { effect: LedEffect; color?: Rgb; speed?: number; brightness?: number },
+  ): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/openrgb/set', {
+      method: 'POST',
+      body: { device, ...patch },
     })
       .then((r) => !!r?.ok)
       .catch(() => false);

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -490,6 +490,17 @@ export type LedActive = {
   brightness: number;
 };
 
+/** An addressable STRIP the agent groups from `prefix[N]` LED nodes (agent >=
+    2.9.85), e.g. a Steam Machine's 17 `valve-leds`. `hw_effects` are the firmware
+    effect names the driver runs on the box itself (patrol/breath/rainbow/…), so
+    the animation survives the app closing. */
+export type StripInfo = {
+  prefix: string;
+  count: number;
+  rgb: boolean;
+  hw_effects: string[];
+};
+
 /** GET /api/leds: the writable LEDs the box exposes + their state.
     `available: false` = nothing controllable here (the card hides). */
 export type LedsState = {
@@ -498,8 +509,11 @@ export type LedsState = {
   /** Supported effect ids (agent >= 2.9.84); absent on an older agent, in which
       case the app shows colour/brightness only and hides the effect controls. */
   effects?: LedEffect[];
-  /** Per-LED running animation, keyed by LED name (agent >= 2.9.84). */
+  /** Per-LED (and per-strip, keyed `strip:<prefix>`) running effect (agent >= 2.9.84). */
   active?: Record<string, LedActive>;
+  /** Addressable strips the agent can drive as a whole (agent >= 2.9.85). Absent
+      on older agents → the app falls back to driving the sweep itself. */
+  strips?: StripInfo[];
 };
 
 /** One OpenRGB controller from GET /api/openrgb (agent >= 2.9.84, cap `openrgb`).
@@ -2639,6 +2653,25 @@ export const api = {
     return request<{ ok: boolean }>(settings, '/api/leds/effect', {
       method: 'POST',
       body: { led, ...patch },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
+  /**
+   * Drive a whole addressable STRIP (agent >= 2.9.85) — the box runs the effect
+   * in firmware (a real night-rider `scanner`, `rainbow`, `breathe`) so it keeps
+   * going with the app closed. `strip` is a prefix the box sent in leds()'s
+   * `strips`; the agent looks it up and 404s otherwise. Resolves false on failure.
+   */
+  setStripEffect(
+    settings: ConnSettings,
+    strip: string,
+    patch: { effect: LedEffect; color?: Rgb; speed?: number; brightness?: number },
+  ): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/leds/effect', {
+      method: 'POST',
+      body: { strip, ...patch },
     })
       .then((r) => !!r?.ok)
       .catch(() => false);

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -479,7 +479,10 @@ export type LedInfo = {
     `scanner` is the KITT sweep — real across multiple LEDs (OpenRGB), a
     bounce-pulse on a single kernel LED. */
 export type LedEffect =
-  | 'solid' | 'off' | 'breathe' | 'pulse' | 'rainbow' | 'strobe' | 'scanner';
+  | 'solid' | 'off' | 'breathe' | 'pulse' | 'rainbow' | 'strobe' | 'scanner'
+  // `manual` = a per-LED painted pattern on a strip (agent >= 2.9.85); the
+  // colours stick because the agent puts each node in the driver's manual mode.
+  | 'manual';
 
 /** The effect currently running on an LED (from GET /api/leds `active`). Absent
     for an LED showing a plain solid colour (that's read from LedInfo instead). */

--- a/app/lib/ledColor.ts
+++ b/app/lib/ledColor.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure colour helpers shared by the LED editors (RgbLedCard, OpenRgbCard).
+ *
+ * Colour and brightness are INDEPENDENT on the box (the multi_intensity hue vs
+ * the master brightness on a kernel LED; per-LED colour vs the effect brightness
+ * on OpenRGB), so the picker always yields a FULL-value hue and the brightness
+ * slider dims it separately.
+ */
+import type { Rgb } from './api';
+
+export const clamp = (v: number, lo: number, hi: number) => Math.max(lo, Math.min(hi, v));
+
+export const cssRgb = (c: Rgb) => `rgb(${c.r}, ${c.g}, ${c.b})`;
+
+export const hexRgb = (c: Rgb) =>
+  '#' + [c.r, c.g, c.b].map((v) => clamp(Math.round(v), 0, 255).toString(16).padStart(2, '0'))
+    .join('').toUpperCase();
+
+/** hue 0–360 (full saturation + value) → {r,g,b} 0–255. */
+export function hueToRgb(h: number): Rgb {
+  const c = 1, x = 1 - Math.abs(((h / 60) % 2) - 1);
+  let r = 0, g = 0, b = 0;
+  if (h < 60) [r, g, b] = [c, x, 0];
+  else if (h < 120) [r, g, b] = [x, c, 0];
+  else if (h < 180) [r, g, b] = [0, c, x];
+  else if (h < 240) [r, g, b] = [0, x, c];
+  else if (h < 300) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+}
+
+/** {r,g,b} → hue 0–360 (drops saturation/value; the picker is hue-only). */
+export function rgbToHue(c: Rgb): number {
+  const r = c.r / 255, g = c.g / 255, b = c.b / 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b), d = max - min;
+  if (d === 0) return 0;
+  let h = 0;
+  if (max === r) h = ((g - b) / d) % 6;
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  h *= 60;
+  return h < 0 ? h + 360 : h;
+}
+
+/** 18 fixed hue swatches for painting a rainbow track behind a hue slider
+ *  (there is no LinearGradient dep in this app). */
+export const HUE_STOPS = Array.from({ length: 18 }, (_, i) => cssRgb(hueToRgb((i / 18) * 360)));

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -1,0 +1,175 @@
+/**
+ * Saved LED presets — the user's own named colour/effect combos for the LIGHT
+ * card (owner ask 2026-08-13: "save presets … save custom LED presets").
+ *
+ * ON DEVICE ONLY, per phone. A preset is just a label + the same fields the app
+ * already POSTs to /api/leds/effect (effect, colour, speed, brightness); the box
+ * has no idea the phone keeps a library. Same module-level external-store shape
+ * as lib/note.ts (SecureStore on native, localStorage on web, load-once,
+ * useSyncExternalStore) so the editor and the preset strip stay in sync.
+ *
+ * Applying a preset is a normal setLedEffect() call; the AGENT is what persists
+ * the *active* choice across a reboot. This library is only the shortcuts.
+ *
+ * On first run (empty storage) a few starter presets are seeded — including
+ * "Night Rider" — so the feature isn't blank. They are ordinary rows the user
+ * can delete; deletions stick (we never re-seed once storage is non-empty).
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import type { LedEffect, Rgb } from './api';
+
+const KEY = 'couchside.ledpresets.v1';
+/** Bounded so a runaway library can't blow SecureStore's per-item size limit. */
+export const PRESET_MAX = 40;
+
+export type LedPreset = {
+  id: string;
+  label: string;
+  effect: LedEffect;
+  /** null for a mono effect (brightness-only) or an effect that ignores colour. */
+  color: Rgb | null;
+  speed: number;
+  brightness: number;
+};
+
+/** Seeded once when the library is empty. "Night Rider" is the owner's example. */
+const DEFAULTS: LedPreset[] = [
+  { id: 'seed-nightrider', label: 'Night Rider', effect: 'scanner',
+    color: { r: 255, g: 0, b: 0 }, speed: 80, brightness: 100 },
+  { id: 'seed-breathe-blue', label: 'Breathe Blue', effect: 'breathe',
+    color: { r: 0, g: 80, b: 255 }, speed: 35, brightness: 90 },
+  { id: 'seed-rainbow', label: 'Rainbow', effect: 'rainbow',
+    color: null, speed: 50, brightness: 100 },
+  { id: 'seed-warm', label: 'Warm', effect: 'solid',
+    color: { r: 255, g: 170, b: 90 }, speed: 50, brightness: 60 },
+];
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key)
+        : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(key);
+}
+
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(key, value);
+    } catch {
+      // storage unavailable (private mode): presets live for this session only
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+let presets: LedPreset[] = [];
+let loadStarted = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+const isRgb = (c: unknown): c is Rgb =>
+  !!c && typeof c === 'object' &&
+  ['r', 'g', 'b'].every((k) => Number.isInteger((c as Record<string, unknown>)[k]));
+
+/** Coerce a parsed value into a clean LedPreset[], dropping anything malformed. */
+function normalize(raw: unknown): LedPreset[] {
+  if (!Array.isArray(raw)) return [];
+  const out: LedPreset[] = [];
+  for (const r of raw) {
+    if (!r || typeof r !== 'object') continue;
+    const p = r as Record<string, unknown>;
+    if (typeof p.id !== 'string' || typeof p.label !== 'string' || typeof p.effect !== 'string') continue;
+    out.push({
+      id: p.id,
+      label: p.label.slice(0, 40),
+      effect: p.effect as LedEffect,
+      color: isRgb(p.color) ? { r: p.color.r, g: p.color.g, b: p.color.b } : null,
+      speed: typeof p.speed === 'number' ? p.speed : 50,
+      brightness: typeof p.brightness === 'number' ? p.brightness : 100,
+    });
+    if (out.length >= PRESET_MAX) break;
+  }
+  return out;
+}
+
+/** Read the stored presets once; seed DEFAULTS if the library is empty/new. */
+export async function loadPresets(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  const raw = await storageGet(KEY);
+  if (typeof raw === 'string' && raw.length > 0) {
+    let parsed: unknown = null;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      parsed = null;
+    }
+    presets = normalize(parsed);
+    if (presets.length > 0) {
+      emit();
+      return;
+    }
+    // stored but unusable (corrupt/empty) -> fall through and re-seed
+  }
+  // First run: seed the starter set and persist it so deletions stick.
+  presets = DEFAULTS.slice();
+  emit();
+  await storageSet(KEY, JSON.stringify(presets));
+}
+void loadPresets();
+
+export function getPresets(): LedPreset[] {
+  return presets;
+}
+
+function persist(): Promise<void> {
+  return storageSet(KEY, JSON.stringify(presets));
+}
+
+function genId(): string {
+  return `p${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`;
+}
+
+/** Save a new preset (newest first). Returns it. No-op past PRESET_MAX. */
+export async function addPreset(p: Omit<LedPreset, 'id'>): Promise<LedPreset | null> {
+  if (presets.length >= PRESET_MAX) return null;
+  const preset: LedPreset = { ...p, id: genId(), label: p.label.slice(0, 40) };
+  presets = [preset, ...presets];
+  emit();
+  await persist();
+  return preset;
+}
+
+/** Remove a preset by id (default or user-added; deletions persist). */
+export async function removePreset(id: string): Promise<void> {
+  const next = presets.filter((p) => p.id !== id);
+  if (next.length === presets.length) return;
+  presets = next;
+  emit();
+  await persist();
+}
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** React hook: live preset list. */
+export function useLedPresets(): LedPreset[] {
+  return useSyncExternalStore(subscribe, () => presets, () => presets);
+}

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -33,6 +33,9 @@ export type LedPreset = {
   color: Rgb | null;
   speed: number;
   brightness: number;
+  /** A per-LED painted pattern (effect==='manual' only): one colour per strip
+      node, null = off. Applying it repaints every LED. */
+  pattern?: (Rgb | null)[];
 };
 
 /** Seeded once when the library is empty. "Night Rider" is the owner's example. */
@@ -99,6 +102,9 @@ function normalize(raw: unknown): LedPreset[] {
       color: isRgb(p.color) ? { r: p.color.r, g: p.color.g, b: p.color.b } : null,
       speed: typeof p.speed === 'number' ? p.speed : 50,
       brightness: typeof p.brightness === 'number' ? p.brightness : 100,
+      pattern: Array.isArray(p.pattern)
+        ? (p.pattern as unknown[]).map((c) => (isRgb(c) ? { r: c.r, g: c.g, b: c.b } : null))
+        : undefined,
     });
     if (out.length >= PRESET_MAX) break;
   }

--- a/app/lib/ledStrip.ts
+++ b/app/lib/ledStrip.ts
@@ -1,0 +1,62 @@
+/**
+ * Group individually-addressable kernel LEDs into a STRIP.
+ *
+ * A Steam Machine / Deck exposes its front strip as N separate /sys/class/leds
+ * nodes — `valve-leds[0]` … `valve-leds[16]` — so the LIGHT card renders one chip
+ * per node (owner: "clunky"). This collapses any `prefix[N]` family into a single
+ * strip so the app can paint across it and sweep a real night-rider — driven from
+ * the app via /api/leds/set (works on ANY agent that has the LED control, no
+ * effect-engine dependency on the box).
+ */
+import type { LedInfo } from './api';
+
+export type LedStrip = {
+  /** Stable id, e.g. "strip:valve-leds". */
+  key: string;
+  /** Human label, e.g. "valve-leds (17)". */
+  label: string;
+  /** The member LEDs, sorted by their [index]. */
+  leds: LedInfo[];
+  /** True if any member has colour channels. */
+  rgb: boolean;
+};
+
+const STRIP_RE = /^(.*?)\[(\d+)\]$/;
+/** Fewer than this many members isn't worth a strip UI — keep them as singles. */
+const MIN_STRIP = 3;
+
+const stripIndex = (name: string): number => {
+  const m = name.match(STRIP_RE);
+  return m ? parseInt(m[2], 10) : 0;
+};
+
+/** Split a flat LED list into detected strips + leftover single LEDs. */
+export function detectStrips(leds: LedInfo[]): { strips: LedStrip[]; singles: LedInfo[] } {
+  const groups = new Map<string, LedInfo[]>();
+  const singles: LedInfo[] = [];
+  for (const l of leds) {
+    const m = l.name.match(STRIP_RE);
+    if (m) {
+      const prefix = m[1];
+      (groups.get(prefix) ?? groups.set(prefix, []).get(prefix)!).push(l);
+    } else {
+      singles.push(l);
+    }
+  }
+  const strips: LedStrip[] = [];
+  for (const [prefix, arr] of groups) {
+    if (arr.length >= MIN_STRIP) {
+      arr.sort((a, b) => stripIndex(a.name) - stripIndex(b.name));
+      strips.push({
+        key: `strip:${prefix}`,
+        label: `${prefix.replace(/[:_-]+$/, '')} (${arr.length})`,
+        leds: arr,
+        rgb: arr.some((l) => l.rgb),
+      });
+    } else {
+      singles.push(...arr);
+    }
+  }
+  strips.sort((a, b) => a.key.localeCompare(b.key));
+  return { strips, singles };
+}

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -309,13 +309,18 @@ function normalizeCaps(raw: unknown): BoxCaps | undefined {
   // capsEqual) and the cap never persists, so the LIGHT card re-probes /api/leds
   // every launch.
   const ledcontrol = bool('ledcontrol');
+  // openrgb = whole-system / addressable RGB via a local OpenRGB server (agent >=
+  // 2.9.84). Same optional-cap drop trap: omit it from the RETURN object below (or
+  // from capsEqual) and the cap never persists, so the OpenRGB card re-probes
+  // /api/openrgb every launch.
+  const openrgb = bool('openrgb');
   return {
     gamepad, steam, media, tv, screen, power_schedule,
     screensaver, couchmode, bigpicture, desktop, steamlink, gaming, streamhost,
     steammenus,
     boxbattery, launchers, file_upload, session_default, display_info, player,
     steaminstall, utilities, screenstream, screenstream_h264, audioswitch,
-    ledcontrol,
+    ledcontrol, openrgb,
   };
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,40 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
+### LED Studio — editor + presets + effects + persistence + OpenRGB (owner ask 2026-08-13)
+- **priority:** P2 · **risk:** medium (effect thread + a new loopback OpenRGB subsystem;
+  strictly allowlisted) · **affects:** agent + app · **depends_on:** the LIGHT card below;
+  OpenRGB installed + `--server` running on the box (P3+). **Spec:**
+  `docs/memory/project_led-studio.md`.
+- Builds the LIGHT card out per the owner's ask: easier editor (native hue/brightness
+  sliders), **saved custom presets** (app-side `couchside.ledpresets.v1`), **automation /
+  effects** (`breathe`/`pulse`/`rainbow`/`strobe` + a **night-rider `scanner`**), and
+  **survive reboot** (agent persists the active effect to `~/.config/couchside/leds.json`
+  and re-applies on login). Two backends behind one effect engine: the existing
+  `/sys/class/leds` path (works on the Steam Machine today) and a new **OpenRGB** stdlib
+  SDK client (127.0.0.1:6742) for whole-system / addressable RGB — the real multi-zone
+  scanner. Owner chose *both in one push*, *addressable real sweep*, *native sliders*.
+- **Caps:** keep `ledcontrol` (effects/presets ride on additive `/api/leds` payload fields,
+  no new cap); add ONE cap `openrgb` (install-gated subsystem). New routes
+  `POST /api/leds/effect`, `GET/POST /api/openrgb[/set]` — all bearer-gated, effect names a
+  frozen set, params reject-don't-sanitise, OpenRGB writes bounded by server-reported counts.
+- **BUILT (agent 2.9.84).** Kernel half: `led-fx` render thread + `POST /api/leds/effect` +
+  additive `effects`/`active` on GET /api/leds + persistence (`~/.config/couchside/leds.json`,
+  restored on login); `RgbLedCard` rewritten with native hue/brightness sliders + effect/speed
+  chips + a per-phone preset library (`lib/ledPresets.ts`, seeded incl. Night Rider). OpenRGB
+  half: hand-rolled stdlib SDK client (127.0.0.1:6742) + `orgb-fx` per-LED scanner +
+  `GET/POST /api/openrgb[/set]` + cap `openrgb` (six sites) + `OpenRgbCard` ("SYSTEM RGB").
+  Shared `lib/ledColor.ts` + `components/TrackSlider.tsx`.
+- **Verified:** 69/69 test files green incl. new `test_led_effects.py` + `test_openrgb.py`
+  (the latter's mock-OpenRGB-server test CAUGHT a real bug — `_update_leds` sent no body).
+  Both endpoints exercised vs `--mock` over curl (401/404/400/200 + observe-both). App
+  PRESSED in the harness (§6): effect chips, Night Rider preset, sliders, Save; SYSTEM RGB
+  scanner moved /api/openrgb active. See BUILD_LOG 2026-08-13.
+- **NOT verified / gates:** no real LED/OpenRGB hardware this session. Kernel path still needs
+  the install-time udev grant on a stock box; OpenRGB wire format proven only vs the mock
+  server + docs (real hardware = final gate). Sliders' DRAG needs on-device proof. Land on a
+  fresh `claude/led-studio` off origin/main (built on the H264 spike branch).
+
 ### Front light-bar / status-LED control (owner ask 2026-08-12)
 - **priority:** P2 · **risk:** medium (writes a hardware sysfs path; strictly allowlisted +
   validated) · **affects:** agent + app · **depends_on:** an install-time udev grant (below)
@@ -35,9 +69,10 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   the target LED (don't blanket-open every LED), and proven on the home Legion Go S / an
   AYANEO before this is "done". Also unverified: which node exists per box, write contention
   with Steam/InputPlumber, AYN `led_mode` gotcha, reported-colour accuracy. Classifier tested
-  only on SYNTHETIC names (no `/sys/class/leds` fixtures yet). OpenRGB fallback: deferred.
-- **Follow-ups:** the scoped udev rule + hardware pass; real sysfs fixtures for the classifier;
-  effects (breathe/rainbow) once a device is in hand.
+  only on SYNTHETIC names (no `/sys/class/leds` fixtures yet).
+- **Follow-ups:** the scoped udev rule + hardware pass; real sysfs fixtures for the classifier.
+  Editor/presets/effects/OpenRGB now tracked as **LED Studio** above
+  (`docs/memory/project_led-studio.md`) — OpenRGB is no longer "deferred".
 
 ### Audio output switcher — pick the box's sink from the phone (user ask 2026-08-12)
 - **priority:** P2 · **risk:** low · **affects:** agent + app · **depends_on:** none

--- a/docs/memory/project_led-studio.md
+++ b/docs/memory/project_led-studio.md
@@ -149,6 +149,16 @@ kernel LED path shipped hardware-unverified.
 - **P4 — app OpenRGB section.** Controller list + drive color/effect from the phone.
 - **P5 — polish/backlog:** box-side preset sync; auto-start the OpenRGB server (argv, opt-in);
   more effects; per-zone scanner direction/tail params.
+- **P6 — per-LED "addressable, made easy" (owner ask 2026-08-13).** "Allow each LED to be
+  addressable but easier to use — v1 demonstrated it but was clunky." Agent side is ALREADY
+  there: `_ORGB.set_frame(idx, colors[])` writes an arbitrary per-LED colour array (the
+  scanner uses it). Missing piece is an APP paint UX + a `POST /api/openrgb/paint {device,
+  colors:[{r,g,b}...]}` (or `per_led`) passthrough. Proposed UX (iterate live on device):
+  a strip rendered as a row of LED cells you tap/DRAG to paint with the picked colour, plus
+  fill helpers (whole-strip, per-ZONE using the zones the agent already reports, gradient
+  between two colours, N-segment split) so common looks need one gesture, not N taps. Drag-
+  paint is the crux and is NOT harness-testable → this is the reason for the on-device dev
+  build. Persist a painted frame like other states so it survives reboot.
 
 ## Risks / must-prove
 - Write contention: Steam/InputPlumber may also drive the Deck LED; our effect thread races

--- a/docs/memory/project_led-studio.md
+++ b/docs/memory/project_led-studio.md
@@ -1,0 +1,160 @@
+# Project: LED Studio — editor, presets, effects, persistence, OpenRGB
+
+**Owner ask (2026-08-13):** the LED control "works good on Steam Machine but I'd like to
+build it out" — an easier in-app editor, saved custom presets, automation/effects (a
+"night rider" KITT scanner named as the example), and survive reboot (a reboot currently
+reverts to stock LED). Follow-up: "make it OpenRGB-compatible … configure system LEDs
+straight from the phone."
+
+**Decisions (asked 2026-08-13):**
+- **Scope:** *both in one push* — kernel-LED buildout AND OpenRGB together.
+- **Night rider:** *addressable → real sweep* — the owner has addressable / motherboard RGB
+  and wants a real dot sweeping. A single front bar can only breathe/pulse; a true scanner
+  needs multiple zones/LEDs ⇒ **OpenRGB is required for the real scanner**.
+- **Editor UX:** *native sliders* (hue / brightness). Sliders are drag = NOT harness-
+  verifiable (CLAUDE.md §6) → must be proven on a real device before ship.
+
+This supersedes the "OpenRGB fallback: deferred" line in ROADMAP and the LIGHT-card
+follow-ups. Prior art: the LIGHT card + `/api/leds` (cap `ledcontrol`, agent 2.9.81) and
+the audio switcher's mock-observable allowlist-switch pattern.
+
+---
+
+## Architecture at a glance
+
+Two LED backends, one app surface:
+
+1. **Kernel LED backend** — `/sys/class/leds` (the existing `ledcontrol` path). The box's
+   front bar / status LED. One-shot color+brightness today; this project adds an **effect
+   engine** (a background thread that animates it) + **persistence** (re-apply on boot).
+   Works on the owner's Steam Machine TODAY, zero new box deps.
+2. **OpenRGB backend** — a hand-rolled stdlib SDK client speaking the OpenRGB binary
+   protocol to a local `openrgb --server` on 127.0.0.1:6742. Whole-system RGB (motherboard,
+   RAM, GPU, strips, fans) with per-LED control ⇒ the real multi-zone scanner. NEW box
+   dependency (install OpenRGB + run its server + i2c/hidraw udev perms). Install-gated:
+   cap `openrgb` appears only when the server answers.
+
+The **effect engine** is backend-agnostic: one `led-fx` daemon thread owns the "current
+effect" (type + params + target) and renders frames by calling either backend's write.
+Setting a new effect replaces the running one. `solid` = no animation (one write, thread
+idle/stopped). Effects: `solid`, `breathe`, `pulse`, `rainbow`, `strobe` (all backends),
+`scanner` (OpenRGB / multi-LED only — degrades to `pulse` on a single LED).
+
+**Persistence:** the active effect+params are written atomically to
+`~/.config/couchside/leds.json` on every change (the fdopen/rename pattern at
+couchsided.py:692; sibling of `screensaver.conf`/`player.conf`). At agent startup a
+`led-restore` step reads it and re-applies (restarts the effect thread). The agent is a
+systemd **user** service → "survive reboot" = re-apply on login. Between boot and agent
+start the LED shows firmware default briefly (acceptable; documented).
+
+**Caps:** keep `ledcontrol` (gates the whole LIGHT surface). Effects/presets/persistence
+ride on **new fields in the `/api/leds` payload** (`effects: [...]`, `active: {...}`), NOT
+a new cap — the app reads them to decide whether to show effect controls (probe-and-appear
+at payload level; old app ignores unknown fields). Add exactly **one** new cap: `openrgb`
+(a distinct, install-gated subsystem the app must know about without 404-probing). One new
+cap = the six-site dance runs once (§4).
+
+**Presets:** the user's named-preset *library* lives **app-side** (`couchside.ledpresets.v1`
+in AsyncStorage, per phone — the note.ts / consoleLayout pattern). Applying a preset POSTs
+the color/effect to the agent; the agent remembers the *last applied* state as the
+boot-restore. (Box-side library sync across phones = deferred backlog.)
+
+---
+
+## Allowlist / security design (CLAUDE.md §3 — zero tolerance)
+
+- **Effect names are a frozen set** (`_LED_EFFECTS`), looked up, never interpolated. Unknown
+  → 400, nothing runs.
+- **Effect params are range-checked and rejected** (not sanitised): speed ∈ frozen set or
+  int 1..100; colors are `{r,g,b}` 0..255 (reuse `_validate_led_body`'s colour check);
+  target LED name looked up in the live `/sys/class/leds` set exactly as today.
+- **The effect thread only ever calls the existing validated writers** (`set_led` /
+  `_led_write` fixed literals, or the OpenRGB client's bounded per-LED writes). No new raw
+  path is exposed.
+- **OpenRGB client is loopback-only** (127.0.0.1:6742), no auth needed on localhost, and every
+  write is bounded by the server-reported controller/zone/LED counts — a client-supplied
+  device index is looked up against the enumerated count and 404s otherwise. The app never
+  names a socket, host, or command string.
+- **`openrgb` is never shelled with `shell=True`.** If we ever launch/start the server it is
+  an argv LIST with a fixed binary chosen by the agent. (v1 does NOT auto-start the server;
+  it only connects if one is already listening — degrade closed.)
+- **Persistence file is user-owned, atomically written, validated on read** — junk → drop to
+  firmware default, never a write of attacker-controlled bytes.
+- Every new route requires the bearer token; none are pre-auth.
+
+---
+
+## Endpoints (all bearer-gated; `--mock` observable)
+
+Kernel + effect engine (cap `ledcontrol`):
+- `GET  /api/leds` — EXISTING; **extend** payload with `effects` (supported effect ids) and
+  `active` (the running effect+params per LED, from persistence). Additive only (§4).
+- `POST /api/leds/set` — EXISTING; unchanged (solid color/brightness). Setting a solid also
+  stops any running effect on that LED and updates persistence.
+- `POST /api/leds/effect` — NEW. Body `{led, effect, color?|colors?, speed?, brightness?}`.
+  Starts/replaces the effect on `led`; `effect:"solid"` or `"off"` stops it. Persists.
+
+OpenRGB (cap `openrgb`):
+- `GET  /api/openrgb` — enumerate controllers → `[{index, name, type, zones:[{name,leds}],
+  led_count}]` + `{available, server}`. Empty/unavailable when no server.
+- `POST /api/openrgb/set` — `{device, color?|per_led?, effect?, speed?, brightness?}`.
+  `device` looked up against the enumerated count. Static color, or start an effect
+  (scanner/rainbow/etc.) driven agent-side per-LED. Persists.
+
+App: `RgbLedCard` grows an effect row + sliders + a preset strip; a new OpenRGB section (or
+a second card) lists controllers and drives them. `lib/api.ts` gains `LedEffect`,
+`OpenRgbState`, `setLedEffect()`, `openrgb()`, `openrgbSet()`. `lib/ledPresets.ts` (new) =
+the app-side preset library.
+
+---
+
+## OpenRGB wire protocol (hand-rolled, stdlib socket+struct)
+
+Header (16 B, little-endian): `b"ORGB"` + `pkt_dev_idx:u32` + `pkt_id:u32` + `pkt_size:u32`.
+Port 6742. Handshake: `SET_CLIENT_NAME(50)` "Couchside" → `REQUEST_PROTOCOL_VERSION(40)`
+(send client ver u32, read server ver, use min) → `REQUEST_CONTROLLER_COUNT(0)` (reply body
+= u32 count) → per device `REQUEST_CONTROLLER_DATA(1)` (send protocol ver u32; reply body =
+`data_size:u32` then controller struct).
+
+Writes: `RGBCONTROLLER_UPDATELEDS(1050)` body = `data_size:u32, num_colors:u16, colors[]`;
+`RGBCONTROLLER_UPDATESINGLELED(1052)` body = `led_idx:i32, color`;
+`RGBCONTROLLER_SETCUSTOMMODE(1100)` (put device in Direct/Custom so our colors stick).
+Color = `struct.pack("<BBBx", r, g, b)` (R,G,B,pad). Strings = `u16 length (incl NUL) + bytes`.
+Counts (modes/zones/leds/colors) = u16, LE. Controller-data parse order: data_size,
+type:i32, name/description/version/serial/location (bstrings), num_modes:u16 + active:i32 +
+modes, num_zones:u16 + zones, num_leds:u16 + leds(name+u32 color), num_colors:u16 + colors.
+Parse is version-sensitive — we parse only what we need (name + total led_count + zone
+names/counts) and pin a conservative client protocol version. **"Wrong version → server
+blindly unpacks → random stuff"** — so version negotiation is mandatory before any write.
+
+Testing without hardware: a tiny in-process mock OpenRGB TCP server in the test speaks the
+protocol so the client's enumerate + frame-write round-trips are exercised in CI (§11
+observe-both-states). **Real OpenRGB hardware remains the final gate**, flagged like the
+kernel LED path shipped hardware-unverified.
+
+---
+
+## Phases
+
+- **P1 — kernel effect engine + persistence (agent).** `_led_effects` module: frozen effect
+  set, one `led-fx` thread, `/api/leds/effect`, extend `/api/leds` payload, persist +
+  boot-restore. Tests: effect allowlist (unknown→400 nothing runs), thread lifecycle
+  (start→replace→stop→reap), persistence round-trip, mock-observable. Works on Steam Machine.
+- **P2 — app editor + presets + effect controls.** Native hue/brightness sliders, effect
+  chips + speed, `+ Save preset` strip backed by `lib/ledPresets.ts`. Harness: press effect
+  chips + preset taps (verifiable); sliders proven on-device (§6). 
+- **P3 — OpenRGB client (agent).** `_openrgb` stdlib client, `/api/openrgb` + `/api/openrgb/set`,
+  cap `openrgb` (six sites), scanner effect via per-LED frames. Tests: mock-server round-trip
+  + parity. Flag: hardware-unverified until owner runs it.
+- **P4 — app OpenRGB section.** Controller list + drive color/effect from the phone.
+- **P5 — polish/backlog:** box-side preset sync; auto-start the OpenRGB server (argv, opt-in);
+  more effects; per-zone scanner direction/tail params.
+
+## Risks / must-prove
+- Write contention: Steam/InputPlumber may also drive the Deck LED; our effect thread races
+  it (documented; last-writer-wins at our frame rate).
+- OpenRGB protocol version drift across box installs → negotiate + parse defensively.
+- OpenRGB not installed / server not running → cap absent, section hidden (degrade closed).
+- Reboot race: OS may reset LEDs at login after our restore → restore with a short retry.
+- Sliders unverifiable in harness → on-device proof required (§6, §11).
+- No OpenRGB hardware reachable this session → mock-server tests + explicit hardware gate.

--- a/protocol/protocol.json
+++ b/protocol/protocol.json
@@ -186,6 +186,7 @@
       "file_upload",
       "gaming",
       "ledcontrol",
+      "openrgb",
       "player",
       "screenstream",
       "screenstream_h264",

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Tests for the LED effect engine + persistence (POST /api/leds/effect, the
+`effects`/`active` fields on GET /api/leds, and reboot restore).
+
+Run: python3 tests/test_led_effects.py
+
+The properties that matter:
+  * ALLOWLIST — an unknown effect id, or an unknown / traversal-shaped /
+    non-writable LED name, starts NOTHING and writes NOTHING (same guarantee as
+    /api/leds/set). Effect ids are looked up in the frozen _LED_EFFECTS.
+  * params are REJECTED not sanitised (speed 1-100, brightness 0-100, colour
+    {r,g,b} 0-255).
+  * the render thread only ever writes the three fixed-literal attributes via
+    the same writers set_led() uses.
+  * persistence round-trips and is REVALIDATED on restore (a junk file never
+    drives a write).
+  * mock is observable: selecting an effect moves GET /api/leds `active`.
+
+Pure stdlib, no pytest -- same style as test_led_control.py. Never touches real
+/sys or the real ~/.config path (both are faked / redirected to a temp file).
+"""
+import importlib.util
+import os
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+# A fake /sys/class/leds: one writable RGB LED (channel order blue,red,green to
+# prove the writer reorders), one locked (non-writable) RGB LED.
+_FAKE = {
+    "multicolor:front": {"name": "multicolor:front", "desc": "multicolor:front",
+        "rgb": True, "notable": True, "writable": True, "max_brightness": 255,
+        "index": ["blue", "red", "green"], "maxint": [255, 255, 255],
+        "brightness": 255, "color": {"r": 0, "g": 0, "b": 0}},
+    "locked::led": {"name": "locked::led", "desc": "locked::led", "rgb": True,
+        "notable": True, "writable": False, "max_brightness": 255,
+        "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+        "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}},
+}
+
+
+def _install_fake(writes):
+    """Redirect the agent's LED FS + persistence at fakes. Returns a restore fn."""
+    saved = {k: getattr(cs, k) for k in
+             ("_list_led_names", "_read_led_raw", "_led_realpath_ok",
+              "_led_read_attr", "_led_write", "_LED_STATE_CONF")}
+    cs._list_led_names = lambda: list(_FAKE)
+    cs._read_led_raw = lambda n: dict(_FAKE[n]) if n in _FAKE else None
+    cs._led_realpath_ok = lambda n: True
+    cs._led_read_attr = lambda name, attr: "[none]" if attr == "trigger" else None
+    cs._led_write = lambda name, attr, value: writes.append((name, attr, value))
+    fd, tmp = tempfile.mkstemp(prefix="test-leds-", suffix=".json")
+    os.close(fd)
+    os.unlink(tmp)
+    cs._LED_STATE_CONF = tmp
+
+    def restore():
+        _reset_engine()
+        for k, v in saved.items():
+            setattr(cs, k, v)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+    return restore
+
+
+def _reset_engine():
+    """Stop the render thread and clear all engine state between tests."""
+    cs._FX_STOP.set()
+    th = cs._FX_THREAD[0]
+    if th is not None:
+        th.join(timeout=1.0)
+    with cs._FX_LOCK:
+        cs._FX_ACTIVE.clear()
+        cs._FX_RAW.clear()
+        cs._LED_PERSIST.clear()
+        cs._FX_THREAD[0] = None
+    cs._FX_STOP.clear()
+    cs._MOCK_FX.clear()
+
+
+def test_validate_effect_body():
+    print("effect body validation (reject, don't sanitise)")
+    e, c, s, b, err = cs._validate_effect_body({"effect": "breathe"})
+    check(err is None and e == "breathe", "accepts a bare known effect")
+    e, c, s, b, err = cs._validate_effect_body(
+        {"effect": "rainbow", "speed": 80, "brightness": 40,
+         "color": {"r": 1, "g": 2, "b": 3}})
+    check(err is None and s == 80 and b == 40 and c == {"r": 1, "g": 2, "b": 3},
+          "accepts full valid params")
+    bad = [{"effect": "nope"}, {"effect": "breathe", "speed": 0},
+           {"effect": "breathe", "speed": 101}, {"effect": "breathe", "speed": True},
+           {"effect": "breathe", "brightness": -1}, {"effect": "breathe", "brightness": 101},
+           {"effect": "breathe", "color": {"r": 256, "g": 0, "b": 0}},
+           {"effect": "breathe", "color": [1, 2, 3]}, {}]
+    for body in bad:
+        _, _, _, _, err = cs._validate_effect_body(body)
+        check(err is not None, "rejects %s" % body)
+
+
+def test_frame_bounds():
+    print("every effect frame stays in range (brightness 0..target, colour valid)")
+    for eff in ("breathe", "pulse", "strobe", "rainbow", "scanner"):
+        params = {"color": {"r": 255, "g": 0, "b": 0}, "speed": 50, "brightness": 80}
+        oob = False
+        badcol = False
+        for i in range(200):
+            col, b = cs._fx_frame(eff, params, i * 0.05)
+            if b is not None and not (0 <= b <= 80):
+                oob = True
+            if col is not None and not cs._is_rgb_triple(col):
+                badcol = True
+        check(not oob, "%s brightness within 0..target" % eff)
+        check(not badcol, "%s colour is always a valid {r,g,b}" % eff)
+
+
+def test_allowlist_effect():
+    print("allowlist: unknown effect / bad LED starts + writes NOTHING")
+    writes = []
+    restore = _install_fake(writes)
+    try:
+        # unknown effect -> 400, nothing active, nothing written
+        res = cs.apply_led_effect("multicolor:front", "kitt-o-matic", None, 50, 80)
+        check(isinstance(res, dict) and res.get("status") == 400, "unknown effect -> 400")
+        check(not cs._FX_ACTIVE and not writes, "unknown effect: no active, no write")
+
+        # bad LED names -> None, nothing active, nothing written
+        for bad in ("nope", "", "../../etc/passwd", "multicolor:front/../x",
+                    "locked::led", None, 123):
+            writes.clear()
+            res = cs.apply_led_effect(bad, "breathe", None, 50, 80)
+            check(res is None, "refused LED %r" % (bad,))
+            check(not cs._FX_ACTIVE, "no effect registered for %r" % (bad,))
+            check(not writes, "nothing written for %r" % (bad,))
+    finally:
+        restore()
+
+
+def test_animate_then_solid_lifecycle():
+    print("animate -> thread renders -> solid stops it (lifecycle + persistence)")
+    writes = []
+    restore = _install_fake(writes)
+    try:
+        res = cs.apply_led_effect("multicolor:front", "breathe",
+                                  {"r": 255, "g": 0, "b": 0}, 100, 100)
+        check(res and res.get("ok") and res["active"]["effect"] == "breathe",
+              "breathe accepted, active reports it")
+        check("multicolor:front" in cs._FX_ACTIVE, "effect registered as active")
+        th = cs._FX_THREAD[0]
+        check(th is not None and th.is_alive(), "render thread running")
+
+        # let it render a few frames, then assert only the fixed-literal attrs
+        # were written (via the same writers set_led uses).
+        time.sleep(0.15)
+        check(writes, "render thread wrote frames")
+        check(all(w[1] in ("trigger", "multi_intensity", "brightness")
+                  for w in writes), "only the three fixed-literal attrs written")
+
+        # persisted as an animated effect
+        saved = cs._led_state_load()
+        check(saved.get("multicolor:front", {}).get("effect") == "breathe",
+              "breathe persisted to disk")
+        # GET active reflects the animation
+        act = cs._led_active_map()
+        check(act.get("multicolor:front", {}).get("effect") == "breathe",
+              "GET active map shows the animation")
+
+        # now a solid stops the animation and re-persists as solid
+        res = cs.apply_led_effect("multicolor:front", "solid",
+                                  {"r": 0, "g": 200, "b": 0}, None, 50)
+        check(res and res.get("ok") and res["active"] is None,
+              "solid accepted, active cleared")
+        # thread should drain (no active) and exit
+        deadline = time.time() + 1.5
+        while cs._FX_THREAD[0] is not None and time.time() < deadline:
+            time.sleep(0.02)
+        check("multicolor:front" not in cs._FX_ACTIVE, "animation removed on solid")
+        check(cs._FX_THREAD[0] is None, "render thread exited when nothing active")
+        check(cs._led_state_load().get("multicolor:front", {}).get("effect") == "solid",
+              "solid persisted (reboot will restore a solid, not the animation)")
+        check("multicolor:front" not in cs._led_active_map(),
+              "GET active omits a solid (reflected by led colour/brightness instead)")
+    finally:
+        restore()
+
+
+def test_persistence_restore_revalidates():
+    print("restore re-applies good records and IGNORES junk (never trusts the file)")
+    writes = []
+    restore = _install_fake(writes)
+    try:
+        # hand-write a persistence file: one good animation, plus junk records
+        # (missing led, bad effect, out-of-range params, wrong colour shape).
+        import json
+        blob = {"version": 1, "leds": {
+            "multicolor:front": {"effect": "rainbow", "speed": 60, "brightness": 70},
+            "ghost::led": {"effect": "breathe"},               # LED not present
+            "multicolor:front-BAD": {"effect": "breathe"},     # not present either
+            "locked::led": {"effect": "breathe"},              # present but non-writable
+        }}
+        with open(cs._LED_STATE_CONF, "w") as f:
+            json.dump(blob, f)
+        cs._led_restore()
+        check("multicolor:front" in cs._FX_ACTIVE
+              and cs._FX_ACTIVE["multicolor:front"]["effect"] == "rainbow",
+              "good record restored (rainbow re-applied)")
+        check("ghost::led" not in cs._FX_ACTIVE and "locked::led" not in cs._FX_ACTIVE,
+              "absent / non-writable LEDs skipped, not written")
+
+        # a totally junk file must not throw and must drive nothing
+        _reset_engine()
+        with open(cs._LED_STATE_CONF, "w") as f:
+            f.write("}{ not json")
+        cs._led_restore()
+        check(not cs._FX_ACTIVE, "corrupt persistence file -> nothing restored")
+    finally:
+        restore()
+
+
+def test_mock_effect_observable():
+    print("mock: selecting an effect moves GET /api/leds `active` (observe both)")
+    saved = dict(cs._MOCK_FX)
+    try:
+        cs._MOCK_FX.clear()
+        st = cs.leds_state(True)
+        check("effects" in st and "breathe" in st["effects"],
+              "mock payload advertises the effect list")
+        check(st.get("active") == {}, "no effect active initially")
+        # simulate the POST /api/leds/effect mock branch
+        cs._MOCK_FX["multicolor:chassis"] = {"effect": "scanner",
+            "color": {"r": 255, "g": 0, "b": 0}, "speed": 80, "brightness": 100}
+        st = cs.leds_state(True)
+        check(st["active"].get("multicolor:chassis", {}).get("effect") == "scanner",
+              "GET reflects the switched-on scanner effect")
+    finally:
+        cs._MOCK_FX.clear()
+        cs._MOCK_FX.update(saved)
+
+
+if __name__ == "__main__":
+    test_validate_effect_body()
+    test_frame_bounds()
+    test_allowlist_effect()
+    test_animate_then_solid_lifecycle()
+    test_persistence_restore_revalidates()
+    test_mock_effect_observable()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all led-effect tests passed")

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Tests for the addressable LED STRIP + hardware effects (valve-leds).
+
+Run: python3 tests/test_led_strip.py
+
+A Steam Machine exposes its strip as N kernel nodes `valve-leds[0..16]` whose
+driver runs animations IN FIRMWARE via an `effect` attr (patrol/breath/rainbow…).
+The agent drives the strip as a whole: the client sends a PREFIX, the members come
+from the live listdir filtered by `prefix[<n>]`, and the `effect` VALUE written
+must be one the device itself lists in `effect_index`.
+
+The property that matters is the allowlist: an unknown / traversal-shaped prefix,
+or a firmware-effect name the device does not publish, must write NOTHING outside
+the fixed-literal attrs on the strip's own live members. Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+# A fake /sys/class/leds: a 5-node valve-leds strip (RGB, firmware effects) + a
+# mono status LED. multi_index proves the writer reorders into device order.
+_N = 5
+_EFFECT_INDEX = "patrol breath factory normal off rainbow demo manual"
+_DELAY_RANGE = "0-20"
+
+
+def _member(name):
+    return {"name": name, "desc": name, "rgb": True, "notable": True,
+            "writable": True, "max_brightness": 255,
+            "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+            "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}}
+
+
+_FAKE = {("valve-leds[%d]" % i): _member("valve-leds[%d]" % i) for i in range(_N)}
+_FAKE["status:white"] = {"name": "status:white", "desc": "status:white",
+    "rgb": False, "notable": True, "writable": True, "max_brightness": 100,
+    "index": [], "maxint": [], "brightness": 0, "color": None}
+
+
+def _install(writes, effect_index=_EFFECT_INDEX):
+    saved = {k: getattr(cs, k) for k in
+             ("_list_led_names", "_read_led_raw", "_led_realpath_ok",
+              "_led_read_attr", "_led_write")}
+    cs._list_led_names = lambda: list(_FAKE)
+    cs._read_led_raw = lambda n: dict(_FAKE[n]) if n in _FAKE else None
+    cs._led_realpath_ok = lambda n: True
+
+    def _read_attr(name, attr):
+        if attr == "effect_index":
+            return effect_index
+        if attr == "delay_range":
+            return _DELAY_RANGE
+        if attr == "trigger":
+            return "[none]"
+        return None
+    cs._led_read_attr = _read_attr
+    cs._led_write = lambda name, attr, value: writes.append((name, attr, value))
+
+    def restore():
+        for k, v in saved.items():
+            setattr(cs, k, v)
+        with cs._FX_LOCK:
+            cs._LED_PERSIST.clear()
+    return restore
+
+
+def test_detect_strip():
+    print("strip detection groups valve-leds[N] (>=3 members)")
+    writes = []
+    restore = _install(writes)
+    try:
+        strips = cs._led_strips()
+        check("valve-leds" in strips, "valve-leds detected as a strip")
+        check(len(strips["valve-leds"]) == _N, "all %d members grouped" % _N)
+        check([int(n[n.index("[") + 1:-1]) for n in strips["valve-leds"]] == list(range(_N)),
+              "members sorted by index")
+        check("status:white" not in strips, "the lone status LED is not a strip")
+    finally:
+        restore()
+
+
+def test_allowlist_unknown_prefix():
+    print("allowlist: unknown / bad prefix writes NOTHING")
+    writes = []
+    restore = _install(writes)
+    try:
+        for bad in ("nope", "valve-leds[", "../x", "", None, 123):
+            writes.clear()
+            res = cs.apply_strip_effect(bad, "scanner", {"r": 255, "g": 0, "b": 0}, 70, 100)
+            check(res is None, "refused prefix %r" % (bad,))
+            check(not writes, "nothing written for %r" % (bad,))
+    finally:
+        restore()
+
+
+def test_scanner_writes_firmware_patrol():
+    print("scanner -> firmware effect=patrol on EVERY member + delay + colour")
+    writes = []
+    restore = _install(writes)
+    try:
+        res = cs.apply_strip_effect("valve-leds", "scanner", {"r": 255, "g": 0, "b": 0}, 70, 100)
+        check(res and res.get("ok") and res["active"]["effect"] == "scanner",
+              "scanner accepted, active reports it")
+        for i in range(_N):
+            n = "valve-leds[%d]" % i
+            check((n, "effect", "patrol") in writes, "%s set effect=patrol" % n)
+            check(any(w[0] == n and w[1] == "delay" for w in writes), "%s got a delay" % n)
+            check(any(w[0] == n and w[1] == "multi_intensity" for w in writes),
+                  "%s got the base colour" % n)
+        # only ever the fixed-literal attrs, only on strip members
+        allowed_attr = {"effect", "enabled", "delay", "brightness", "multi_intensity", "trigger"}
+        members = {"valve-leds[%d]" % i for i in range(_N)}
+        check(all(w[1] in allowed_attr for w in writes), "only fixed-literal attrs written")
+        check(all(w[0] in members for w in writes), "only strip members written")
+    finally:
+        restore()
+
+
+def test_effect_value_must_be_published():
+    print("a firmware effect the device does NOT list is never written as `effect`")
+    writes = []
+    # this device only publishes 'normal off manual' -- NOT patrol/breath/rainbow
+    restore = _install(writes, effect_index="normal off manual")
+    try:
+        res = cs.apply_strip_effect("valve-leds", "scanner", {"r": 255, "g": 0, "b": 0}, 70, 100)
+        check(res and res.get("ok"), "still accepted (falls back to manual paint)")
+        check(not any(w[1] == "effect" and w[2] == "patrol" for w in writes),
+              "patrol NEVER written when the device doesn't list it")
+        check(any(w[1] == "effect" and w[2] == "manual" for w in writes)
+              or all(w[1] != "effect" for w in writes),
+              "fell back to manual (or wrote no effect), not an unlisted value")
+    finally:
+        restore()
+
+
+def test_solid_and_off():
+    print("solid = manual paint; off = brightness 0")
+    writes = []
+    restore = _install(writes)
+    try:
+        cs.apply_strip_effect("valve-leds", "solid", {"r": 0, "g": 200, "b": 0}, 50, 80)
+        check(any(w[1] == "effect" and w[2] == "manual" for w in writes),
+              "solid puts the strip in manual mode")
+        check(any(w[1] == "multi_intensity" for w in writes), "solid paints the colour")
+        writes.clear()
+        cs.apply_strip_effect("valve-leds", "off", None, 50, 100)
+        check(all(w[2] == "0" for w in writes if w[1] == "brightness"),
+              "off writes brightness 0")
+        check(not any(w[1] == "effect" and w[2] == "patrol" for w in writes),
+              "off never leaves a running firmware effect")
+    finally:
+        restore()
+
+
+def test_delay_maps_speed():
+    print("speed -> device delay (higher speed = smaller delay), clamped to range")
+    d_fast = cs._strip_delay("valve-leds[0]", 100)   # need real read; fake it
+    # use a fake read for delay_range
+    saved = cs._led_read_attr
+    cs._led_read_attr = lambda name, attr: _DELAY_RANGE if attr == "delay_range" else None
+    try:
+        check(cs._strip_delay("x", 100) == 0, "speed 100 -> delay 0 (fastest)")
+        check(cs._strip_delay("x", 1) == 20, "speed 1 -> delay 20 (slowest)")
+        mid = cs._strip_delay("x", 50)
+        check(9 <= mid <= 11, "speed 50 -> mid delay (%s)" % mid)
+    finally:
+        cs._led_read_attr = saved
+
+
+def test_strips_in_payload():
+    print("GET /api/leds advertises strips (mock)")
+    st = cs.leds_state(True)
+    strips = st.get("strips")
+    check(isinstance(strips, list) and strips, "mock payload lists a strip")
+    vs = next((s for s in strips if s["prefix"] == "valve-leds"), None)
+    check(vs and vs["count"] >= 3 and vs["rgb"], "valve-leds strip with RGB members")
+    check(vs and "patrol" in vs["hw_effects"], "hw_effects advertised (patrol)")
+
+
+if __name__ == "__main__":
+    test_detect_strip()
+    test_allowlist_unknown_prefix()
+    test_scanner_writes_firmware_patrol()
+    test_effect_value_must_be_published()
+    test_solid_and_off()
+    test_delay_maps_speed()
+    test_strips_in_payload()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all led-strip tests passed")

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -183,6 +183,39 @@ def test_delay_maps_speed():
         cs._led_read_attr = saved
 
 
+def test_manual_mode_preserves_colours():
+    print("manual = effect=manual on every member, colours PRESERVED (no fill)")
+    writes = []
+    restore = _install(writes)
+    try:
+        res = cs.apply_strip_effect("valve-leds", "manual", None, 50, 90)
+        check(res and res.get("ok"), "manual accepted")
+        for i in range(_N):
+            n = "valve-leds[%d]" % i
+            check((n, "effect", "manual") in writes, "%s set effect=manual" % n)
+        check(not any(w[1] == "multi_intensity" for w in writes),
+              "manual does NOT repaint (colours kept so the phone can paint a pattern)")
+    finally:
+        restore()
+
+
+def test_paint_auto_switches_to_manual():
+    print("painting a strip node auto-sets effect=manual FIRST so the colour sticks")
+    writes = []
+    restore = _install(writes)
+    try:
+        res = cs.set_led("valve-leds[3]", 100, {"r": 255, "g": 0, "b": 0})
+        check(res and res.get("ok"), "paint accepted")
+        attrs = [w[1] for w in writes if w[0] == "valve-leds[3]"]
+        check("effect" in attrs and "multi_intensity" in attrs
+              and attrs.index("effect") < attrs.index("multi_intensity"),
+              "effect=manual written before the colour (so a running effect can't override it)")
+        check(("valve-leds[3]", "effect", "manual") in writes,
+              "the effect written is 'manual' (the device lists it)")
+    finally:
+        restore()
+
+
 def test_strips_in_payload():
     print("GET /api/leds advertises strips (mock)")
     st = cs.leds_state(True)
@@ -199,6 +232,8 @@ if __name__ == "__main__":
     test_scanner_writes_firmware_patrol()
     test_effect_value_must_be_published()
     test_solid_and_off()
+    test_manual_mode_preserves_colours()
+    test_paint_auto_switches_to_manual()
     test_delay_maps_speed()
     test_strips_in_payload()
     print()

--- a/tests/test_openrgb.py
+++ b/tests/test_openrgb.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Tests for the OpenRGB backend (GET /api/openrgb, POST /api/openrgb/set) and
+the hand-rolled OpenRGB SDK client.
+
+Run: python3 tests/test_openrgb.py
+
+There is no OpenRGB hardware in CI, so the wire format is proven against an
+IN-PROCESS mock OpenRGB TCP server that speaks the documented protocol
+(SET_CLIENT_NAME / REQUEST_PROTOCOL_VERSION / REQUEST_CONTROLLER_COUNT /
+REQUEST_CONTROLLER_DATA / UPDATE_LEDS). This proves the client's handshake,
+controller-data parse (name + zones + summed LED count) and per-LED frame writes
+round-trip -- but REAL hardware remains the final gate (see the PR / spec).
+
+The property that matters for the allowlist: a client `device` is an int index
+LOOKED UP in the live controller list -- an out-of-range index writes NOTHING and
+404s; the client never names a socket/host/command. Effect ids are the frozen
+_LED_EFFECTS set.
+
+Pure stdlib, no pytest -- same style as the other agent tests. The client is
+pointed at 127.0.0.1:<ephemeral> (the mock), never a real OpenRGB daemon, and the
+persistence file is redirected to a temp path.
+"""
+import importlib.util
+import os
+import socket
+import struct
+import tempfile
+import threading
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+def wait_for(pred, timeout=2.0):
+    """Poll pred() until true or timeout (the mock server processes writes on a
+    per-connection thread, so a captured frame lands slightly after the call)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if pred():
+            return True
+        time.sleep(0.02)
+    return pred()
+
+
+# ---- a minimal mock OpenRGB server -----------------------------------------
+SERVER_PROTO = 3
+# device index -> (name, [(zone_name, led_count), ...])
+DEVICES = [
+    ("ASUS Aura Motherboard", [("Addressable 1", 8), ("Onboard", 4)]),   # 12 LEDs
+    ("Corsair Vengeance RGB", [("DIMM 1", 10), ("DIMM 2", 10)]),         # 20 LEDs
+]
+
+
+def _bstr(s):
+    b = s.encode("utf-8")
+    return struct.pack("<H", len(b) + 1) + b + b"\x00"
+
+
+def _build_controller(idx):
+    """A proto-3 controller-data blob matching the agent's parser layout."""
+    name, zones = DEVICES[idx]
+    body = b""
+    body += struct.pack("<i", 0)                      # device type
+    body += _bstr(name)
+    body += _bstr("desc")                             # description
+    body += _bstr("1.0")                              # version
+    body += _bstr("SERIAL")                           # serial
+    body += _bstr("loc")                              # location
+    body += struct.pack("<H", 1)                      # num_modes
+    body += struct.pack("<i", 0)                      # active mode
+    # one mode (proto-3 field layout, incl. brightness fields)
+    body += _bstr("Direct")                           # mode name
+    body += struct.pack("<i", 0)                      # value
+    body += struct.pack("<I", 0)                      # flags
+    body += struct.pack("<II", 0, 100)                # speed_min, speed_max
+    body += struct.pack("<II", 0, 100)                # brightness_min, brightness_max (proto>=3)
+    body += struct.pack("<II", 0, 0)                  # colors_min, colors_max
+    body += struct.pack("<I", 50)                     # speed
+    body += struct.pack("<I", 100)                    # brightness (proto>=3)
+    body += struct.pack("<I", 0)                      # direction
+    body += struct.pack("<I", 0)                      # color_mode
+    body += struct.pack("<H", 0)                      # num mode colors
+    body += struct.pack("<H", len(zones))             # num_zones
+    total = 0
+    for zname, zleds in zones:
+        body += _bstr(zname)
+        body += struct.pack("<i", 0)                  # zone type
+        body += struct.pack("<I", 0)                  # leds_min
+        body += struct.pack("<I", zleds)              # leds_max
+        body += struct.pack("<I", zleds)              # leds_count
+        body += struct.pack("<H", 0)                  # matrix_len (none)
+        total += zleds
+    # per-LED section (parser stops before this, but a real server sends it)
+    body += struct.pack("<H", total)
+    for i in range(total):
+        body += _bstr("LED %d" % i) + struct.pack("<I", 0)
+    body += struct.pack("<H", 0)                      # num device colors
+    return struct.pack("<I", len(body) + 4) + body    # prefix data_size
+
+
+def _recv_exact(conn, n):
+    buf = b""
+    while len(buf) < n:
+        chunk = conn.recv(n - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+def _reply(conn, dev, pid, payload):
+    conn.sendall(b"ORGB" + struct.pack("<III", dev, pid, len(payload)) + payload)
+
+
+class MockOpenRGB:
+    def __init__(self):
+        self.srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self.srv.bind(("127.0.0.1", 0))
+        self.srv.listen(1)
+        self.port = self.srv.getsockname()[1]
+        self.frames = []          # (dev_idx, [(r,g,b), ...]) captured from UPDATE_LEDS
+        self.custom_mode = []     # dev indices that got SET_CUSTOM_MODE
+        self._stop = False
+        self.t = threading.Thread(target=self._serve, daemon=True)
+        self.t.start()
+
+    def _serve(self):
+        self.srv.settimeout(0.5)
+        while not self._stop:
+            try:
+                conn, _ = self.srv.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            threading.Thread(target=self._client, args=(conn,), daemon=True).start()
+
+    def _client(self, conn):
+        conn.settimeout(2.0)
+        while not self._stop:
+            try:
+                hdr = _recv_exact(conn, 16)
+            except OSError:
+                return
+            if not hdr or hdr[:4] != b"ORGB":
+                return
+            dev, pid, size = struct.unpack("<III", hdr[4:16])
+            body = _recv_exact(conn, size) if size else b""
+            if body is None and size:
+                return
+            if pid == 50:                              # SET_CLIENT_NAME
+                pass
+            elif pid == 40:                            # REQUEST_PROTOCOL_VERSION
+                _reply(conn, 0, 40, struct.pack("<I", SERVER_PROTO))
+            elif pid == 0:                             # REQUEST_CONTROLLER_COUNT
+                _reply(conn, 0, 0, struct.pack("<I", len(DEVICES)))
+            elif pid == 1:                             # REQUEST_CONTROLLER_DATA
+                _reply(conn, dev, 1, _build_controller(dev))
+            elif pid == 1100:                          # SET_CUSTOM_MODE
+                self.custom_mode.append(dev)
+            elif pid == 1050:                          # UPDATE_LEDS
+                self.frames.append((dev, self._parse_leds(body)))
+
+    @staticmethod
+    def _parse_leds(body):
+        n = struct.unpack_from("<H", body, 4)[0]       # skip u32 data_size
+        out = []
+        off = 6
+        for _ in range(n):
+            r, g, b = body[off], body[off + 1], body[off + 2]
+            out.append((r, g, b))
+            off += 4
+        return out
+
+    def stop(self):
+        self._stop = True
+        try:
+            self.srv.close()
+        except OSError:
+            pass
+
+
+def _point_client_at(server):
+    """Redirect the agent's OpenRGB client + persistence at the mock server and a
+    temp file. Returns a restore fn."""
+    saved = {k: getattr(cs, k) for k in ("_ORGB_HOST", "_ORGB_PORT", "_ORGB",
+                                         "_ORGB_STATE_CONF")}
+    cs._ORGB_HOST = "127.0.0.1"
+    cs._ORGB_PORT = server.port
+    cs._ORGB = cs._OpenRGBClient()
+    cs._ORGB_CACHE["ctrls"] = []
+    cs._ORGB_CACHE["at"] = 0.0
+    fd, tmp = tempfile.mkstemp(prefix="test-orgb-", suffix=".json")
+    os.close(fd)
+    os.unlink(tmp)
+    cs._ORGB_STATE_CONF = tmp
+
+    def restore():
+        cs._ORGB_FX_STOP.set()
+        th = cs._ORGB_FX_THREAD[0]
+        if th is not None:
+            th.join(timeout=1.0)
+        with cs._ORGB_FX_LOCK:
+            cs._ORGB_FX_ACTIVE.clear()
+            cs._ORGB_PERSIST.clear()
+            cs._ORGB_FX_THREAD[0] = None
+        cs._ORGB_FX_STOP.clear()
+        try:
+            cs._ORGB._drop()
+        except Exception:
+            pass
+        for k, v in saved.items():
+            setattr(cs, k, v)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+
+
+    return restore
+
+
+def test_enumerate_wire():
+    print("client enumerates controllers over the wire (name + zones + LED count)")
+    srv = MockOpenRGB()
+    restore = _point_client_at(srv)
+    try:
+        ctrls = cs._ORGB.controllers()
+        check(len(ctrls) == 2, "two controllers enumerated")
+        check(ctrls[0]["name"] == "ASUS Aura Motherboard", "controller 0 name parsed")
+        check(ctrls[0]["led_count"] == 12, "controller 0 LED count = sum of zones (8+4)")
+        check([z["name"] for z in ctrls[0]["zones"]] == ["Addressable 1", "Onboard"],
+              "controller 0 zone names parsed")
+        check(ctrls[1]["led_count"] == 20, "controller 1 LED count = 10+10")
+        check(cs.openrgb_available() is True, "openrgb_available() true when server answers")
+    finally:
+        restore()
+        srv.stop()
+
+
+def test_frame_write_wire():
+    print("set_frame writes a per-LED UPDATE_LEDS frame that round-trips")
+    srv = MockOpenRGB()
+    restore = _point_client_at(srv)
+    try:
+        colors = [{"r": 10, "g": 20, "b": 30}, {"r": 255, "g": 0, "b": 128}]
+        ok = cs._ORGB.set_frame(0, colors)
+        check(ok is True, "set_frame returned ok")
+        wait_for(lambda: bool(srv.frames))
+        check(srv.custom_mode and srv.custom_mode[-1] == 0,
+              "device put into custom/direct mode first")
+        check(srv.frames and srv.frames[-1][0] == 0, "frame addressed to device 0")
+        got = srv.frames[-1][1] if srv.frames else None
+        check(got == [(10, 20, 30), (255, 0, 128)],
+              "colours round-trip R,G,B in order (got %s)" % got)
+    finally:
+        restore()
+        srv.stop()
+
+
+def test_apply_allowlist():
+    print("apply_openrgb allowlist: unknown device/effect writes NOTHING")
+    srv = MockOpenRGB()
+    restore = _point_client_at(srv)
+    try:
+        # unknown effect -> 400, no frame
+        srv.frames.clear()
+        res = cs.apply_openrgb(0, "kitt", None, 50, 100)
+        check(isinstance(res, dict) and res.get("status") == 400, "unknown effect -> 400")
+        check(not srv.frames, "unknown effect wrote no frame")
+        # out-of-range device -> None, no frame
+        for bad in (99, -1, "0", None, True):
+            srv.frames.clear()
+            res = cs.apply_openrgb(bad, "solid", {"r": 1, "g": 2, "b": 3}, 50, 100)
+            check(res is None, "device %r refused" % (bad,))
+            check(not srv.frames, "device %r wrote no frame" % (bad,))
+        # valid solid -> a full-device frame of that colour
+        srv.frames.clear()
+        res = cs.apply_openrgb(0, "solid", {"r": 0, "g": 200, "b": 0}, 50, 100)
+        check(res and res.get("ok") and res["active"] is None, "solid accepted")
+        wait_for(lambda: bool(srv.frames))
+        frame = srv.frames[-1][1] if srv.frames else []
+        check(len(frame) == 12 and all(px == (0, 200, 0) for px in frame),
+              "solid wrote 12 LEDs all green")
+    finally:
+        restore()
+        srv.stop()
+
+
+def test_scanner_effect_moves():
+    print("scanner effect renders a moving lit dot (a real KITT sweep)")
+    n = 12
+    color = {"r": 255, "g": 0, "b": 0}
+    # brightest LED index over time should move, not stay put
+    peaks = []
+    for k in range(6):
+        frame = cs._orgb_frame("scanner", n, color, k * 0.3, 60)
+        peak = max(range(n), key=lambda i: frame[i]["r"])
+        peaks.append(peak)
+    check(len(set(peaks)) > 1, "the lit position moves across frames (peaks=%s)" % peaks)
+    # rainbow frames are all valid colours
+    rb = cs._orgb_frame("rainbow", n, color, 0.7, 50)
+    check(len(rb) == n and all(cs._is_rgb_triple(c) for c in rb),
+          "rainbow frame is n valid colours")
+
+
+def test_persistence_roundtrip():
+    print("apply persists + restore re-applies (revalidated)")
+    srv = MockOpenRGB()
+    restore = _point_client_at(srv)
+    try:
+        cs.apply_openrgb(1, "scanner", {"r": 0, "g": 0, "b": 255}, 70, 90)
+        saved = cs._orgb_state_load()
+        check(saved.get("1", {}).get("effect") == "scanner", "scanner persisted for device 1")
+        # wipe in-memory, restore from disk
+        cs._ORGB_FX_STOP.set()
+        th = cs._ORGB_FX_THREAD[0]
+        if th:
+            th.join(timeout=1.0)
+        with cs._ORGB_FX_LOCK:
+            cs._ORGB_FX_ACTIVE.clear()
+            cs._ORGB_FX_THREAD[0] = None
+        cs._ORGB_FX_STOP.clear()
+        cs._orgb_restore()
+        check(1 in cs._ORGB_FX_ACTIVE and cs._ORGB_FX_ACTIVE[1]["effect"] == "scanner",
+              "restore re-applied the scanner effect")
+    finally:
+        restore()
+        srv.stop()
+
+
+def test_mock_state_observable():
+    print("--mock: GET /api/openrgb reflects a selected effect (observe both)")
+    saved = dict(cs._MOCK_ORGB_FX)
+    try:
+        cs._MOCK_ORGB_FX.clear()
+        st = cs.openrgb_state(True)
+        check(st["available"] is True and len(st["controllers"]) == 2,
+              "mock advertises two controllers")
+        check(st["active"] == {}, "no effect active initially")
+        cs._MOCK_ORGB_FX[0] = {"effect": "scanner", "color": {"r": 255, "g": 0, "b": 0},
+                               "speed": 80, "brightness": 100}
+        st = cs.openrgb_state(True)
+        check(st["active"].get("0", {}).get("effect") == "scanner",
+              "GET reflects the switched-on scanner")
+    finally:
+        cs._MOCK_ORGB_FX.clear()
+        cs._MOCK_ORGB_FX.update(saved)
+
+
+if __name__ == "__main__":
+    test_enumerate_wire()
+    test_frame_write_wire()
+    test_apply_allowlist()
+    test_scanner_effect_moves()
+    test_persistence_roundtrip()
+    test_mock_state_observable()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all openrgb tests passed")


### PR DESCRIPTION
Builds out the LED control per the owner ask (2026-08-13): an easier editor, saved custom presets, effects/automation incl. a real **night rider** scanner, **survive reboot**, and **OpenRGB** whole-system RGB. Owner chose *both in one push* / *addressable real sweep* / *native sliders*. Agent 2.9.83 → **2.9.84**. Spec: `docs/memory/project_led-studio.md`.

## Kernel-LED half (rides on cap `ledcontrol`, no new cap)
- **Effect engine** — one `led-fx` daemon thread renders breathe / pulse / rainbow / strobe / **scanner** via the SAME validated writers `set_led()` uses. `POST /api/leds/effect`; `GET /api/leds` gains additive `effects` + `active` fields (old apps ignore them).
- **Persistence** — active effect (and solids) written to `~/.config/couchside/leds.json`, re-applied by a startup `led-restore` thread → **survives reboot** (agent is a systemd *user* service → restore on login).
- **App** — `RgbLedCard` rewritten: native hue/brightness PanResponder sliders + effect/speed chips + a per-phone preset library (`lib/ledPresets.ts`, seeded incl. "Night Rider").

## OpenRGB half (new cap `openrgb`, six sites; linux-only)
- Hand-rolled **stdlib** SDK client to a loopback OpenRGB server (`127.0.0.1:6742`): handshake, version negotiation, controller enumeration (name + zones + summed LED count), per-LED `UPDATE_LEDS` frames. An `orgb-fx` thread renders a real **multi-zone scanner**. `GET /api/openrgb`, `POST /api/openrgb/set`; persistence + `orgb-restore` startup thread. App `OpenRgbCard` ("SYSTEM RGB").
- Shared `lib/ledColor.ts` + `components/TrackSlider.tsx` used by both cards.

## Allowlist (CLAUDE.md §3)
- Effect ids = frozen `_LED_EFFECTS` (unknown → 400, nothing runs).
- Kernel LED name looked up in the live `/sys/class/leds` set (unknown/traversal/non-writable → 404, **nothing written**); the render thread writes only the three fixed-literal attrs on a name validated at start.
- OpenRGB `device` = int index looked up against the live controller count (out-of-range → 404, no frame written); the client is **loopback-only** and never receives a socket/host/command.
- Params reject rather than sanitise. Persistence files are user-owned, atomic, revalidated on read.

## Verified
- **69/69 test files green**, incl. new `tests/test_led_effects.py` (allowlist + thread lifecycle + persistence-revalidate + mock-observable) and `tests/test_openrgb.py` (wire format vs an **in-process mock OpenRGB server** — which **caught a real bug**: `_update_leds` sent the packet header without the body). Both wired into CI.
- Both endpoints end-to-end vs `--mock` over curl (401/404/400/200 + observe-both).
- App driven in the web harness by **pressing** real controls (§6): LIGHT effect chip, Night Rider preset (scanner red @80), Solid clears, hue slider → correct computed colour, brightness 100→40, Save (library 4→5 persisted); SYSTEM RGB scanner on device 0 moved `/api/openrgb` active.

## NOT verified — needs hardware
- **No real LED lit.** Kernel path still needs the **install-time udev grant** on a stock box (sysfs root-owned).
- **No real OpenRGB daemon.** Wire format proven vs the mock server + docs only — real hardware is the final gate (protocol version, zone-matrix parse, write contention).
- Native slider **drag** isn't harness-testable (tap-to-set was pressed); needs a real-device pass before ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)