### PR TITLE
docs(release): 2.9.46 / agent 2.9.85 build notes (LED Studio)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,22 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.85
+
+**Your light bar, brought to life.** If your box has an addressable RGB strip —
+like a Steam Machine's — the app now drives the whole strip at once. Run a real
+"night rider" sweep, a rainbow, or a breathe, and they run **on the box itself**,
+so they keep going with the phone closed, asleep, or gone, and come back after a
+reboot. Paint each LED its own colour by hand and save the look, pick one colour
+and brightness for the whole strip, and save named presets you can tap to recall.
+
+**Whole-system RGB.** If you run OpenRGB on the box, a new card controls your
+motherboard, RAM and strip lighting from the phone too — including a real sweep
+across the zones.
+
+Everything the LIGHT card does still works, and simple front/status LEDs now get
+effects and presets as well.
+
 ## 2.9.83
 
 **Pairing now works on desktop-session boxes.** On a box sitting at the Linux

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,9 +1,5 @@
-Remote desktop, now fluid. See and control your box's whole desktop from your phone, with smooth hardware-accelerated H.264 video. Move the cursor with a trackpad or just tap where you want to click, type with a full keyboard, and flip to a full-screen landscape mode.
+Light up your box. If it has an addressable RGB strip — like a Steam Machine's — you can now drive the whole strip from your phone: a real "night rider" sweep, rainbow, breathe, or a solid colour. Effects run on the box, so they keep going with the app closed and come back after a reboot.
 
-Navigate Steam's Big Picture from the couch — point and tap your way through Game Mode menus.
+Paint each LED its own colour and save the pattern, name your presets to recall them with a tap, and set colour and brightness with smooth sliders.
 
-Switch the box's audio output from your phone: speakers, headphones, or HDMI, without getting up.
-
-Set the colour of your box's front light bar right in the app.
-
-Also new: a quick note scratchpad on the controller. Plus fixes and polish.
+Whole-system RGB via OpenRGB when it's installed — control your motherboard, RAM and strips too. Plus fixes and polish.

--- a/app/changelogs/whatsnew-play-en-US.txt
+++ b/app/changelogs/whatsnew-play-en-US.txt
@@ -1,3 +1,5 @@
-Remote desktop, now fluid: see and control your box's desktop from your phone with smooth, hardware-accelerated H.264 video. Move the cursor with a trackpad or tap where you want to click, use a full keyboard, and flip to a full-screen landscape mode.
+Light up your box. If it has an addressable RGB strip (like a Steam Machine's), drive the whole strip from your phone: a real night-rider sweep, rainbow, breathe, or a solid colour — running on the box, so they keep going with the app closed and survive a reboot.
 
-Navigate Steam Big Picture from the couch. Switch the box's audio output from your phone. Set your front light-bar colour in the app. Plus a note scratchpad on the controller, and the usual fixes.
+Paint each LED its own colour and save the pattern, name your presets, and set colour + brightness with smooth sliders.
+
+Whole-system RGB via OpenRGB when it's installed. Plus fixes and polish.


### PR DESCRIPTION
Release notes for the LED Studio release (2.9.46 / agent 2.9.85). Agent CHANGELOG 2.9.85 section (becomes the GitHub release body + the box 'What's new'), and the App Store + Play whatsnew. Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)