### PR TITLE
feat(led): name presets before saving + protect built-in presets

### DIFF
--- a/app/components/PresetNameModal.tsx
+++ b/app/components/PresetNameModal.tsx
@@ -1,0 +1,102 @@
+/**
+ * A small themed dialog to NAME a preset before saving it. Used by the LED cards
+ * (RgbLedCard, StripLightCard). Cross-platform (a plain RN Modal + TextInput, not
+ * iOS-only Alert.prompt) so it works on Android too. Pre-filled with the card's
+ * auto-generated label; blank falls back to that label.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  Modal, Pressable, StyleSheet, Text, TextInput, View,
+} from 'react-native';
+
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+
+export function PresetNameModal(props: {
+  visible: boolean;
+  defaultName: string;
+  onSubmit: (name: string) => void;
+  onClose: () => void;
+}) {
+  const { visible, defaultName, onSubmit, onClose } = props;
+  const t = useTheme();
+  const styles = useThemedStyles(makeStyles);
+  const [name, setName] = useState(defaultName);
+  const inputRef = useRef<TextInput>(null);
+
+  useEffect(() => {
+    if (visible) {
+      setName(defaultName);
+      // let the modal mount before focusing so the keyboard opens reliably
+      const id = setTimeout(() => inputRef.current?.focus(), 120);
+      return () => clearTimeout(id);
+    }
+  }, [visible, defaultName]);
+
+  const submit = () => onSubmit(name.trim() || defaultName);
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.overlay} onPress={onClose} accessibilityLabel="Dismiss">
+        {/* Inner press swallows taps so tapping the card doesn't dismiss. */}
+        <Pressable style={styles.card} onPress={() => {}}>
+          <Text style={styles.title}>NAME THIS PRESET</Text>
+          <TextInput
+            ref={inputRef}
+            value={name}
+            onChangeText={setName}
+            selectTextOnFocus
+            maxLength={40}
+            placeholder="Preset name"
+            placeholderTextColor={t.textFaint}
+            returnKeyType="done"
+            onSubmitEditing={submit}
+            accessibilityLabel="Preset name"
+            style={styles.input}
+          />
+          <View style={styles.row}>
+            <Pressable
+              onPress={onClose} accessibilityRole="button" accessibilityLabel="Cancel"
+              style={({ pressed }) => [styles.btn, pressed && styles.pressed]}>
+              <Text style={styles.btnText}>Cancel</Text>
+            </Pressable>
+            <Pressable
+              onPress={submit} accessibilityRole="button" accessibilityLabel="Save preset"
+              style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+              <Text style={[styles.btnText, styles.btnTextPrimary]}>Save</Text>
+            </Pressable>
+          </View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    overlay: {
+      flex: 1, backgroundColor: 'rgba(0,0,0,0.6)',
+      alignItems: 'center', justifyContent: 'center', padding: 28,
+    },
+    card: {
+      width: '100%', maxWidth: 360, backgroundColor: t.card,
+      borderRadius: 16, borderWidth: 1, borderColor: t.cardBorder, padding: 18,
+    },
+    title: {
+      color: t.textDim, fontSize: 11, fontWeight: '700', letterSpacing: 1.2,
+      fontFamily: mono, marginBottom: 12,
+    },
+    input: {
+      color: t.text, fontSize: 16, fontFamily: mono,
+      borderWidth: 1, borderColor: t.cardBorder, borderRadius: 10,
+      paddingVertical: 10, paddingHorizontal: 12, backgroundColor: t.bg,
+    },
+    row: { flexDirection: 'row', justifyContent: 'flex-end', gap: 10, marginTop: 16 },
+    btn: {
+      borderRadius: 999, borderWidth: 1, borderColor: t.cardBorder,
+      paddingVertical: 8, paddingHorizontal: 18,
+    },
+    btnPrimary: { borderColor: t.blue, backgroundColor: t.blue },
+    pressed: { opacity: 0.6 },
+    btnText: { color: t.textDim, fontSize: 14, fontFamily: mono, fontWeight: '700' },
+    btnTextPrimary: { color: '#fff' },
+  });

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -34,10 +34,11 @@ import {
   api, hostKey, type LedEffect, type LedInfo, type LedsState, type Rgb,
 } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
+import { PresetNameModal } from '@/components/PresetNameModal';
 import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
 import { detectStrips } from '@/lib/ledStrip';
 import {
-  addPreset, removePreset, useLedPresets, type LedPreset,
+  addPreset, isBuiltinPreset, removePreset, useLedPresets, type LedPreset,
 } from '@/lib/ledPresets';
 import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
@@ -79,6 +80,8 @@ export function RgbLedCard() {
 
   const [busy, setBusy] = useState(false);
   const [selName, setSelName] = useState<string | null>(null);
+  const [namePrompt, setNamePrompt] = useState<
+    { label: string; build: (name: string) => Omit<LedPreset, 'id'> } | null>(null);
 
   // Local editor state; seeded from the box once per selected LED, then the
   // user's edits drive the UI (poll is a backstop, not the source of truth).
@@ -167,23 +170,27 @@ export function RgbLedCard() {
   };
 
   const saveCurrent = () => {
-    const label = EFFECT_META[effect].label +
-      (led.rgb && EFFECT_META[effect].usesColor ? ` ${hexRgb(color)}` : '');
-    void addPreset({
-      label,
-      effect,
-      color: led.rgb && EFFECT_META[effect].usesColor ? color : null,
-      speed: Math.round(speed),
-      brightness: Math.round(bright),
-    });
     hapticLight();
+    const usesColor = led.rgb && EFFECT_META[effect].usesColor;
+    setNamePrompt({
+      label: EFFECT_META[effect].label + (usesColor ? ` ${hexRgb(color)}` : ''),
+      build: (name) => ({
+        label: name, effect, color: usesColor ? color : null,
+        speed: Math.round(speed), brightness: Math.round(bright),
+      }),
+    });
   };
 
-  const confirmDelete = (p: LedPreset) =>
+  const confirmDelete = (p: LedPreset) => {
+    if (isBuiltinPreset(p.id)) {
+      Alert.alert('Built-in preset', `"${p.label}" is preinstalled and can't be deleted.`);
+      return;
+    }
     Alert.alert('Delete preset', `Remove "${p.label}"?`, [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Delete', style: 'destructive', onPress: () => void removePreset(p.id) },
     ]);
+  };
 
   return (
     <Card index={6}>
@@ -357,6 +364,13 @@ export function RgbLedCard() {
       </View>
 
       <Text style={styles.hint}>Long-press a preset to delete it.</Text>
+
+      <PresetNameModal
+        visible={!!namePrompt}
+        defaultName={namePrompt?.label ?? ''}
+        onSubmit={(name) => { if (namePrompt) void addPreset(namePrompt.build(name)); setNamePrompt(null); }}
+        onClose={() => setNamePrompt(null)}
+      />
     </Card>
   );
 }

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -19,12 +19,15 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import React, { useEffect, useRef, useState } from 'react';
 import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 
+import { PresetNameModal } from '@/components/PresetNameModal';
 import { TrackSlider } from '@/components/TrackSlider';
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, type LedEffect, type LedsState, type Rgb } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
-import { addPreset, removePreset, useLedPresets, type LedPreset } from '@/lib/ledPresets';
+import {
+  addPreset, isBuiltinPreset, removePreset, useLedPresets, type LedPreset,
+} from '@/lib/ledPresets';
 import { detectStrips, type LedStrip } from '@/lib/ledStrip';
 import { useSkinKit } from '@/lib/skin';
 import { useSettings } from '@/lib/SettingsContext';
@@ -84,6 +87,10 @@ export function StripLightCard() {
   const [speedPct, setSpeedPct] = useState(55);
   const [frame, setFrame] = useState<(Rgb | null)[]>([]);
   const [busy, setBusy] = useState(false);
+  // Pending "name this preset" prompt: the auto label + a builder that turns the
+  // typed name into the full preset to save.
+  const [namePrompt, setNamePrompt] = useState<
+    { label: string; build: (name: string) => Omit<LedPreset, 'id'> } | null>(null);
 
   const poll = usePoll<LedsState | null>(
     () => api.leds(settings), POLL_MS, ready && configured, hostKey(settings));
@@ -233,31 +240,43 @@ export function StripLightCard() {
     }
   };
 
+  /** Open the "name this preset" prompt, pre-filled with an auto label. */
   const saveCurrent = () => {
     hapticLight();
-    // In Manual mode, save the whole painted pattern (one colour per LED).
     if (effect === 'manual') {
-      void addPreset({
-        label: `Custom ${strip.leds.length}`, effect: 'manual', color: null,
-        speed: Math.round(speedPct), brightness: Math.round(bright),
-        pattern: frame.map((c) => c ?? null),
+      const pattern = frame.map((c) => c ?? null);
+      setNamePrompt({
+        label: `Custom ${strip.leds.length}`,
+        build: (name) => ({
+          label: name, effect: 'manual', color: null,
+          speed: Math.round(speedPct), brightness: Math.round(bright), pattern,
+        }),
       });
       return;
     }
-    const label = EFFECTS.find((x) => x.id === effect)?.label ?? 'Look';
+    const base = EFFECTS.find((x) => x.id === effect)?.label ?? 'Look';
     const usesColor = effect !== 'rainbow' && effect !== 'off';
-    void addPreset({
-      label: label + (usesColor ? ` ${hexRgb(color)}` : ''),
-      effect: effect as LedEffect, color: usesColor ? color : null,
-      speed: Math.round(speedPct), brightness: Math.round(bright),
+    setNamePrompt({
+      label: base + (usesColor ? ` ${hexRgb(color)}` : ''),
+      build: (name) => ({
+        label: name, effect: effect as LedEffect, color: usesColor ? color : null,
+        speed: Math.round(speedPct), brightness: Math.round(bright),
+      }),
     });
   };
 
-  const confirmDelete = (p: LedPreset) =>
+  /** Long-press a preset to delete it — but PREINSTALLED (seeded) presets are
+   *  protected, so those explain instead of deleting. */
+  const confirmDelete = (p: LedPreset) => {
+    if (isBuiltinPreset(p.id)) {
+      Alert.alert('Built-in preset', `"${p.label}" is preinstalled and can't be deleted.`);
+      return;
+    }
     Alert.alert('Delete preset', `Remove "${p.label}"?`, [
       { text: 'Cancel', style: 'cancel' },
       { text: 'Delete', style: 'destructive', onPress: () => void removePreset(p.id) },
     ]);
+  };
 
   return (
     <Card index={7}>
@@ -393,6 +412,13 @@ export function StripLightCard() {
             ? 'Effects run on the box — they keep going with the app closed. Long-press a preset to delete.'
             : 'Tap a cell to paint it. Scanner sweeps a dot across the strip.'}
       </Text>
+
+      <PresetNameModal
+        visible={!!namePrompt}
+        defaultName={namePrompt?.label ?? ''}
+        onSubmit={(name) => { if (namePrompt) void addPreset(namePrompt.build(name)); setNamePrompt(null); }}
+        onClose={() => setNamePrompt(null)}
+      />
     </Card>
   );
 }

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -22,7 +22,7 @@ import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 import { PresetNameModal } from '@/components/PresetNameModal';
 import { TrackSlider } from '@/components/TrackSlider';
 import { usePoll } from '@/hooks/usePoll';
-import { api, hostKey, type LedEffect, type LedsState, type Rgb } from '@/lib/api';
+import { api, hostKey, type LedEffect, type LedInfo, type LedsState, type Rgb } from '@/lib/api';
 import { hapticLight } from '@/lib/haptics';
 import { cssRgb, hexRgb, hueToRgb, rgbToHue, HUE_STOPS } from '@/lib/ledColor';
 import {
@@ -57,6 +57,14 @@ const scale = (c: Rgb, f: number): Rgb => ({
 function stripDeviceLabel(prefix: string): string {
   if (prefix.startsWith('valve-leds')) return 'Steam Machine strip';
   return prefix.replace(/[:_-]+$/, '');
+}
+
+/** LEDs in PHYSICAL left-to-right order for the customizer. The Steam Machine's
+ *  `valve-leds` index runs opposite to the physical strip, so cell 0 painted the
+ *  wrong end ("the bar is backwards") — flip it so the row matches the hardware. */
+function displayLeds(strip: LedStrip): LedInfo[] {
+  const flip = strip.leds[0]?.name.startsWith('valve-leds');
+  return flip ? strip.leds.slice().reverse() : strip.leds;
 }
 
 /** One frame of the APP-driven fallback animation (only used on old agents). */
@@ -114,7 +122,7 @@ export function StripLightCard() {
     if (!strip) return;
     if (seeded.current === strip.key) return;
     seeded.current = strip.key;
-    setFrame(strip.leds.map((l) => (l.brightness_pct > 0 ? l.color : null)));
+    setFrame(displayLeds(strip).map((l) => (l.brightness_pct > 0 ? l.color : null)));
     const a = strip && poll.data?.active?.[`strip:${agentStrip?.prefix}`];
     if (a) { setEffect(a.effect as StripEffect); setBright(a.brightness); if (a.color) setHue(rgbToHue(a.color)); }
     else {
@@ -126,7 +134,8 @@ export function StripLightCard() {
   // APP-driven fallback animation (old agents only). No-op in agent mode.
   useEffect(() => {
     if (agentMode || !strip || (effect !== 'scanner')) return;
-    const n = strip.leds.length;
+    const ol = displayLeds(strip);
+    const n = ol.length;
     let tick = 0;
     let first = true;
     let last: (Rgb | null)[] = new Array(n).fill(null);
@@ -137,7 +146,7 @@ export function StripLightCard() {
       for (let i = 0; i < n; i++) {
         if (first || !sameCell(next[i], last[i])) {
           const cell = next[i];
-          void api.setLed(settings, strip.leds[i].name, cell ? { color: cell, brightness: b } : { brightness: 0 });
+          void api.setLed(settings, ol[i].name, cell ? { color: cell, brightness: b } : { brightness: 0 });
         }
       }
       setFrame(next); last = next; first = false; tick++;
@@ -148,6 +157,9 @@ export function StripLightCard() {
 
   if (!poll.data || strips.length === 0 || !strip) return null;
 
+  // Cells, paints and patterns all operate in PHYSICAL order (flipped for the
+  // Steam Machine so the row matches the strip).
+  const orderedLeds = displayLeds(strip);
   const color = hueToRgb(hue);
   const animated = effect === 'scanner' || effect === 'rainbow' || effect === 'breathe';
   const shown = agentMode
@@ -172,8 +184,8 @@ export function StripLightCard() {
     // App fallback: solid/off fill immediately; scanner runs the loop above.
     if (e === 'solid' || e === 'off') {
       const b = Math.round(bright);
-      strip.leds.forEach((l) => void api.setLed(settings, l.name, e === 'off' ? { brightness: 0 } : { color, brightness: b }));
-      setFrame(strip.leds.map(() => (e === 'off' ? null : color)));
+      orderedLeds.forEach((l) => void api.setLed(settings, l.name, e === 'off' ? { brightness: 0 } : { color, brightness: b }));
+      setFrame(orderedLeds.map(() => (e === 'off' ? null : color)));
     }
   };
 
@@ -189,15 +201,15 @@ export function StripLightCard() {
     }
     if (effect === 'solid') {
       const b = Math.round(bright);
-      strip.leds.forEach((l) => void api.setLed(settings, l.name, { color, brightness: b }));
-      setFrame(strip.leds.map(() => color));
+      orderedLeds.forEach((l) => void api.setLed(settings, l.name, { color, brightness: b }));
+      setFrame(orderedLeds.map(() => color));
     }
   };
 
   /** Paint one cell — a per-LED customizer (best in Solid). */
   const paintCell = (i: number) => {
     hapticLight();
-    void api.setLed(settings, strip.leds[i].name, { color, brightness: Math.round(bright) });
+    void api.setLed(settings, orderedLeds[i].name, { color, brightness: Math.round(bright) });
     setFrame((f) => { const c = f.slice(); c[i] = color; return c; });
   };
 
@@ -212,17 +224,17 @@ export function StripLightCard() {
     // A painted PATTERN preset: enter manual mode, then repaint every LED.
     if (p.pattern && p.pattern.length) {
       setEffect('manual'); setBright(p.brightness);
-      const pat = strip.leds.map((_, i) => p.pattern![i] ?? null);
+      const pat = orderedLeds.map((_, i) => p.pattern![i] ?? null);
       setFrame(pat);
       if (agentMode && agentStrip) {
         void api.setStripEffect(settings, agentStrip.prefix, { effect: 'manual', brightness: p.brightness })
-          .then(() => Promise.all(strip.leds.map((l, i) =>
+          .then(() => Promise.all(orderedLeds.map((l, i) =>
             api.setLed(settings, l.name, pat[i]
               ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) }
               : { brightness: 0 }))))
           .then(() => poll.refresh());
       } else {
-        strip.leds.forEach((l, i) => void api.setLed(settings, l.name, pat[i]
+        orderedLeds.forEach((l, i) => void api.setLed(settings, l.name, pat[i]
           ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) } : { brightness: 0 }));
       }
       return;
@@ -246,7 +258,7 @@ export function StripLightCard() {
     if (effect === 'manual') {
       const pattern = frame.map((c) => c ?? null);
       setNamePrompt({
-        label: `Custom ${strip.leds.length}`,
+        label: `Custom ${orderedLeds.length}`,
         build: (name) => ({
           label: name, effect: 'manual', color: null,
           speed: Math.round(speedPct), brightness: Math.round(bright), pattern,
@@ -283,7 +295,7 @@ export function StripLightCard() {
       <View style={styles.header}>
         <Text style={styles.cardTitle}>LIGHT STRIP</Text>
         <View style={styles.headerRight}>
-          <Text style={styles.count}>{stripDeviceLabel(agentStrip?.prefix ?? strip.key)} · {strip.leds.length}</Text>
+          <Text style={styles.count}>{stripDeviceLabel(agentStrip?.prefix ?? strip.key)} · {orderedLeds.length}</Text>
           <Pressable
             onPress={() => { hapticLight(); poll.refresh(); }}
             hitSlop={10} accessibilityRole="button" accessibilityLabel="Refresh strip"
@@ -296,7 +308,7 @@ export function StripLightCard() {
       {/* The strip as ONE row (matches the single physical line) — tap a cell to
           paint it. Cells flex to share the width so 17 fit without wrapping. */}
       <View style={styles.strip}>
-        {strip.leds.map((l, i) => {
+        {orderedLeds.map((l, i) => {
           const c = frame[i] ?? null;
           return (
             <Pressable

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -159,8 +159,13 @@ export async function addPreset(p: Omit<LedPreset, 'id'>): Promise<LedPreset | n
   return preset;
 }
 
-/** Remove a preset by id (default or user-added; deletions persist). */
+/** True for a preinstalled (seeded) preset — those can't be deleted. */
+export const isBuiltinPreset = (id: string): boolean => id.startsWith('seed-');
+
+/** Remove a USER-made preset by id (deletions persist). Built-in (seeded) presets
+ *  are protected: this is a no-op for them. */
 export async function removePreset(id: string): Promise<void> {
+  if (isBuiltinPreset(id)) return;
   const next = presets.filter((p) => p.id !== id);
   if (next.length === presets.length) return;
   presets = next;


### PR DESCRIPTION
Follow-ups to #450, requested while testing on-device.

- **Name presets before saving** — Save opens a themed "name this preset" dialog (`PresetNameModal`, a plain RN Modal + TextInput so it works on iOS *and* Play, not iOS-only `Alert.prompt`), pre-filled with the auto-generated label and editable. Used by both the LIGHT and LIGHT STRIP cards.
- **Protect built-in presets** — the preinstalled seeded presets (Night Rider, etc.; ids `seed-*`) can't be deleted: `removePreset()` no-ops for them, and long-pressing one explains rather than offering delete. User-made presets still delete via long-press.

App-only; no agent change. tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)