### PR TITLE
chore(app): record shipped build numbers (ios 179 / android 96)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "178",
+      "buildNumber": "179",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 95
+      "versionCode": 96
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
EAS autoIncrement bumped these for the 2.9.49 production builds; recording so the next release seeds above them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)