### PR TITLE
release: TLS P5 pinned transport + Game Mode screen fix (app 2.9.49 / agent 2.9.87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,6 +324,14 @@ jobs:
       - name: Unit tests (TLS availability advertisement)
         run: python3 tests/test_tls_advertise.py
 
+      # TLS (P5): short-lived tickets let the un-pinnable native <Image> loader +
+      # streamed uploader avoid putting the bearer token on the wire on a TLS box.
+      # The load-bearing invariants: mint is bearer-gated, a ticket authorizes only
+      # image GETs (never a control route like /api/status), and a single-use upload
+      # ticket is burned on first use so a sniffed URL can't be replayed.
+      - name: Unit tests (TLS tickets)
+        run: python3 tests/test_tls_ticket.py
+
       # Pairing PIN full-screen launch resolver. A desktop-session box is a system
       # service with a partial env, so a bare xdg-open failed and the PIN never
       # showed (a hard stop for pairing). Pins the browser->--kiosk argv mapping

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,18 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.87
+
+**A much faster remote screen in Game Mode.** When your box is in Steam Game Mode
+(Big Picture), opening the remote screen viewer on the phone used to hang for
+several seconds — sometimes up to ten — before the first picture appeared. Now it
+goes straight to the live preview, so what's on your TV shows up on the phone in
+about a second. (Game Mode can't do the fully smooth video the desktop uses — that
+is a limit of the game compositor itself, not the app — so this is the fastest
+preview Game Mode can give.) Desktop sessions are unchanged and still stream smooth
+video. The viewer also keeps up now when you switch between Game Mode and the
+desktop without restarting anything.
+
 ## 2.9.86
 
 **Correct CPU temperature on AMD boxes.** On some AMD builds (for example a Ryzen

--- a/agent/couchside-portal.py
+++ b/agent/couchside-portal.py
@@ -264,8 +264,37 @@ def _open_pipewire_fd():
 
 # ---------------------------------------------------------------- the verbs ---
 
+def _screencast_backend_ok():
+    """True only when the portal ACTUALLY implements ScreenCast AND RemoteDesktop
+    — i.e. a real backend is present (a KDE / wlroots DESKTOP session). In Steam
+    Game Mode the xdg-desktop-portal frontend runs but has NO screencast backend:
+    both interfaces are absent (Get raises UnknownMethod), _ensure_session's
+    CreateSession can never succeed, and /ws/screen would 101-then-close. Reporting
+    it here keeps caps.screenstream[_h264] HONEST — without it the box advertises a
+    fluid tier that does not exist, and the app burns its full connect timeout on
+    each dead tier (H.264 then MJPEG) before falling back to the still-frame poller.
+
+    Cheap Properties.Get(version) — NO session, NO consent dialog: a live backend
+    answers in ms, a missing one raises immediately. Short-circuits on the first
+    absent interface. Degrade closed (§3.7): any error, or a hung portal, reads as
+    no-backend (False)."""
+    for iface in (_IF_SC, _IF_RD):
+        try:
+            _con.call_sync(
+                _PORTAL, _OBJ, "org.freedesktop.DBus.Properties", "Get",
+                GLib.Variant("(ss)", (iface, "version")),
+                GLib.VariantType.new("(v)"), Gio.DBusCallFlags.NONE, 800, None)
+        except Exception:
+            return False
+    return True
+
+
 def verb_status():
     h264 = _h264_available()
+    # Whether a working portal screencast backend exists (desktop) or not (game
+    # mode). The agent gates caps.screenstream[_h264] on this so a game-mode box
+    # never advertises a fluid tier it can't serve. Cheap + consent-free.
+    backend = _screencast_backend_ok()
     # Read the session WITHOUT taking _SLOCK. _ensure_session holds _SLOCK for its
     # ENTIRE run, including the Start call that BLOCKS on the user's consent (up to
     # _CONSENT_TIMEOUT_S). The agent probes this verb on a ~2s budget to fill
@@ -275,7 +304,8 @@ def verb_status():
     # `_SESSION = {...}` as its last step and _close_session sets it to None, both
     # atomic under the GIL, so a reader sees either None or a fully-built dict.
     sess = _SESSION
-    base = {"ok": True, "h264": h264, "h264_profiles": sorted(_H264_PROFILES)}
+    base = {"ok": True, "screencast": backend,
+            "h264": h264, "h264_profiles": sorted(_H264_PROFILES)}
     if sess is None:
         base["session"] = False
         return base

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3428,11 +3428,12 @@ def real_status():
         **({"audio": audio} if audio else {}),
         "net": net_info_cached(),
         "agent_version": VERSION,
-        # CAPS is a boot-time snapshot, but "desktop" is SESSION-volatile (it
-        # flips with every Game Mode <-> desktop switch), so recompute it per
-        # request — a cheap pgrep — or the app's desktop cluster would freeze
-        # at whatever session the agent booted in.
-        "caps": dict(CAPS, desktop=desktop_available()),
+        # CAPS is a boot-time snapshot, but a few caps are SESSION-volatile — they
+        # flip with every Game Mode <-> desktop switch — so recompute them per
+        # request or the app would freeze at whatever session the agent booted in.
+        # `desktop` is a cheap pgrep; screenstream[_h264] track the portal backend
+        # (present on desktop, absent in Game Mode) and share a short-TTL probe.
+        "caps": dict(CAPS, desktop=desktop_available(), **live_screenstream_caps()),
         # False when the config dir isn't writable by the agent user, so the app
         # can warn that TV pairing / launcher edits won't persist (agent >= 2.9.12).
         "config_writable": CONFIG_WRITABLE,
@@ -6380,6 +6381,37 @@ def screenstream_h264_available():
     game-mode box (no backend) never advertises the H.264 tier it can't serve."""
     r = _portal_call("status", timeout=2)
     return bool(r and r.get("ok") and r.get("h264") and _portal_backend_ok(r))
+
+
+_SCREENCAST_CAPS = {"ts": 0.0, "val": None}
+_SCREENCAST_CAPS_TTL = 5.0
+
+
+def live_screenstream_caps():
+    """Session-volatile screenstream[_h264] caps for /api/status — recomputed per
+    request like `desktop`, NOT read from the boot-time CAPS snapshot.
+
+    The portal's ScreenCast/RemoteDesktop backend is present on a KDE desktop
+    session and ABSENT in Steam Game Mode, so these caps flip with every Game Mode
+    <-> desktop switch. Freezing them at boot leaves stale caps in either direction:
+    a box booted in desktop that launches Game Mode keeps screenstream=True and the
+    app burns a connect timeout on each dead fluid tier before the poller (the ~10s
+    lag); a box booted in Game Mode switched to desktop would never be offered fluid.
+
+    One portal `status` probe answers both caps. A short TTL bounds a burst of
+    pollers (and a fleet of phones) to at most one probe every few seconds. Degrade
+    closed (§3.7): no helper, no backend, or any error -> both False."""
+    now = time.monotonic()
+    c = _SCREENCAST_CAPS
+    if c["val"] is not None and now - c["ts"] < _SCREENCAST_CAPS_TTL:
+        return c["val"]
+    r = _portal_call("status", timeout=2)
+    if r and r.get("ok") and _portal_backend_ok(r):
+        val = {"screenstream": True, "screenstream_h264": bool(r.get("h264"))}
+    else:
+        val = {"screenstream": False, "screenstream_h264": False}
+    c["ts"], c["val"] = now, val
+    return val
 
 
 def _portal_stream_h264(profile, timeout=10):

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -234,6 +234,44 @@ TLS_ADVERT = None  # public TLS advert {"port","fp","spki"} or None (dark). Set 
 CONFIG_PANEL = None  # optional {"device","baud"} RS-232 panel-control config
 CONFIG_WEBOS = None  # optional {"host","mac","client_key"} LG webOS TV config
 CONFIG_SAMSUNG = None  # optional {"host","mac","token"} Samsung Tizen TV config
+
+# --- Short-lived tickets for un-pinnable native loaders (TLS P5) -------------
+# The app pins its OWN TLS socket for the API/WS (react-native-tcp-socket), but the
+# platform <Image> loader and the streamed file uploader CANNOT pin a self-signed
+# cert -- so on a TLS box they'd otherwise carry the bearer token in cleartext
+# (?token= / an Authorization header over http). Instead the app mints a SHORT-LIVED
+# TICKET over the ALREADY-PINNED channel (POST /api/ticket) and passes ?ticket= on
+# those requests. A ticket is NOT the bearer token: it grants only cover-art reads
+# for a few minutes (multi-use) or ONE file upload (single-use), never box control.
+# So even if a ticket is sniffed off the plaintext URL, the real token stays secret.
+_TICKETS = {}                 # ticket_hex -> {"exp": epoch, "once": bool}
+_TICKETS_LOCK = threading.Lock()
+_TICKET_TTL = 300             # seconds
+
+def _mint_ticket(once=False):
+    """Mint a short-lived ticket. once=True -> single-use (file upload)."""
+    t = os.urandom(16).hex()
+    now = time.time()
+    with _TICKETS_LOCK:
+        for k in [k for k, v in _TICKETS.items() if v["exp"] < now]:
+            _TICKETS.pop(k, None)  # opportunistic prune of the expired
+        _TICKETS[t] = {"exp": now + _TICKET_TTL, "once": bool(once)}
+    return t
+
+def _ticket_ok(t):
+    """True iff t is an unexpired ticket. A single-use ticket is CONSUMED here, so
+    a sniffed upload ticket cannot be replayed (the real upload already burned it)."""
+    if not t:
+        return False
+    now = time.time()
+    with _TICKETS_LOCK:
+        v = _TICKETS.get(t)
+        if not v or v["exp"] < now:
+            _TICKETS.pop(t, None)
+            return False
+        if v["once"]:
+            _TICKETS.pop(t, None)
+        return True
 CONFIG_ROKU = None  # optional {"host","name"} Roku (ECP) TV config
 CONFIG_ANDROIDTV = None  # optional {"host","cert","key","name","mac"} Android TV config
 CONFIG_VIDAA = None  # optional {"host","name","mac"} Hisense VIDAA (MQTT) config
@@ -18592,9 +18630,17 @@ class Handler(BaseHTTPRequestHandler):
         if self._authorized():
             return True
         try:
-            supplied = (parse_qs(parsed.query).get("token") or [""])[0]
+            q = parse_qs(parsed.query)
+            supplied = (q.get("token") or [""])[0]
+            ticket = (q.get("ticket") or [""])[0]
         except Exception:
             return False
+        # A short-lived TLS ticket (minted over the PINNED channel, POST /api/ticket)
+        # is accepted for image GETs so the app never puts the real bearer token on
+        # an un-pinnable <Image> request on a TLS box. Reads only -- no state-changing
+        # route uses _authorized_image, and a ticket can never satisfy _authorized().
+        if ticket and _ticket_ok(ticket):
+            return True
         return bool(supplied) and hmac.compare_digest(supplied, self.token)
 
     # -- verbs ---------------------------------------------------------------
@@ -19297,12 +19343,39 @@ class Handler(BaseHTTPRequestHandler):
                                  "port": self.port}, started)
                 return
 
+            # A single-use upload TICKET (minted over the pinned channel) lets the
+            # native streamed uploader push a file WITHOUT the bearer token on the
+            # wire. Checked before the token gate; the ticket is burned on use so a
+            # sniffed URL can't be replayed. Only /api/upload accepts it; every other
+            # state-changing route still demands the real token below.
+            if path == "/api/upload":
+                try:
+                    tk = (parse_qs(parsed.query).get("ticket") or [""])[0]
+                except Exception:
+                    tk = ""
+                if tk and _ticket_ok(tk):
+                    self._handle_upload(parsed, started)
+                    return
+
             # Authorize BEFORE reading the body: an unauthenticated client must
             # not be able to make us allocate for its body. Reject + close so the
             # undrained body can't desync a keep-alive connection.
             if not self._authorized():
                 self.close_connection = True
                 self._send(401, {"error": "unauthorized"}, started)
+                return
+
+            # POST /api/ticket[?once=1] — mint a short-lived ticket the app uses in
+            # ?ticket= on un-pinnable <Image> (cover art) / upload requests, so the
+            # real token never rides those cleartext URLs on a TLS box. Reachable
+            # only PAST the token gate, so a ticket can only be minted by a client
+            # that already holds the token (over the pinned channel).
+            if path == "/api/ticket":
+                try:
+                    once = (parse_qs(parsed.query).get("once") or [""])[0] in ("1", "true", "yes")
+                except Exception:
+                    once = False
+                self._send(200, {"ticket": _mint_ticket(once), "ttl": _TICKET_TTL}, started)
                 return
 
             # POST /api/upload?name=<filename> — a phone->box file drop. Handled

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -6348,13 +6348,25 @@ def _portal_stream(profile, timeout=10):
         return None
 
 
+def _portal_backend_ok(r):
+    """Honor the helper's `screencast` flag: True only when the portal really has
+    a ScreenCast/RemoteDesktop backend (desktop session), False in Steam Game Mode
+    where it is absent. A helper that predates the field omits it -> trust `ok`
+    (old behavior); helper and agent ship together, so a live box always reports
+    it. Keeps caps.screenstream[_h264] honest so the app skips the dead fluid tiers
+    in game mode instead of stalling on each one's connect timeout."""
+    sc = r.get("screencast")
+    return True if sc is None else bool(sc)
+
+
 def screenstream_available():
-    """True when the opt-in remote-desktop module is reachable on its socket.
-    A boot-time hint for caps.screenstream; /ws/screen re-checks live and degrades
-    closed. `status` needs no consent, so this never pops a dialog. Wrapped in
-    safe() at the call site, so any failure reads as unavailable (§3.7)."""
+    """True when the opt-in remote-desktop module is reachable on its socket AND a
+    real portal screencast backend is present. A boot-time hint for caps.screenstream;
+    /ws/screen re-checks live and degrades closed. `status` needs no consent, so this
+    never pops a dialog. Wrapped in safe() at the call site, so any failure reads as
+    unavailable (§3.7)."""
     r = _portal_call("status", timeout=2)
-    return bool(r and r.get("ok"))
+    return bool(r and r.get("ok") and _portal_backend_ok(r))
 
 
 def screenstream_h264_available():
@@ -6364,9 +6376,10 @@ def screenstream_h264_available():
     /ws/h264 (the WebCodecs tier) when the WebView also supports VideoDecoder, and
     /ws/h264 re-checks live + degrades closed. Does NOT require libnice — that is
     only for the parked /ws/webrtc path. The helper's `status` computes h264
-    honestly (see _h264_available there)."""
+    honestly (see _h264_available there). Also gated on a real portal backend, so a
+    game-mode box (no backend) never advertises the H.264 tier it can't serve."""
     r = _portal_call("status", timeout=2)
-    return bool(r and r.get("ok") and r.get("h264"))
+    return bool(r and r.get("ok") and r.get("h264") and _portal_backend_ok(r))
 
 
 def _portal_stream_h264(profile, timeout=10):

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.86"
+VERSION = "2.9.87"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.48",
+    "version": "2.9.49",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.46",
+    "version": "2.9.48",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "176",
+      "buildNumber": "178",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 94
+      "versionCode": 95
     },
     "web": {
       "bundler": "metro",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,1 @@
-Light up your box. If it has an addressable RGB strip — like a Steam Machine's — you can now drive the whole strip from your phone: a real "night rider" sweep, rainbow, breathe, or a solid colour. Effects run on the box, so they keep going with the app closed and come back after a reboot.
-
-Paint each LED its own colour and save the pattern, name your presets to recall them with a tap, and set colour and brightness with smooth sliders.
-
-Whole-system RGB via OpenRGB when it's installed — control your motherboard, RAM and strips too. Plus fixes and polish.
+A much faster remote screen in Game Mode. When your box is in Steam Big Picture / Game Mode, opening the remote screen viewer on your phone used to hang for several seconds before the first picture appeared. Now it shows the live preview right away — what's on your TV shows up on your phone in about a second. Desktop sessions still stream smooth video. Plus reliability fixes and polish.

--- a/app/components/BoxScanPair.tsx
+++ b/app/components/BoxScanPair.tsx
@@ -130,6 +130,10 @@ export function BoxScanPair({
           port: r.port ?? box.port,
           token: r.token,
           lastIp: box.ip,
+          // TOFU-pin a discovered box that advertised TLS (fp came over the LAN,
+          // not a QR — see FoundBox). Absent -> plaintext, as before.
+          tlsPort: box.tlsPort,
+          fp: box.fp,
         });
         setPhase({ k: 'idle' });
         setPin('');

--- a/app/components/BoxScanQr.tsx
+++ b/app/components/BoxScanQr.tsx
@@ -210,6 +210,8 @@ function ScannerModal({ onClose }: { onClose: () => void }) {
           port: link.port,
           token: link.token,
           lastIp: link.ip,
+          tlsPort: link.tlsPort,
+          fp: link.fp,
         });
         // The success beat fires HERE, after the collision gate and the write
         // — not on decode. A success haptic before the one dialog that defends

--- a/app/components/BoxSwitcher.tsx
+++ b/app/components/BoxSwitcher.tsx
@@ -17,6 +17,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { LockBadge } from '@/components/EncryptionBadge';
 import { RemotePowerBar } from '@/components/RemotePowerBar';
 import { hapticSelection } from '@/lib/haptics';
 import {
@@ -112,6 +113,7 @@ export function BoxSwitcher() {
           <Text style={styles.pillLabel} numberOfLines={1}>
             {pillLabel}
           </Text>
+          {boxes.length > 0 && activeBox && <LockBadge secure={activeBox.secure} size={13} />}
           {boxes.length > 0 && (
             <Ionicons
               name={open ? 'chevron-up' : 'chevron-down'}
@@ -156,6 +158,7 @@ export function BoxSwitcher() {
                         {box.host}:{box.port}
                       </Text>
                     </View>
+                    <LockBadge secure={box.secure} size={14} />
                     {isActive && (
                       <Ionicons name="checkmark" size={18} color={t.blue} />
                     )}

--- a/app/components/EncryptionBadge.tsx
+++ b/app/components/EncryptionBadge.tsx
@@ -1,0 +1,56 @@
+/**
+ * Encryption indicator for a box.
+ *
+ * Honest by construction: a `secure` box is pinned + fail-closed — if the cert
+ * pin ever fails it goes UNREACHABLE, never silently plaintext — so "secure" ==
+ * genuinely encrypted whenever the box is reachable. A box that isn't `secure`
+ * talks plain HTTP, token and all. So the badge never lies:
+ *   - closed green lock  -> TLS, cert-pinned to the one paired (encrypted)
+ *   - open amber lock     -> plain HTTP (token + traffic in the clear)
+ */
+import Ionicons from '@expo/vector-icons/Ionicons';
+import { Alert, Pressable, Text, View } from 'react-native';
+
+import { useTheme } from '@/lib/theme';
+
+const AMBER = '#e0a12e';
+
+/** Compact lock glyph — for the box switcher pill + fleet rows. */
+export function LockBadge({ secure, size = 13 }: { secure?: boolean; size?: number }) {
+  const t = useTheme();
+  return (
+    <Ionicons
+      name={secure ? 'lock-closed' : 'lock-open-outline'}
+      size={size}
+      color={secure ? t.green : AMBER}
+      accessibilityLabel={secure ? 'Encrypted connection' : 'Unencrypted connection'}
+    />
+  );
+}
+
+/** Lock + word + a tap-through explainer — for the setup / box-detail screen. */
+export function EncryptionBadge({ secure }: { secure?: boolean }) {
+  const t = useTheme();
+  const explain = () =>
+    Alert.alert(
+      secure ? 'Encrypted connection' : 'Unencrypted connection',
+      secure
+        ? 'Traffic to this box — including your access token — is encrypted with TLS, and '
+          + "the box's certificate is pinned to the exact one you paired. Nobody else on your "
+          + 'network can read it.'
+        : 'This box uses plain HTTP: your access token and traffic travel in the clear on your '
+          + 'local network. Update the box agent, enable encryption on the box, and re-pair '
+          + '(scan its QR) to turn it on.',
+    );
+  return (
+    <Pressable onPress={explain} hitSlop={8}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+        <LockBadge secure={secure} size={15} />
+        <Text style={{ color: secure ? t.green : AMBER, fontSize: 13, fontWeight: '600' }}>
+          {secure ? 'Encrypted' : 'Unencrypted'}
+        </Text>
+        <Ionicons name="information-circle-outline" size={13} color={t.textDim} />
+      </View>
+    </Pressable>
+  );
+}

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -146,7 +146,7 @@ export function StripLightCard() {
       for (let i = 0; i < n; i++) {
         if (first || !sameCell(next[i], last[i])) {
           const cell = next[i];
-          void api.setLed(settings, ol[i].name, cell ? { color: cell, brightness: b } : { brightness: 0 });
+          void api.setLed(settings, ol[i].name, cell ? { color: cell, brightness: b } : { brightness: 0 }).catch(() => {});
         }
       }
       setFrame(next); last = next; first = false; tick++;
@@ -184,7 +184,7 @@ export function StripLightCard() {
     // App fallback: solid/off fill immediately; scanner runs the loop above.
     if (e === 'solid' || e === 'off') {
       const b = Math.round(bright);
-      orderedLeds.forEach((l) => void api.setLed(settings, l.name, e === 'off' ? { brightness: 0 } : { color, brightness: b }));
+      orderedLeds.forEach((l) => void api.setLed(settings, l.name, e === 'off' ? { brightness: 0 } : { color, brightness: b }).catch(() => {}));
       setFrame(orderedLeds.map(() => (e === 'off' ? null : color)));
     }
   };
@@ -196,12 +196,12 @@ export function StripLightCard() {
       void api.setStripEffect(settings, agentStrip.prefix, {
         effect: effect as LedEffect, brightness: Math.round(bright),
         speed: Math.round(speedPct), ...(effect === 'rainbow' ? {} : { color }),
-      });
+      }).catch(() => {});
       return;
     }
     if (effect === 'solid') {
       const b = Math.round(bright);
-      orderedLeds.forEach((l) => void api.setLed(settings, l.name, { color, brightness: b }));
+      orderedLeds.forEach((l) => void api.setLed(settings, l.name, { color, brightness: b }).catch(() => {}));
       setFrame(orderedLeds.map(() => color));
     }
   };
@@ -209,7 +209,7 @@ export function StripLightCard() {
   /** Paint one cell — a per-LED customizer (best in Solid). */
   const paintCell = (i: number) => {
     hapticLight();
-    void api.setLed(settings, orderedLeds[i].name, { color, brightness: Math.round(bright) });
+    void api.setLed(settings, orderedLeds[i].name, { color, brightness: Math.round(bright) }).catch(() => {});
     setFrame((f) => { const c = f.slice(); c[i] = color; return c; });
   };
 
@@ -232,10 +232,11 @@ export function StripLightCard() {
             api.setLed(settings, l.name, pat[i]
               ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) }
               : { brightness: 0 }))))
-          .then(() => poll.refresh());
+          .then(() => poll.refresh())
+          .catch(() => {});
       } else {
         orderedLeds.forEach((l, i) => void api.setLed(settings, l.name, pat[i]
-          ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) } : { brightness: 0 }));
+          ? { color: pat[i] as Rgb, brightness: Math.round(p.brightness) } : { brightness: 0 }).catch(() => {}));
       }
       return;
     }
@@ -246,7 +247,7 @@ export function StripLightCard() {
       void api.setStripEffect(settings, agentStrip.prefix, {
         effect: e as LedEffect, brightness: p.brightness, speed: p.speed,
         ...(e === 'rainbow' ? {} : { color: p.color ?? hueToRgb(h) }),
-      }).then(() => poll.refresh());
+      }).then(() => poll.refresh()).catch(() => {});
     } else {
       void applyEffect(e);
     }

--- a/app/lib/DeepLink.tsx
+++ b/app/lib/DeepLink.tsx
@@ -54,11 +54,11 @@ export function DeepLinkHandler() {
         return;
       }
 
-      const { host, port, token, ip } = parsed.link;
+      const { host, port, token, ip, tlsPort, fp } = parsed.link;
 
       // Navigate only once the box is actually stored and active, so the Pad
       // opens against the box that was just paired rather than the previous one.
-      void addBox({ host, port, token, lastIp: ip }).then(navigateAfterPair, () => {
+      void addBox({ host, port, token, lastIp: ip, tlsPort, fp }).then(navigateAfterPair, () => {
         // addBox failed (storage write) — stay put rather than opening a remote
         // for a box that was never saved.
       });

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { AppState, AppStateStatus } from 'react-native';
 
 import { pingMatchesBox } from './api';
+import { resolveTlsPin } from './boxTlsPair';
 import { getPref } from './prefs';
 import { isAllowedPairHost } from './pairLink';
 import {
@@ -36,6 +37,14 @@ export type AddBoxInput = {
   padMode?: Box['padMode'];
   /** Fallback IP (e.g. from the pairing QR's &ip= param). */
   lastIp?: string;
+  /**
+   * TLS advert from the pairing QR (agent >= P2): the HTTPS port + DER-cert
+   * SHA-256. When both are present, addBox derives + verifies the pin
+   * (resolveTlsPin) and stores `secure` — otherwise the box pairs over plaintext,
+   * exactly as before. Only the QR/deep-link paths supply these.
+   */
+  tlsPort?: number;
+  fp?: string;
   /**
    * The user personally typed this host into the manual add form. ONLY that
    * form may set it. Every other producer of a host string is a machine
@@ -144,6 +153,18 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       const inputIp =
         input.lastIp && isValidLanIp(input.lastIp) ? input.lastIp : undefined;
 
+      // TLS pin (spec §2): when the QR advertised a tls_port + fp, fetch the cert
+      // over plaintext, verify SHA-256(DER)==fp (the QR-delivered anchor), and
+      // derive the modulus to pin. Null on any failure/mismatch -> the box pairs
+      // over plaintext (no regression). This is the ONE place a pin is enabled.
+      const pin =
+        typeof input.tlsPort === 'number' && input.fp
+          ? await resolveTlsPin(host, port, input.tlsPort, input.fp)
+          : null;
+      const pinFields = pin
+        ? { secure: true as const, tlsPort: pin.tlsPort, fp: pin.fp, pinModulus: pin.pinModulus }
+        : {};
+
       const existing = cur.boxes.find((b) => sameTarget(b, host, port));
       if (existing) {
         // Update the match's token/name in place; make it active. No duplicate.
@@ -154,6 +175,9 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
           padMode: input.padMode ?? existing.padMode,
           // A fresh pairing's IP is newer than whatever was cached.
           lastIp: inputIp || existing.lastIp,
+          // Re-pairing with a verified TLS advert refreshes the pin (covers a box
+          // that re-signed its cert); a link without one leaves the pin untouched.
+          ...pinFields,
         };
         const boxes = cur.boxes.map((b) => (b.id === existing.id ? updated : b));
         await commit({ boxes, activeBoxId: existing.id });
@@ -169,6 +193,7 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
         // A newly paired box starts on the user's preferred input mode.
         padMode: input.padMode ?? getPref('defaultPadMode'),
         lastIp: inputIp,
+        ...pinFields,
       };
       await commit({
         boxes: [...cur.boxes, box],

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -157,9 +157,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
       // over plaintext, verify SHA-256(DER)==fp (the QR-delivered anchor), and
       // derive the modulus to pin. Null on any failure/mismatch -> the box pairs
       // over plaintext (no regression). This is the ONE place a pin is enabled.
+      // Fetch the cert over the IP when we have one (a QR/discovery `ip=`): an
+      // mDNS `.local` host may not resolve on the phone (observed on iOS), which
+      // would silently drop the box to plaintext. The pin binds to the cert (its
+      // modulus), not the address, so fetching by IP is equivalent + reliable.
       const pin =
         typeof input.tlsPort === 'number' && input.fp
-          ? await resolveTlsPin(host, port, input.tlsPort, input.fp)
+          ? await resolveTlsPin(inputIp || host, port, input.tlsPort, input.fp)
           : null;
       const pinFields = pin
         ? { secure: true as const, tlsPort: pin.tlsPort, fp: pin.fp, pinModulus: pin.pinModulus }

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -292,6 +292,12 @@ export function useSettings(): SettingsContextValue {
       volumeTarget: activeBox.volumeTarget,
       caps: activeBox.caps,
       lastSeen: activeBox.lastSeen,
+      // TLS pin — without these the pinned transport never engages (the poll,
+      // gamepad + screen all read settings from HERE, not activeSettings()).
+      secure: activeBox.secure,
+      tlsPort: activeBox.tlsPort,
+      fp: activeBox.fp,
+      pinModulus: activeBox.pinModulus,
     };
   }, [activeBox]);
 

--- a/app/lib/__tests__/boxTlsCodec.test.ts
+++ b/app/lib/__tests__/boxTlsCodec.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure codec for the pinned-TLS transport — lib/boxTlsCodec.ts.
+ *
+ * WHY THIS FILE EXISTS. Both functions fail SILENTLY:
+ *
+ *  - normalizeModulus feeds the pin compare in boxTls.connectPinned. If it does
+ *    not reduce getPeerCertificate's format and node-forge's format to the SAME
+ *    string, the compare is wrong in one of two ways, both silent: always-unequal
+ *    (the user is locked out of their own box, looks like "TLS broken"), or — the
+ *    dangerous one — always-equal (the pin is defeated, an MITM cert is accepted).
+ *  - parseHttpResponse turns raw box replies into status/headers/body. A mis-parse
+ *    corrupts every response with no error. The head/body split must be byte-exact
+ *    so a UTF-8 body cannot shift the header boundary.
+ *
+ * Install-free (no forge/native imports) so it runs in CI's fast test glob.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizeModulus, parseHttpResponse } from '../boxTlsCodec.ts';
+
+test('normalizeModulus reduces getPeerCertificate vs forge formats to one string', () => {
+  // The whole point: a colon-delimited uppercase modulus (one platform's shape)
+  // and a bare lowercase one (the other's) must compare EQUAL.
+  const a = normalizeModulus('AB:CD:EF:01:23');
+  const b = normalizeModulus('abcdef0123');
+  assert.equal(a, 'abcdef0123');
+  assert.equal(a, b);
+});
+
+test('normalizeModulus strips 0x, whitespace, case', () => {
+  assert.equal(normalizeModulus('0xABCD'), 'abcd');
+  assert.equal(normalizeModulus('  ab cd  '), 'abcd');
+  assert.equal(normalizeModulus('ABCD'), 'abcd');
+});
+
+test('normalizeModulus drops a leading DER sign byte / zero padding', () => {
+  // openssl/DER prepend a 00 to keep the high-bit-set integer positive; the raw
+  // key does not. Both must normalize the same.
+  assert.equal(normalizeModulus('00abcd'), 'abcd');
+  assert.equal(normalizeModulus('0000abcd'), 'abcd');
+  assert.equal(normalizeModulus('00abcd'), normalizeModulus('abcd'));
+});
+
+test('normalizeModulus returns null for empty / all-zero / nullish (never "")', () => {
+  // A null pin must be caught by the caller as "no pin", never silently equal to
+  // another empty normalization.
+  assert.equal(normalizeModulus(''), null);
+  assert.equal(normalizeModulus(null), null);
+  assert.equal(normalizeModulus(undefined), null);
+  assert.equal(normalizeModulus('0000'), null);
+  assert.equal(normalizeModulus(':::'), null);
+});
+
+const enc = (s: string) => new Uint8Array(Buffer.from(s, 'latin1'));
+
+test('parseHttpResponse: status + lowercased headers + JSON body', () => {
+  const raw = enc(
+    'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 11\r\n\r\n{"ok":true}',
+  );
+  const r = parseHttpResponse(raw);
+  assert.ok(r);
+  assert.equal(r.status, 200);
+  assert.equal(r.headers['content-type'], 'application/json');
+  assert.equal(r.headers['content-length'], '11');
+  assert.deepEqual(JSON.parse(r.body), { ok: true });
+});
+
+test('parseHttpResponse: 401 and other statuses parse', () => {
+  const r = parseHttpResponse(enc('HTTP/1.1 401 Unauthorized\r\n\r\n{"error":"unauthorized"}'));
+  assert.ok(r);
+  assert.equal(r.status, 401);
+  assert.deepEqual(JSON.parse(r.body), { error: 'unauthorized' });
+});
+
+test('parseHttpResponse returns null until the CRLFCRLF header terminator arrives', () => {
+  assert.equal(parseHttpResponse(enc('HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n')), null);
+  assert.equal(parseHttpResponse(enc('')), null);
+});
+
+test('parseHttpResponse: a UTF-8 body does not shift the header boundary', () => {
+  // Build the head as latin1 and the body as UTF-8 (a multibyte char), then splice
+  // the raw bytes — exactly what arrives on the wire. The head scan must find the
+  // separator by bytes, and the body must decode back to the original string.
+  const body = '{"name":"café ☕ 日本"}';
+  const head = 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n';
+  const raw = new Uint8Array(Buffer.concat([Buffer.from(head, 'latin1'), Buffer.from(body, 'utf8')]));
+  const r = parseHttpResponse(raw);
+  assert.ok(r);
+  assert.equal(r.status, 200);
+  assert.equal(r.body, body);
+  assert.equal(JSON.parse(r.body).name, 'café ☕ 日本');
+});
+
+test('parseHttpResponse: colons in the body do not leak into header parsing', () => {
+  const raw = enc('HTTP/1.1 200 OK\r\nX-A: 1\r\n\r\n{"ratio":"16:9","t":"a:b:c"}');
+  const r = parseHttpResponse(raw);
+  assert.ok(r);
+  assert.deepEqual(Object.keys(r.headers), ['x-a']);
+  assert.equal(r.headers['x-a'], '1');
+  assert.deepEqual(JSON.parse(r.body), { ratio: '16:9', t: 'a:b:c' });
+});

--- a/app/lib/__tests__/boxTlsCodec.test.ts
+++ b/app/lib/__tests__/boxTlsCodec.test.ts
@@ -17,7 +17,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { normalizeModulus, parseHttpResponse } from '../boxTlsCodec.ts';
+import { httpFrameLength, normalizeModulus, parseHttpResponse } from '../boxTlsCodec.ts';
 
 test('normalizeModulus reduces getPeerCertificate vs forge formats to one string', () => {
   // The whole point: a colon-delimited uppercase modulus (one platform's shape)
@@ -99,4 +99,40 @@ test('parseHttpResponse: colons in the body do not leak into header parsing', ()
   assert.deepEqual(Object.keys(r.headers), ['x-a']);
   assert.equal(r.headers['x-a'], '1');
   assert.deepEqual(JSON.parse(r.body), { ratio: '16:9', t: 'a:b:c' });
+});
+
+// httpFrameLength: frames responses on a REUSED keep-alive socket. A wrong length
+// desyncs the stream — every subsequent response on that socket is garbage.
+test('httpFrameLength: -1 until the header terminator, then headers+Content-Length', () => {
+  assert.equal(httpFrameLength(enc('HTTP/1.1 200 OK\r\nContent-Length: 11\r\n')), -1); // headers incomplete
+  const full = 'HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n{"ok":true}';
+  assert.equal(httpFrameLength(enc(full)), full.length);
+  assert.equal(httpFrameLength(enc(full)), full.indexOf('\r\n\r\n') + 4 + 11);
+});
+
+test('httpFrameLength: case-insensitive Content-Length; no CL = header-only', () => {
+  const lc = 'HTTP/1.1 200 OK\r\ncontent-length: 3\r\n\r\nabc';
+  assert.equal(httpFrameLength(enc(lc)), lc.length);
+  const none = 'HTTP/1.1 204 No Content\r\nX: y\r\n\r\n';
+  assert.equal(httpFrameLength(enc(none)), none.length); // sep+4, no body
+});
+
+test('httpFrameLength: with two responses buffered, returns ONLY the first', () => {
+  // The crux of keep-alive framing: the frame length must stop at the end of the
+  // first response so the leftover bytes are handed to the next one intact.
+  const first = 'HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello';
+  const second = 'HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi';
+  const n = httpFrameLength(enc(first + second));
+  assert.equal(n, first.length);
+  // the remainder is exactly the second response, framable on its own
+  const restBytes = enc(first + second).subarray(n);
+  assert.equal(httpFrameLength(restBytes), second.length);
+});
+
+test('httpFrameLength: body not fully arrived still returns the total expected length', () => {
+  // Headers say 11 bytes but only 4 arrived — caller keeps buffering until it has n.
+  const partial = 'HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\n{"ok';
+  const n = httpFrameLength(enc(partial));
+  assert.equal(n, partial.indexOf('\r\n\r\n') + 4 + 11);
+  assert.ok(enc(partial).length < n); // caller correctly waits for more
 });

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -5,6 +5,7 @@
 import { Buffer } from 'buffer';
 import { isPinMismatchError, pinnedRequest, type PinnedResponse } from './boxTransport.ts';
 import { isDeclaredTooLarge, isUsableBodySize } from './responseCap';
+import { ensureImageTicket, getImageTicket, mintUploadTicket } from './ticket.ts';
 import { Settings } from './settings';
 
 /** The subset of Settings the API client actually needs. */
@@ -1389,11 +1390,23 @@ export async function uploadFile(
 ): Promise<UploadResult> {
   const { File, UploadType } = await import('expo-file-system');
   const host = resolveEffectiveHost(settings);
-  const url = `${baseUrl({ host, port: settings.port })}/api/upload?name=${encodeURIComponent(name)}`;
+  let url = `${baseUrl({ host, port: settings.port })}/api/upload?name=${encodeURIComponent(name)}`;
+  let headers: Record<string, string> = { Authorization: `Bearer ${settings.token}` };
+  // Secure box: the native streamed uploader can't pin, so keep the token off the
+  // wire with a SINGLE-USE ticket (minted over the pinned channel). The file bytes
+  // still ride plaintext http (documented residual), but the token does not. A rare
+  // mint failure falls back to the token header for just this one request.
+  if (settings.secure && settings.pinModulus && settings.tlsPort) {
+    const t = await mintUploadTicket(settings, host);
+    if (t) {
+      url = `http://${host}:${settings.port}/api/upload?name=${encodeURIComponent(name)}&ticket=${encodeURIComponent(t)}`;
+      headers = {};
+    }
+  }
   const task = new File(fileUri).createUploadTask(url, {
     httpMethod: 'POST',
     uploadType: UploadType.BINARY_CONTENT,
-    headers: { Authorization: `Bearer ${settings.token}` },
+    headers,
     onProgress: ({ bytesSent, totalBytes }: { bytesSent: number; totalBytes: number }) => {
       if (onProgress && totalBytes > 0) onProgress(bytesSent / totalBytes);
     },
@@ -2163,6 +2176,17 @@ export const api = {
    */
   steamCoverSource(settings: ConnSettings, appid: number): ImageSource {
     const host = resolveEffectiveHost(settings);
+    // Secure box: the token can't ride an un-pinnable <Image>, so authorize with a
+    // short-lived TLS TICKET (minted over the pinned channel) instead. Until a
+    // ticket is warm (the first ~second on a fresh secure box) the request 401s and
+    // the tile shows its text fallback — never the token. Cover art is public, so
+    // its bytes over http are not sensitive; only the token needed protecting.
+    if (settings.secure && settings.pinModulus && settings.tlsPort) {
+      ensureImageTicket(settings, host);
+      const t = getImageTicket(host, settings.port);
+      const base = `http://${host}:${settings.port}/api/steam/${appid}/cover`;
+      return { uri: t ? `${base}?ticket=${encodeURIComponent(t)}` : base };
+    }
     // The token goes in BOTH the header and the query, on purpose.
     //
     // MEASURED, not assumed: React Native's <Image> accepts source.headers, and

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -3,11 +3,15 @@
  * Base URL: http://<host>:<port>  (default port 8787)
  */
 import { Buffer } from 'buffer';
+import { isPinMismatchError, pinnedRequest, type PinnedResponse } from './boxTransport.ts';
 import { isDeclaredTooLarge, isUsableBodySize } from './responseCap';
 import { Settings } from './settings';
 
 /** The subset of Settings the API client actually needs. */
-export type ConnSettings = Pick<Settings, 'host' | 'port' | 'token' | 'lastIp'>;
+export type ConnSettings = Pick<
+  Settings,
+  'host' | 'port' | 'token' | 'lastIp' | 'secure' | 'tlsPort' | 'pinModulus'
+>;
 
 /**
  * A remote image source (uri + optional request headers). Structurally a subset
@@ -1474,6 +1478,20 @@ export async function screenFrameSource(
 }
 
 /** One fetch attempt against a specific host. Throws ApiError on transport failure. */
+/**
+ * Adapt a PinnedResponse to the subset of the fetch `Response` shape that
+ * request() consumes (status, ok, json(), text()) — so the pinned-TLS path drops
+ * into the existing host-selection + error-handling flow unchanged.
+ */
+function pinnedToResponse(pr: PinnedResponse): Response {
+  return {
+    status: pr.status,
+    ok: pr.status >= 200 && pr.status < 300,
+    json: async () => JSON.parse(pr.body || 'null'),
+    text: async () => pr.body,
+  } as unknown as Response;
+}
+
 async function attempt(
   host: string,
   settings: ConnSettings,
@@ -1502,6 +1520,24 @@ async function attempt(
     );
   });
   try {
+    // Secure box (spec §2/P5): the bearer token rides a modulus-pinned TLS
+    // socket, never a cleartext header. FAIL CLOSED — there is deliberately no
+    // http fallback here, because a blocked/spoofed TLS port must NOT be allowed
+    // to downgrade the token back onto the wire. (The probe/ping/pair paths stay
+    // plaintext: they are pre-auth and carry no token.)
+    if (settings.secure && settings.pinModulus && settings.tlsPort) {
+      const pr = await Promise.race([
+        pinnedRequest(host, settings.tlsPort, settings.pinModulus, {
+          method,
+          path,
+          token: auth ? settings.token : undefined,
+          body: body !== undefined ? JSON.stringify(body) : undefined,
+          timeoutMs,
+        }),
+        hardDeadline,
+      ]);
+      return pinnedToResponse(pr);
+    }
     const headers: Record<string, string> = {};
     if (auth) headers.Authorization = `Bearer ${settings.token}`;
     if (body !== undefined) headers['Content-Type'] = 'application/json';
@@ -1514,6 +1550,12 @@ async function attempt(
     return await Promise.race([fetchPromise, hardDeadline]);
   } catch (e: unknown) {
     if (e instanceof ApiError) throw e; // hard-deadline timeout, already shaped
+    if (isPinMismatchError(e)) {
+      // A secure box presented an unexpected cert. Fail closed, do NOT retry over
+      // plaintext; surface as unreachable so the reconnect loop keeps trying the
+      // pinned transport (a re-pair is the real fix).
+      throw new ApiError('unreachable', 'TLS certificate pin mismatch');
+    }
     if (e instanceof Error && e.name === 'AbortError') {
       throw new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`);
     }

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1419,6 +1419,50 @@ export function base64FromArrayBuffer(buf: ArrayBuffer): string {
 }
 
 /**
+ * GET a binary body (cover art, screen frames) with bearer auth. On a `secure`
+ * box the token AND the bytes ride the modulus-pinned TLS socket (never cleartext
+ * header/query); plaintext http otherwise. Returns content-type + the declared
+ * length (for the caller's pre-decode cap) + the raw bytes, or null on non-2xx /
+ * transport error. NOTE: over the pinned path the whole body is read before this
+ * returns, so the Content-Length pre-read refusal is advisory there — a paired
+ * (trusted) box only; a hard read cap on pinnedRequest is a follow-up.
+ */
+async function binaryGet(
+  settings: ConnSettings,
+  path: string,
+  signal?: AbortSignal,
+): Promise<{ contentType: string; declaredLen: string | null; bytes: Uint8Array } | null> {
+  const host = resolveEffectiveHost(settings);
+  try {
+    if (settings.secure && settings.pinModulus && settings.tlsPort) {
+      const pr = await pinnedRequest(host, settings.tlsPort, settings.pinModulus, {
+        method: 'GET',
+        path,
+        token: settings.token,
+      });
+      if (pr.status < 200 || pr.status >= 300) return null;
+      return {
+        contentType: pr.headers['content-type'] || 'image/jpeg',
+        declaredLen: pr.headers['content-length'] ?? null,
+        bytes: pr.bodyBytes,
+      };
+    }
+    const res = await fetch(`http://${host}:${settings.port}${path}`, {
+      headers: { Authorization: `Bearer ${settings.token}` },
+      signal,
+    });
+    if (!res.ok) return null;
+    return {
+      contentType: res.headers.get('Content-Type') || 'image/jpeg',
+      declaredLen: res.headers.get('Content-Length'),
+      bytes: new Uint8Array(await res.arrayBuffer()),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Album art for a player's current track, as a base64 `data:` URI for <Image>.
  * Fetches from the resolved host (§3b) with the bearer token (an <Image> URL
  * can't carry Authorization) and inlines the bytes, so nothing sensitive lands
@@ -1429,25 +1473,15 @@ export async function mediaArtSource(
   player: string,
   artKey: string,
 ): Promise<string | null> {
-  const host = resolveEffectiveHost(settings);
-  const url = `http://${host}:${settings.port}/api/media/art?player=${encodeURIComponent(
-    player,
-  )}&k=${encodeURIComponent(artKey)}`;
-  try {
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` } });
-    if (!res.ok) return null;
-    // Refuse an oversized body BEFORE reading it — the only point where refusing
-    // actually avoids buffering the bytes (KI-035).
-    if (isDeclaredTooLarge(res.headers.get('Content-Length'))) return null;
-    const type = res.headers.get('Content-Type') || 'image/jpeg';
-    const buf = await res.arrayBuffer();
-    // Backstop for a missing or dishonest Content-Length: stop here rather than
-    // base64-amplifying it ~1.33x and handing a giant string to <Image>.
-    if (!isUsableBodySize(buf.byteLength)) return null;
-    return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
-  } catch {
-    return null;
-  }
+  const path = `/api/media/art?player=${encodeURIComponent(player)}&k=${encodeURIComponent(artKey)}`;
+  const r = await binaryGet(settings, path);
+  if (!r) return null;
+  // Refuse an oversized body (plaintext: before reading; see binaryGet's note).
+  if (isDeclaredTooLarge(r.declaredLen)) return null;
+  // Backstop for a missing/dishonest Content-Length: stop rather than base64-
+  // amplifying it ~1.33x and handing a giant string to <Image>.
+  if (!isUsableBodySize(r.bytes.byteLength)) return null;
+  return `data:${r.contentType};base64,${Buffer.from(r.bytes).toString('base64')}`;
 }
 
 /**
@@ -1460,21 +1494,14 @@ export async function mediaArtSource(
 export async function screenFrameSource(
   settings: ConnSettings, signal?: AbortSignal,
 ): Promise<string | null> {
-  const host = resolveEffectiveHost(settings);
-  const url = `http://${host}:${settings.port}/api/screen/frame?t=${Date.now()}`;
-  try {
-    const res = await fetch(url, { headers: { Authorization: `Bearer ${settings.token}` }, signal });
-    if (!res.ok) return null;
-    // Same cap as album art, and it matters more here: the preview POLLS, so an
-    // oversized frame gets a fresh chance at the phone's memory every tick.
-    if (isDeclaredTooLarge(res.headers.get('Content-Length'))) return null;
-    const type = res.headers.get('Content-Type') || 'image/jpeg';
-    const buf = await res.arrayBuffer();
-    if (!isUsableBodySize(buf.byteLength)) return null;
-    return `data:${type};base64,${base64FromArrayBuffer(buf)}`;
-  } catch {
-    return null;
-  }
+  const path = `/api/screen/frame?t=${Date.now()}`;
+  const r = await binaryGet(settings, path, signal);
+  if (!r) return null;
+  // Same cap as album art, and it matters more here: the preview POLLS, so an
+  // oversized frame gets a fresh chance at the phone's memory every tick.
+  if (isDeclaredTooLarge(r.declaredLen)) return null;
+  if (!isUsableBodySize(r.bytes.byteLength)) return null;
+  return `data:${r.contentType};base64,${Buffer.from(r.bytes).toString('base64')}`;
 }
 
 /** One fetch attempt against a specific host. Throws ApiError on transport failure. */

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -50,7 +50,26 @@ export type FoundBox = {
   port: number;
   /** Agent version (so the UI can flag a box too old to PIN-pair). */
   version: string;
+  /**
+   * TLS advert (agent >= P2): the HTTPS port + DER-cert SHA-256 the box announced
+   * on /api/ping / the UDP reply. Present ONLY as a validated pair. Used to pin a
+   * discovered box at pair time. NOTE the trust: unlike a QR fp (read off the box's
+   * own screen), this fp arrives over the LAN — TOFU, i.e. it stops a PASSIVE
+   * eavesdropper but not an active MITM present at first pairing.
+   */
+  tlsPort?: number;
+  fp?: string;
 };
+
+/** Extract + validate a box's advertised TLS pin fields from a ping/UDP reply. */
+function readTlsAdvert(d: Record<string, unknown>): { tlsPort?: number; fp?: string } {
+  const p = d.tls_port;
+  const f = typeof d.tls_fp === 'string' ? d.tls_fp.toLowerCase() : '';
+  if (typeof p === 'number' && Number.isInteger(p) && p >= 1 && p <= 65535 && /^[0-9a-f]{64}$/.test(f)) {
+    return { tlsPort: p, fp: f };
+  }
+  return {};
+}
 
 /**
  * The device's own LAN IPv4, used to derive the /24 to sweep. Best-effort —
@@ -104,6 +123,7 @@ async function pingHost(ip: string, port: number, timeoutMs: number): Promise<Fo
       ip,
       port,
       version: typeof d.version === 'string' ? d.version : '',
+      ...readTlsAdvert(d),
     };
   } catch {
     return null; // unreachable / not an agent / timed out
@@ -238,6 +258,7 @@ function udpProbe(
             ip: rinfo.address,
             port: typeof d.port === 'number' ? d.port : port,
             version: typeof d.version === 'string' ? d.version : '',
+            ...readTlsAdvert(d),
           };
           found.set(rinfo.address, box);
           // Same drain fix as the HTTP sweep: replies land in milliseconds but

--- a/app/lib/boxTls.ts
+++ b/app/lib/boxTls.ts
@@ -1,0 +1,192 @@
+/**
+ * Pinned TLS transport to a Couchside box (TLS P5, phase 5a).
+ *
+ * THE WALL (spec §1): RN's fetch/WebSocket/<Image>/WebView give no self-signed
+ * trust override, and — proven by the 2026-08-13 device spike (spec §2) —
+ * react-native-tcp-socket's `{ca}` option does NOT enforce a pin on iOS (the
+ * native side manually accepts every cert once a `ca` is present). The one
+ * mechanism that authenticates on BOTH iOS and Android is a MANUAL pin: connect
+ * accept-all (encrypt), then read the live cert via getPeerCertificate() and
+ * compare its RSA modulus to the modulus captured at pairing. This module is that
+ * transport: `connectPinned` + a hand-rolled HTTP/1.1 client over the socket. The
+ * RFC6455 WS client (phase 5b) rides the same `connectPinned`.
+ *
+ * Trust root = physical possession of the box at pairing (the fingerprint is read
+ * off the box's own screen and delivered in the QR); the modulus is derived from
+ * the PEM whose integrity that fingerprint proves. On mismatch we DESTROY the
+ * socket before a byte of app data is sent — an active MITM presenting any other
+ * cert is rejected in JS.
+ *
+ * Plaintext http/ws is NEVER removed (spec Decision B): callers fall back to it
+ * for boxes without a pin. This module is only used when a box has `secure` +
+ * `pinModulus`.
+ */
+import { Buffer } from 'buffer';
+import forge from 'node-forge';
+import TcpSocket from 'react-native-tcp-socket';
+
+import { normalizeModulus, parseHttpResponse, type PinnedResponse } from './boxTlsCodec';
+
+export { normalizeModulus, parseHttpResponse } from './boxTlsCodec';
+export type { PinnedResponse } from './boxTlsCodec';
+
+/**
+ * RSA modulus (normalized hex) of a PEM certificate, via node-forge. Called at
+ * PAIRING time on the PEM fetched from /api/tls/cert (whose integrity the QR fp
+ * proves) to derive the value we pin. Lives here (not the pure codec) because it
+ * needs forge; its output must match getPeerCertificate's live modulus at connect
+ * — device-verified end-to-end by the 2026-08-13 spike, and forge's modulus
+ * derivation is cross-checked against openssl in lib/tvdirect/__tests__.
+ */
+export function modulusFromPem(pem: string): string | null {
+  try {
+    const cert = forge.pki.certificateFromPem(pem);
+    const key = cert.publicKey as forge.pki.rsa.PublicKey;
+    if (!key?.n) return null;
+    return normalizeModulus(key.n.toString(16));
+  } catch {
+    return null;
+  }
+}
+
+/** A live, pinned TLS byte stream. Mirrors the shape lib/tvdirect uses. */
+export type PinnedSocket = {
+  write(bytes: Uint8Array): void;
+  onData(cb: (bytes: Uint8Array) => void): void;
+  onClose(cb: () => void): void;
+  close(): void;
+};
+
+export class PinMismatchError extends Error {
+  constructor(
+    readonly liveModulus: string | null,
+    readonly pinnedModulus: string,
+  ) {
+    super('TLS pin mismatch: the box presented a certificate whose key does not match the pinned one');
+    this.name = 'PinMismatchError';
+  }
+}
+
+type PeerCert = { modulus?: string; pubkey?: string } | null;
+
+// getPeerCertificate fires before the native TLS handshake finishes (see the
+// atvnative note) — poll briefly until the modulus is available.
+async function readLiveModulus(sock: { getPeerCertificate?: () => Promise<PeerCert> }, timeoutMs = 6000): Promise<string | null> {
+  if (typeof sock.getPeerCertificate !== 'function') return null;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const cert = await sock.getPeerCertificate();
+      if (cert && cert.modulus) return normalizeModulus(cert.modulus);
+    } catch {
+      // not secured yet — retry
+    }
+    if (Date.now() >= deadline) return null;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+}
+
+/**
+ * Open a TLS socket to the box and AUTHENTICATE it by modulus pin. Resolves only
+ * once the live cert's modulus matches `pinModulus`; rejects (and destroys the
+ * socket) on mismatch, on a missing modulus, or on any connect error.
+ *
+ * `pinModulus` must already be normalized (use modulusFromPem at pairing time).
+ * `{ca}` is passed too — harmless on iOS (ignored), and it gives Android native
+ * enforcement for free — but the modulus compare below is the load-bearing check
+ * on both platforms.
+ */
+export function connectPinned(
+  host: string,
+  port: number,
+  pinModulus: string,
+  opts?: { caPem?: string; timeoutMs?: number },
+): Promise<PinnedSocket> {
+  const timeoutMs = opts?.timeoutMs ?? 12000;
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let dataCb: ((b: Uint8Array) => void) | null = null;
+    let closeCb: (() => void) | null = null;
+    const fail = (e: Error) => {
+      if (settled) return;
+      settled = true;
+      try { sock.destroy(); } catch {}
+      reject(e);
+    };
+    const timer = setTimeout(() => fail(new Error('pinned connect timeout')), timeoutMs);
+    // ca/rejectUnauthorized are read natively but absent from the .d.ts -> cast.
+    const tlsOpts: Record<string, unknown> = { host, port };
+    if (opts?.caPem) { tlsOpts.ca = opts.caPem; tlsOpts.rejectUnauthorized = true; }
+    else { tlsOpts.rejectUnauthorized = false; }
+    const sock = (TcpSocket.connectTLS as unknown as (o: Record<string, unknown>, cb: () => void) => any)(
+      tlsOpts,
+      () => {
+        // Secure (encrypted) — now authenticate by modulus before resolving.
+        void (async () => {
+          const live = await readLiveModulus(sock);
+          if (settled) return;
+          if (!live || live !== pinModulus) {
+            clearTimeout(timer);
+            fail(new PinMismatchError(live, pinModulus));
+            return;
+          }
+          settled = true;
+          clearTimeout(timer);
+          resolve({
+            write: (b) => sock.write(Buffer.from(b) as unknown as string),
+            onData: (cb) => { dataCb = cb; },
+            onClose: (cb) => { closeCb = cb; },
+            close: () => { try { sock.destroy(); } catch {} },
+          });
+        })();
+      },
+    );
+    sock.on('data', (d: string | Buffer) => {
+      const bytes = typeof d === 'string' ? Uint8Array.from(Buffer.from(d, 'base64')) : Uint8Array.from(d);
+      dataCb?.(bytes);
+    });
+    sock.on('error', (e: Error) => fail(e));
+    sock.on('close', () => { if (settled) closeCb?.(); else fail(new Error('socket closed before TLS pin verified')); });
+  });
+}
+
+// ---- Hand-rolled HTTP/1.1 client over the pinned socket ---------------------
+
+/**
+ * One HTTP/1.1 request over a freshly-pinned socket, `Connection: close` so the
+ * box closes when done and we read the whole response. Replaces `fetch` for box
+ * calls when the box is `secure`. Small JSON responses only — this is the box
+ * control API, not a bulk transfer.
+ */
+export async function pinnedRequest(
+  host: string,
+  port: number,
+  pinModulus: string,
+  req: { method?: string; path: string; token?: string; body?: string; caPem?: string; timeoutMs?: number },
+): Promise<PinnedResponse> {
+  const sock = await connectPinned(host, port, pinModulus, { caPem: req.caPem, timeoutMs: req.timeoutMs });
+  return new Promise<PinnedResponse>((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    let done = false;
+    const finish = (fn: () => void) => { if (done) return; done = true; try { sock.close(); } catch {} fn(); };
+    const readTimer = setTimeout(
+      () => finish(() => reject(new Error('pinned request read timeout'))),
+      req.timeoutMs ?? 12000,
+    );
+    sock.onData((b) => chunks.push(b));
+    sock.onClose(() => {
+      clearTimeout(readTimer);
+      const raw = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+      const parsed = parseHttpResponse(new Uint8Array(raw));
+      finish(() => (parsed ? resolve(parsed) : reject(new Error('malformed HTTP response'))));
+    });
+    const method = req.method ?? 'GET';
+    const bodyBytes = req.body ? Buffer.from(req.body, 'utf8') : null;
+    let head = `${method} ${req.path} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n`;
+    if (req.token) head += `Authorization: Bearer ${req.token}\r\n`;
+    if (bodyBytes) head += `Content-Type: application/json\r\nContent-Length: ${bodyBytes.length}\r\n`;
+    head += '\r\n';
+    sock.write(new Uint8Array(Buffer.from(head, 'utf8')));
+    if (bodyBytes) sock.write(new Uint8Array(bodyBytes));
+  });
+}

--- a/app/lib/boxTls.ts
+++ b/app/lib/boxTls.ts
@@ -24,7 +24,7 @@
 import { Buffer } from 'buffer';
 import TcpSocket from 'react-native-tcp-socket';
 
-import { normalizeModulus, parseHttpResponse, type PinnedResponse } from './boxTlsCodec';
+import { httpFrameLength, normalizeModulus, parseHttpResponse, type PinnedResponse } from './boxTlsCodec';
 
 export { normalizeModulus, parseHttpResponse } from './boxTlsCodec';
 export type { PinnedResponse } from './boxTlsCodec';
@@ -133,43 +133,166 @@ export function connectPinned(
   });
 }
 
-// ---- Hand-rolled HTTP/1.1 client over the pinned socket ---------------------
+// ---- Hand-rolled HTTP/1.1 client over a REUSED pinned socket ----------------
+//
+// A per-box persistent connection: connect + verify the modulus ONCE, then reuse
+// the socket for every request with HTTP/1.1 keep-alive + Content-Length framing.
+// The alternative — a fresh TLS handshake + getPeerCertificate retry PER request —
+// stacks into seconds of latency on repeated calls (the screen still-frame poll,
+// dozens of connects per second). Requests to one box are serialized over its one
+// socket; the connection self-heals on close/error (the pin is re-verified on the
+// reconnect). The agent is HTTP/1.1 and sends an exact Content-Length on every
+// response, so framing on a reused socket is safe.
+
+function u8concat(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a);
+  out.set(b, a.length);
+  return out;
+}
+
+type PendingReq = {
+  bytes: Uint8Array;
+  resolve: (r: PinnedResponse) => void;
+  reject: (e: Error) => void;
+  timeoutMs: number;
+};
+
+class PinnedConn {
+  private sock: PinnedSocket | null = null;
+  private connectP: Promise<PinnedSocket> | null = null;
+  private queue: PendingReq[] = [];
+  private active: PendingReq | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private buf: Uint8Array = new Uint8Array(0);
+  private wantLen = -1; // total bytes (headers+body) of the in-flight response, -1 until headers parse
+
+  constructor(
+    private host: string,
+    private port: number,
+    private pin: string,
+    private caPem?: string,
+  ) {}
+
+  request(bytes: Uint8Array, timeoutMs: number): Promise<PinnedResponse> {
+    return new Promise((resolve, reject) => {
+      this.queue.push({ bytes, resolve, reject, timeoutMs });
+      void this.pump();
+    });
+  }
+
+  private ensureSock(): Promise<PinnedSocket> {
+    if (this.sock) return Promise.resolve(this.sock);
+    if (!this.connectP) {
+      this.connectP = connectPinned(this.host, this.port, this.pin, { caPem: this.caPem })
+        .then((s) => {
+          this.sock = s;
+          this.buf = new Uint8Array(0);
+          s.onData((b) => this.onData(b));
+          s.onClose(() => this.onClose());
+          return s;
+        })
+        .finally(() => {
+          this.connectP = null;
+        });
+    }
+    return this.connectP;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.active || this.queue.length === 0) return;
+    const req = this.queue[0];
+    this.active = req;
+    this.wantLen = -1;
+    let sock: PinnedSocket;
+    try {
+      sock = await this.ensureSock();
+    } catch (e) {
+      this.failActive(e as Error);
+      return;
+    }
+    this.timer = setTimeout(() => this.failActive(new Error('pinned request timeout')), req.timeoutMs);
+    try {
+      sock.write(req.bytes);
+    } catch (e) {
+      this.failActive(e as Error);
+    }
+  }
+
+  private onData(bytes: Uint8Array): void {
+    if (!this.active) return; // stray bytes with nothing in flight — drop
+    this.buf = u8concat(this.buf, bytes);
+    if (this.wantLen < 0) {
+      this.wantLen = httpFrameLength(this.buf);
+      if (this.wantLen < 0) return; // headers still arriving
+    }
+    if (this.buf.length < this.wantLen) return; // body still arriving
+    const raw = this.buf.subarray(0, this.wantLen);
+    const rest = this.buf.slice(this.wantLen);
+    const parsed = parseHttpResponse(raw);
+    const req = this.active;
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    this.queue.shift();
+    this.active = null;
+    this.wantLen = -1;
+    this.buf = rest;
+    if (parsed) req!.resolve(parsed);
+    else req!.reject(new Error('malformed HTTP response'));
+    void this.pump();
+  }
+
+  private failActive(e: Error): void {
+    const req = this.active;
+    if (this.timer) { clearTimeout(this.timer); this.timer = null; }
+    this.active = null;
+    this.wantLen = -1;
+    // A mid-response error may have left the stream desynced — drop the socket so
+    // the next request reconnects and re-verifies the pin.
+    try { this.sock?.close(); } catch {}
+    this.sock = null;
+    this.buf = new Uint8Array(0);
+    if (req) {
+      this.queue.shift();
+      req.reject(e);
+    }
+    void this.pump();
+  }
+
+  private onClose(): void {
+    this.sock = null;
+    this.buf = new Uint8Array(0);
+    if (this.active) this.failActive(new Error('pinned socket closed'));
+    else void this.pump();
+  }
+}
+
+const POOL = new Map<string, PinnedConn>();
 
 /**
- * One HTTP/1.1 request over a freshly-pinned socket, `Connection: close` so the
- * box closes when done and we read the whole response. Replaces `fetch` for box
- * calls when the box is `secure`. Small JSON responses only — this is the box
- * control API, not a bulk transfer.
+ * One HTTP/1.1 request over a REUSED, modulus-pinned keep-alive socket to the box.
+ * Replaces fetch for box calls when the box is secure. Requests to the same box
+ * share one TLS connection (handshake + pin verify amortized), serialized in order.
  */
-export async function pinnedRequest(
+export function pinnedRequest(
   host: string,
   port: number,
   pinModulus: string,
   req: { method?: string; path: string; token?: string; body?: string; caPem?: string; timeoutMs?: number },
 ): Promise<PinnedResponse> {
-  const sock = await connectPinned(host, port, pinModulus, { caPem: req.caPem, timeoutMs: req.timeoutMs });
-  return new Promise<PinnedResponse>((resolve, reject) => {
-    const chunks: Uint8Array[] = [];
-    let done = false;
-    const finish = (fn: () => void) => { if (done) return; done = true; try { sock.close(); } catch {} fn(); };
-    const readTimer = setTimeout(
-      () => finish(() => reject(new Error('pinned request read timeout'))),
-      req.timeoutMs ?? 12000,
-    );
-    sock.onData((b) => chunks.push(b));
-    sock.onClose(() => {
-      clearTimeout(readTimer);
-      const raw = Buffer.concat(chunks.map((c) => Buffer.from(c)));
-      const parsed = parseHttpResponse(new Uint8Array(raw));
-      finish(() => (parsed ? resolve(parsed) : reject(new Error('malformed HTTP response'))));
-    });
-    const method = req.method ?? 'GET';
-    const bodyBytes = req.body ? Buffer.from(req.body, 'utf8') : null;
-    let head = `${method} ${req.path} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n`;
-    if (req.token) head += `Authorization: Bearer ${req.token}\r\n`;
-    if (bodyBytes) head += `Content-Type: application/json\r\nContent-Length: ${bodyBytes.length}\r\n`;
-    head += '\r\n';
-    sock.write(new Uint8Array(Buffer.from(head, 'utf8')));
-    if (bodyBytes) sock.write(new Uint8Array(bodyBytes));
-  });
+  const key = `${host}:${port}:${pinModulus.slice(0, 16)}`;
+  let conn = POOL.get(key);
+  if (!conn) {
+    conn = new PinnedConn(host, port, pinModulus, req.caPem);
+    POOL.set(key, conn);
+  }
+  const method = req.method ?? 'GET';
+  const bodyBytes = req.body ? Buffer.from(req.body, 'utf8') : null;
+  let head = `${method} ${req.path} HTTP/1.1\r\nHost: ${host}\r\nConnection: keep-alive\r\n`;
+  if (req.token) head += `Authorization: Bearer ${req.token}\r\n`;
+  if (bodyBytes) head += `Content-Type: application/json\r\nContent-Length: ${bodyBytes.length}\r\n`;
+  head += '\r\n';
+  const reqBytes = bodyBytes
+    ? u8concat(new Uint8Array(Buffer.from(head, 'utf8')), new Uint8Array(bodyBytes))
+    : new Uint8Array(Buffer.from(head, 'utf8'));
+  return conn.request(reqBytes, req.timeoutMs ?? 12000);
 }

--- a/app/lib/boxTls.ts
+++ b/app/lib/boxTls.ts
@@ -22,32 +22,15 @@
  * `pinModulus`.
  */
 import { Buffer } from 'buffer';
-import forge from 'node-forge';
 import TcpSocket from 'react-native-tcp-socket';
 
 import { normalizeModulus, parseHttpResponse, type PinnedResponse } from './boxTlsCodec';
 
 export { normalizeModulus, parseHttpResponse } from './boxTlsCodec';
 export type { PinnedResponse } from './boxTlsCodec';
-
-/**
- * RSA modulus (normalized hex) of a PEM certificate, via node-forge. Called at
- * PAIRING time on the PEM fetched from /api/tls/cert (whose integrity the QR fp
- * proves) to derive the value we pin. Lives here (not the pure codec) because it
- * needs forge; its output must match getPeerCertificate's live modulus at connect
- * — device-verified end-to-end by the 2026-08-13 spike, and forge's modulus
- * derivation is cross-checked against openssl in lib/tvdirect/__tests__.
- */
-export function modulusFromPem(pem: string): string | null {
-  try {
-    const cert = forge.pki.certificateFromPem(pem);
-    const key = cert.publicKey as forge.pki.rsa.PublicKey;
-    if (!key?.n) return null;
-    return normalizeModulus(key.n.toString(16));
-  } catch {
-    return null;
-  }
-}
+// Pairing-time forge helpers live in boxTlsPair (no native import); re-exported
+// here for convenience.
+export { certFpFromPem, modulusFromPem, resolveTlsPin, type TlsPin } from './boxTlsPair';
 
 /** A live, pinned TLS byte stream. Mirrors the shape lib/tvdirect uses. */
 export type PinnedSocket = {

--- a/app/lib/boxTlsCodec.ts
+++ b/app/lib/boxTlsCodec.ts
@@ -29,7 +29,14 @@ export function normalizeModulus(v?: string | null): string | null {
   return h || null;
 }
 
-export type PinnedResponse = { status: number; headers: Record<string, string>; body: string };
+export type PinnedResponse = {
+  status: number;
+  headers: Record<string, string>;
+  /** Body decoded as UTF-8 (the box control API is JSON). */
+  body: string;
+  /** Raw body bytes — for binary responses (cover art, screen frames). */
+  bodyBytes: Uint8Array;
+};
 
 /**
  * Parse a raw HTTP/1.1 response buffer into status + headers + body. Returns null
@@ -48,6 +55,7 @@ export function parseHttpResponse(raw: Uint8Array): PinnedResponse | null {
     const idx = lines[i].indexOf(':');
     if (idx > 0) headers[lines[i].slice(0, idx).trim().toLowerCase()] = lines[i].slice(idx + 1).trim();
   }
-  const body = Buffer.from(raw.subarray(sep + 4)).toString('utf8');
-  return { status, headers, body };
+  const bodyBytes = raw.subarray(sep + 4);
+  const body = Buffer.from(bodyBytes).toString('utf8');
+  return { status, headers, body, bodyBytes };
 }

--- a/app/lib/boxTlsCodec.ts
+++ b/app/lib/boxTlsCodec.ts
@@ -59,3 +59,19 @@ export function parseHttpResponse(raw: Uint8Array): PinnedResponse | null {
   const body = Buffer.from(bodyBytes).toString('utf8');
   return { status, headers, body, bodyBytes };
 }
+
+/**
+ * Total byte length (headers + body) of ONE HTTP/1.1 response at the front of an
+ * accumulating buffer, or -1 while the header block (CRLFCRLF) is still arriving.
+ * The body length is the `Content-Length` header (the agent always sends an exact
+ * one; a response with none is treated as header-only). This is what frames a
+ * REUSED keep-alive socket — read exactly this many bytes, the rest belongs to the
+ * next response. Header bytes are scanned as latin1 so the CRLF search is byte-exact.
+ */
+export function httpFrameLength(raw: Uint8Array): number {
+  const head = Buffer.from(raw).toString('latin1');
+  const sep = head.indexOf('\r\n\r\n');
+  if (sep < 0) return -1;
+  const cl = /content-length:\s*(\d+)/i.exec(head.slice(0, sep));
+  return sep + 4 + (cl ? parseInt(cl[1], 10) : 0);
+}

--- a/app/lib/boxTlsCodec.ts
+++ b/app/lib/boxTlsCodec.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure codec for the pinned-TLS transport (TLS P5) — NO forge / native imports, so
+ * it runs in CI's install-free fast test glob (`lib/__tests__/*.test.ts`), exactly
+ * like lib/tvdirect/atvcrypto.ts is split from the native atvnative.ts.
+ *
+ * Holds the two pieces whose failures are SILENT and therefore must be tested:
+ *  - modulus NORMALIZE (not derive — that needs forge, so it lives in boxTls.ts):
+ *    getPeerCertificate and node-forge format the modulus differently, so a bad
+ *    normalize makes the pin compare in boxTls.connectPinned either always-fail
+ *    (locks the user out of their own box) or always-pass (defeats the pin).
+ *  - the HTTP/1.1 response parser: a mis-parse silently corrupts every box reply.
+ *
+ * `buffer` here is Node's built-in module (resolves without npm install).
+ */
+import { Buffer } from 'buffer';
+
+/**
+ * Normalize an RSA modulus hex string for comparison. getPeerCertificate (native)
+ * and node-forge format differently — colons, `0x`, case, a leading DER sign byte
+ * — so BOTH sides run through this before an equality check.
+ */
+export function normalizeModulus(v?: string | null): string | null {
+  if (!v) return null;
+  let h = v.toLowerCase().replace(/[^0-9a-f]/g, '');
+  // Leading zeros are never significant in a big-integer hex: node-forge's
+  // n.toString(16) emits none, while a DER INTEGER prepends a 00 sign byte for a
+  // high-bit-set modulus (every RSA-2048 key). Strip all so both sides match.
+  h = h.replace(/^0+/, '');
+  return h || null;
+}
+
+export type PinnedResponse = { status: number; headers: Record<string, string>; body: string };
+
+/**
+ * Parse a raw HTTP/1.1 response buffer into status + headers + body. Returns null
+ * if the header terminator (CRLFCRLF) has not arrived yet. Body is decoded UTF-8
+ * (the box API is JSON); header bytes are treated as latin1 so the CRLF scan is
+ * byte-exact regardless of any UTF-8 in the body.
+ */
+export function parseHttpResponse(raw: Uint8Array): PinnedResponse | null {
+  const head = Buffer.from(raw).toString('latin1');
+  const sep = head.indexOf('\r\n\r\n');
+  if (sep < 0) return null;
+  const lines = head.slice(0, sep).split('\r\n');
+  const status = parseInt((lines[0] || '').split(' ')[1] || '0', 10);
+  const headers: Record<string, string> = {};
+  for (let i = 1; i < lines.length; i++) {
+    const idx = lines[i].indexOf(':');
+    if (idx > 0) headers[lines[i].slice(0, idx).trim().toLowerCase()] = lines[i].slice(idx + 1).trim();
+  }
+  const body = Buffer.from(raw.subarray(sep + 4)).toString('utf8');
+  return { status, headers, body };
+}

--- a/app/lib/boxTlsPair.ts
+++ b/app/lib/boxTlsPair.ts
@@ -1,0 +1,83 @@
+/**
+ * PAIRING-time TLS pin derivation (TLS P5) — forge + fetch, NO native import, so
+ * the pairing flow (lib/SettingsContext) can use it without pulling in
+ * react-native-tcp-socket. The live-connect transport (boxTls / boxWs) is the
+ * native side; this is the one-time derive that runs when a box is paired.
+ *
+ * Trust model (spec §2): the `fp` (DER-cert SHA-256) is delivered in the pairing
+ * QR — the physical-presence anchor read off the box's own screen. We fetch the
+ * cert over PLAINTEXT (convenient), prove its integrity by re-hashing to `fp`,
+ * then derive the RSA modulus that the pinned transport compares against at every
+ * connect. A pin is ENABLED only on a verified match; anything else -> plaintext.
+ */
+import forge from 'node-forge';
+
+import { normalizeModulus } from './boxTlsCodec';
+
+/** RSA modulus (normalized hex) of a PEM certificate, via node-forge. */
+export function modulusFromPem(pem: string): string | null {
+  try {
+    const cert = forge.pki.certificateFromPem(pem);
+    const key = cert.publicKey as forge.pki.rsa.PublicKey;
+    if (!key?.n) return null;
+    return normalizeModulus(key.n.toString(16));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * SHA-256 of a PEM certificate's DER encoding, lowercase hex — the SAME value the
+ * agent advertises as `fp` (hashlib.sha256(DER).hexdigest()).
+ */
+export function certFpFromPem(pem: string): string | null {
+  try {
+    const cert = forge.pki.certificateFromPem(pem);
+    const der = forge.asn1.toDer(forge.pki.certificateToAsn1(cert)).getBytes();
+    const md = forge.md.sha256.create();
+    md.update(der);
+    return md.digest().toHex();
+  } catch {
+    return null;
+  }
+}
+
+export type TlsPin = { secure: true; tlsPort: number; fp: string; pinModulus: string };
+
+/**
+ * Given the box's advertised `tlsPort` + the `fp` from the QR, fetch the cert over
+ * plaintext, verify SHA-256(DER)==fp, and derive the modulus to pin. Returns null
+ * on ANY failure — unreachable/missing cert, or an fp MISMATCH (tamper/MITM) — so
+ * the caller stores the box WITHOUT `secure` and stays on plaintext (no regression
+ * from today). The pin is only ever enabled on a verified fp match.
+ */
+export async function resolveTlsPin(
+  host: string,
+  port: number,
+  tlsPort: number,
+  fp: string,
+  timeoutMs = 8000,
+): Promise<TlsPin | null> {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetch(`http://${host}:${port}/api/tls/cert`, { signal: ctrl.signal, cache: 'no-store' });
+    } finally {
+      clearTimeout(timer);
+    }
+    if (!res.ok) return null;
+    const j = (await res.json()) as { cert?: unknown };
+    const pem = typeof j?.cert === 'string' ? j.cert : '';
+    if (!pem) return null;
+    const gotFp = certFpFromPem(pem);
+    const want = fp.trim().toLowerCase();
+    if (!gotFp || gotFp !== want) return null; // integrity fail -> do NOT pin
+    const pinModulus = modulusFromPem(pem);
+    if (!pinModulus) return null;
+    return { secure: true, tlsPort, fp: want, pinModulus };
+  } catch {
+    return null;
+  }
+}

--- a/app/lib/boxTransport.ts
+++ b/app/lib/boxTransport.ts
@@ -29,18 +29,17 @@ export type BoxSocketLike = {
   close(): void;
 };
 
-// Metro bundles these static-string requires normally; a Node unit test never
-// hits them (plaintext only), so react-native-only packages stay unloaded there.
-const req = (m: string): unknown =>
-  (globalThis as { require?: (m: string) => unknown }).require?.(m) ??
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
-  (typeof require === 'function' ? require(m) : (() => { throw new Error('native transport unavailable'); })());
-
+// The require string MUST be a literal so Metro statically bundles the native
+// module. A Node unit test never reaches these (secure branch only), so `require`
+// being undefined in ESM there is harmless. eslint-disable: this indirection is
+// the whole point — keep the native package out of the static import graph.
 function nativeTls(): typeof import('./boxTls') {
-  return req('./boxTls') as typeof import('./boxTls');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('./boxTls');
 }
 function nativeWs(): typeof import('./boxWs') {
-  return req('./boxWs') as typeof import('./boxWs');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  return require('./boxWs');
 }
 
 export type PinnedRequestOpts = {

--- a/app/lib/boxTransport.ts
+++ b/app/lib/boxTransport.ts
@@ -1,0 +1,83 @@
+/**
+ * Fast-glob-SAFE boundary to the pinned-TLS transport (TLS P5).
+ *
+ * `api.ts`, `gamepad.ts` and `screenstream.ts` are exercised in CI's install-free
+ * unit-test glob, so they must NOT statically import the native transport
+ * (boxTls -> react-native-tcp-socket, boxWs -> react-native-get-random-values):
+ * those packages don't resolve without node_modules and would break every test
+ * that imports these files (see ci.yml — the same reason atvnative is isolated).
+ *
+ * So the native modules are loaded LAZILY here, ONLY on the secure branch (a box
+ * the user paired with TLS). Plaintext callers — and the unit tests, which only
+ * ever exercise plaintext — never touch `require`, keeping the import graph clean.
+ * In Metro (the real app) `require('./boxTls')` is a static string it bundles
+ * normally; in a Node test the secure branch is never reached, so it never runs.
+ */
+import type { PinnedResponse } from './boxTlsCodec';
+
+export type { PinnedResponse } from './boxTlsCodec';
+
+/** The WHATWG-WebSocket subset both a real WebSocket and PinnedWebSocket satisfy. */
+export type BoxSocketLike = {
+  binaryType: string;
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((ev: { data: string | ArrayBuffer }) => void) | null;
+  onerror: ((e?: unknown) => void) | null;
+  onclose: (() => void) | null;
+  send(data: string | ArrayBuffer | ArrayBufferView): void;
+  close(): void;
+};
+
+// Metro bundles these static-string requires normally; a Node unit test never
+// hits them (plaintext only), so react-native-only packages stay unloaded there.
+const req = (m: string): unknown =>
+  (globalThis as { require?: (m: string) => unknown }).require?.(m) ??
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+  (typeof require === 'function' ? require(m) : (() => { throw new Error('native transport unavailable'); })());
+
+function nativeTls(): typeof import('./boxTls') {
+  return req('./boxTls') as typeof import('./boxTls');
+}
+function nativeWs(): typeof import('./boxWs') {
+  return req('./boxWs') as typeof import('./boxWs');
+}
+
+export type PinnedRequestOpts = {
+  method?: string;
+  path: string;
+  token?: string;
+  body?: string;
+  timeoutMs?: number;
+};
+
+/** One pinned HTTP/1.1 request (JSON) to a secure box. */
+export function pinnedRequest(
+  host: string,
+  port: number,
+  pinModulus: string,
+  req: PinnedRequestOpts,
+): Promise<PinnedResponse> {
+  return nativeTls().pinnedRequest(host, port, pinModulus, req);
+}
+
+/** True if `e` is the pin-mismatch error (without statically importing its class). */
+export function isPinMismatchError(e: unknown): boolean {
+  return e instanceof Error && e.name === 'PinMismatchError';
+}
+
+/**
+ * Open a box WebSocket — pinned when the box is `secure` (token rides the
+ * encrypted, cert-pinned handshake path), plaintext `ws://` otherwise. `path`
+ * includes the leading slash + any `?token=` query. Plaintext is never removed.
+ */
+export function openBoxSocket(
+  conn: { host: string; port: number; secure?: boolean; tlsPort?: number; pinModulus?: string },
+  path: string,
+): BoxSocketLike {
+  if (conn.secure && conn.pinModulus && conn.tlsPort) {
+    const Ctor = nativeWs().PinnedWebSocket;
+    return new Ctor(conn.host, conn.tlsPort, conn.pinModulus, path);
+  }
+  return new WebSocket(`ws://${conn.host}:${conn.port}${path}`) as unknown as BoxSocketLike;
+}

--- a/app/lib/boxWs.ts
+++ b/app/lib/boxWs.ts
@@ -1,0 +1,171 @@
+/**
+ * Pinned WebSocket to a Couchside box (TLS P5, phase 5b).
+ *
+ * A WHATWG-`WebSocket`-shaped client over a modulus-pinned TLS socket
+ * (connectPinned, boxTls) + the existing transport-agnostic RFC6455 codec
+ * (lib/tvdirect/ws.ts, already used for webOS TVs). Exposes exactly the surface
+ * the box WS callers use — `binaryType`, `readyState`, `onopen/onmessage/onerror/
+ * onclose`, `send`, `close` — so `gamepad.ts` and `screenstream.ts` can swap
+ * `new WebSocket(ws://…)` for this when the box is `secure`, with the token riding
+ * an ENCRYPTED, authenticated socket instead of a cleartext `?token=` query.
+ *
+ * Authentication is the modulus pin in connectPinned (spec §2 — `{ca}` is
+ * unenforceable on iOS). We therefore skip Sec-WebSocket-Accept verification (the
+ * peer is already proven by the pin); the handshake still requires a `101`.
+ *
+ * Native-only (imports react-native-tcp-socket via boxTls); verified on-device.
+ * Plaintext `ws://` is never removed — this is used only for pinned boxes.
+ */
+import 'react-native-get-random-values'; // installs globalThis.crypto.getRandomValues
+
+import { connectPinned, type PinnedSocket } from './boxTls';
+import {
+  OPCODE,
+  encodeFrame,
+  encodeText,
+  frameText,
+  handshake,
+  makeDecoder,
+  parseHandshakeResponse,
+} from './tvdirect/ws';
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+function randomBytes(n: number): Uint8Array {
+  const a = new Uint8Array(n);
+  const g = globalThis as { crypto?: { getRandomValues?: (a: Uint8Array) => Uint8Array } };
+  const grv = g.crypto?.getRandomValues?.bind(g.crypto);
+  if (!grv) throw new Error('no platform CSPRNG for WS masks');
+  return grv(a);
+}
+
+function toArrayBuffer(u: Uint8Array): ArrayBuffer {
+  return u.buffer.slice(u.byteOffset, u.byteOffset + u.byteLength) as ArrayBuffer;
+}
+
+export type PinnedWsOpts = { caPem?: string; timeoutMs?: number };
+
+export class PinnedWebSocket {
+  static readonly CONNECTING = CONNECTING;
+  static readonly OPEN = OPEN;
+  static readonly CLOSING = CLOSING;
+  static readonly CLOSED = CLOSED;
+
+  binaryType: 'arraybuffer' | 'blob' = 'blob';
+  readyState: number = CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((ev: { data: string | ArrayBuffer }) => void) | null = null;
+  onerror: ((e?: unknown) => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  private sock: PinnedSocket | null = null;
+  private decoder = makeDecoder();
+  private expectAccept: string | null = null;
+  private upgraded = false;
+  private hsBuf: Uint8Array = new Uint8Array(0);
+
+  constructor(host: string, port: number, pinModulus: string, path: string, opts?: PinnedWsOpts) {
+    connectPinned(host, port, pinModulus, { caPem: opts?.caPem, timeoutMs: opts?.timeoutMs })
+      .then((sock) => {
+        if (this.readyState === CLOSED) { try { sock.close(); } catch {} return; } // closed before connect
+        this.sock = sock;
+        sock.onData((b) => this.onBytes(b));
+        sock.onClose(() => this.handleClose());
+        // No sha1 -> accept header not verified; the modulus pin already
+        // authenticated the peer (ws.ts handshake still requires a 101).
+        const { request } = handshake(host, { randomBytes }, path);
+        sock.write(request);
+      })
+      .catch((e) => this.fail(e));
+  }
+
+  private onBytes(bytes: Uint8Array): void {
+    if (!this.upgraded) {
+      // Accumulate until the handshake response is complete.
+      const merged = new Uint8Array(this.hsBuf.length + bytes.length);
+      merged.set(this.hsBuf);
+      merged.set(bytes, this.hsBuf.length);
+      this.hsBuf = merged;
+      const res = parseHandshakeResponse(this.hsBuf, this.expectAccept);
+      if (!res.done) return;
+      if (!res.ok) { this.fail(new Error(res.error || 'ws handshake failed')); return; }
+      this.upgraded = true;
+      this.readyState = OPEN;
+      this.hsBuf = new Uint8Array(0);
+      this.onopen?.();
+      if (res.rest && res.rest.length) this.pump(res.rest); // server pipelined a frame
+      return;
+    }
+    this.pump(bytes);
+  }
+
+  private pump(bytes: Uint8Array): void {
+    for (const frame of this.decoder.push(bytes)) {
+      if (frame.opcode === OPCODE.text) {
+        this.onmessage?.({ data: frameText(frame) });
+      } else if (frame.opcode === OPCODE.binary) {
+        this.onmessage?.({ data: toArrayBuffer(frame.payload) });
+      } else if (frame.opcode === OPCODE.ping) {
+        this.rawSend(OPCODE.pong, frame.payload);
+      } else if (frame.opcode === OPCODE.close) {
+        this.close();
+      }
+      // pong: ignore
+    }
+  }
+
+  private rawSend(opcode: number, payload: Uint8Array): void {
+    if (!this.sock || this.readyState !== OPEN) return;
+    try {
+      this.sock.write(encodeFrame(opcode, payload, randomBytes(4)));
+    } catch (e) {
+      this.fail(e);
+    }
+  }
+
+  send(data: string | ArrayBuffer | ArrayBufferView): void {
+    if (!this.sock || this.readyState !== OPEN) return;
+    try {
+      if (typeof data === 'string') {
+        this.sock.write(encodeText(data, randomBytes(4)));
+      } else {
+        const u = data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        this.sock.write(encodeFrame(OPCODE.binary, u, randomBytes(4)));
+      }
+    } catch (e) {
+      this.fail(e);
+    }
+  }
+
+  close(): void {
+    if (this.readyState === CLOSED || this.readyState === CLOSING) {
+      this.readyState = CLOSED;
+      return;
+    }
+    if (this.sock && this.readyState === OPEN) {
+      try { this.sock.write(encodeFrame(OPCODE.close, new Uint8Array(0), randomBytes(4))); } catch {}
+    }
+    this.readyState = CLOSING;
+    try { this.sock?.close(); } catch {}
+    this.handleClose();
+  }
+
+  private fail(e: unknown): void {
+    if (this.readyState === CLOSED) return;
+    this.onerror?.(e);
+    this.handleClose();
+  }
+
+  private handleClose(): void {
+    if (this.readyState === CLOSED) return;
+    this.readyState = CLOSED;
+    try { this.sock?.close(); } catch {}
+    this.sock = null;
+    this.onclose?.();
+  }
+}

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -30,6 +30,7 @@
  *   The hello `text` field advertises how much of a typed string the agent can
  *   deliver; sendText() strips non-typeable chars when it is not "unicode".
  */
+import { openBoxSocket, type BoxSocketLike } from './boxTransport.ts';
 import type { Settings } from './settings';
 
 export type GamepadStatus =
@@ -279,7 +280,10 @@ const CONNECT_TIMEOUT_MS = 4000;
 
 export type GamepadStatusListener = (status: GamepadStatus, dev: string | null) => void;
 
-type Conn = Pick<Settings, 'host' | 'port' | 'token' | 'lastIp'>;
+type Conn = Pick<
+  Settings,
+  'host' | 'port' | 'token' | 'lastIp' | 'secure' | 'tlsPort' | 'pinModulus'
+>;
 
 function clamp(v: number, lo: number, hi: number): number {
   return v < lo ? lo : v > hi ? hi : v;
@@ -309,7 +313,7 @@ const SEARCH_KEY_GAP_MS = 120;
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
 export class GamepadClient {
-  private ws: WebSocket | null = null;
+  private ws: BoxSocketLike | null = null;
   private status: GamepadStatus = 'closed';
   private dev: string | null = null;
   /** Text capability from the hello frame ('unicode'|'ascii'); null until known. */
@@ -954,7 +958,7 @@ export class GamepadClient {
     this.teardownSocket(false);
     this.setStatus('connecting', null);
 
-    const { host, port, token, lastIp } = this.conn;
+    const { host, port, token, lastIp, secure, tlsPort, pinModulus } = this.conn;
     // Resolve to a NON-EMPTY host. `host` is blank when the box was paired by IP
     // before its mDNS name was learned (the settings default host is ''), and the
     // cached LAN IP is then the real address — the HTTP API falls back to it the
@@ -976,15 +980,18 @@ export class GamepadClient {
       this.setStatus('error', null);
       return;
     }
-    const url =
-      `ws://${target}:${port}/ws/gamepad?token=${encodeURIComponent(token)}` +
+    // On a secure box the token + query ride the ENCRYPTED, cert-pinned handshake
+    // (openBoxSocket picks the tlsPort); plaintext ws:// on `target` otherwise. The
+    // input-path lifecycle below is UNCHANGED — only the socket's construction is.
+    const path =
+      `/ws/gamepad?token=${encodeURIComponent(token)}` +
       `&handoff=${this.handoffAsk ? 'ask' : 'takeover'}` +
       `&name=${encodeURIComponent(this.deviceName)}` +
       (this.noPad ? '&nopad=1' : '');
 
-    let ws: WebSocket;
+    let ws: BoxSocketLike;
     try {
-      ws = new WebSocket(url);
+      ws = openBoxSocket({ host: target, port, secure, tlsPort, pinModulus }, path);
     } catch {
       this.setStatus('error', null);
       this.scheduleReconnect();
@@ -1030,7 +1037,7 @@ export class GamepadClient {
       this.startPing();
     };
 
-    ws.onmessage = (ev: WebSocketMessageEvent) => {
+    ws.onmessage = (ev: { data: string | ArrayBuffer }) => {
       // A reconnect can replace this.ws while this socket's callbacks are still
       // pending, so ignore events from a socket we have already superseded.
       // (Same guard in onerror/onclose below.)

--- a/app/lib/pairLink.ts
+++ b/app/lib/pairLink.ts
@@ -119,6 +119,15 @@ export type PairLink = {
   token: string;
   /** Optional cached LAN IP fallback. Absent when the link omitted or failed it. */
   ip?: string;
+  /**
+   * TLS pin (agent >= P2): the HTTPS port + DER-cert SHA-256 the box advertised
+   * in the QR fragment (`&tlsport=&fp=`). Present ONLY as a pair — both are needed
+   * to derive + verify a pin — and both are validated (else dropped, non-fatal;
+   * the box still pairs over plaintext). The fp is the physical-presence anchor:
+   * at pairing the app fetches the cert and asserts SHA-256(DER)==fp.
+   */
+  tlsPort?: number;
+  fp?: string;
 };
 
 /**
@@ -319,9 +328,29 @@ export function parsePairLink(
   const rawIp = (params.ip ?? '').trim();
   const ip = rawIp && isLanIpv4(rawIp, true) ? rawIp : undefined;
 
+  // TLS advert (agent >= P2): `tlsport` + `fp`. Both required to pin — a lone one
+  // is useless — and both validated. A bad/partial pair is DROPPED, not fatal:
+  // the box still pairs over plaintext (degrade closed), exactly like a bad `ip`.
+  let tlsPort: number | undefined;
+  let fp: string | undefined;
+  const rawTlsPort = (params.tlsport ?? '').trim();
+  const rawFp = (params.fp ?? '').trim().toLowerCase();
+  if (rawTlsPort && rawFp && /^[0-9]{1,5}$/.test(rawTlsPort) && /^[0-9a-f]{64}$/.test(rawFp)) {
+    const n = Number(rawTlsPort);
+    if (n >= 1 && n <= 65535) { tlsPort = n; fp = rawFp; }
+  }
+
   // Unknown params are ignored, not fatal: they cannot reach anything, and
   // refusing them would break forward compatibility with a newer agent.
-  return { ok: true, link: { host, port, token, ip } };
+  const link: PairLink = { host, port, token, ip };
+  // Additive: the tls keys appear ONLY when a valid pair was present, so a
+  // plaintext link's shape is byte-identical to before (matters for the parser
+  // round-trip tests + any deep-equal consumer).
+  if (tlsPort !== undefined && fp !== undefined) {
+    link.tlsPort = tlsPort;
+    link.fp = fp;
+  }
+  return { ok: true, link };
 }
 
 /**
@@ -361,6 +390,8 @@ export function buildPairLink(box: {
   port: number;
   token: string;
   lastIp?: string;
+  tlsPort?: number;
+  fp?: string;
 }): string | null {
   const host = (box.host ?? '').trim();
   if (!hostShapeOk(host)) return null;
@@ -374,6 +405,15 @@ export function buildPairLink(box: {
   // A lastIp that would not survive the reader is dropped, not fatal — same
   // policy as the reader's own ip handling.
   if (box.lastIp && isLanIpv4(box.lastIp, true)) q += `&ip=${encodeURIComponent(box.lastIp)}`;
+  // TLS advert — written only as a valid pair the reader would accept (a fp is a
+  // 64-hex DER-cert SHA-256), else dropped. Mirrors agent build_pair_url().
+  const fp = (box.fp ?? '').trim().toLowerCase();
+  if (
+    typeof box.tlsPort === 'number' && Number.isInteger(box.tlsPort) &&
+    box.tlsPort >= 1 && box.tlsPort <= 65535 && /^[0-9a-f]{64}$/.test(fp)
+  ) {
+    q += `&tlsport=${box.tlsPort}&fp=${fp}`;
+  }
   const url = `https://couchside.tv/pair#${q}`;
   return url.length > MAX_RAW_LEN ? null : url;
 }

--- a/app/lib/screenstream.ts
+++ b/app/lib/screenstream.ts
@@ -20,6 +20,7 @@
  * the P1 still-frame poller.
  */
 import { base64FromArrayBuffer, resolveEffectiveHost, type ConnSettings } from './api';
+import { openBoxSocket, type BoxSocketLike } from './boxTransport.ts';
 import { isUsableBodySize } from './responseCap';
 
 export type StreamStatus = 'connecting' | 'connected' | 'error' | 'closed';
@@ -31,7 +32,7 @@ const CONNECT_TIMEOUT_MS = 8000;
 const BACKOFF_MS = [500, 1000, 2000, 4000];
 
 export class ScreenStreamClient {
-  private ws: WebSocket | null = null;
+  private ws: BoxSocketLike | null = null;
   private settings: ConnSettings | null = null;
   private profile: StreamProfile = '720p20';
   private active = false;
@@ -92,12 +93,22 @@ export class ScreenStreamClient {
       this.scheduleReconnect();
       return;
     }
-    const url =
-      `ws://${host}:${port}/ws/screen?token=${encodeURIComponent(token)}` +
-      `&profile=${this.profile}`;
-    let ws: WebSocket;
+    // Path (token + profile) rides the ENCRYPTED handshake on a secure box; the
+    // pinned transport picks its own tlsPort. Plaintext ws:// otherwise.
+    const path =
+      `/ws/screen?token=${encodeURIComponent(token)}&profile=${this.profile}`;
+    let ws: BoxSocketLike;
     try {
-      ws = new WebSocket(url);
+      ws = openBoxSocket(
+        {
+          host,
+          port,
+          secure: this.settings.secure,
+          tlsPort: this.settings.tlsPort,
+          pinModulus: this.settings.pinModulus,
+        },
+        path,
+      );
     } catch {
       this.setStatus('error');
       this.scheduleReconnect();
@@ -123,7 +134,7 @@ export class ScreenStreamClient {
       this.backoffIdx = 0;
       this.setStatus('connected');
     };
-    ws.onmessage = (ev: WebSocketMessageEvent) => {
+    ws.onmessage = (ev: { data: string | ArrayBuffer }) => {
       if (ws !== this.ws) return;
       const data = ev.data as unknown;
       if (typeof data === 'string') return; // this stream carries no text frames

--- a/app/lib/settings.ts
+++ b/app/lib/settings.ts
@@ -63,6 +63,20 @@ export type Box = {
    * neither. See lib/lastSeen.ts.
    */
   lastSeen?: number;
+  /**
+   * TLS (on-wire encryption, agent >= P4). Set at pairing ONLY when the box
+   * advertised a `tls_port` AND the cert fetched over plaintext matched the `fp`
+   * from the pairing QR (see lib/boxTls.resolveTlsPin). When `secure`, box traffic
+   * routes through the modulus-pinned transport (lib/boxTls / lib/boxWs) on
+   * `tlsPort`; `pinModulus` is the RSA key the live cert must present. Plaintext is
+   * never removed — an unset/false `secure` keeps today's http/ws behaviour.
+   */
+  secure?: boolean;
+  tlsPort?: number;
+  /** DER-cert SHA-256 from the QR — the integrity anchor kept for reference. */
+  fp?: string;
+  /** Normalized RSA modulus the pinned transport compares against at connect. */
+  pinModulus?: string;
 };
 
 /**
@@ -84,6 +98,11 @@ export type Settings = {
   caps?: BoxCaps;
   /** Unix ms the active box was last reached (see Box.lastSeen). */
   lastSeen?: number;
+  /** TLS pin of the active box (see Box.secure/tlsPort/fp/pinModulus). */
+  secure?: boolean;
+  tlsPort?: number;
+  fp?: string;
+  pinModulus?: string;
 };
 
 /** Safe placeholder used when no box is active (nothing paired yet). */
@@ -345,9 +364,23 @@ function normalizeBox(raw: unknown): Box | null {
     typeof o.lastSeen === 'number' && Number.isFinite(o.lastSeen) && o.lastSeen > 0
       ? o.lastSeen
       : undefined;
+  // TLS pin fields. `secure` is honoured ONLY with a valid tlsPort AND pinModulus
+  // (a secure box that can't be reached/verified would be a dead box), so a
+  // corrupt/partial persist degrades to plaintext rather than a stuck connection.
+  const tlsPort =
+    typeof o.tlsPort === 'number' && Number.isInteger(o.tlsPort) && o.tlsPort >= 1 && o.tlsPort <= 65535
+      ? o.tlsPort
+      : undefined;
+  const fp = typeof o.fp === 'string' && /^[0-9a-f]{64}$/i.test(o.fp) ? o.fp.toLowerCase() : undefined;
+  const pinModulus =
+    typeof o.pinModulus === 'string' && /^[0-9a-f]+$/i.test(o.pinModulus) && o.pinModulus.length >= 64
+      ? o.pinModulus.toLowerCase()
+      : undefined;
+  const secure = o.secure === true && tlsPort !== undefined && !!pinModulus ? true : undefined;
   return {
     id, name, host, port, token, padMode: normalizePadMode(o.padMode),
     lastIp, mac, volumeTarget, caps, lastSeen,
+    secure, tlsPort, fp, pinModulus,
   };
 }
 
@@ -439,6 +472,10 @@ export function activeSettings(state: BoxesState): Settings {
     volumeTarget: active.volumeTarget,
     caps: active.caps,
     lastSeen: active.lastSeen,
+    secure: active.secure,
+    tlsPort: active.tlsPort,
+    fp: active.fp,
+    pinModulus: active.pinModulus,
   };
 }
 

--- a/app/lib/ticket.ts
+++ b/app/lib/ticket.ts
@@ -1,0 +1,81 @@
+/**
+ * Short-lived TLS tickets for the un-pinnable native loaders (TLS P5).
+ *
+ * The app pins its own socket for the API/WS, but the platform <Image> loader
+ * (cover art) and the streamed file uploader cannot pin a self-signed cert. So on
+ * a `secure` box the app mints a ticket over the ALREADY-PINNED channel (agent
+ * POST /api/ticket) and passes it as ?ticket= on those requests — the real bearer
+ * token never rides those cleartext URLs. A ticket grants only cover reads
+ * (multi-use, short TTL) or one upload (single-use); it can't drive the box.
+ *
+ * Plaintext boxes keep ?token= (there is no TLS to protect anyway). Imports only
+ * the fast-glob-safe boxTransport boundary — no native package at module load.
+ */
+import { pinnedRequest } from './boxTransport.ts';
+
+type Conn = {
+  host: string;
+  port: number;
+  token: string;
+  secure?: boolean;
+  tlsPort?: number;
+  pinModulus?: string;
+};
+
+function canPin(c: Conn): c is Conn & { tlsPort: number; pinModulus: string } {
+  return !!(c.secure && c.tlsPort && c.pinModulus);
+}
+
+const imageCache = new Map<string, { ticket: string; exp: number }>();
+const inflight = new Set<string>();
+
+const keyOf = (host: string, port: number): string => `${host}:${port}`;
+
+/** The current valid multi-use image ticket for this box, or null. Synchronous —
+ *  callers read it inline for an <Image> uri and fall back to the text card when
+ *  it's null (the first ~second on a fresh secure box, before the mint lands). */
+export function getImageTicket(host: string, port: number): string | null {
+  const e = imageCache.get(keyOf(host, port));
+  return e && e.exp > Date.now() ? e.ticket : null;
+}
+
+/** Keep a fresh multi-use image ticket warm for a secure box (fire-and-forget).
+ *  No-ops when one is still valid (>1min left) or a mint is already in flight. */
+export function ensureImageTicket(c: Conn, host: string): void {
+  if (!canPin(c)) return;
+  const k = keyOf(host, c.port);
+  const e = imageCache.get(k);
+  if (e && e.exp > Date.now() + 60_000) return;
+  if (inflight.has(k)) return;
+  inflight.add(k);
+  pinnedRequest(host, c.tlsPort, c.pinModulus, { method: 'POST', path: '/api/ticket', token: c.token })
+    .then((r) => {
+      const j = JSON.parse(r.body || '{}');
+      if (typeof j.ticket === 'string' && j.ticket) {
+        const ttl = typeof j.ttl === 'number' ? j.ttl : 300;
+        // Expire our copy 30s early so we never present a ticket the box just dropped.
+        imageCache.set(k, { ticket: j.ticket, exp: Date.now() + ttl * 1000 - 30_000 });
+      }
+    })
+    .catch(() => {})
+    .finally(() => {
+      inflight.delete(k);
+    });
+}
+
+/** Mint a fresh SINGLE-USE upload ticket over the pinned channel. Null on failure
+ *  (caller then degrades to the token header — a rare, single-request exposure). */
+export async function mintUploadTicket(c: Conn, host: string): Promise<string | null> {
+  if (!canPin(c)) return null;
+  try {
+    const r = await pinnedRequest(host, c.tlsPort, c.pinModulus, {
+      method: 'POST',
+      path: '/api/ticket?once=1',
+      token: c.token,
+    });
+    const j = JSON.parse(r.body || '{}');
+    return typeof j.ticket === 'string' && j.ticket ? j.ticket : null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/test_portal_module.py
+++ b/tests/test_portal_module.py
@@ -141,6 +141,45 @@ try:
     check("legacy helper (no field) -> screenstream_h264 True (trust ok)",
           cs.screenstream_h264_available(), True)
 
+    # --- 2c. live_screenstream_caps: session-volatile, cached, degrade closed
+    # /api/status recomputes these per request (like `desktop`) so a Game Mode <->
+    # desktop switch is reflected WITHOUT restarting the agent — the whole point of
+    # the fix. One probe answers both; a short TTL bounds re-probing.
+    print()
+    print("2c. live_screenstream_caps: session-volatile + TTL cache + degrade closed")
+
+    def reset_live_cache():
+        cs._SCREENCAST_CAPS["ts"] = 0.0
+        cs._SCREENCAST_CAPS["val"] = None
+
+    reset_live_cache()
+    one_status({"ok": True, "screencast": True, "h264": True})
+    check("live: backend + h264 -> both True", cs.live_screenstream_caps(),
+          {"screenstream": True, "screenstream_h264": True})
+
+    reset_live_cache()
+    one_status({"ok": True, "screencast": False, "h264": True})
+    check("live: no backend (game mode) -> both False", cs.live_screenstream_caps(),
+          {"screenstream": False, "screenstream_h264": False})
+
+    reset_live_cache()
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    check("live: no helper -> both False (degrade closed)", cs.live_screenstream_caps(),
+          {"screenstream": False, "screenstream_h264": False})
+
+    # TTL cache: a second call within TTL returns the cached value with NO re-probe.
+    # Proven by pointing the socket at a dead path after the first probe — a
+    # re-probe would degrade to False, so an unchanged True proves it was cached.
+    reset_live_cache()
+    one_status({"ok": True, "screencast": True, "h264": False})
+    first = cs.live_screenstream_caps()
+    cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
+    second = cs.live_screenstream_caps()
+    check("live: within-TTL call is cached (no re-probe)", second, first)
+    check("live: cached value survives a dead socket (proves no re-probe)",
+          second, {"screenstream": True, "screenstream_h264": False})
+
+    reset_live_cache()
     cs.PORTAL_SOCKET = saved_portal_socket
 
     # --- 3. absolute pointer input on /ws/gamepad --------------------------

--- a/tests/test_portal_module.py
+++ b/tests/test_portal_module.py
@@ -106,6 +106,43 @@ try:
     cs.PORTAL_SOCKET = "/nonexistent-couchside-test/portal.sock"
     check("absent helper -> cap False (degrade closed)", cs.screenstream_available(), False)
 
+    # --- 2b. fluid caps gated on a REAL portal backend (the game-mode fix) --
+    # A reachable helper is NOT enough: Steam Game Mode has no ScreenCast/
+    # RemoteDesktop backend, so /ws/screen would 101-then-close. The helper reports
+    # `screencast`; the agent must report screenstream[_h264] False when it is False,
+    # or the app burns a connect timeout on each dead fluid tier before the poller.
+    print()
+    print("2b. screenstream[_h264] honest: no portal backend -> caps False")
+
+    def one_status(reply):
+        path, _ = fake_portal([reply])
+        cs.PORTAL_SOCKET = path
+
+    # desktop: backend present -> both caps True
+    one_status({"ok": True, "screencast": True, "h264": True})
+    check("backend present -> screenstream True", cs.screenstream_available(), True)
+    one_status({"ok": True, "screencast": True, "h264": True})
+    check("backend present + h264 -> screenstream_h264 True",
+          cs.screenstream_h264_available(), True)
+
+    # game mode: reachable helper but NO backend -> both caps False
+    one_status({"ok": True, "screencast": False, "h264": True})
+    check("no backend -> screenstream False (game-mode fix)",
+          cs.screenstream_available(), False)
+    one_status({"ok": True, "screencast": False, "h264": True})
+    check("no backend -> screenstream_h264 False even with h264",
+          cs.screenstream_h264_available(), False)
+
+    # legacy helper that predates the field -> trust `ok` (no regression)
+    one_status({"ok": True, "h264": True})
+    check("legacy helper (no field) -> screenstream True (trust ok)",
+          cs.screenstream_available(), True)
+    one_status({"ok": True, "h264": True})
+    check("legacy helper (no field) -> screenstream_h264 True (trust ok)",
+          cs.screenstream_h264_available(), True)
+
+    cs.PORTAL_SOCKET = saved_portal_socket
+
     # --- 3. absolute pointer input on /ws/gamepad --------------------------
     print()
     print("3. {t:'ma'}/{t:'mbp'}: holder gate + allowlist")

--- a/tests/test_tls_ticket.py
+++ b/tests/test_tls_ticket.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Short-lived TLS tickets (P5) — POST /api/ticket + ?ticket= on un-pinnable loads.
+
+Run: python3 tests/test_tls_ticket.py
+
+The app pins its own TLS socket for the API/WS, but the native <Image> loader and
+the streamed uploader cannot pin a self-signed cert. Rather than put the bearer
+token on those cleartext requests, the app mints a SHORT-LIVED ticket over the
+pinned channel and passes ?ticket=. This proves the ticket is a strictly weaker
+credential than the token:
+
+  * mint is BEARER-GATED (401 without the token) — a ticket can't bootstrap a ticket.
+  * a valid ticket authorizes an IMAGE GET (?ticket=) but NOT a control route.
+  * a single-use ('once') ticket is BURNED on first use — a sniffed upload URL
+    cannot be replayed.
+  * expired / unknown / empty tickets are refused (degrade closed).
+
+Pure stdlib, no pytest.
+"""
+import http.client
+import importlib.util
+import json
+import os
+import threading
+import time
+from http.server import ThreadingHTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+TOKEN = "test-secret-token"
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label + ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+# ---- ticket lifecycle (pure) -----------------------------------------------
+
+def test_ticket_lifecycle():
+    t = cs._mint_ticket(once=False)
+    check(cs._ticket_ok(t) and cs._ticket_ok(t), "multi-use ticket validates repeatedly", t)
+
+    o = cs._mint_ticket(once=True)
+    first = cs._ticket_ok(o)
+    second = cs._ticket_ok(o)
+    check(first and not second, "single-use ticket is CONSUMED after one use", (first, second))
+
+    check(not cs._ticket_ok(""), "empty ticket refused")
+    check(not cs._ticket_ok("deadbeef" * 4), "unknown ticket refused")
+
+    # Expired: mint then force its expiry into the past.
+    e = cs._mint_ticket()
+    with cs._TICKETS_LOCK:
+        cs._TICKETS[e]["exp"] = time.time() - 1
+    check(not cs._ticket_ok(e), "expired ticket refused")
+    with cs._TICKETS_LOCK:
+        check(e not in cs._TICKETS, "expired ticket is pruned on access")
+
+
+# ---- live endpoint + image-route acceptance --------------------------------
+
+class _QuietServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def handle_error(self, request, client_address):
+        import ssl
+        import sys
+        exc = sys.exc_info()[1]
+        if isinstance(exc, (ConnectionError, ssl.SSLError, OSError)):
+            return
+        super().handle_error(request, client_address)
+
+
+def _serve():
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True
+    cs.Handler.tls_info = None
+    srv = _QuietServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _req(port, method, path, token=None):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    headers = {"Connection": "close"}
+    if token:
+        headers["Authorization"] = "Bearer " + token
+    conn.request(method, path, headers=headers)
+    resp = conn.getresponse()
+    body = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(body or b"{}")
+    except ValueError:
+        return resp.status, {}
+
+
+def test_endpoint_and_image_auth():
+    srv, port = _serve()
+    try:
+        # mint is bearer-gated
+        st, _ = _req(port, "POST", "/api/ticket", token=None)
+        check(st == 401, "POST /api/ticket without token -> 401", st)
+        st, body = _req(port, "POST", "/api/ticket", token=TOKEN)
+        ticket = body.get("ticket", "")
+        check(st == 200 and len(ticket) == 32, "POST /api/ticket with token -> 200 + ticket", (st, body))
+
+        # a valid ticket authorizes an IMAGE GET (?ticket=): _authorized_image
+        # passes, so we DON'T get a 401 (404/200 depending on cover presence).
+        st, _ = _req(port, "GET", "/api/steam/123/cover?ticket=" + ticket)
+        check(st != 401, "valid ticket authorizes /api/steam/<id>/cover (not 401)", st)
+        # a garbage ticket does NOT authorize the image
+        st, _ = _req(port, "GET", "/api/steam/123/cover?ticket=" + ("00" * 16))
+        check(st == 401, "garbage ticket on cover -> 401", st)
+
+        # a ticket must NOT satisfy a control route (state-changing): the query
+        # form is scoped to image GETs only.
+        st, _ = _req(port, "GET", "/api/status?ticket=" + ticket)
+        check(st == 401, "ticket does NOT authorize /api/status (control) -> 401", st)
+
+        # single-use upload ticket: valid once (upload handler runs), then burned.
+        st, b = _req(port, "POST", "/api/ticket?once=1", token=TOKEN)
+        up = b.get("ticket", "")
+        st1, _ = _req(port, "POST", "/api/upload?name=x.bin&ticket=" + up)
+        st2, _ = _req(port, "POST", "/api/upload?name=x.bin&ticket=" + up)
+        # first use is NOT a 401 (handler reached); the second, burned, IS a 401.
+        check(st1 != 401 and st2 == 401,
+              "single-use upload ticket accepted once then refused (no replay)", (st1, st2))
+    finally:
+        srv.shutdown()
+
+
+if __name__ == "__main__":
+    test_ticket_lifecycle()
+    test_endpoint_and_image_auth()
+    print()
+    if _fail:
+        print("FAILED: %d" % len(_fail))
+        for f in _fail:
+            print("  - " + f)
+        raise SystemExit(1)
+    print("all TLS ticket tests passed")


### PR DESCRIPTION
Coordinated release: end-to-end TLS on the wire (app-side pinning) + the Game Mode remote-screen fix.

## App — TLS P5 (pinned transport)
- The bearer token rides a **modulus-pinned TLS socket** instead of a cleartext header whenever a box advertises TLS and was paired with its fingerprint. Fail-closed: a pin mismatch surfaces as `unreachable`, never a plaintext downgrade.
- Keep-alive pinned-socket reuse (no per-request TLS handshake); pinned WS for gamepad/screen; pinned binary art; and short-lived **tickets** for the un-pinnable native loaders (cover art `<Image>`, streamed upload) so the token never rides a cleartext query.
- **Encryption badge** — honest by construction (secure box is pinned + fail-closed, so "secure" == genuinely encrypted while reachable).
- Backward compatible: existing plaintext boxes (no fingerprint) stay plaintext; non-updating boxes are unaffected (dual-listen, never flip).

## Agent 2.9.87 — Game Mode screen fix
- **Honest, session-volatile `screenstream[_h264]` caps.** Game Mode has no portal ScreenCast/RemoteDesktop backend, so the fluid tiers can't open there — the box was advertising them as available (false positive), and the app burned an ~8s connect timeout on each dead tier (H.264 then MJPEG) before the still-frame poller: the ~10s lag. Now the caps are truthful and recomputed per request (like `desktop`), so Game Mode goes straight to the ~1.5s poller and a desktop⇄game switch is tracked without an agent restart.
- P5 short-lived ticket endpoints (dark until the app pins).

## Robustness
- Fire-and-forget LED writes now `.catch()` so an unreachable / pin-mismatched box can't red-screen the dev build.

## Verified
- Game Mode fix device-verified on the phone + on bazzite 10.1.1.60: caps False in Game Mode, True on desktop, live override beats the boot snapshot (portal stop → caps flip), status latency 22ms, reachability intact.
- TLS P5 device-verified in prior sessions (iPhone + Razr + the live-encrypted prod box).
- tsc clean; app fast suite 462/0; agent portal + parity suites green.

## Not verified
- Fully fluid video in Game Mode is a gamescope/portal platform limit (no screencast backend) — not achievable from the agent; desktop sessions keep the smooth stream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)