### PR TITLE
fix(agent): report real CPU temp on AMD (k10temp), not a static board sensor (#449)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,14 @@ jobs:
       - name: Unit tests (disk mounts)
         run: python3 tests/test_disk_mounts.py
 
+      # CPU temperature sensor selection (issue #449). An AMD 7800X3D board read a
+      # static 16.8C forever because the reader only knew Intel's coretemp and, on
+      # AMD, latched the first board/NVMe hwmon. Asserts a recognized CPU driver
+      # (coretemp/k10temp/zenpower) wins over a decoy board sensor sorted before it,
+      # a CPU-typed thermal zone beats a random hwmon, and both directions of #449.
+      - name: Unit tests (CPU temp sensor selection)
+        run: python3 tests/test_cpu_temp.py
+
       # USB wake sources (/api/usb-wake), read-only. Two field reports are
       # encoded here: arming only the ROOT HUBS misses controllers (their signal
       # arrives through a dongle further down the tree), and arming EVERY device

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,7 +18,13 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
-## 2.9.85
+## 2.9.86
+
+**Correct CPU temperature on AMD boxes.** On some AMD builds (for example a Ryzen
+7800X3D on a Gigabyte board) the Console showed a single, frozen CPU temperature
+that never moved. The box was reading the wrong sensor. It now finds the real CPU
+temperature on AMD as well as Intel, so the reading tracks your machine. Everything
+from the last update is here too:
 
 **Your light bar, brought to life.** If your box has an addressable RGB strip —
 like a Steam Machine's — the app now drives the whole strip at once. Run a real

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.85"
+VERSION = "2.9.86"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -1079,12 +1079,52 @@ def read_load():
         return [0.0, 0.0, 0.0]
 
 
-def read_cpu_temp_c():
-    """Scan hwmon for coretemp; fall back to any temp1_input; then thermal zones."""
+# hwmon `name` values that expose a real CPU package temperature at temp1_input.
+# Intel: coretemp. AMD Zen/Zen2/Zen3/Zen4: k10temp (Tctl at temp1_input); zenpower
+# is the out-of-tree equivalent; k8temp covers ancient AMD. A recognized CPU driver
+# MUST win over the generic "first temp1_input" fallback: on desktop boards the
+# first hwmon is often a Super-I/O / NVMe / chipset sensor reading a static value
+# (issue #449 — an AMD 7800X3D board reported a fixed 16.8C because there is no
+# coretemp and the fallback latched a board sensor).
+_CPU_HWMON_NAMES = ("coretemp", "k10temp", "zenpower", "k8temp")
+
+
+def _cpu_thermal_zone(thermal_root):
+    """A thermal_zone/temp whose `type` names the CPU package (x86_pkg_temp, or a
+    type containing cpu/tctl/tdie). More trustworthy than a random hwmon sensor,
+    less so than a recognized CPU hwmon driver. None if none match."""
     try:
-        coretemp_path = None
+        for type_file in sorted(glob.glob(
+                os.path.join(thermal_root, "thermal_zone*", "type"))):
+            try:
+                with open(type_file) as f:
+                    t = f.read().strip().lower()
+            except OSError:
+                continue
+            if ("x86_pkg_temp" in t or "cpu" in t or "tctl" in t or "tdie" in t):
+                temp = os.path.join(os.path.dirname(type_file), "temp")
+                if os.path.exists(temp):
+                    return temp
+    except Exception:
+        pass
+    return None
+
+
+def read_cpu_temp_c(hwmon_root="/sys/class/hwmon", thermal_root="/sys/class/thermal"):
+    """CPU package temperature in °C, or None.
+
+    Preference order, most-specific first, so a static board/NVMe sensor can never
+    shadow the real CPU reading (issue #449):
+      1. a recognized CPU-temp hwmon driver (coretemp / k10temp / zenpower / k8temp),
+      2. an x86_pkg_temp / cpu-typed thermal zone,
+      3. any hwmon temp1_input (last resort — may be a board/NVMe sensor),
+      4. any thermal zone.
+    Roots are parameters purely so a sysfs fixture can exercise the selection."""
+    try:
+        cpu_path = None
         fallback_path = None
-        for name_file in sorted(glob.glob("/sys/class/hwmon/hwmon*/name")):
+        for name_file in sorted(glob.glob(
+                os.path.join(hwmon_root, "hwmon*", "name"))):
             hwmon_dir = os.path.dirname(name_file)
             try:
                 with open(name_file) as f:
@@ -1094,13 +1134,14 @@ def read_cpu_temp_c():
             temp_file = os.path.join(hwmon_dir, "temp1_input")
             if not os.path.exists(temp_file):
                 continue
-            if name == "coretemp" and coretemp_path is None:
-                coretemp_path = temp_file
+            if name in _CPU_HWMON_NAMES and cpu_path is None:
+                cpu_path = temp_file
             if fallback_path is None:
                 fallback_path = temp_file
-        path = coretemp_path or fallback_path
+        path = cpu_path or _cpu_thermal_zone(thermal_root) or fallback_path
         if path is None:
-            for tz in sorted(glob.glob("/sys/class/thermal/thermal_zone*/temp")):
+            for tz in sorted(glob.glob(
+                    os.path.join(thermal_root, "thermal_zone*", "temp"))):
                 path = tz
                 break
         if path is None:

--- a/tests/test_cpu_temp.py
+++ b/tests/test_cpu_temp.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""CPU temperature sensor selection (read_cpu_temp_c).
+
+Run: python3 tests/test_cpu_temp.py
+
+Regression for issue #449: on an AMD 7800X3D board (Gigabyte x870i Pro Ice) the
+reported CPU temp was stuck at 16.8C and never moved. Root cause: the reader only
+recognized Intel's `coretemp`, and on AMD (no coretemp) it fell through to "the
+first hwmon with temp1_input" — which latched a static board/NVMe sensor. AMD Zen
+exposes the real CPU temp via `k10temp` (Tctl at temp1_input), so a recognized CPU
+driver must win over the generic fallback.
+
+Fixtures build a faithful /sys/class/hwmon + /sys/class/thermal tree. The k10temp
+layout (name=k10temp, temp1_input in millidegrees, temp1_label=Tctl) matches real
+Zen hardware; the decoy value/name reproduces the #449 shape (a low, static board
+sensor sorted BEFORE the CPU driver, so the fallback would latch it).
+
+Every test carries a control — an input whose answer is known — and the #449 case
+asserts BOTH that the CPU value is returned AND that the decoy 16.8 is not.
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label +
+          ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+def _mk(root, kind, index, files):
+    """Create <root>/<kind><index>/ with the given {filename: contents}."""
+    d = os.path.join(root, "%s%d" % (kind, index))
+    os.makedirs(d, exist_ok=True)
+    for fn, val in files.items():
+        with open(os.path.join(d, fn), "w") as f:
+            f.write(str(val))
+    return d
+
+
+def _hwmon(root, index, name, temp1_input=None, label=None):
+    files = {"name": name}
+    if temp1_input is not None:
+        files["temp1_input"] = temp1_input
+    if label is not None:
+        files["temp1_label"] = label
+    return _mk(root, "hwmon", index, files)
+
+
+def _zone(root, index, ztype, temp):
+    return _mk(root, "thermal_zone", index, {"type": ztype, "temp": temp})
+
+
+def _roots():
+    base = tempfile.mkdtemp(prefix="cputemp_")
+    h = os.path.join(base, "hwmon")
+    t = os.path.join(base, "thermal")
+    os.makedirs(h)
+    os.makedirs(t)
+    return h, t
+
+
+def test_amd_k10temp_wins_over_board_sensor():
+    """THE #449 control: a decoy board sensor (hwmon0, static 16.8C) sorts before
+    k10temp (hwmon3, 52.0C). The CPU driver must win by NAME, not by scan order."""
+    h, t = _roots()
+    _hwmon(h, 0, "nvme", temp1_input=16800)          # decoy, latches fallback first
+    _hwmon(h, 1, "iwlwifi_1", temp1_input=44000)     # another non-CPU sensor
+    _hwmon(h, 3, "k10temp", temp1_input=52000, label="Tctl")
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got == 52.0, "AMD: k10temp (52.0) wins over first-hwmon decoy", got)
+    check(got != 16.8, "AMD: the static 16.8 board sensor is NOT reported", got)
+
+
+def test_zenpower_recognized():
+    h, t = _roots()
+    _hwmon(h, 0, "nct6798", temp1_input=16800)        # Super-I/O decoy
+    _hwmon(h, 2, "zenpower", temp1_input=61500)
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got == 61.5, "AMD: zenpower recognized as a CPU driver", got)
+
+
+def test_intel_coretemp_still_works():
+    h, t = _roots()
+    _hwmon(h, 0, "acpitz", temp1_input=27000)         # decoy first
+    _hwmon(h, 1, "coretemp", temp1_input=45000)
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got == 45.0, "Intel: coretemp still selected (no regression)", got)
+
+
+def test_cpu_thermal_zone_beats_random_hwmon():
+    """No recognized CPU hwmon driver: a CPU-typed thermal zone must be preferred
+    over a random board hwmon sensor."""
+    h, t = _roots()
+    _hwmon(h, 0, "nvme", temp1_input=39000)           # only a board sensor in hwmon
+    _zone(t, 0, "acpitz", 30000)                      # non-CPU zone, ignored
+    _zone(t, 1, "x86_pkg_temp", 58000)                # the CPU package zone
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got == 58.0, "x86_pkg_temp zone beats a random hwmon sensor", got)
+
+
+def test_fallback_to_board_sensor_when_nothing_better():
+    """No CPU driver and no CPU zone: still return SOMETHING (degrade, not None) so
+    a box we can't classify keeps a reading rather than a blank."""
+    h, t = _roots()
+    _hwmon(h, 0, "nvme", temp1_input=38000)
+    _zone(t, 0, "acpitz", 31000)                      # not CPU-typed
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got == 38.0, "fallback: last-resort hwmon temp1_input still reported", got)
+
+
+def test_none_when_no_sensors():
+    h, t = _roots()
+    got = cs.read_cpu_temp_c(hwmon_root=h, thermal_root=t)
+    check(got is None, "no sensors at all -> None (degrade closed)", got)
+
+
+if __name__ == "__main__":
+    test_amd_k10temp_wins_over_board_sensor()
+    test_zenpower_recognized()
+    test_intel_coretemp_still_works()
+    test_cpu_thermal_zone_beats_random_hwmon()
+    test_fallback_to_board_sensor_when_nothing_better()
+    test_none_when_no_sensors()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all CPU-temp tests passed")


### PR DESCRIPTION
## Problem

Issue #449: on a custom SteamOS build (Gigabyte x870i Pro Ice + AMD Ryzen 7800X3D), the Console's CPU temperature was frozen at **16.8°C** and never moved, while monitoring software on the box showed correct, changing temps.

## Root cause

`read_cpu_temp_c()` scanned hwmon **only for Intel's `coretemp`**. On AMD there is no `coretemp`, so it fell through to *"the first hwmon with `temp1_input`"* — which on a desktop board is typically a Super-I/O / NVMe / chipset sensor that reads a low, static value. That static sensor is what showed 16.8°C.

## Fix

Selection is now, most-specific first:
1. a recognized **CPU-temp hwmon driver** — `coretemp` (Intel) or `k10temp` / `zenpower` / `k8temp` (AMD Zen exposes Tctl at `temp1_input`) — **wins**;
2. an `x86_pkg_temp` / cpu-typed **thermal zone**;
3. any hwmon `temp1_input` (last resort — may be a board sensor);
4. any thermal zone.

`hwmon_root` / `thermal_root` are parameters purely so a sysfs fixture can exercise the selection.

## Tests

`tests/test_cpu_temp.py` (new, wired into CI) builds faithful sysfs fixtures. The **#449 control**: a decoy `nvme`/16.8°C at `hwmon0` (sorts first) + `k10temp`/52°C at `hwmon3` → asserts **52.0 is returned AND 16.8 is not**. Also: `zenpower` recognized, `coretemp` no-regression, cpu-typed thermal zone beats a random hwmon, degrade-to-fallback still returns a value, and no-sensors → `None`.

## Not verified

Not run on the reporter's exact hardware. The `k10temp` `temp1_input`=Tctl layout is standard-kernel but unconfirmed on that specific board — worth asking the reporter to confirm on the next agent build (or to paste `for f in /sys/class/hwmon/hwmon*/name; do echo "$f: $(cat $f)"; done` if it's still wrong).

Agent bumped to 2.9.86 with a matching CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
