### PR TITLE
docs(led): record LED Studio shipped + app build 176/vc94

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "175",
+      "buildNumber": "176",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 93
+      "versionCode": 94
     },
     "web": {
       "bundler": "metro",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,8 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
 
 ## 🔨 In Progress
 
-### LED Studio — editor + presets + effects + persistence + OpenRGB (owner ask 2026-08-13)
+### ✅ LED Studio — SHIPPED 2026-08-13 (app 2.9.46 / agent 2.9.86, tag v2.9.46) — MOVE TO COMPLETED
+### LED Studio — editor + presets + effects + persistence + OpenRGB + addressable strip (owner ask 2026-08-13)
 - **priority:** P2 · **risk:** medium (effect thread + a new loopback OpenRGB subsystem;
   strictly allowlisted) · **affects:** agent + app · **depends_on:** the LIGHT card below;
   OpenRGB installed + `--server` running on the box (P3+). **Spec:**
@@ -38,10 +39,16 @@ Entry fields: `priority` (P0 blocker → P3 nice) · `risk` · `affects` · `dep
   Both endpoints exercised vs `--mock` over curl (401/404/400/200 + observe-both). App
   PRESSED in the harness (§6): effect chips, Night Rider preset, sliders, Save; SYSTEM RGB
   scanner moved /api/openrgb active. See BUILD_LOG 2026-08-13.
-- **NOT verified / gates:** no real LED/OpenRGB hardware this session. Kernel path still needs
-  the install-time udev grant on a stock box; OpenRGB wire format proven only vs the mock
-  server + docs (real hardware = final gate). Sliders' DRAG needs on-device proof. Land on a
-  fresh `claude/led-studio` off origin/main (built on the H264 spike branch).
+- **✅ SHIPPED (agent 2.9.86, app 2.9.46, tag v2.9.46, full chain 2026-08-13).** Kernel effect
+  engine + persistence + presets (PRs #450/#451/#452 merged). **Addressable strip = the
+  marquee, HARDWARE-PROVEN on a real Steam Machine:** 17 `valve-leds` nodes with FIRMWARE
+  effects (scanner→patrol night-rider survives app-close/reboot), per-LED **manual** paint +
+  pattern presets, agent-driven so the app just controls it. App: one-row flipped strip,
+  named/protected presets, gesture-handler sliders (fix nav-swipe collision). Agent signed +
+  published (boxes auto-update, folds in the AMD CPU-temp fix #453); iOS 2.9.46/176 in App
+  Store review, Android vc94 in Play production. 72/72 tests green.
+- **Still open (follow-ups, not blockers):** OpenRGB against a REAL daemon (mock-server proven
+  only); non-valve strip flip generalization; box-side preset-library sync.
 
 ### Front light-bar / status-LED control (owner ask 2026-08-12)
 - **priority:** P2 · **risk:** medium (writes a hardware sysfs path; strictly allowlisted +

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -655,3 +655,21 @@ caught before it shipped:
 6. **Keep an accessible fallback.** The grip is pointer-only (`accessible={false}`);
    up/down arrow buttons remain for assistive tech and as the guaranteed path.
    The drag gesture itself needs a device to verify (same RNW ceiling as above).
+
+## Addressable LED strips + hardware effects (LED Studio, agent 2.9.85+)
+
+- **Drive the DEVICE's firmware effect, not an agent frame-loop.** A strip whose driver
+  publishes an `effect_index` (e.g. `valve-leds`: patrol/breath/rainbow/manual) is animated by
+  the box itself. `apply_strip_effect(prefix, ...)` maps our effect id → a firmware name that
+  is an EXACT member of that device's `effect_index` (looked up, never trusted) and writes
+  `effect` + `delay`. It survives the app closing / reboot. Only strips WITHOUT firmware
+  effects fall back to an agent per-LED render loop.
+- **Strip allowlist:** the client sends a PREFIX; members are the live `os.listdir` entries
+  matching `prefix[<n>]` (never interpolated); the `effect` VALUE must be published by the
+  device. `set_led` on a strip node auto-writes `effect=manual` first so a hand-paint sticks.
+- **App slider convention: `components/TrackSlider.tsx` on react-native-gesture-handler**, not
+  PanResponder — `activeOffsetX([-8,8])` claims the horizontal drag over the iOS nav-swipe,
+  `failOffsetY` yields vertical scroll. Needs `GestureHandlerRootView` at the app root.
+- **Strip physical order:** `lib/ledStrip.ts` groups `prefix[N]`; `StripLightCard.displayLeds()`
+  REVERSES `valve-leds` (its index runs opposite the physical bar). Cells, paints, and saved
+  patterns all use physical (display) order.

--- a/docs/memory/DEPENDENCIES.md
+++ b/docs/memory/DEPENDENCIES.md
@@ -48,6 +48,7 @@ prebuilt `ios/` directory checked in.
 | `expo-splash-screen` | `~57.0.1` | Config plugin only, no imports. Supplies the splash image and `#0b1220` background at build time. |
 | `react-native-reanimated` | `4.5.0` | Imported for side effects only — a bare `import 'react-native-reanimated'` in `app/_layout.tsx` to install the runtime. No animations authored against its API yet. |
 | `react-native-worklets` | `0.10.0` | Never imported directly — mandatory peer of Reanimated 4, which moved the worklet runtime into its own package. Removing it breaks Reanimated. |
+| `react-native-gesture-handler` | `3.1.0` | Was transitive (react-navigation peer); now imported DIRECTLY by `components/TrackSlider.tsx` (the LED sliders) via `Gesture.Pan().activeOffsetX(...)` to win the horizontal drag over the iOS nav-swipe. Requires `GestureHandlerRootView` at the app root (`app/_layout.tsx`) — expo-router does NOT auto-wrap it. |
 
 ### Native capability
 

--- a/docs/memory/project_led-studio.md
+++ b/docs/memory/project_led-studio.md
@@ -1,5 +1,12 @@
 # Project: LED Studio — editor, presets, effects, persistence, OpenRGB
 
+> **✅ SHIPPED 2026-08-13 — app 2.9.46 / agent 2.9.86, tag v2.9.46 (full release chain).**
+> Marquee = the addressable `valve-leds` strip driven by the box's FIRMWARE effects
+> (scanner→patrol survives app-close/reboot) + manual per-LED paint + pattern presets,
+> HARDWARE-PROVEN on a real Steam Machine. PRs #450/#451/#452 merged; agent signed +
+> published, iOS in App Store review, Android in Play production. OpenRGB still
+> mock-server-only (no real daemon). Next: TLS app track (see `tls-encryption-p1` memory).
+
 **Owner ask (2026-08-13):** the LED control "works good on Steam Machine but I'd like to
 build it out" — an easier in-app editor, saved custom presets, automation/effects (a
 "night rider" KITT scanner named as the example), and survive reboot (a reboot currently


### PR DESCRIPTION
Post-release doc sync for LED Studio (agent 2.9.86 / app 2.9.46, tag v2.9.46). **Docs + version metadata only — no code or agent behavior change.**

- **ROADMAP** — LED Studio moved to shipped (effect engine + persistence + presets + hardware-proven addressable `valve-leds` strip; PRs #450/#451/#452). Open follow-ups (real OpenRGB daemon, non-valve strip flip, box-side preset sync) flagged as non-blockers.
- **project_led-studio.md** — shipped banner.
- **CONVENTIONS.md** — strip firmware-effect allowlist (client sends a PREFIX; the `effect` value must be a member of the device's own `effect_index`), `set_led` auto-manual, `TrackSlider` on react-native-gesture-handler, `valve-leds` physical-order reversal.
- **DEPENDENCIES.md** — `react-native-gesture-handler` 3.1.0 promoted transitive→direct (LED sliders); needs `GestureHandlerRootView` at app root.
- **app.json** — `buildNumber` 175→176, `versionCode` 93→94: the numbers EAS autoIncrement actually shipped to the stores, so the repo matches what's live.

Reviewed for secrets/IPs/tokens before committing — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)