### PR TITLE
chore(app): record shipped 2.9.49 store notes

### DIFF
--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,1 +1,5 @@
-A much faster remote screen in Game Mode. When your box is in Steam Big Picture / Game Mode, opening the remote screen viewer on your phone used to hang for several seconds before the first picture appeared. Now it shows the live preview right away — what's on your TV shows up on your phone in about a second. Desktop sessions still stream smooth video. Plus reliability fixes and polish.
+A much faster remote screen in Game Mode: in Steam Big Picture, the remote viewer no longer hangs for several seconds before the first picture — it shows the live preview right away, in about a second. Desktop sessions still stream smooth video.
+
+Added TLS encryption with certificate pinning for the connection to your box, so a box that enables it keeps your traffic and access token off your network. A lock badge shows when it's on.
+
+Plus reliability fixes and polish.


### PR DESCRIPTION
The 'What's New' text actually submitted to both stores for 2.9.49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)