### PR TITLE
fix(agent): update page never falsely reports "didn't finish"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,11 +466,14 @@ jobs:
         run: python3 tests/test_pair_page.py
 
       # The on-box UPDATE progress page. It polls /api/ping across the agent's
-      # own restart and must express THREE outcomes, not one: version changed
-      # (updated), unreachable a while (restarting), and reachable-but-unchanged
-      # for a long time (STALLED — the installer died before restarting, so the
-      # old agent keeps answering). The stall branch is the fix for a real box
-      # that span forever; this pins all three so a refactor cannot drop them.
+      # own restart. SUCCESS (version changed) is the ONE state that stops the
+      # poll; unreachable == restarting and reachable-but-unchanged == still
+      # installing are BOTH non-terminal — they escalate wording and, after a
+      # generous wait, a SOFT recovery hint, but NEVER declare failure and never
+      # stop watching. That is the fix for two real boxes: one that span forever
+      # on a stalled install (Legion Go S), and one that FALSELY said "didn't
+      # finish" on a slow-but-successful restart (SteamOS Steam Machine). The
+      # test executes the pure updDecide() under node to observe both states.
       - name: Unit tests (update page)
         run: python3 tests/test_update_page.py
 

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -1921,64 +1921,97 @@ def render_update_page():
 <p class="dots" id="d"><span>&#9679;</span><span>&#9679;</span><span>&#9679;</span></p>
 <p id="hint" style="display:none;font-size:.95rem;color:#6b7a90;margin-top:1.4rem"></p>
 </div><script>
-/* Poll /api/ping (the one pre-auth endpoint) until the version CHANGES.
-   Three outcomes, not one:
-     - version changes            -> Updated (success).
-     - unreachable for a while     -> the service is restarting (expected).
-     - reachable, SAME version,    -> the update STALLED. The installer copies
-       for a long time                the new file first, then restarts; if it
-                                       dies in between (e.g. it needed a sudo
-                                       password it could not get in the detached
-                                       run), the OLD agent keeps answering the
-                                       same version forever. Without this branch
-                                       the page spins forever for that case,
-                                       telling the user it was still working
-                                       when it was not.
-   A genuine restart shows up as MISSES (unreachable), which reset the stall
-   clock -- so `same` only climbs while the old agent stays healthy, which is
-   exactly the stalled case. */
-var was=null, misses=0, same=0;
-var STALL=90;   /* ~3 min of reachable + unchanged version -> call it stalled */
-function stalled(){
-  document.getElementById('t').textContent='Update didn\u2019t finish';
-  document.getElementById('t').style.color='#f0b232';
-  document.getElementById('s').textContent='The box is still running '+was+'.';
-  document.getElementById('d').style.display='none';
-  var h=document.getElementById('hint');
-  h.style.display='block';
-  h.innerHTML='Try Update again from the app. If it keeps stopping here, open a '
-    +'terminal on the box and run:<br><br>'
-    +'<code style="color:#9fb3cc">curl -fsSL https://couchside.tv/install.sh | bash</code>';
+/* Served ONCE, then keeps polling /api/ping (the one pre-auth endpoint) across
+   the agent's own restart. The ONLY reliable success signal is the reported
+   version CHANGING from the one we first saw, so success is the one state that
+   ever stops the poll. Every other state keeps polling.
+
+   THE TRAP THIS FIXES (real box, SteamOS Steam Machine, 2026-08-13): the update
+   SUCCEEDED (2.9.83 -> 2.9.86) but the page said "Update didn't finish". The old
+   logic declared a HARD FAILURE after ~3 min of the old agent still answering,
+   then STOPPED polling -- so when the new agent finished its slow restart (a
+   ~6s CEC probe + Steam log watchers) a moment later, the page never saw it. A
+   detector that fires only the failure half AND then stops looking ships a
+   scary, wrong message on a successful update.
+
+   The rule now: NEVER declare failure, NEVER stop watching for success.
+     - version changed         -> Updated. Stop. (the one terminal, reliable state)
+     - unreachable             -> restarting (expected mid-update); escalate the
+                                  wording, but this is never a failure.
+     - reachable, SAME version -> still the old agent answering: "installing",
+                                  then only after a GENEROUS wait a SOFT "taking
+                                  longer" hint with a recovery command -- while
+                                  STILL polling, so a late success flips it to
+                                  Updated. Every tick past the hint is itself the
+                                  final confirming ping. */
+var was=null, same=0, miss=0, DONE=false;
+
+// --UPD-DECIDE-START
+var SLOW=20;         /* ticks, 2s each: 40s reachable+same -> "still working"    */
+var STUCK=300;       /* 10 min reachable+SAME before a SOFT recovery hint. Was 90
+                        (~3 min) AND terminal -- that pairing is exactly what
+                        flagged a slow-but-working box as failed. Non-terminal now */
+var RESTART_MISS=8;  /* 16s unreachable -> "restarting the service"              */
+var LONG_MISS=150;   /* 5 min unreachable -> suggest a reboot (still not "failed") */
+/* Pure decision: given the first-seen version `was`, this poll's version `ver`
+   (null == unreachable) and the running same/miss counters, name the state.
+   done:true ONLY for 'updated' -- there is deliberately NO terminal failure
+   state, so the poll can always still catch a late success. */
+function updDecide(was, ver, same, miss){
+  if(ver!==null && was!==null && ver!==was){
+    return {done:true, state:'updated', version:ver};
+  }
+  if(ver===null){
+    if(miss>=LONG_MISS) return {done:false, state:'long_restart'};
+    if(miss>=RESTART_MISS) return {done:false, state:'restarting'};
+    return {done:false, state:'installing'};
+  }
+  if(same>=STUCK) return {done:false, state:'maybe_stuck'};
+  if(same>=SLOW)  return {done:false, state:'slow'};
+  return {done:false, state:'installing'};
 }
+// --UPD-DECIDE-END
+
+function apply(d){
+  var t=document.getElementById('t'), s=document.getElementById('s'),
+      dots=document.getElementById('d'), h=document.getElementById('hint');
+  if(d.state!=='maybe_stuck') h.style.display='none';
+  if(d.state==='updated'){
+    t.textContent='Updated'; t.className='ok';
+    s.textContent='Now running '+d.version+'.';
+    dots.style.display='none';
+    DONE=true; return;                          /* the one terminal state */
+  }
+  if(d.state==='maybe_stuck'){
+    /* NON-TERMINAL: we keep polling. On a slow box the old agent can answer for
+       minutes while a real update is still in flight, so we SOFTEN to a recovery
+       hint -- we do NOT claim it failed. A later tick that sees the new version
+       overwrites this with "Updated". */
+    s.textContent='Still on '+was+'. This is taking longer than usual \u2014 keep this screen up.';
+    h.style.display='block';
+    h.innerHTML='If it stays here, open a terminal on the box and run:<br><br>'
+      +'<code style="color:#9fb3cc">curl -fsSL https://couchside.tv/install.sh | bash</code>';
+    return;
+  }
+  if(d.state==='slow'){ s.textContent='Still working\u2026 downloading and installing.'; return; }
+  if(d.state==='restarting'){ s.textContent='Restarting the service\u2026'; return; }
+  if(d.state==='long_restart'){
+    s.textContent='Taking longer than usual. If the screen stays here, reboot the box.'; return; }
+  s.textContent='Keep the box powered on. This takes about a minute.';  /* installing */
+}
+
 function tick(){
   fetch('/api/ping',{cache:'no-store'}).then(function(r){return r.json()}).then(function(j){
-    misses=0;
-    if(was===null){ was=j.version; }
-    else if(j.version!==was){
-      document.getElementById('t').textContent='Updated';
-      document.getElementById('t').className='ok';
-      document.getElementById('s').textContent='Now running '+j.version+'.';
-      document.getElementById('d').style.display='none';
-      document.getElementById('hint').style.display='none';
-      return;                                  /* stop polling: success */
-    } else {
-      /* reachable, same version: normal for the download/install phase */
-      same++;
-      if(same===20){ document.getElementById('s').textContent=
-        'Still working\u2026 downloading and installing.'; }
-      if(same>=STALL){ stalled(); return; }    /* stop polling: stalled */
-    }
-    setTimeout(tick,2000);
+    if(was===null) was=j.version;
+    miss=0;
+    if(j.version!==was) same=0; else same++;
+    apply(updDecide(was, j.version, same, miss));
   }).catch(function(){
-    /* The agent restarts mid-update, so a failed poll is EXPECTED, not an
-       error. A restart also means we are NOT stalled -- reset that clock. */
-    misses++; same=0;
-    if(misses>8){ document.getElementById('s').textContent=
-      'Restarting the service\u2026'; }
-    if(misses>150){ document.getElementById('s').textContent=
-      'Taking longer than usual. If the screen stays here, reboot the box.'; }
-    setTimeout(tick,2000);
-  });
+    /* A failed poll mid-update is EXPECTED (the agent is restarting), not an
+       error -- and a restart means we are NOT stuck, so reset the same clock. */
+    same=0; miss++;
+    apply(updDecide(was, null, same, miss));
+  }).then(function(){ if(!DONE) setTimeout(tick,2000); });
 }
 tick();
 </script></body></html>"""

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -87,7 +87,13 @@ export function AgentUpdateBanner() {
       setMsg('Updating — your box will restart. This can take a minute.');
       const target = check.latest;
       let done = false;
-      for (let i = 0; i < 40 && !done; i++) {
+      // Poll generously. A slow box (e.g. a SteamOS Steam Machine whose restart
+      // runs a ~6s CEC probe + Steam log watchers) can take minutes to come back
+      // up on the new version; a short window meant we gave up before it did and
+      // showed "may still be finishing" on an update that actually succeeded.
+      // ~6 min at 3s. This never reports FAILURE — only success or a soft
+      // "still finishing" — and the version display self-corrects once it's up.
+      for (let i = 0; i < 120 && !done; i++) {
         await new Promise((r) => setTimeout(r, 3000));
         // Show what the box is ACTUALLY doing. The installer writes a
         // transcript the app never read, so this used to be a canned message

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1227,6 +1227,22 @@ recommendation was wrong, not merely superseded.
 
 ## ✅ Completed
 
+### Update-completion false-negative fixed — browser-verified 2026-08-13 (SteamOS Steam Machine)
+- **was:** P2 (owner-reported 2026-08-13) · **affects:** agent on-box `/update` page + app
+  `AgentUpdateBanner` · **branch:** `claude/bold-kilby-b2a611`
+- **The bug:** on a slow-restarting box (steamdeck@10.1.1.34) the agent updated 2.9.83 → 2.9.86
+  successfully, but the on-box progress page said "Update didn't finish. The box is still running
+  2.9.83." The poller declared a HARD FAILURE at `same>=STALL` (90 ticks ≈ 3 min of the old agent
+  still answering) and then STOPPED polling — so a slow restart (real-mode ~6s CEC probe + Steam
+  log watchers + the install phase) tripped it and the page never saw the new version arrive.
+- **The fix:** success (version changed) is now the ONLY terminal state; restarting + installing
+  are non-terminal and NEVER declare failure. Extracted pure `updDecide()`; `STUCK` 90→300 ticks
+  (~10 min) and its hint is a SOFT recovery message while polling continues, so a late success
+  flips to "Updated". App banner confirm loop 40→120 iters (~6 min). No VERSION bump (page-only).
+- **Verified:** node-exec unit test of both states + LIVE browser repro of the exact sequence
+  (same-version → restarting → success), screenshot of green "Updated / Now running 2.9.86.".
+  NOT re-run on the real steamdeck yet — owner to confirm at next agent bump.
+
 ### Couch Mode gamescope-session filename fix — VERIFIED on hardware 2026-08-10 (Legion Go S)
 - **was:** P2 (owner-reported 2026-08-10) · **affects:** agent · **branch/PR:**
   `claude/couchmode-gamescope-session-detect` → #432

--- a/tests/test_update_page.py
+++ b/tests/test_update_page.py
@@ -4,22 +4,37 @@
 Run: python3 tests/test_update_page.py
 
 WHY THIS EXISTS. The page is served ONCE and then keeps polling /api/ping across
-the agent's own restart, watching for the version to change. The original page
-had only ONE outcome — success (version changed) — and otherwise spun forever.
+the agent's own restart, watching for the version to change.
 
-A real box (Legion Go S, system-service install, 2026-07-23) hit the failure the
-page could not express: the detached installer copied the new agent file but
-died at a password `sudo` before restarting the service, so the OLD agent kept
-answering the SAME version. The page span its loader indefinitely, telling the
-user it was "still working" when it had stalled. This asserts the three-outcome
-logic is present so a refactor cannot silently regress to the one-outcome page.
+Two real bugs shaped it:
 
-The page is a JS string (no JS engine here), so these are STRUCTURAL assertions —
-the same approach test_pair_page uses for the handoff. They pin the branches, not
-the pixels; the on-box render itself is proven live.
+  1. Legion Go S (system-service install, 2026-07-23): the detached installer
+     copied the new agent file but died at a password `sudo` before restarting,
+     so the OLD agent kept answering the SAME version. The page span its loader
+     forever, telling the user it was "still working" when it had stalled.
+
+  2. SteamOS Steam Machine (2026-08-13): the OPPOSITE false report. The update
+     SUCCEEDED (2.9.83 -> 2.9.86) but the page said "Update didn't finish". The
+     fix for (1) had made the reachable-but-unchanged branch declare a HARD
+     FAILURE after ~3 min and then STOP polling -- so a box whose new agent was
+     merely slow to restart (a ~6s CEC probe + log watchers) tripped it, and the
+     page never saw the new version come up moments later.
+
+So the detector has to observe BOTH states without ever lying: success stops the
+poll; a long unchanged wait shows a SOFT, non-terminal hint and KEEPS polling, so
+a late success still flips the page to "Updated". This test pins that.
+
+The decision lives in a pure `updDecide(was, ver, same, miss)` function inside the
+page's JS, fenced by // --UPD-DECIDE-START / --UPD-DECIDE-END. When `node` is on
+PATH (it is on the CI runner) we extract and EXECUTE it against a table that
+exercises both states -- an actual behavioural test, not just a grep. Structural
+assertions back it up and run everywhere. (Pure stdlib, no pytest.)
 """
 import importlib.util
+import json
 import os
+import shutil
+import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -31,6 +46,9 @@ _spec.loader.exec_module(cs)
 
 FAILURES = []
 
+START = "// --UPD-DECIDE-START"
+END = "// --UPD-DECIDE-END"
+
 
 def check(name, got, want):
     if got == want:
@@ -38,6 +56,27 @@ def check(name, got, want):
     else:
         print("  FAIL  %s (got %r, want %r)" % (name, got, want))
         FAILURES.append(name)
+
+
+def _decide_block(html):
+    """The self-contained thresholds + updDecide() source, ready for node."""
+    i = html.index(START)
+    j = html.index(END)
+    return html[i:j]
+
+
+def _run_decide(block, was, ver, same, miss):
+    """Execute updDecide() under node and return its object. `ver=None` -> JS
+    null (unreachable). Raises if node disagrees, so the caller can assert."""
+    def js(v):
+        return "null" if v is None else json.dumps(v)
+    harness = (block + "\nprocess.stdout.write(JSON.stringify(updDecide(%s,%s,%d,%d)));"
+               % (js(was), js(ver), same, miss))
+    p = subprocess.run(["node", "-"], input=harness,
+                       capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError("node failed: %s" % p.stderr.strip())
+    return json.loads(p.stdout)
 
 
 def test_self_contained_and_polls_preauth_ping():
@@ -52,43 +91,105 @@ def test_self_contained_and_polls_preauth_ping():
     check("cache-busted", "no-store" in html, True)
 
 
-def test_success_outcome_present():
-    """Version changes -> Updated. This is the happy path and must survive."""
-    print("test_success_outcome_present")
+def test_success_is_the_only_terminal_state():
+    """Version changed -> Updated, and it is the ONLY state that stops the poll.
+    Structurally: exactly one `DONE=true`, and the reschedule is guarded by it."""
+    print("test_success_is_the_only_terminal_state")
     html = cs.render_update_page()
-    check("compares against first-seen version", "j.version!==was" in html, True)
     check("announces the new version", "Now running" in html, True)
+    check("marks done on success only", html.count("DONE=true") == 1, True)
+    # The poll reschedules on EVERY tick unless DONE -- so nothing but success
+    # can end it (the 2026-08-13 regression was a failure branch that returned
+    # out of the loop and stopped watching).
+    check("reschedule guarded by DONE", "if(!DONE) setTimeout(tick,2000)" in html, True)
+    # No hard-failure HEADLINE and no scary-orange flip -- the 2026-08-13
+    # regression set the title to a failure string. (A comment may still mention
+    # the history, so we target the UI assignment + the orange color, not the
+    # words anywhere on the page.)
+    check("no failure headline assignment", ".textContent='Update didn" not in html, True)
+    check("no scary-orange title flip", "#f0b232" not in html, True)
 
 
-def test_restart_outcome_present():
-    """Unreachable for a while == the service is restarting (expected), and a
-    failed poll must NOT be treated as an error immediately."""
-    print("test_restart_outcome_present")
+def test_restart_is_never_a_failure():
+    """Unreachable == restarting (expected); it escalates wording but never fails
+    and never stops the poll."""
+    print("test_restart_is_never_a_failure")
     html = cs.render_update_page()
-    check("has a catch/miss branch", ".catch(" in html and "misses" in html, True)
+    check("has a catch/miss branch", ".catch(" in html and "miss++" in html, True)
     check("says 'Restarting'", "Restarting the service" in html, True)
+    # A restart resets the same-version clock so it is not mistaken for a stall.
+    check("restart resets the same clock", "same=0; miss++" in html, True)
 
 
-def test_stall_outcome_present():
-    """THE fix: reachable + SAME version for a long time == stalled, not working.
-    Must stop the spinner, say the box is still on the old version, and give a
-    recovery path — never spin forever."""
-    print("test_stall_outcome_present")
+def test_stall_hint_is_soft_and_non_terminal():
+    """Long unchanged wait -> a recovery hint, but NOT a failure and NOT the end
+    of polling, so a late success still wins."""
+    print("test_stall_hint_is_soft_and_non_terminal")
     html = cs.render_update_page()
-    check("tracks consecutive same-version polls", "same++" in html, True)
-    check("has a stall threshold", "STALL" in html and "same>=STALL" in html, True)
-    check("stall message present", "Update didn" in html, True)
+    check("has a generous same threshold", "STUCK" in html and "same>=STUCK" in html, True)
     check("offers a recovery command", "install.sh | bash" in html, True)
-    # A restart resets the stall clock — a genuine restart (unreachable) must not
-    # be mistaken for a stall.
-    check("restart resets the stall clock", "same=0" in html, True)
+    check("maybe_stuck is not a terminal/done state", "state:'maybe_stuck'" in html
+          and "done:false, state:'maybe_stuck'" in html, True)
+    # Generosity: the old 90-tick (~3 min) window is what misfired; the new one
+    # must be materially larger. Parse it rather than trust a comment.
+    try:
+        val = int(html.split("var STUCK=", 1)[1].split(";", 1)[0].strip())
+    except Exception:
+        val = -1
+    check("STUCK window >= 240 ticks (~8 min)", val >= 240, True)
+
+
+def test_decide_observes_both_states():
+    """The heart of it: run updDecide() for real and prove it fires BOTH ways --
+    success on a version change, and NEVER a terminal failure otherwise, even
+    after a very long unchanged wait. Skips only if node is unavailable."""
+    print("test_decide_observes_both_states")
+    if not shutil.which("node"):
+        print("  SKIP  node not on PATH (behavioural check skipped)")
+        return
+    block = _decide_block(cs.render_update_page())
+
+    # --- success half: the version changed. This is the case the 2026-08-13
+    #     box hit AFTER a long wait, and it must resolve to done:true. ---
+    d = _run_decide(block, "2.9.83", "2.9.86", 5, 0)
+    check("version change -> updated/done", d.get("state") == "updated" and d.get("done") is True, True)
+    check("updated reports new version", d.get("version") == "2.9.86", True)
+    # Even after sitting on the old version for ages, the very next tick that sees
+    # the new version succeeds -- the exact false-negative that shipped.
+    d = _run_decide(block, "2.9.83", "2.9.86", 999, 0)
+    check("late success still wins", d.get("state") == "updated" and d.get("done") is True, True)
+
+    # --- not-yet half: still the old version / unreachable. NONE of these may be
+    #     terminal (done:false), so the poll keeps looking for success. ---
+    for name, ver, same, miss in [
+        ("fresh install (same, early)", "2.9.83", 1, 0),
+        ("slow (same, 40s)", "2.9.83", 20, 0),
+        ("very long same wait", "2.9.83", 999, 0),
+        ("restarting (unreachable)", None, 0, 10),
+        ("long restart (unreachable)", None, 0, 200),
+    ]:
+        d = _run_decide(block, "2.9.83", ver, same, miss)
+        check("%s is non-terminal" % name, d.get("done") is False, True)
+
+    # State names are distinct so the UI can distinguish "still old" from "not
+    # answering" (the fix direction: restarting != stuck).
+    installing = _run_decide(block, "2.9.83", "2.9.83", 1, 0)["state"]
+    slow = _run_decide(block, "2.9.83", "2.9.83", 20, 0)["state"]
+    stuck = _run_decide(block, "2.9.83", "2.9.83", 999, 0)["state"]
+    restarting = _run_decide(block, "2.9.83", None, 0, 10)["state"]
+    longr = _run_decide(block, "2.9.83", None, 0, 200)["state"]
+    check("reachable-same escalates installing->slow->maybe_stuck",
+          (installing, slow, stuck) == ("installing", "slow", "maybe_stuck"), True)
+    check("unreachable escalates restarting->long_restart",
+          (restarting, longr) == ("restarting", "long_restart"), True)
 
 
 if __name__ == "__main__":
     for fn in (test_self_contained_and_polls_preauth_ping,
-               test_success_outcome_present,
-               test_restart_outcome_present,
-               test_stall_outcome_present):
+               test_success_is_the_only_terminal_state,
+               test_restart_is_never_a_failure,
+               test_stall_hint_is_soft_and_non_terminal,
+               test_decide_observes_both_states):
         fn()
     if FAILURES:
         print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))


### PR DESCRIPTION
## The bug
On a slow-restarting box (SteamOS Steam Machine), the agent updated **2.9.83 → 2.9.86 successfully**, but the on-box `/update` progress page showed:

> Update didn't finish. The box is still running 2.9.83.

The page polls the pre-auth `/api/ping` across the agent's own restart, watching for the version to change. The old poller declared a **hard failure** at `same>=STALL` (90 ticks ≈ 3 min of the OLD agent still answering) and then **stopped polling**. A slow-but-successful restart — real-mode startup runs a ~6s CEC probe + Steam log watchers, on top of the install phase — exceeded that window, tripped the failure branch, and the page never saw the new version come up moments later. The detector fired only the failure half **and then stopped looking**.

## The fix
- **Success (version changed) is the ONLY terminal state.** Extracted a pure `updDecide(was, ver, same, miss)` (sentinel-fenced `// --UPD-DECIDE-*`).
- Unreachable == *restarting* and reachable-same == *installing* are **non-terminal**: they escalate wording (installing → slow @40s → restarting @16s → long_restart @5min) and, after a **generous** wait (`STUCK` 90→300 ticks ≈ 10 min), a **soft** recovery hint — but keep polling, so a late success flips the page to **Updated**. No more scary orange "didn't finish" headline.
- App `AgentUpdateBanner`: inline confirm loop 40→120 iters (~2 → ~6 min). It already only ever showed a soft "may still be finishing", never a failure — just too short a window.

Page-only: **no VERSION bump**, no route/cap/protocol change. `/update` stays loopback + Host-header gated; the page polls only the pre-auth `/api/ping`.

## Tests
`tests/test_update_page.py` now **executes the pure `updDecide()` under `node`** (skips if node absent — present on `ubuntu-latest`) to prove **both** states: success on a version change (including *after* a long same-version wait — the exact false-negative), and never-terminal otherwise. Structural guards pin: success is the one `DONE=true`, the reschedule is guarded by `!DONE`, no failure-headline assignment / no `#f0b232`, `STUCK ≥ 240`.

## Verified
- `python3 tests/test_update_page.py` green on the `main` base (incl. node-exec of both states); `py_compile` OK.
- **Live** in a browser against the REAL `render_update_page()` + a toggleable mock `/api/ping` — reproduced the exact sequence: same-version repeatedly → stayed "Updating…", no failure, kept polling → unreachable ~20s → "Restarting the service…" (`miss=20`) → flipped to 2.9.86 → green **"Updated / Now running 2.9.86."**, dots hidden, `DONE=true`, **polling stopped**.

**Not verified:** the 10-min `maybe_stuck` soft-hint rendering (too long to watch live — covered by the node test + structural asserts); and no run on the actual steamdeck yet — worth confirming at its next real update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)