### PR TITLE
feat(agent): TLS P1 — optional dark HTTPS/WSS listener + self-signed cert lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,24 @@ jobs:
       - name: Unit tests (remote-desktop portal helper logic)
         run: python3 tests/test_portal_helper_logic.py
 
+      # TLS (P1, dark/additive): the box-side cert lifecycle. Parse degrades
+      # closed (a bad tls block never enables, never raises); the mint carries the
+      # real SANs (IP + .local + loopback, not the ATV DNS:couchside-only); and an
+      # IP-drift re-sign REUSES the key so the SPKI pin is stable while the cert fp
+      # changes — asserted in both directions, since a regression would break every
+      # phone's pin on a subnet move.
+      - name: Unit tests (TLS cert lifecycle)
+        run: python3 tests/test_tls_cert.py
+
+      # TLS (P1): the reachability + auth gate over the ENCRYPTED listener — the
+      # same ping-200 / no-token-401 / token-200 triad CLAUDE.md §4 protects, but
+      # TLS-wrapped via the exact production seam (ssl.wrap_socket the listener,
+      # the hand-rolled Handler serves unchanged). Plus /api/tls/cert (enabled ->
+      # 200+PEM, disabled -> 404) and the decisive control: the advertised fp
+      # equals the fingerprint of the cert the server actually presents.
+      - name: Unit tests (TLS reachability smoke)
+        run: python3 tests/test_tls_smoke.py
+
       # Pairing PIN full-screen launch resolver. A desktop-session box is a system
       # service with a partial env, so a bare xdg-open failed and the PIN never
       # showed (a hard stop for pairing). Pins the browser->--kiosk argv mapping

--- a/agent/README.md
+++ b/agent/README.md
@@ -355,9 +355,26 @@ success, so the app's TV strip can be built without any hardware.
   frame captured to a tmpfs file that is deleted immediately after
   (rate-clamped to ~2/s, 12 MiB cap; client passes no path). The `lines`
   parameter is clamped; errors return brief JSON, never tracebacks.
-- **LAN-only, plain HTTP**: there is no TLS. Keep port 8787 on your local
-  network and do **not** port-forward it. Anyone with the token on your LAN
-  controls the box.
+- **LAN-only, plain HTTP** (TLS is on the roadmap; see below). Today the
+  transport is unencrypted: the bearer token rides HTTP headers and
+  `ws://…?token=` in the clear, so anyone who can *sniff your local network*
+  (a promiscuous device, a compromised switch/AP) can read it and control the
+  box. That is an accepted trade-off **on a home LAN you trust** — the token is
+  the gate and there is no cloud tier to attack.
+
+  > ⚠️ **Do not port-forward Couchside to the internet.** Couchside is built for
+  > a trusted home LAN. Exposing port 8787 (or any Couchside port) publicly is
+  > unsafe: a single bearer token is the only gate, there is no account to lock
+  > and no cloud tier to revoke, and anyone who can reach the port can attempt to
+  > pair. For remote access, use a VPN or Tailscale/WireGuard back to your home
+  > network — **never** a router port-forward.
+
+  **Coming: opt-in TLS.** A dark, additive HTTPS listener (self-signed cert,
+  trusted-on-first-use by a fingerprint you confirm off the box's own screen at
+  pairing — the SSH model) is in progress so the token stops crossing the LAN in
+  the clear. It will not change the port-forward guidance above: TLS protects the
+  wire, it does not make public exposure safe. See
+  `docs/memory/project_tls-encryption.md`.
 
 ## SteamOS vs Bazzite notes
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -54,6 +54,7 @@ XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
 DEFAULT_CONFIG_PATH = "/etc/couchside/config.json"
 DEFAULT_PORT = 8787
+DEFAULT_TLS_PORT = 8788  # HTTPS listener when tls.enabled; plaintext stays on DEFAULT_PORT
 
 # ---------------------------------------------------------------------------
 # Config: watched units + recovery actions
@@ -225,6 +226,7 @@ WATCHLIST_NAMES = {name for name, _scope in WATCHLIST}
 ACTIONS = dict(DEFAULT_ACTIONS)
 ACTION_ORDER = list(DEFAULT_ACTION_ORDER)
 CONFIG_PORT = None  # optional "port" from config.json
+CONFIG_TLS = None  # optional {"enabled","port","cert","key","sans","fp","spki"} TLS block
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
 CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
@@ -583,12 +585,43 @@ def _parse_config(raw):
             roku, androidtv, vidaa, lgcom, guide)
 
 
+def _parse_tls(raw):
+    """Parse+validate the optional top-level "tls" block. Returns a normalized
+    dict ({"enabled": bool, "port": int, ...persisted cert fields}) or None when
+    absent.
+
+    Degrade-closed: any validation failure returns a DISABLED config (or None),
+    never raises. A malformed tls block can neither crash the agent nor silently
+    flip encryption on. cert/key/sans/fp/spki are written by _tls_ensure and
+    round-tripped here — mirrors the androidtv cert-in-config precedent."""
+    tls_raw = raw.get("tls")
+    if tls_raw is None:
+        return None
+    if not isinstance(tls_raw, dict):
+        print("warning: tls must be an object, ignoring", file=sys.stderr, flush=True)
+        return None
+    port = tls_raw.get("port", DEFAULT_TLS_PORT)
+    if isinstance(port, bool) or not isinstance(port, int) or not (1 <= port <= 65535):
+        print("warning: tls.port must be 1..65535, using %d" % DEFAULT_TLS_PORT,
+              file=sys.stderr, flush=True)
+        port = DEFAULT_TLS_PORT
+    out = {"enabled": bool(tls_raw.get("enabled", False)), "port": port}
+    for field in ("cert", "key", "spki", "fp"):
+        val = tls_raw.get(field)
+        if isinstance(val, str) and val:
+            out[field] = val
+    sans = tls_raw.get("sans")
+    if isinstance(sans, list) and all(isinstance(x, str) and x for x in sans):
+        out["sans"] = sans
+    return out
+
+
 def load_config(path):
     """Load config.json into the module globals; fall back to defaults."""
     global WATCHLIST, WATCHLIST_NAMES, ACTIONS, ACTION_ORDER, CONFIG_PORT
     global LAUNCHERS, CONFIG_PATH, CONFIG_PANEL, CONFIG_WEBOS, CONFIG_SAMSUNG
     global CONFIG_ROKU, CONFIG_ANDROIDTV, CONFIG_VIDAA, ALLOW_APP_UPDATE
-    global CONFIG_LGCOM, CONFIG_TV_ACTIVE
+    global CONFIG_LGCOM, CONFIG_TV_ACTIVE, CONFIG_TLS
     global ALLOW_APP_LAUNCHERS, CONFIG_GUIDE
     # ABSOLUTE on purpose: every rewrite derives the temp-file directory from
     # os.path.dirname(CONFIG_PATH), and a relative path has no directory part.
@@ -629,6 +662,7 @@ def load_config(path):
     active = raw.get("tv_active")
     CONFIG_TV_ACTIVE = active if isinstance(active, str) and active else None
     CONFIG_GUIDE = guide
+    CONFIG_TLS = _parse_tls(raw)
     print("config loaded from %s: %d units, %d actions, %d launchers"
           % (path, len(WATCHLIST), len(ACTIONS), len(LAUNCHERS)), flush=True)
 
@@ -18374,6 +18408,7 @@ class Handler(BaseHTTPRequestHandler):
     token_file = None   # path to re-read the current token for /pair
     port = DEFAULT_PORT  # advertised in the pairing deep link
     mock = False
+    tls_info = None     # public TLS bits {cert_pem,fp,spki,port} or None (dark). /api/tls/cert
 
     def log_message(self, fmt, *args):  # route BaseHTTPRequestHandler logs away
         pass
@@ -18624,6 +18659,23 @@ class Handler(BaseHTTPRequestHandler):
                 self._send(200, {"ok": True, "app": APP_NAME,
                                  "version": VERSION, "ip": own_ip,
                                  "host": short_host}, started)
+                return
+
+            if path == "/api/tls/cert":
+                # Pre-auth like /api/ping: the server's cert is PUBLIC — it is what
+                # the TLS handshake presents to anyone who connects anyway. During
+                # pairing the app fetches it to PIN it, having already learned the
+                # fingerprint from the QR/PIN (the trusted, physical-presence
+                # channel), so it verifies SHA-256(cert)==fp before trusting it.
+                # No secret is disclosed. Disabled/dark -> 404 (feature absent).
+                info = self.tls_info
+                if not info:
+                    self._send(404, {"error": "tls not enabled"}, started)
+                    return
+                self._send(200, {"cert": info.get("cert_pem"),
+                                 "fp": info.get("fp"),
+                                 "spki": info.get("spki"),
+                                 "port": info.get("port")}, started)
                 return
 
             if not path.startswith("/api/"):
@@ -21391,6 +21443,213 @@ class Handler(BaseHTTPRequestHandler):
         return True
 
 
+# ---------------------------------------------------------------------------
+# TLS (P1): optional self-signed HTTPS/WSS listener alongside the plaintext one.
+#
+# DARK by default. When config.tls.enabled is true the agent mints (or reuses)
+# a self-signed SERVER cert, serves HTTPS on config.tls.port (default 8788), and
+# leaves the plaintext DEFAULT_PORT listener UNTOUCHED — every shipped app speaks
+# http://, so TLS is strictly additive/negotiated, never a flip (CLAUDE.md §4).
+# Wrapping the listening socket gives HTTP requests, the hand-rolled WS upgrade,
+# and the whole WS frame loop WSS for free: they all ride self.connection, which
+# becomes the accepted SSLSocket. Cert generation shells to `openssl` (stdlib ssl
+# cannot create X.509) using an argv LIST — same in-character shell-out as the
+# Android-TV client-cert path (_atv_generate_cert), never shell=True.
+#
+# Every failure here DEGRADES CLOSED: no cert / no openssl / unwritable config ->
+# HTTPS listener simply does not start, plaintext serving is never affected.
+#
+# Trust anchoring lives on the app side (pin the cert by the SHA-256 fingerprint
+# delivered in the pairing QR/PIN); see docs/memory/project_tls-encryption.md.
+# ---------------------------------------------------------------------------
+
+def _tls_desired_sans():
+    """SANs the server cert must cover: the live LAN IP (the box is usually
+    reached by IP), the .local + bare hostname (mDNS), and loopback (the on-box
+    /pair fetch). De-duped, order preserved."""
+    sans = []
+    ip = _pair_lan_ip()
+    if ip:
+        sans.append("IP:" + ip)
+    short = socket.gethostname().split(".")[0]
+    if short:
+        sans.append("DNS:" + short + ".local")
+        sans.append("DNS:" + short)
+    sans += ["DNS:couchside", "DNS:localhost", "IP:127.0.0.1"]
+    seen = set()
+    out = []
+    for s in sans:
+        if s not in seen:
+            seen.add(s)
+            out.append(s)
+    return out
+
+
+def _tls_generate_server_cert(sans, existing_key_pem=None):
+    """Mint a self-signed SERVER cert via openssl. Returns (cert_pem, key_pem).
+
+    SERVER variant of _atv_generate_cert (:_atv_generate_cert): real SANs
+    (IP + hostnames), a leaf (basicConstraints=CA:FALSE) carrying serverAuth EKU.
+    RSA-2048 to match the PROVEN Android-TV cert shape and keep the app-side pin
+    spike (EC vs RSA, CA:FALSE vs CA:TRUE — see the spec) to one variable at a
+    time. When existing_key_pem is given the key is REUSED so the SPKI hash stays
+    stable across an IP-drift re-sign; otherwise a fresh key is generated. argv is
+    a LIST, never a shell string."""
+    d = tempfile.mkdtemp(prefix="couchside-tls-")
+    cp = os.path.join(d, "server-cert.pem")
+    kp = os.path.join(d, "server-key.pem")
+    argv = ["openssl", "req", "-x509", "-days", "3650", "-nodes",
+            "-subj", "/CN=couchside",
+            "-addext", "subjectAltName=" + ",".join(sans),
+            "-addext", "basicConstraints=CA:FALSE",
+            "-addext", "keyUsage=digitalSignature,keyEncipherment",
+            "-addext", "extendedKeyUsage=serverAuth",
+            "-out", cp]
+    if existing_key_pem:
+        with open(kp, "w") as f:
+            f.write(existing_key_pem)
+        os.chmod(kp, 0o600)
+        argv += ["-key", kp]
+    else:
+        argv += ["-newkey", "rsa:2048", "-keyout", kp]
+    subprocess.run(argv, check=True, capture_output=True)
+    os.chmod(kp, 0o600)
+    with open(cp) as f:
+        cert_pem = f.read()
+    with open(kp) as f:
+        key_pem = f.read()
+    return cert_pem, key_pem
+
+
+def _tls_fp(cert_pem):
+    """SHA-256 of the DER cert (full-cert fingerprint). Pure stdlib. None on fail."""
+    try:
+        return hashlib.sha256(ssl.PEM_cert_to_DER_cert(cert_pem)).hexdigest()
+    except Exception:
+        return None
+
+
+def _tls_spki_fp(cert_path):
+    """SHA-256 of the DER SubjectPublicKeyInfo — STABLE across re-signs that reuse
+    the key, so it is the recommended app pin (a subnet move won't break it).
+    Needs the pubkey DER; openssl extracts it. None on failure (degrade to fp)."""
+    try:
+        r1 = subprocess.run(
+            ["openssl", "x509", "-in", cert_path, "-pubkey", "-noout"],
+            check=True, capture_output=True)
+        r2 = subprocess.run(
+            ["openssl", "pkey", "-pubin", "-outform", "DER"],
+            input=r1.stdout, check=True, capture_output=True)
+        return hashlib.sha256(r2.stdout).hexdigest()
+    except Exception:
+        return None
+
+
+def _tls_materialize(cert_pem, key_pem):
+    """Write cert/key PEM to a fresh temp dir; return (cert_path, key_path).
+    ssl.load_cert_chain needs file paths. Key chmod 0600 (mirrors _atv_write_cert)."""
+    d = tempfile.mkdtemp(prefix="couchside-tls-")
+    cp = os.path.join(d, "cert.pem")
+    kp = os.path.join(d, "key.pem")
+    with open(cp, "w") as f:
+        f.write(cert_pem)
+    with open(kp, "w") as f:
+        f.write(key_pem)
+    os.chmod(kp, 0o600)
+    return cp, kp
+
+
+def _tls_ensure(cfg, persist=True):
+    """Ensure a server cert exists and covers the current LAN IP. Mints on first
+    run, re-signs (reusing the key -> stable SPKI) when a newly-needed SAN appears
+    (IP drift). When persist, writes cert/key/sans/fp/spki back to config.json so
+    the same identity survives a restart. Returns a serve dict
+    {cert_path,key_path,port,fp,spki,cert_pem} or None when TLS is disabled or no
+    cert could be produced (degrade closed -> caller starts no HTTPS listener)."""
+    if not cfg or not cfg.get("enabled"):
+        return None
+    port = cfg.get("port", DEFAULT_TLS_PORT)
+    desired = _tls_desired_sans()
+    cert_pem = cfg.get("cert")
+    key_pem = cfg.get("key")
+    have_sans = cfg.get("sans") or []
+    need_mint = not (cert_pem and key_pem)
+    need_resign = (not need_mint) and any(s not in have_sans for s in desired)
+    try:
+        if need_mint:
+            merged = desired
+            cert_pem, key_pem = _tls_generate_server_cert(merged)
+        elif need_resign:
+            merged = list(have_sans)
+            for s in desired:
+                if s not in merged:
+                    merged.append(s)
+            cert_pem, key_pem = _tls_generate_server_cert(
+                merged, existing_key_pem=key_pem)
+        else:
+            merged = have_sans
+    except Exception as e:
+        print("warning: TLS cert generation failed (%s); HTTPS listener disabled"
+              % e, file=sys.stderr, flush=True)
+        return None
+    cp, kp = _tls_materialize(cert_pem, key_pem)
+    fp = _tls_fp(cert_pem)
+    spki = _tls_spki_fp(cp)
+    if persist and (need_mint or need_resign):
+        new_cfg = {"enabled": True, "port": port, "cert": cert_pem,
+                   "key": key_pem, "sans": merged}
+        if fp:
+            new_cfg["fp"] = fp
+        if spki:
+            new_cfg["spki"] = spki
+        try:
+            with CONFIG_LOCK:
+                _config_set_field("tls", new_cfg)
+            global CONFIG_TLS
+            CONFIG_TLS = new_cfg
+        except Exception as e:
+            print("warning: could not persist TLS cert (%s); using in-memory cert"
+                  % e, file=sys.stderr, flush=True)
+    return {"cert_path": cp, "key_path": kp, "port": port,
+            "fp": fp, "spki": spki, "cert_pem": cert_pem}
+
+
+def _tls_start(host, handler_cls, force_enable=False):
+    """If TLS is enabled, mint/ensure the cert and start an HTTPS
+    BoundedThreadingHTTPServer on its own daemon thread, sharing the same Handler
+    /token/CAPS as the plaintext server. Returns the public serve dict (for
+    Handler.tls_info + the banner) or None. NEVER raises: any failure leaves the
+    plaintext listener serving alone.
+
+    force_enable (the --tls dev/CI flag) enables TLS regardless of config and does
+    NOT persist (an ephemeral cert per boot; SPKI stability is irrelevant there)."""
+    cfg = CONFIG_TLS
+    if force_enable:
+        cfg = dict(cfg or {})
+        cfg["enabled"] = True
+        cfg.setdefault("port", DEFAULT_TLS_PORT)
+    try:
+        info = _tls_ensure(cfg, persist=not force_enable)
+    except Exception as e:
+        print("warning: TLS setup failed (%s); serving plaintext only" % e,
+              file=sys.stderr, flush=True)
+        return None
+    if not info:
+        return None
+    try:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(certfile=info["cert_path"], keyfile=info["key_path"])
+        tls_srv = BoundedThreadingHTTPServer((host, info["port"]), handler_cls)
+        tls_srv.daemon_threads = True
+        tls_srv.socket = ctx.wrap_socket(tls_srv.socket, server_side=True)
+    except Exception as e:
+        print("warning: HTTPS listener on %d failed to start (%s); plaintext only"
+              % (info["port"], e), file=sys.stderr, flush=True)
+        return None
+    threading.Thread(target=tls_srv.serve_forever, daemon=True, name="tls").start()
+    return info
+
+
 class BoundedThreadingHTTPServer(ThreadingHTTPServer):
     """ThreadingHTTPServer with a hard cap on concurrent connections so a
     connection flood cannot exhaust threads/FDs. A non-blocking semaphore is
@@ -21461,6 +21720,9 @@ def main():
                    help="write the stored boot preference and exit (ExecStop hook)")
     p.add_argument("--mock", action="store_true",
                    help="serve fake data, never run real commands")
+    p.add_argument("--tls", action="store_true",
+                   help="force-enable the HTTPS listener (overrides config "
+                        "tls.enabled; ephemeral cert, not persisted; dev/CI)")
     args = p.parse_args()
 
     load_config(args.config)
@@ -21518,9 +21780,20 @@ def main():
         # Same for OpenRGB devices, when an OpenRGB server is present.
         threading.Thread(target=_orgb_restore_worker,
                          daemon=True, name="orgb-restore").start()
+    # Optional HTTPS/WSS listener (dark unless config.tls.enabled or --tls). Shares
+    # this Handler; failures degrade closed and never touch the plaintext server.
+    tls_serve = _tls_start(args.host, Handler, force_enable=args.tls)
+    Handler.tls_info = ({"cert_pem": tls_serve["cert_pem"], "fp": tls_serve["fp"],
+                         "spki": tls_serve["spki"], "port": tls_serve["port"]}
+                        if tls_serve else None)
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)
+    if tls_serve:
+        print("tls: HTTPS on %s:%d  spki=%s" % (
+            args.host, tls_serve["port"], (tls_serve["spki"] or "?")[:16]), flush=True)
+    else:
+        print("tls: disabled (plaintext only)", flush=True)
     info = tv_info()
     print("tv: %s" % ("%s (%s)" % (info["backend"], info["adapter"])
                       if info else "unavailable"), flush=True)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -360,6 +360,55 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 📋 Planned
 
+### TLS / on-wire encryption — stop the LAN sniffing the token (public critique 2026-08-13)
+- **priority:** P2 · **risk:** medium-high (the RN self-signed-trust wall is real; box side
+  is low-risk, app side needs a hand-rolled HTTP/1.1 + RFC6455 client over a raw TLS socket) ·
+  **affects:** agent + app + couchside.tv QR producer · **depends_on:** nothing built; box
+  side (P1–P4) ships without the app; app flip (P5) is gated on the trust app-track.
+- **Origin:** a public critic — *"everything unencrypted, anyone on your home network can
+  hijack it"* — a fair hit. Today the bearer token rides cleartext HTTP headers and
+  `ws://…?token=` query strings on the LAN. **Full spec: `docs/memory/project_tls-encryption.md`.**
+- **Two settled decisions:** (A) TLS is a **transport concern, NOT a capability** — caps are
+  read over the transport (auth-gated `/api/status`), so a cap can't select the *first*
+  scheme; advertise on the pre-auth surface (`/api/ping` + UDP + pair link). No `protocol.json`
+  cap, no six-edit-site drift. (B) **Dual-listen, never flip** — keep 8787 plaintext forever
+  (every shipped app hardcodes `http://`/`ws://`); add HTTPS on a 2nd port as a daemon thread
+  sharing the same `Handler`/token/CAPS. Wrapping the listener socket gives HTTP + the
+  hand-rolled WS upgrade + frame loop WSS for free (all ride `self.connection`).
+- **The wall (why non-trivial):** RN `fetch`/`WebSocket`/`<Image>`/`WebView` expose **no**
+  trust override — self-signed on a LAN IP fails platform trust with no seam.
+  `NSAllowsArbitraryLoads` does NOT trust bad certs; Android needs a build-time trust anchor
+  but the cert is per-box. The one self-signed-capable transport already in the app is
+  `react-native-tcp-socket` (`^6.4.2`, proven on the TV path, [[rn-tcp-socket-tls-truth]]).
+- **Trust model:** route box traffic through rn-tcp-socket TLS, **pin `{ca: box PEM }`**
+  anchored to a SHA-256 fingerprint delivered in the pairing **QR/PIN read off the box's own
+  screen** (physical-access TOFU, SSH host-key model — resists active MITM, not just passive
+  sniffing). Pin on **SPKI** so a subnet-move re-sign (key reused) never breaks the pin.
+- **Cert:** mint via the existing `openssl req -x509` precedent (`_atv_generate_cert`, SERVER
+  variant: SAN=IP+.local, `serverAuth`), store PEM in `/var/lib/couchside/config.json` (agent
+  runs as user, can't write `/etc`) — same cert-in-config pattern the ATV block already uses.
+- **The sharp exception:** the H.264 marquee WebView has **no cert-override hook** for its
+  in-page `wss://`. P1 = swap the token for a single-use **stream ticket** over the pinned
+  control channel (token off the wire; pixels stay cleartext = disclosed residual); P2 =
+  optional frame-bridge via `postMessage` (needs a throughput spike to keep "verified smooth").
+- **Phases:** P1 agent cert+dual-listen (dark) · P2 additive `/api/ping`+UDP+QR advertisement
+  (dark) · P3 app reads/persists pin fields (dark, still http) · P4 installer opt-in enable ·
+  **P5 (gated)** app flips to `https`/`wss` + validates the pin, http fallback never removed.
+  P1–P4 are backward-compat and shippable today; P5 waits on the app trust-track.
+- **✅ P1 BUILT + DARK (2026-08-13, this branch) — agent side, backward-compat, tested.**
+  `agent/couchsided.py` now serves an optional self-signed HTTPS/WSS listener beside plaintext
+  8787 (`tls.enabled` config, or `--tls` for CI). Cert mint (SERVER variant of `_atv_generate_cert`,
+  real SANs), SPKI-stable IP-drift re-sign, persisted to config, pre-auth `GET /api/tls/cert`.
+  Tests: `tests/test_tls_cert.py` + `tests/test_tls_smoke.py` (2 CI steps). Locally smoke-verified
+  on macOS: HTTPS ping/401/authed triad, `/api/tls/cert`, **advertised fp == live-handshake fp**,
+  plaintext still 200, persistence. See BUILD_LOG 2026-08-13.
+- **✅ README port-forward warning SHIPPED** (`agent/README.md` security section — threat rationale,
+  boxed ⚠ warning, VPN/Tailscale guidance).
+- **Next step:** the **device spike** (spike #1) — does `react-native-tcp-socket {ca}` validate
+  this self-signed leaf on iOS + Android RN 0.86, and CA:FALSE vs CA:TRUE? Needs hardware; gates
+  the whole app track (P3/P5). In parallel, box-side P2 (advertise `tls_port`/`fp` on `/api/ping`
+  + UDP + pair link) can land — additive, no app dependency.
+
 ### Apple Watch + desktop widgets — quick actions (owner ask 2026-08-10)
 - **priority:** P2 · **risk:** medium-high (NEW native surfaces: WidgetKit + watchOS;
   App Intents; runs OUTSIDE the RN runtime) · **affects:** app + a native config plugin ·

--- a/docs/memory/project_tls-encryption.md
+++ b/docs/memory/project_tls-encryption.md
@@ -1,0 +1,361 @@
+# Project spec — TLS / on-wire encryption for Couchside
+
+> Status: **🔨 P1 BUILT + DARK (2026-08-13), rest planned.** Box-side HTTPS
+> listener + cert lifecycle + `/api/tls/cert` shipped on the H.264 branch, dark by
+> default, tested (`tests/test_tls_cert.py`, `tests/test_tls_smoke.py`). README
+> port-forward warning shipped. **App track (P3/P5) blocked on the device spike.**
+> Grounded 2026-08-13 by a 5-agent investigation (app transport inventory, agent
+> server surface, protocol/caps/tests impact, trust-model panel, cert-lifecycle
+> panel). Every file:line below was read, not guessed.
+>
+> **P1 as-built notes:** cert shape = RSA-2048, `CA:FALSE` + `serverAuth` (the
+> `CA:TRUE`-vs-`CA:FALSE` question in §3 is deferred to the device spike — trivial
+> re-sign to flip). `--tls` flag force-enables with an ephemeral (non-persisted)
+> cert for CI; real enablement is config-driven and persists. `/api/tls/cert` is
+> PRE-AUTH (cert is public). No cap added (Decision A held).
+>
+> Origin: a public critique ("everything unencrypted, anyone on your home network
+> can hijack it") — a fair hit. Today the bearer token rides cleartext HTTP headers
+> and `ws://…?token=` query strings on the LAN. This spec closes that.
+
+---
+
+## 0. The two load-bearing decisions (settled)
+
+**Decision A — TLS is a transport concern, NOT a capability.**
+Do **not** add a `tls`/`secure`/`https` key to `protocol.json`, the CAPS dict, or
+`BoxCaps`. Caps are read *over* the transport (auth-gated `GET /api/status`,
+`app/lib/api.ts:578`), so a cap can never decide whether the *first* connection is
+`http` vs `https` — chicken-and-egg. Scheme selection must be signalled on the one
+**pre-auth** surface (`/api/ping` + UDP discovery + pair link). A `capabilities.tls`
+flag would add the six-edit-site drift + harness churn + CI parity surface and solve
+nothing the transport layer doesn't already own. Skip it. (If a *post-connect
+informational* cap is ever wanted, the six sites are catalogued in §7 and
+`tests/test_protocol_parity.py` keeps them honest — but it's drift, not need.)
+
+**Decision B — dual-listen, never flip.**
+Keep the plaintext listener on **8787 forever**. Every app already in the wild
+hardcodes `http://`/`ws://` (§2). Add HTTPS/WSS on a **second listener, second port**,
+as its own daemon thread sharing the same `Handler`, token, and CAPS. Additive,
+opt-in, negotiated. A TLS-only flip of 8787 bricks every installed app — non-negotiable
+per CLAUDE.md §4 "never change existing API response shapes / old apps must keep working."
+
+---
+
+## 1. Current state (grounded)
+
+### Box agent (`agent/couchsided.py`, pure stdlib, single file)
+- `import ssl` already present (`:29`); `from http.server import … ThreadingHTTPServer` (`:40`).
+- **Plaintext server**: `BoundedThreadingHTTPServer((args.host, port), Handler)` (`:20365`)
+  → `serve_forever()` (`:20388`). Class at `:20255` overrides only the connection-cap
+  hooks, not `get_request`/`server_bind` — so `get_request()` is the inherited
+  `self.socket.accept()`.
+- **Hand-rolled WebSocket** rides the SAME socket: upgrade writes `101` via
+  `self.connection.sendall` (gamepad `:19466`, screen `:19505`, +2 more `:19650/:19758`);
+  the entire frame loop uses `self.connection` (`_gamepad_session` `:19885`).
+  → **Wrapping the listener socket in TLS gives HTTP + WS-upgrade + frame-loop WSS for
+  free**, because `self.connection` becomes the accepted `SSLSocket`. No per-handler change.
+- **Existing self-signed cert precedent**: `_atv_generate_cert` (`:10587`) shells
+  `openssl req -x509 -newkey rsa:2048 -nodes …` (argv `:10593`); `_atv_write_cert`
+  (`:10607`) materializes PEM → temp files (`load_cert_chain` needs paths), key `chmod 0600`.
+  **This is a CLIENT cert today** (talks TO smart TVs); it proves the mint/store/wrap
+  pattern, not the server intent.
+- **Cert-in-config precedent**: the ATV block persists `{host,cert,key}` PEM *inside*
+  config.json, round-tripped at `:509`. Storing a server cert+key the same way is
+  established, not new.
+- **Ownership**: agent runs as `User=__USER__` (`agent/couchside.service:36`), NOT root.
+  It **cannot write into root-owned `/etc/couchside/`**. Agent-mutated config lives at
+  **`/var/lib/couchside/config.json`** (user-owned dir `chmod 700`, file `chmod 600`,
+  `install.sh:134,983-985,1088-1089`). Token at `/etc/couchside/token` (root dir,
+  chowned to user).
+- **Discovery advertises no scheme, no TLS port**: UDP reply
+  `{couchside,name,host,port,version}` (`:17152`); `GET /api/ping` (pre-auth, `:17611`)
+  → `{ok,app,version,ip,host}` (`:17626`). Both carry `version` (so new apps can gate).
+- **Pair link**: `build_pair_url` (`:16879`) →
+  `https://couchside.tv/pair#host=&port=&token=&ip=` — box params ride the URL **fragment**;
+  that `port` is the plaintext port.
+- **openssl**: assumed present on the cert path (no fallback there); installer treats it
+  as preferred-but-optional (token gen falls back to `secrets`). Degrade-closed: no openssl
+  → leave HTTPS listener down, plaintext unaffected.
+
+### App (Expo SDK 57 / RN 0.86, managed workflow — no `ios/`/`android/` dirs)
+- **Scheme hardcoded at ~11 box call sites**: `baseUrl()` `http://` (`api.ts:1216`);
+  explicit `http://` at `api.ts:1362` (media art), `:1393` (screen frame), `:1638`
+  (unauth PIN pairing); `SettingsContext.tsx:313` + `boxDiscovery.ts:94` (ping/sweep);
+  `<Image>` steam cover `api.ts:2045`; `ws://` gamepad `gamepad.ts:980`, screen
+  `screenstream.ts:96`, and **in-WebView** H.264 `H264DecoderView.tsx:139`.
+- **iOS ATS** (`app.json:11-24`): only `NSAllowsLocalNetworking:true` — permits
+  *cleartext* to LAN IPs; does **nothing** to trust a self-signed HTTPS cert.
+- **Android** (`app.json:53-60`, via `expo-build-properties`):
+  `usesCleartextTraffic:true`; **no `network_security_config.xml`, no trust anchor.**
+- **Native modules present**: `react-native-tcp-socket ^6.4.2` (the ONLY self-signed-TLS-
+  capable transport, used today only for TV control in `app/lib/tvdirect/`),
+  `react-native-webview 13.16.1`, `node-forge ^1.3.1`, `expo-build-properties`.
+  Absent: `react-native-ssl-pinning`, `react-native-webrtc` (stripped on RN 0.86).
+- **Stored box identity** (`Box`, `settings.ts:26-66`): `{id,name,host,port,token,
+  padMode,lastIp?,mac?,volumeTarget?,caps?,lastSeen?}` — **no `secure`/`scheme`/cert-pin
+  field.** Room to add cleanly (the `mac`/`caps` additions are the reference; a plain
+  `Box` field does NOT trigger the six-edit-site rule — that's `BoxCaps`-only).
+- **`PairLink`** (`pairLink.ts:115-121`): `{host,port,token,ip?}` — no scheme/fingerprint.
+
+### THE WALL (why this is hard)
+RN's `fetch()`, WHATWG `WebSocket`, `<Image src>`, and `WebView` all delegate TLS trust
+to the platform and expose **no per-request `rejectUnauthorized`, no CA pin, no
+cert-challenge callback.** A self-signed cert on a bare LAN IP fails the platform trust
+evaluation with **no seam to override it** — this is the absence of an API, not a config
+gap. `NSAllowsArbitraryLoads` only relaxes cleartext + TLS-quality floor; it does **not**
+disable X.509 server-trust (self-signed `https://` still fails). Android needs a
+build-time `network-security-config` trust anchor — but the cert is **per-box, minted at
+install**, so there's nothing to bake. The app's ONE self-signed-capable transport
+(`react-native-tcp-socket.connectTLS`) cannot back `fetch`/`WebSocket`/`<Image>`/`WebView`.
+
+---
+
+## 2. Trust model — the crux (recommended)
+
+**Route all RN-side box traffic through `react-native-tcp-socket` over TLS, pin the
+box's self-signed cert with `{ ca: <box PEM> }`, where the PEM is anchored to the
+SHA-256 fingerprint shown in the pairing QR/PIN.** Over that raw TLS socket, hand-roll
+an HTTP/1.1 client (replaces `fetch`) and an RFC6455 client (replaces `new WebSocket`) —
+mirroring how the agent already hand-rolls its own HTTP server + WS upgrade over one socket.
+
+Why this and not the alternatives:
+
+| Option | iOS | Android | Trust | New native work | Verdict |
+|---|---|---|---|---|---|
+| **A. rn-tcp-socket + hand-rolled HTTP/WS over TLS, `{ca}` pin** | ✅ | ✅ | **pinning** (physical-access TOFU) | none (module present) | **ADOPT** |
+| B. `NSAllowsArbitraryLoads` / cleartext flags | ❌ | ❌ | none — does NOT trust bad certs | plist/NSC | reject |
+| C. Local CA / user installs a profile (mkcert) | ⚠️ brutal | ❌ (Android 7+ ignores user CAs for app traffic) | CA install | profile + NSC | reject (friction) |
+| D. `react-native-ssl-pinning` for fetch | ⚠️ | ⚠️ | pinning, **fetch only** (no WS) | +1 dep | reject (redundant with A) |
+| E. app-layer crypto (Noise/WireGuard) / token-only wrap | — | — | mixed | varies | reject the crypto (stdlib has no X25519/ChaCha; can't roll in pure Python). **Keep one idea: the stream ticket (§4).** |
+
+### The pairing sequence (the trust anchor)
+```
+1. Install:  box mints self-signed cert (SAN=IP + .local), stores PEM,
+             computes fp = SHA-256(DER) and spki = SHA-256(SPKI).
+2. Pair QR:  https://couchside.tv/pair#host=&port=8787&token=&ip=&tlsport=N&fp=<hex>
+             (fp is shown ON THE BOX'S OWN SCREEN — the physical-access anchor)
+3. App:      read fp from QR (trusted channel)
+             GET http://box:8787/api/tls/cert  -> PEM         (plaintext, convenient)
+             assert SHA-256(PEM) == fp                        (detects a swapped PEM)
+             store { secure:true, tlsPort:N, certPin:PEM } on the Box
+4. Connect:  TcpSocket.connectTLS({ host, port:tlsPort, ca: certPin })  -> HARD PIN
+             hand-rolled HTTP/1.1 + RFC6455 ride this socket
+```
+A skeptic accepts this because the trust root is **physical possession of the box at
+pairing** (you read the fingerprint off its screen), not trust-on-first-use over a
+hostile wire. The plaintext PEM fetch is *not* trusted — its integrity is proven by the
+QR-delivered fingerprint. After pairing, `{ca}` pinning means an active MITM presenting
+any other cert is rejected by the TLS stack. That is confidentiality **and** authenticity
+against a hostile LAN — the property bare `rejectUnauthorized:false` (no pin) quietly lacks.
+
+### The `react-native-tcp-socket` `.d.ts` trap (repo lesson [[rn-tcp-socket-tls-truth]])
+- `rejectUnauthorized` is **missing from the TS types** but read by native
+  `ios/TcpSocketClient.m startTLS:` (GCDAsyncSocket manual trust → `completionHandler(YES)`),
+  Android mirrors it. **Verify against native source, not the `.d.ts`.** Pass via a
+  loosely-typed options object, exactly as `app/lib/tvdirect/atvnative.ts:72` already does.
+- `{ ca }` is the **strong mode** (the code calls it "strictly stronger; wins when the
+  caller has one") — library-enforced validation replaces manual fingerprint compare.
+- `getPeerCertificate()` works but is a **device minefield** (why it's the fallback, not
+  primary): `secureConnect` fires on TCP connect not TLS finish (build 122 bug — must
+  poll); native returns `nil` until manual trust evaluated; exposes `{modulus,pubkey}`
+  (better for a public-key pin than whole-cert SHA-256).
+
+---
+
+## 3. Box-side design (cert lifecycle + dual-listen)
+
+### Cert mint (SERVER variant of `_atv_generate_cert`)
+Lazy at startup, only when `config.tls.enabled`. Shell to `openssl`; if absent, log +
+leave HTTPS down (degrade closed). Three deliberate changes vs the ATV client cert:
+real SANs (IP + `.local` + hostname), leaf shape, `serverAuth` EKU.
+
+```python
+argv = ["openssl","req","-x509","-newkey","rsa:2048","-keyout",kp,"-out",cp,
+        "-days","3650","-nodes","-subj","/CN=couchside",
+        "-addext","subjectAltName=IP:<lan-ip>,DNS:<host>.local,DNS:<host>,"
+                  "DNS:couchside,DNS:localhost,IP:127.0.0.1",
+        "-addext","basicConstraints=CA:FALSE",            # ⚠ SPIKE — see below
+        "-addext","keyUsage=digitalSignature,keyEncipherment",
+        "-addext","extendedKeyUsage=serverAuth"]
+# re-sign path: argv[3:6] = ["-key", existing_key_path]  # reuse key → SPKI stable
+```
+> **⚠ OPEN DESIGN POINT (spike #1):** the two design panels disagree on `basicConstraints`.
+> The cert-lifecycle panel wants a proper leaf (`CA:FALSE`+`serverAuth`). The trust-model
+> panel wants `CA:TRUE` to match the *proven* ATV cert shape, arguing
+> `{ca: selfSignedLeaf}` validation is cleaner when the pinned cert is its own anchor.
+> **Resolve on-device**: does `react-native-tcp-socket`'s `{ca}` validate a self-signed
+> `CA:FALSE` leaf, or does it need `CA:TRUE`? Pick whichever actually validates on both
+> iOS + Android, RN 0.86.
+
+Fingerprints are **pure stdlib** (no openssl needed to compute):
+`hashlib.sha256(ssl.PEM_cert_to_DER_cert(cert_pem)).hexdigest()`. **SPKI hash** (stable
+across IP-drift re-signs when the key is reused) is the **recommended app pin**; full-cert
+`fp` is exposed too for display/debug.
+
+### Storage — user-owned state, never `/etc`
+New top-level section in `/var/lib/couchside/config.json`, written by the existing atomic
+writer `_write_config_atomic` (`:655`), parsed alongside the ATV block in `load_config`
+(`:588`). Key `chmod 0600`. Never git, never `/etc`, never world-readable.
+```json
+"tls": { "enabled": false, "port": 8788,
+         "cert": "-----BEGIN CERTIFICATE-----…", "key": "-----BEGIN PRIVATE KEY-----…",
+         "sans": ["IP:10.1.1.235","DNS:box.local","DNS:localhost","IP:127.0.0.1"],
+         "fp": "…sha256(DER)…", "spki": "…sha256(SPKI)…" }
+```
+
+### IP-drift rotation (subnet moves — home 10.1 ↔ work 10.7 per box inventory)
+At startup compute desired SANs from live IP+hostname. If a new IP appeared,
+**re-sign REUSING the stored key** → new cert covers the new IP, `spki` unchanged, `fp`
+changes. Keep old IPs in the SAN set (avoid thrash on ping-pong). **Pin on SPKI** so the
+app's pin survives every subnet move silently; only a lost/reset key rotates SPKI, which
+surfaces as an SSH-style "box identity changed — re-confirm" prompt.
+
+### Dual-listen seam (main(), between `:20365` and `:20388`)
+```python
+server = BoundedThreadingHTTPServer((args.host, port), Handler)   # plaintext, unchanged
+if TLS_ENABLED and _tls_ready():
+    cp, kp = _tls_materialize()                        # PEM -> temp files, key 0600
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER); ctx.load_cert_chain(cp, kp)
+    tls_srv = BoundedThreadingHTTPServer((args.host, CONFIG_TLS_PORT or port+1), Handler)
+    tls_srv.socket = ctx.wrap_socket(tls_srv.socket, server_side=True)
+    threading.Thread(target=tls_srv.serve_forever, daemon=True).start()
+server.serve_forever()                                 # plaintext stays primary
+```
+Same `Handler`/token/CAPS — no state duplication. **Landmine (bounded):** default
+`wrap_socket` does the handshake inside `accept()` on the TLS listener's own thread; a
+stalled/malicious handshake blocks only the TLS accept loop, not plaintext. Deferred-
+handshake hardening (`do_handshake_on_connect=False` via `get_request`/`finish_request`
+override) is a later ticket, noted-not-done.
+
+### Advertisement — additive only (never repurpose `port`)
+Present **only when TLS enabled**:
+- `GET /api/ping` (`:17626`) → add `tls_port`, `tls_fp`, `tls_spki`. Existing keys untouched.
+- UDP reply (`:17152`) → same three. Existing keys untouched.
+- `/pair` page + `build_pair_url` fragment (`:16879`) → add `&tlsport=<n>&fp=<spki>`.
+Old apps ignore unknown keys; new apps gate on presence of `tls_port`.
+
+### New endpoint
+`GET /api/tls/cert` → PEM text (cert is public by nature; can be pre-auth). Needs the
+standard happy-path / auth / unknown-input tests (CLAUDE.md §6).
+
+---
+
+## 4. The four transport planes
+
+| Plane | Today | Under TLS |
+|---|---|---|
+| JSON API + upload (`fetch`) | `http://` | Pinned TLS via rn-tcp-socket + hand-rolled HTTP/1.1. Token only on TLS. |
+| Gamepad WS | `ws://` | Pinned TLS + RFC6455 client. **Latency-sensitive → spike (safety-critical input path).** |
+| Screen MJPEG WS | `ws://` | Pinned TLS + RFC6455 client (RN-side, so it can move). |
+| `<Image>` steam cover | `http://…?token=` | Fetch bytes over the pinned socket → hand `<Image>` a `data:` URI (art frames already do this). Token off the wire. |
+| **H.264 WebView WS** | `ws://` in WebView, `baseUrl:'http://localhost/'` | **EXCEPTION — no cert-override hook inside a WebView.** See below. |
+
+**The H.264 WebView is the sharpest blocker.** `H264DecoderView.tsx:159` deliberately
+sets `baseUrl:'http://localhost/'` because `http://localhost` is a secure context (so
+`VideoDecoder` exists) AND, unlike `https://localhost`, lets an http-origin page open a
+plain `ws://` with no mixed-content block. Moving the in-page `new WebSocket` to
+`wss://<self-signed>` fails cert validation with **no bypass** (WKWebView has no WebSocket
+cert override; `react-native-webview` wires no `onReceivedSslError` accept path).
+- **Phase 1 (ship):** keep plaintext `ws://` but swap the URL's long-lived `token` for a
+  **single-use stream ticket** minted over the pinned control channel. The durable secret
+  never rides cleartext; pixels stay cleartext on the LAN as a **disclosed residual.**
+- **Phase 2 (optional):** bridge decoded frames from an RN-side pinned socket into the
+  WebView via `postMessage` (page opens no socket; localhost secure-context trick still
+  holds) — **only if a throughput spike proves it keeps the "verified smooth" framerate.**
+
+> Token also rides the WS query string on gamepad/screen/h264 today — so token exposure
+> isn't fully closed until those endpoints move to TLS (or the token moves out of the
+> query into a WS subprotocol). Tracked as a P5+ follow-up.
+
+---
+
+## 5. Phased plan
+
+P1–P4 are **box-side, backward-compatible, shippable today.** P1–P3 ship **DARK**
+(`tls.enabled=false`; app persists fields but still connects `http`). P4 is user opt-in.
+The single **flip (P5)** is app-side and **GATED** on the RN self-signed-trust app-track.
+
+| Phase | Ships | Default | Lands | Tests (CLAUDE.md §6) |
+|---|---|---|---|---|
+| **P1** cert lifecycle + dual-listen | agent | dark | `_tls_generate_server_cert`, config `tls` section, SPKI/fp compute, IP-drift re-sign (key reused), 2nd SSL-wrapped listener gated by flag | cert-gen unit (SANs/fp/spki/key-0600); **re-sign-on-IP-change unit** (spki stable, fp changes); **https smoke** (`curl -k` ping-200 / no-token-401 / token-200 on the encrypted listener); **plaintext smoke stays green** |
+| **P2** additive advertisement | agent | dark | `/api/ping` + UDP + `/pair` + `build_pair_url` gain `tls_*` (only when enabled) | **additive-shape assertion** (TLS-off == legacy byte-shape; TLS-on adds only new keys); `/pair` loopback + Host-check still enforced; parity unchanged (no cap) |
+| **P3** app reads/persists (dark) | app | dark (`http`) | `Box`/`Settings`/`PairLink` gain `secure`/`tlsPort`/`certPin`/`fp`; `normalizeBox` round-trips; pair parser reads new fragment keys | **harness: press Connect/pair**, assert fields persist AND app still reaches `--mock` over http (render ≠ test) |
+| **P4** installer/opt-in enable | agent/installer | user opt-in | `couchside tls on` sets `enabled=true`, mints, starts HTTPS listener | boot `enabled:true` mock: both listeners serve; both triads pass in one run |
+| **P5** app flip (GATED) | app | flip-on when pinned | app prefers `https`/`wss` + validates pinned SPKI when box advertises `tls_port`; **http fallback never removed** | harness vs TLS mock; pin-mismatch surfaced, not silently trusted |
+
+**P5 hard dependency (stated, not hand-waved):** the RN trust wall (§1). P5 needs a
+separate app-track deliverable — the hand-rolled HTTP/1.1 + RFC6455 clients over
+`react-native-tcp-socket`, `{ca}` pinning. The box side (P1–P4) is fully valuable without
+it: the day the app-track lands, P5 is a scheme flip with pin data already persisted.
+
+---
+
+## 6. Threat model — honest
+
+**TLS fixes:** passive token theft on the LAN (today the Bearer token is cleartext in
+headers and `ws://…?token=` — a promiscuous roommate device / compromised switch/AP /
+Wireshark reads it and owns the box); replay of a sniffed token; passive capture of screen
+frames + gamepad/trackpad input + media metadata; active tampering after the handshake.
+
+**TLS does NOT fix:** (a) an active MITM on the **very first pairing**, before any
+fingerprint is pinned — the intrinsic TOFU gap; mitigated because the fingerprint travels
+the same channel as the token (the `/pair` QR/PIN on the box's own screen), and an attacker
+who can subvert *that* already has physical/screen access, at which point TLS is moot;
+after first pin, SPKI pinning detects any later substitution (SSH host-key model).
+(b) **Authorization** — TLS is confidentiality/integrity, not a second factor; the single
+bearer token is still the gate. (c) **Identity beyond TOFU** — no CA, no revocation.
+
+**Why self-signed-without-CA is correct (not a compromise):** no public CA will issue for
+RFC1918 IPs or `.local` names — there is no authority for private addresses. A private CA
+on a consumer box is heavier, adds a root-key liability, and is **no more trustworthy**
+than TOFU here, because the real trust root is physical possession of the box at pairing.
+This is exactly the SSH model, the accepted norm for this problem.
+
+**README port-forward warning (drop-in):**
+> ⚠️ **Do not port-forward Couchside to the internet.** Couchside is built for a trusted
+> home LAN. Its TLS (agent X.Y+) encrypts traffic so nobody on your local network can read
+> your access token — but the certificate is **self-signed and trusted on first use** (like
+> SSH), not backed by a public certificate authority. That is safe on a LAN you control,
+> where you confirm the box's fingerprint by reading it off the box's own screen while
+> pairing. It is **not** safe to expose publicly: a single bearer token is the only gate,
+> there is no account to lock and no cloud tier to revoke, and anyone who can reach the port
+> can attempt to pair. For remote access use a VPN or Tailscale/WireGuard back to your home
+> network — **never** a router port-forward.
+
+(Independently: add this warning to the agent README NOW, decoupled from TLS — the critic
+was right that it's a gap, and it's a one-paragraph doc fix.)
+
+---
+
+## 7. If a `tls` cap is ever wanted anyway (six sites, for reference)
+Decision A says don't. But if a post-connect informational cap is later desired, the sites
+are: agent CAPS dict (`couchsided.py:~1635`) + mock tuple (`~1580`); app `BoxCaps`
+(`api.ts:81`) + `normalizeCaps` (`settings.ts:~311`, both the `const` AND the return
+object — the classic silent miss) + `capsEqual` (`api.ts:~1276`); `protocol.json` `keys[]`
+cross-platform group (`:164-174`). `tests/test_protocol_parity.py` auto-enforces all six.
+
+## 8. Spikes-before-trust (nothing here is settled by reading code)
+1. **`{ca: <self-signed cert>}` actually validates the box peer** on iOS + Android, RN 0.86
+   — and resolves the `CA:TRUE` vs `CA:FALSE` question (§3). Fallback: `getPeerCertificate`
+   key-pin.
+2. **Hand-rolled RFC6455 client latency on the gamepad path** matches native `WebSocket`
+   (safety-critical, most-concurrent code → create→hold→hand-off→reap lifecycle test, not
+   a happy-path demo).
+3. **`getPeerCertificate` fallback** reliably returns the cert on both platforms after the
+   polling fix (prove before depending on it).
+4. **H.264 frame-bridge throughput** (Phase 2 only) — `postMessage` bitstream into the
+   WebView at the marquee framerate without regressing "verified smooth."
+5. **QR density** — pair link + `fp` (or inline PEM ~500B) scans reliably full-screen off the box.
+6. **Agent handshake-on-accept serialization** under concurrent-connect load; defer-to-worker if it stalls.
+
+Per CLAUDE.md §11: the PR body states each of these as NOT-yet-verified. No "should work."
+
+## 9. Effort (rough)
+Agent P1–P2: ~1–2 days (mostly precedent). App track (P3 + the hand-rolled HTTP/1.1 +
+RFC6455 clients for P5): ~1–2 weeks incl. spikes. The README port-forward warning: minutes,
+ship it independently now.
+
+## Related memory
+[[rn-tcp-socket-tls-truth]] · [[native-serverTrust-tv-unlock]] · [[h264-tier-webcodecs-not-webrtc]]
+· [[remote-desktop-and-screen-capture]] · [[security-audit-status]] · [[androidtv-app-direct-proven]]

--- a/tests/test_tls_cert.py
+++ b/tests/test_tls_cert.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Tests for the box-side TLS cert lifecycle (P1): parse, mint, re-sign, pin.
+
+Run: python3 tests/test_tls_cert.py
+
+TLS is a DARK, additive transport (see docs/memory/project_tls-encryption.md):
+the agent keeps its plaintext listener and, when tls.enabled, serves HTTPS on a
+second port with a self-signed cert it mints via openssl. These are the unit
+checks for the cert plumbing that does NOT need a live socket (the live handshake
++ auth gate over TLS is test_tls_smoke.py).
+
+Load-bearing property proven here: an IP-drift RE-SIGN reuses the private key, so
+the SPKI hash (the recommended app pin) is STABLE while the full-cert fingerprint
+changes. If that ever regressed, every phone's pin would break on a subnet move —
+so it is asserted in BOTH directions (spki same, fp different), not just one.
+
+Degrade-closed is proven too: a malformed tls block yields a disabled/None config
+rather than raising, so a bad field can neither crash the agent nor silently flip
+encryption on.
+
+Pure stdlib, no pytest -- same style as the other agent tests.
+"""
+import hashlib
+import importlib.util
+import os
+import ssl
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label +
+          ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+def _spki(cert_pem):
+    d = tempfile.mkdtemp(prefix="tlst_")
+    p = os.path.join(d, "c.pem")
+    with open(p, "w") as f:
+        f.write(cert_pem)
+    return cs._tls_spki_fp(p)
+
+
+def _san(cert_pem):
+    """SubjectAltName strings from a PEM, via the same openssl the agent assumes."""
+    import subprocess
+    d = tempfile.mkdtemp(prefix="tlss_")
+    p = os.path.join(d, "c.pem")
+    with open(p, "w") as f:
+        f.write(cert_pem)
+    r = subprocess.run(["openssl", "x509", "-in", p, "-noout", "-ext",
+                        "subjectAltName"], capture_output=True, text=True)
+    return r.stdout
+
+
+def test_parse_tls():
+    # absent -> None
+    check(cs._parse_tls({}) is None, "no tls block -> None")
+    # enabled + explicit port
+    got = cs._parse_tls({"tls": {"enabled": True, "port": 9443}})
+    check(got == {"enabled": True, "port": 9443}, "enabled+port parsed", got)
+    # default port when omitted
+    got = cs._parse_tls({"tls": {"enabled": True}})
+    check(got and got["port"] == cs.DEFAULT_TLS_PORT,
+          "default port applied", got)
+    # enabled defaults false
+    got = cs._parse_tls({"tls": {}})
+    check(got == {"enabled": False, "port": cs.DEFAULT_TLS_PORT},
+          "enabled defaults False", got)
+    # DEGRADE CLOSED: bad types never raise, never enable
+    check(cs._parse_tls({"tls": 5}) is None, "non-dict tls -> None (no raise)")
+    got = cs._parse_tls({"tls": {"enabled": True, "port": "nope"}})
+    check(got and got["port"] == cs.DEFAULT_TLS_PORT,
+          "bad port falls back to default (no raise)", got)
+    got = cs._parse_tls({"tls": {"enabled": True, "port": True}})
+    check(got and got["port"] == cs.DEFAULT_TLS_PORT,
+          "bool port rejected (bool is not a valid port)", got)
+    # cert/key/sans round-trip
+    got = cs._parse_tls({"tls": {"enabled": True, "cert": "C", "key": "K",
+                                 "sans": ["IP:1.2.3.4"], "fp": "ff"}})
+    check(got.get("cert") == "C" and got.get("key") == "K"
+          and got.get("sans") == ["IP:1.2.3.4"] and got.get("fp") == "ff",
+          "cert/key/sans/fp round-trip", got)
+    # a non-string sans list is dropped, not crashed
+    got = cs._parse_tls({"tls": {"enabled": True, "sans": [1, 2]}})
+    check("sans" not in got, "invalid sans dropped", got)
+
+
+def test_desired_sans():
+    sans = cs._tls_desired_sans()
+    check("DNS:localhost" in sans and "IP:127.0.0.1" in sans,
+          "desired SANs cover loopback", sans)
+    check("DNS:couchside" in sans, "desired SANs include couchside", sans)
+    # the .local hostname is present (mDNS reachability)
+    check(any(s.startswith("DNS:") and s.endswith(".local") for s in sans),
+          "desired SANs include a .local hostname", sans)
+
+
+def test_mint_and_fingerprints():
+    sans = ["IP:10.0.0.5", "DNS:box.local", "DNS:localhost", "IP:127.0.0.1"]
+    cert_pem, key_pem = cs._tls_generate_server_cert(sans)
+    check(cert_pem.startswith("-----BEGIN CERTIFICATE-----"), "cert is PEM")
+    check("PRIVATE KEY" in key_pem, "key is PEM")
+    # the cert actually carries the SANs we asked for (the DNS:couchside-only bug
+    # the ATV precedent would have shipped is what this guards against)
+    san_txt = _san(cert_pem)
+    check("10.0.0.5" in san_txt and "box.local" in san_txt
+          and "127.0.0.1" in san_txt, "cert SAN carries IP + .local + loopback",
+          san_txt.strip())
+    # fingerprints are real 64-hex
+    fp = cs._tls_fp(cert_pem)
+    spki = _spki(cert_pem)
+    check(isinstance(fp, str) and len(fp) == 64, "fp is 64-hex sha256", fp)
+    check(isinstance(spki, str) and len(spki) == 64, "spki is 64-hex sha256", spki)
+    # fp is the DER-cert sha256 (independent recompute)
+    der = ssl.PEM_cert_to_DER_cert(cert_pem)
+    check(fp == hashlib.sha256(der).hexdigest(), "fp == sha256(DER cert)")
+    # the cert loads as a servable chain (would raise if malformed)
+    d = tempfile.mkdtemp(prefix="tlsl_")
+    cp, kp = os.path.join(d, "c"), os.path.join(d, "k")
+    open(cp, "w").write(cert_pem)
+    open(kp, "w").write(key_pem)
+    ok = True
+    try:
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ctx.load_cert_chain(cp, kp)
+    except Exception as e:
+        ok = False
+        detail = e
+    check(ok, "cert+key load as a TLS_SERVER chain",
+          "" if ok else detail)
+
+
+def test_resign_reuses_key_spki_stable():
+    """IP drift: re-sign with a new SAN reusing the key. SPKI (the pin) must be
+    stable; the full-cert fp must change; the key bytes must be identical."""
+    c1, k1 = cs._tls_generate_server_cert(["DNS:localhost", "IP:127.0.0.1"])
+    c2, k2 = cs._tls_generate_server_cert(
+        ["DNS:localhost", "IP:127.0.0.1", "IP:10.9.9.9"], existing_key_pem=k1)
+    check(k1 == k2, "re-sign reused the private key verbatim")
+    check(_spki(c1) == _spki(c2), "SPKI STABLE across re-sign (pin survives)")
+    check(cs._tls_fp(c1) != cs._tls_fp(c2), "full-cert fp CHANGED across re-sign")
+    check("10.9.9.9" in _san(c2), "re-signed cert carries the new IP SAN")
+
+
+def test_materialize_key_perms():
+    cp, kp = cs._tls_materialize("CERTPEM", "KEYPEM")
+    mode = oct(os.stat(kp).st_mode & 0o777)
+    check(mode == "0o600", "materialized key is chmod 0600", mode)
+    check(open(cp).read() == "CERTPEM" and open(kp).read() == "KEYPEM",
+          "materialized files hold the PEM")
+
+
+def test_ensure_disabled_returns_none():
+    check(cs._tls_ensure(None) is None, "ensure(None) -> None")
+    check(cs._tls_ensure({"enabled": False}) is None, "ensure(disabled) -> None")
+
+
+if __name__ == "__main__":
+    test_parse_tls()
+    test_desired_sans()
+    test_mint_and_fingerprints()
+    test_resign_reuses_key_spki_stable()
+    test_materialize_key_perms()
+    test_ensure_disabled_returns_none()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all TLS cert-lifecycle tests passed")

--- a/tests/test_tls_smoke.py
+++ b/tests/test_tls_smoke.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""HTTPS/WSS reachability + auth-gate smoke over the real TLS wrap seam (P1).
+
+Run: python3 tests/test_tls_smoke.py
+
+CLAUDE.md §4 protects reachability: /api/ping, /api/status and the auth gate are
+smoke-tested on every push. This is the ENCRYPTED-listener half of that gate — it
+proves the same triad (ping 200 / no-token 401 / token 200) holds when the socket
+is TLS-wrapped, using the exact production path: cs._tls_ensure() mints the cert,
+the listener socket is ssl.wrap_socket'd, and the hand-rolled Handler serves over
+it unchanged (HTTP requests and, by the same socket, the WS upgrade).
+
+Also covers the new /api/tls/cert endpoint per CLAUDE.md §6:
+  * happy path  : enabled -> 200 with cert + fp + spki
+  * "auth"/gate : disabled (tls_info None) -> 404, feature absent
+  * the DECISIVE control: the advertised fp equals the fingerprint of the cert
+    the server ACTUALLY presents in the live handshake — i.e. the pin the app
+    would store is the pin it would validate against. Observed in both states.
+
+Pure stdlib, no pytest.
+"""
+import hashlib
+import http.client
+import importlib.util
+import json
+import os
+import ssl
+import threading
+from http.server import ThreadingHTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+TOKEN = "test-secret-token"
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label +
+          ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+class _QuietServer(ThreadingHTTPServer):
+    """A smoke test opens and drops sockets deliberately (a bare handshake to read
+    the peer cert; abrupt closes). Those surface as ConnectionReset/SSL errors in
+    the worker thread, which stock ThreadingHTTPServer prints as a scary traceback.
+    Swallow only that expected noise; anything else still bubbles up."""
+
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        import sys
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionError, ssl.SSLError, OSError)):
+            return
+        super().handle_error(request, client_address)
+
+
+def _tls_server():
+    """Start an HTTPS Handler exactly as main() does: ensure a cert, wrap the
+    listening socket, serve on a thread. Returns (srv, port, info)."""
+    info = cs._tls_ensure({"enabled": True, "port": 0}, persist=False)
+    assert info, "cert ensure failed"
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=info["cert_path"], keyfile=info["key_path"])
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True
+    cs.Handler.port = 0
+    cs.Handler.tls_info = {"cert_pem": info["cert_pem"], "fp": info["fp"],
+                           "spki": info["spki"], "port": info["port"]}
+    srv = _QuietServer(("127.0.0.1", 0), cs.Handler)
+    srv.socket = ctx.wrap_socket(srv.socket, server_side=True)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1], info
+
+
+def _https(port, method, path, token=TOKEN):
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE   # self-signed: the app pins by fp instead
+    conn = http.client.HTTPSConnection("127.0.0.1", port, timeout=10, context=ctx)
+    headers = {"Authorization": "Bearer " + token} if token is not None else {}
+    headers["Connection"] = "close"   # no keep-alive reader left blocking at shutdown
+    conn.request(method, path, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(data or b"{}")
+    except ValueError:
+        return resp.status, {}
+
+
+def _live_cert_fp(port):
+    """SHA-256 of the DER cert the server presents in the actual handshake."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    with ctx.wrap_socket(__import__("socket").create_connection(("127.0.0.1", port),
+                         timeout=10), server_hostname="couchside") as s:
+        der = s.getpeercert(binary_form=True)
+    return hashlib.sha256(der).hexdigest()
+
+
+def test_https_reachability_and_gate():
+    srv, port, info = _tls_server()
+    try:
+        st, body = _https(port, "GET", "/api/ping")
+        check(st == 200 and body.get("ok") is True, "HTTPS /api/ping -> 200 ok",
+              (st, body))
+        st, _ = _https(port, "GET", "/api/status", token=None)
+        check(st == 401, "HTTPS /api/status no-token -> 401 (gate holds on TLS)", st)
+        st, _ = _https(port, "GET", "/api/status", token="wrong")
+        check(st == 401, "HTTPS /api/status wrong-token -> 401", st)
+        st, body = _https(port, "GET", "/api/status")
+        check(st == 200, "HTTPS /api/status good-token -> 200", (st, body))
+
+        # /api/tls/cert happy path
+        st, body = _https(port, "GET", "/api/tls/cert")
+        check(st == 200 and body.get("cert", "").startswith(
+              "-----BEGIN CERTIFICATE-----"), "GET /api/tls/cert -> 200 + PEM", st)
+        check(len(body.get("fp", "")) == 64 and len(body.get("spki", "")) == 64,
+              "/api/tls/cert returns fp + spki", body.get("fp"))
+
+        # THE CONTROL: advertised fp == the cert actually served in the handshake
+        live = _live_cert_fp(port)
+        check(body.get("fp") == live,
+              "advertised fp == live handshake cert fp (pin is validatable)",
+              (body.get("fp"), live))
+    finally:
+        srv.shutdown()
+
+
+def test_tls_cert_404_when_disabled():
+    """Same route, tls_info None -> 404 (feature absent). Plaintext server here so
+    the 'disabled' state is unambiguous."""
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True
+    cs.Handler.tls_info = None
+    srv = _QuietServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    port = srv.server_address[1]
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request("GET", "/api/tls/cert", headers={"Connection": "close"})
+        st = conn.getresponse().status
+        conn.close()
+        check(st == 404, "GET /api/tls/cert -> 404 when TLS disabled", st)
+        # and the plaintext listener still answers ping (dual-listen, no flip)
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+        conn.request("GET", "/api/ping", headers={"Connection": "close"})
+        st = conn.getresponse().status
+        conn.close()
+        check(st == 200, "plaintext /api/ping still 200 (backward compat)", st)
+    finally:
+        srv.shutdown()
+
+
+if __name__ == "__main__":
+    test_https_reachability_and_gate()
+    test_tls_cert_404_when_disabled()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all TLS smoke tests passed")


### PR DESCRIPTION
Box-side half of on-wire encryption — the answer to the recurring "everything is unencrypted, anyone on your LAN can sniff the token" critique. **P1 of a phased plan; ships DARK.**

## What this is (and isn't)

**DARK by default.** Unless `config.tls.enabled` (or the `--tls` dev flag), nothing changes and plaintext `8787` is untouched — every shipped app keeps working. This is strictly additive; **no existing API response shape changes**, and TLS is a **transport concern, not a capability** (no `protocol.json` / CAPS edit).

**This is the box side only.** The RN app cannot yet *use* TLS — `fetch`/`WebSocket` expose no self-signed trust override, so the app-side trust track (pin the cert via `react-native-tcp-socket` `{ca}` + a hand-rolled HTTP/WS client, anchored to a fingerprint from the pairing QR) is **device-spike-gated and NOT in this PR**. Full plan: `docs/memory/project_tls-encryption.md`.

## Mechanism

- **Dual-listen, never flip.** A second `BoundedThreadingHTTPServer` on `tls.port` (default `8788`), its listening socket `ssl.wrap_socket`'d, sharing the same `Handler`/token/CAPS. The hand-rolled WS upgrade + frame loop ride `self.connection`, so **WSS comes free** with no per-handler change.
- **Cert lifecycle.** `_tls_generate_server_cert` is the SERVER variant of the existing `_atv_generate_cert` (openssl **argv LIST**, never a shell string): real SANs (`IP:` + `.local` + loopback), `serverAuth` leaf. Re-signs on IP drift **reusing the key**, so the SPKI hash (the app's pin) stays stable across a subnet move. Persisted as PEM in the user-owned `/var/lib/couchside/config.json` (the agent runs as the user, can't write `/etc`).
- **Degrades closed.** No `openssl`, bad `tls` block, unwritable config → HTTPS listener simply doesn't start; plaintext is never affected. A malformed `tls` config never raises and never silently enables encryption.
- **`GET /api/tls/cert`** (pre-auth — the cert is public, it's what the handshake presents anyway) returns the PEM + `fp` + `spki` so the app can pin it. `404` when dark.

## Tests (both wired into CI)

- `tests/test_tls_cert.py` — parse degrades closed, mint carries real SANs (not the ATV `DNS:couchside`-only), IP-drift re-sign keeps **SPKI stable while the cert fp changes** (asserted both directions), materialized key is `0600`.
- `tests/test_tls_smoke.py` — over the **real wrap seam**: HTTPS `/api/ping`→200, no-token→**401**, token→200; `/api/tls/cert` 200-with-PEM / 404-when-dark; and the decisive control — **the advertised `fp` equals the fingerprint of the cert the server actually presents in the live handshake**.

Verified locally on macOS (openssl 3.6): the HTTPS triad, the fp==live-handshake control, plaintext `8787` still serving (dual-listen, no flip), and config persistence. Rebased onto current `main` (agent 2.9.86); VERSION intentionally **not** bumped (dark, no user-visible change → no changelog gate).

## Not verified

The app-side `{ca}` self-signed validation on iOS + Android RN 0.86 (CA:FALSE vs CA:TRUE) is the open device spike that gates the whole app track. This PR is safe to merge without it — it's off by default and box-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
