### PR TITLE
feat(agent): TLS P2 — advertise HTTPS listener additively (dark)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,14 @@ jobs:
       - name: Unit tests (TLS reachability smoke)
         run: python3 tests/test_tls_smoke.py
 
+      # TLS (P2): availability is advertised on the three pre-auth surfaces a
+      # TLS-aware app can reach (GET /api/ping, the UDP discovery reply, the
+      # pairing QR). The load-bearing assertion is the additive control — when TLS
+      # is dark the bytes are exactly today's, and when enabled the tls_* fields
+      # are the ONLY difference — so an old app keeps working (CLAUDE.md §4).
+      - name: Unit tests (TLS availability advertisement)
+        run: python3 tests/test_tls_advertise.py
+
       # Pairing PIN full-screen launch resolver. A desktop-session box is a system
       # service with a partial env, so a bare xdg-open failed and the PIN never
       # showed (a hard stop for pairing). Pins the browser->--kiosk argv mapping

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -227,6 +227,10 @@ ACTIONS = dict(DEFAULT_ACTIONS)
 ACTION_ORDER = list(DEFAULT_ACTION_ORDER)
 CONFIG_PORT = None  # optional "port" from config.json
 CONFIG_TLS = None  # optional {"enabled","port","cert","key","sans","fp","spki"} TLS block
+TLS_ADVERT = None  # public TLS advert {"port","fp","spki"} or None (dark). Set by main()
+                   # after _tls_start; read by the UDP discovery reply + build_pair_url so
+                   # a future app can DISCOVER the HTTPS listener + pin fingerprint. Never
+                   # a secret (the cert is what the handshake presents anyway).
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
 CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
@@ -17913,6 +17917,16 @@ def build_pair_url(token, port):
     ip = _pair_lan_ip()
     if ip:
         url += "&ip=" + quote(ip, safe="")
+    # When the optional HTTPS listener is up, carry its port + the cert
+    # fingerprint in the QR fragment so the app can pin the box's self-signed
+    # cert at pairing (physical-presence trust anchor: the fp is read off the
+    # box's own screen). Appended only when TLS is enabled -> the plaintext-only
+    # pairing link is unchanged. port= stays the plaintext port for compat.
+    adv = TLS_ADVERT
+    if adv and adv.get("port"):
+        url += "&tlsport=%d" % adv["port"]
+        if adv.get("fp"):
+            url += "&fp=" + quote(adv["fp"], safe="")
     return url
 
 
@@ -18162,6 +18176,26 @@ def render_pin_page(pin):
 COUCHSIDE_DISCOVER_MAGIC = b"COUCHSIDE_DISCOVER?"
 
 
+def _discovery_reply(port):
+    """The dict a discovery probe gets back. Existing keys first, in the order
+    every shipped app already parses; the optional TLS advert is appended ONLY
+    when the HTTPS listener is up, so the dark reply is byte-for-byte unchanged.
+    Pure (reads the TLS_ADVERT module global) so the both-states byte-identity is
+    unit-testable without a socket."""
+    short = socket.gethostname().split(".")[0] or "couchside"
+    payload = {"couchside": True, "name": short,
+               "host": short + ".local", "port": port,
+               "version": VERSION}
+    adv = TLS_ADVERT
+    if adv and adv.get("port"):
+        payload["tls_port"] = adv["port"]
+        if adv.get("fp"):
+            payload["tls_fp"] = adv["fp"]
+        if adv.get("spki"):
+            payload["tls_spki"] = adv["spki"]
+    return payload
+
+
 def _udp_discovery_responder(port):
     """Answer LAN discovery probes on UDP <port>. Best-effort daemon; a bind
     failure just disables discovery (the app can still add a box by IP)."""
@@ -18180,10 +18214,7 @@ def _udp_discovery_responder(port):
             continue
         if not data.startswith(COUCHSIDE_DISCOVER_MAGIC):
             continue
-        short = socket.gethostname().split(".")[0] or "couchside"
-        reply = json.dumps({"couchside": True, "name": short,
-                            "host": short + ".local", "port": port,
-                            "version": VERSION}).encode()
+        reply = json.dumps(_discovery_reply(port)).encode()
         try:
             s.sendto(reply, addr)
         except OSError:
@@ -18656,9 +18687,21 @@ class Handler(BaseHTTPRequestHandler):
                 except OSError:
                     own_ip = None
                 short_host = socket.gethostname().split(".")[0] or None
-                self._send(200, {"ok": True, "app": APP_NAME,
-                                 "version": VERSION, "ip": own_ip,
-                                 "host": short_host}, started)
+                resp = {"ok": True, "app": APP_NAME,
+                        "version": VERSION, "ip": own_ip,
+                        "host": short_host}
+                # Advertise the optional HTTPS listener so a TLS-aware app can
+                # discover it (and the fingerprint to pin) over the plaintext
+                # channel it already uses. Appended AFTER the existing keys and
+                # ONLY when TLS is enabled -> the dark payload is byte-unchanged.
+                info = self.tls_info
+                if info and info.get("port"):
+                    resp["tls_port"] = info["port"]
+                    if info.get("fp"):
+                        resp["tls_fp"] = info["fp"]
+                    if info.get("spki"):
+                        resp["tls_spki"] = info["spki"]
+                self._send(200, resp, started)
                 return
 
             if path == "/api/tls/cert":
@@ -21786,6 +21829,12 @@ def main():
     Handler.tls_info = ({"cert_pem": tls_serve["cert_pem"], "fp": tls_serve["fp"],
                          "spki": tls_serve["spki"], "port": tls_serve["port"]}
                         if tls_serve else None)
+    # Public advert bits (no cert PEM) for the surfaces that have no Handler in hand:
+    # the UDP discovery reply and build_pair_url read this module global. Stays None
+    # while TLS is dark, so those payloads/URLs are byte-for-byte unchanged.
+    global TLS_ADVERT
+    TLS_ADVERT = ({"port": tls_serve["port"], "fp": tls_serve["fp"],
+                   "spki": tls_serve["spki"]} if tls_serve else None)
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -404,10 +404,16 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   plaintext still 200, persistence. See BUILD_LOG 2026-08-13.
 - **✅ README port-forward warning SHIPPED** (`agent/README.md` security section — threat rationale,
   boxed ⚠ warning, VPN/Tailscale guidance).
+- **✅ P2 BUILT + DARK (2026-08-13, `feat/agent-tls-p2`) — additive advertisement, agent side.**
+  `/api/ping` + the UDP discovery reply + `build_pair_url` gain `tls_port`/`tls_fp`/`tls_spki`
+  (QR carries `tlsport`+`fp`) **only when TLS is enabled**; dark payloads stay byte-identical.
+  `TLS_ADVERT` global + `_discovery_reply()` helper. Test `tests/test_tls_advertise.py` (3rd CI
+  step): additive-shape control on all 3 surfaces + degrade-closed, proven in-process AND live
+  (`--tls` vs not, ping + UDP round-trip both states). No cap → parity unchanged.
 - **Next step:** the **device spike** (spike #1) — does `react-native-tcp-socket {ca}` validate
   this self-signed leaf on iOS + Android RN 0.86, and CA:FALSE vs CA:TRUE? Needs hardware; gates
-  the whole app track (P3/P5). In parallel, box-side P2 (advertise `tls_port`/`fp` on `/api/ping`
-  + UDP + pair link) can land — additive, no app dependency.
+  the whole app track (P3/P5). Box-side P1+P2 now complete — the app track is the only remaining
+  box-independent-blocked work.
 
 ### Apple Watch + desktop widgets — quick actions (owner ask 2026-08-10)
 - **priority:** P2 · **risk:** medium-high (NEW native surfaces: WidgetKit + watchOS;

--- a/docs/memory/project_tls-encryption.md
+++ b/docs/memory/project_tls-encryption.md
@@ -1,9 +1,12 @@
 # Project spec — TLS / on-wire encryption for Couchside
 
-> Status: **🔨 P1 BUILT + DARK (2026-08-13), rest planned.** Box-side HTTPS
-> listener + cert lifecycle + `/api/tls/cert` shipped on the H.264 branch, dark by
-> default, tested (`tests/test_tls_cert.py`, `tests/test_tls_smoke.py`). README
-> port-forward warning shipped. **App track (P3/P5) blocked on the device spike.**
+> Status: **🔨 P1 + P2 BUILT + DARK (2026-08-13), rest planned.** Box-side HTTPS
+> listener + cert lifecycle + `/api/tls/cert` (P1, merged `ea43155`/#454), plus the
+> additive availability advertisement (P2, branch `feat/agent-tls-p2`): `/api/ping`
+> + the UDP discovery reply + `build_pair_url` gain `tls_*` fields **only when TLS is
+> enabled** — dark payloads stay byte-identical. Dark by default, tested
+> (`tests/test_tls_cert.py`, `tests/test_tls_smoke.py`, `tests/test_tls_advertise.py`).
+> README port-forward warning shipped. **App track (P3/P5) blocked on the device spike.**
 > Grounded 2026-08-13 by a 5-agent investigation (app transport inventory, agent
 > server surface, protocol/caps/tests impact, trust-model panel, cert-lifecycle
 > panel). Every file:line below was read, not guessed.
@@ -232,8 +235,19 @@ override) is a later ticket, noted-not-done.
 Present **only when TLS enabled**:
 - `GET /api/ping` (`:17626`) → add `tls_port`, `tls_fp`, `tls_spki`. Existing keys untouched.
 - UDP reply (`:17152`) → same three. Existing keys untouched.
-- `/pair` page + `build_pair_url` fragment (`:16879`) → add `&tlsport=<n>&fp=<spki>`.
+- `/pair` page + `build_pair_url` fragment (`:16879`) → add `&tlsport=<n>&fp=<hex>`.
 Old apps ignore unknown keys; new apps gate on presence of `tls_port`.
+
+**BUILT (P2, `feat/agent-tls-p2`).** `TLS_ADVERT` module global (`{port,fp,spki}` or None)
+is set by `main()` right after `_tls_start`; `_discovery_reply()` and `build_pair_url()`
+read it, `/api/ping` reads the equivalent `Handler.tls_info`. The QR carries `fp` = the
+**DER cert fingerprint** (`_tls_fp`, the same value `/api/tls/cert` returns and the P1
+smoke test pins), NOT the SPKI — resolves the earlier `fp=<spki>` line here: the QR fp is a
+pairing-time integrity check on the fetched PEM (`SHA-256(PEM)==fp`), and the box re-fetches
+the PEM on any re-sign, so the *stable* SPKI pin is not needed in the one-shot QR. `spki` is
+still advertised on `/api/ping` + UDP for an app that wants the stable pin. Additive control
+proven in `test_tls_advertise.py` (dark == legacy bytes; enabled adds only `tls_*`) AND live
+(agent `--tls` vs not: ping + UDP round-trip, both states).
 
 ### New endpoint
 `GET /api/tls/cert` → PEM text (cert is public by nature; can be pre-auth). Needs the
@@ -279,7 +293,7 @@ The single **flip (P5)** is app-side and **GATED** on the RN self-signed-trust a
 | Phase | Ships | Default | Lands | Tests (CLAUDE.md §6) |
 |---|---|---|---|---|
 | **P1** cert lifecycle + dual-listen | agent | dark | `_tls_generate_server_cert`, config `tls` section, SPKI/fp compute, IP-drift re-sign (key reused), 2nd SSL-wrapped listener gated by flag | cert-gen unit (SANs/fp/spki/key-0600); **re-sign-on-IP-change unit** (spki stable, fp changes); **https smoke** (`curl -k` ping-200 / no-token-401 / token-200 on the encrypted listener); **plaintext smoke stays green** |
-| **P2** additive advertisement | agent | dark | `/api/ping` + UDP + `/pair` + `build_pair_url` gain `tls_*` (only when enabled) | **additive-shape assertion** (TLS-off == legacy byte-shape; TLS-on adds only new keys); `/pair` loopback + Host-check still enforced; parity unchanged (no cap) |
+| **P2** additive advertisement ✅ BUILT | agent | dark | `/api/ping` + UDP + `build_pair_url` gain `tls_*` (only when enabled); `TLS_ADVERT` global + `_discovery_reply()` helper | ✅ `test_tls_advertise.py`: additive-shape control (TLS-off == legacy bytes; TLS-on adds only `tls_*`) on all 3 surfaces + degrade-closed (advert without port → nothing); parity unchanged (no cap) |
 | **P3** app reads/persists (dark) | app | dark (`http`) | `Box`/`Settings`/`PairLink` gain `secure`/`tlsPort`/`certPin`/`fp`; `normalizeBox` round-trips; pair parser reads new fragment keys | **harness: press Connect/pair**, assert fields persist AND app still reaches `--mock` over http (render ≠ test) |
 | **P4** installer/opt-in enable | agent/installer | user opt-in | `couchside tls on` sets `enabled=true`, mints, starts HTTPS listener | boot `enabled:true` mock: both listeners serve; both triads pass in one run |
 | **P5** app flip (GATED) | app | flip-on when pinned | app prefers `https`/`wss` + validates pinned SPKI when box advertises `tls_port`; **http fallback never removed** | harness vs TLS mock; pin-mismatch surfaced, not silently trusted |

--- a/tests/test_tls_advertise.py
+++ b/tests/test_tls_advertise.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""TLS availability advertisement on the pre-auth surfaces (TLS P2).
+
+Run: python3 tests/test_tls_advertise.py
+
+TLS is a TRANSPORT concern, not a capability (it can't be read over the transport
+whose scheme it selects), so a future TLS-aware app must DISCOVER the HTTPS listener
+on the surfaces it already reaches unauthenticated: GET /api/ping, the UDP discovery
+reply, and the pairing QR (build_pair_url). This proves those three advertise the
+listener additively.
+
+The decisive control (CLAUDE.md §11 observe-both-states): when TLS is DARK the payload
+is BYTE-FOR-BYTE what every shipped app already parses, and when TLS is ENABLED the new
+tls_* fields are the ONLY difference — stripping them reproduces the dark bytes exactly.
+That is what keeps an old app working against a TLS-advertising agent (CLAUDE.md §4:
+never change existing response shapes; additive only).
+
+Pure stdlib, no pytest.
+"""
+import http.client
+import importlib.util
+import json
+import os
+import threading
+from http.server import ThreadingHTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+TOKEN = "test-secret-token"
+# A plausible advert: real fp/spki are 64-hex SHA-256 digests.
+ADVERT = {"port": 8791, "fp": "ab" * 32, "spki": "cd" * 32}
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label +
+          ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+def _strip_tls(d):
+    return {k: v for k, v in d.items() if not str(k).startswith("tls_")}
+
+
+# ---- /api/ping (pre-auth) --------------------------------------------------
+
+class _QuietServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        import ssl
+        import sys
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionError, ssl.SSLError, OSError)):
+            return
+        super().handle_error(request, client_address)
+
+
+def _plain_ping(port):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    conn.request("GET", "/api/ping", headers={"Connection": "close"})
+    resp = conn.getresponse()
+    body = json.loads(resp.read() or b"{}")
+    st = resp.status
+    conn.close()
+    return st, body
+
+
+def test_ping_advertises_additively():
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True
+    saved = cs.Handler.tls_info
+    srv = _QuietServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    port = srv.server_address[1]
+    try:
+        # DARK: tls_info None -> no tls_* keys at all.
+        cs.Handler.tls_info = None
+        st, dark = _plain_ping(port)
+        check(st == 200, "ping 200 (dark)", st)
+        check(not any(str(k).startswith("tls_") for k in dark),
+              "ping dark: no tls_* keys", list(dark))
+
+        # ENABLED: tls_info set -> tls_port/fp/spki appended, nothing else changed.
+        cs.Handler.tls_info = {"cert_pem": "x", "fp": ADVERT["fp"],
+                               "spki": ADVERT["spki"], "port": ADVERT["port"]}
+        st, on = _plain_ping(port)
+        check(st == 200, "ping 200 (tls enabled)", st)
+        check(on.get("tls_port") == ADVERT["port"] and
+              on.get("tls_fp") == ADVERT["fp"] and
+              on.get("tls_spki") == ADVERT["spki"],
+              "ping enabled: tls_port/tls_fp/tls_spki present + correct",
+              {k: on.get(k) for k in ("tls_port", "tls_fp", "tls_spki")})
+        # THE CONTROL: the enabled payload minus the tls_* keys IS the dark payload.
+        check(_strip_tls(on) == dark,
+              "ping enabled minus tls_* == dark payload (additive only)",
+              (dark, on))
+    finally:
+        cs.Handler.tls_info = saved
+        srv.shutdown()
+
+
+# ---- UDP discovery reply ----------------------------------------------------
+
+def test_discovery_reply_additive():
+    saved = cs.TLS_ADVERT
+    try:
+        cs.TLS_ADVERT = None
+        dark = cs._discovery_reply(8787)
+        dark_bytes = json.dumps(dark).encode()
+        check(set(dark) == {"couchside", "name", "host", "port", "version"},
+              "discovery dark: exactly the 5 legacy keys", list(dark))
+
+        cs.TLS_ADVERT = dict(ADVERT)
+        on = cs._discovery_reply(8787)
+        check(on.get("tls_port") == ADVERT["port"] and
+              on.get("tls_fp") == ADVERT["fp"] and
+              on.get("tls_spki") == ADVERT["spki"],
+              "discovery enabled: tls_port/tls_fp/tls_spki present",
+              {k: on.get(k) for k in ("tls_port", "tls_fp", "tls_spki")})
+        # CONTROL: strip tls_* -> byte-identical to the dark reply (order preserved).
+        check(json.dumps(_strip_tls(on)).encode() == dark_bytes,
+              "discovery enabled minus tls_* is byte-identical to dark",
+              (dark_bytes, json.dumps(_strip_tls(on)).encode()))
+    finally:
+        cs.TLS_ADVERT = saved
+
+
+def test_discovery_advert_absent_when_no_port():
+    """Degrade-closed: a half-populated advert (no port) advertises nothing."""
+    saved = cs.TLS_ADVERT
+    try:
+        cs.TLS_ADVERT = {"fp": ADVERT["fp"]}  # no port
+        r = cs._discovery_reply(8787)
+        check(not any(str(k).startswith("tls_") for k in r),
+              "discovery: advert without a port -> no tls_* keys", list(r))
+    finally:
+        cs.TLS_ADVERT = saved
+
+
+# ---- pairing QR (build_pair_url) -------------------------------------------
+
+def test_pair_url_additive():
+    saved = cs.TLS_ADVERT
+    try:
+        cs.TLS_ADVERT = None
+        dark = cs.build_pair_url("tok", 8787)
+        check(dark.startswith("https://couchside.tv/pair#host="),
+              "pair url dark: shape unchanged", dark)
+        check("tlsport=" not in dark and "&fp=" not in dark,
+              "pair url dark: no tlsport / fp", dark)
+
+        cs.TLS_ADVERT = dict(ADVERT)
+        on = cs.build_pair_url("tok", 8787)
+        # CONTROL: the dark URL is an exact prefix; TLS params are strictly appended.
+        check(on.startswith(dark),
+              "pair url enabled: dark url is an exact prefix (additive)", (dark, on))
+        check(on == dark + "&tlsport=%d&fp=%s" % (ADVERT["port"], ADVERT["fp"]),
+              "pair url enabled: appends &tlsport=&fp= only", on)
+    finally:
+        cs.TLS_ADVERT = saved
+
+
+if __name__ == "__main__":
+    test_ping_advertises_additively()
+    test_discovery_reply_additive()
+    test_discovery_advert_absent_when_no_port()
+    test_pair_url_additive()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all TLS advertise tests passed")


### PR DESCRIPTION
Box-side **P2** of on-wire encryption, following P1 (#454). **Dark** (no behavior change unless `tls.enabled`/`--tls`), **additive**, no cap.

## What
A TLS-aware app can't read a capability to learn the box speaks HTTPS — TLS is the transport the cap would ride. So it must **discover** the optional HTTPS listener on the pre-auth surfaces it already reaches. Adds, **only when TLS is enabled**:

| Surface | New fields |
|---|---|
| `GET /api/ping` | `tls_port`, `tls_fp`, `tls_spki` |
| UDP discovery reply | `tls_port`, `tls_fp`, `tls_spki` |
| `build_pair_url` / pairing QR | `&tlsport=<n>&fp=<hex>` |

`fp` = the **DER cert fingerprint** `_tls_fp` already returns from `/api/tls/cert` (the value the P1 smoke test proves equals the live-handshake cert) — the app verifies `SHA-256(PEM)==fp` at pairing, physical-presence anchor. This resolves a stale `fp=<spki>` line in the spec; `spki` is still advertised on ping+UDP for the stable pin.

## How it stays safe
- **Backward compat is load-bearing:** every field is appended *after* the existing keys and *only* when TLS is on, so a dark agent's payloads are **byte-for-byte** what every shipped app parses (CLAUDE.md §4).
- New `TLS_ADVERT` module global (public `{port,fp,spki}` or None) set by `main()` after `_tls_start`, for surfaces with no `Handler` in hand.
- `_discovery_reply()` extracted (pure) so the both-states byte-identity is unit-testable.
- No cap, no `protocol.json` change, no six-edit-site drift. **VERSION unbumped** — dark box-side work earns no CHANGELOG note until TLS is enabled (P4/P5).

## Tests (`tests/test_tls_advertise.py`, wired as the 3rd TLS CI step)
Observe-both-states + the additive control on all three surfaces:
- dark payload == legacy bytes; enabled payload minus `tls_*` == the dark bytes exactly
- degrade-closed: an advert missing its port advertises nothing

Also verified **live** (not just unit): ran the agent `--tls` and without, hit `/api/ping` over plaintext and sent a real UDP `COUCHSIDE_DISCOVER?` probe — `tls_*` present in both surfaces when on (fp consistent across surfaces + matches the banner spki), absent when off.

## Not in scope
App track (P3/P5) — still gated on the `react-native-tcp-socket {ca}` device spike. Box-side P1+P2 are now complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)