### PR TITLE
feat: TLS on by default + app auto-pins a known box (turnkey encryption)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.88
+
+**Encryption, on by default.** Your box now protects its connection automatically.
+On this update it creates its own security certificate and starts serving an
+encrypted channel **alongside** the normal one — nothing you use changes, and older
+phones keep working exactly as before (the plain connection never goes away). Pair
+or re-pair this box in the app to see the new green lock, which means the link to
+this box is encrypted and pinned to this exact machine so nothing else on your
+network can read it. (Prefer it off? Set `tls` `enabled` to false in the box config.)
+
 ## 2.9.87
 
 **A much faster remote screen in Game Mode.** When your box is in Steam Game Mode

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.87"
+VERSION = "2.9.88"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -629,25 +629,32 @@ def _parse_config(raw):
 
 def _parse_tls(raw):
     """Parse+validate the optional top-level "tls" block. Returns a normalized
-    dict ({"enabled": bool, "port": int, ...persisted cert fields}) or None when
-    absent.
+    dict ({"enabled": bool, "port": int, ...persisted cert fields}).
 
-    Degrade-closed: any validation failure returns a DISABLED config (or None),
-    never raises. A malformed tls block can neither crash the agent nor silently
-    flip encryption on. cert/key/sans/fp/spki are written by _tls_ensure and
-    round-tripped here — mirrors the androidtv cert-in-config precedent."""
+    TLS is ON BY DEFAULT (since 2.9.88): an ABSENT or malformed tls block yields an
+    ENABLED config, so a box auto-mints a self-signed cert and serves HTTPS on
+    DEFAULT_TLS_PORT ALONGSIDE the untouched plaintext listener (dual-listen, never
+    flips — old apps keep using 8787; new apps can pin). To OPT OUT, set
+    `"tls": {"enabled": false}`.
+
+    Degrade-closed still holds: this only asks for TLS — cert generation happens in
+    _tls_ensure, and if it fails (no openssl, etc.) the HTTPS listener simply never
+    starts and the plaintext listener serves alone. cert/key/sans/fp/spki are
+    written by _tls_ensure and round-tripped here."""
+    default_on = {"enabled": True, "port": DEFAULT_TLS_PORT}
     tls_raw = raw.get("tls")
     if tls_raw is None:
-        return None
+        return dict(default_on)
     if not isinstance(tls_raw, dict):
-        print("warning: tls must be an object, ignoring", file=sys.stderr, flush=True)
-        return None
+        print("warning: tls must be an object, using defaults (TLS on)",
+              file=sys.stderr, flush=True)
+        return dict(default_on)
     port = tls_raw.get("port", DEFAULT_TLS_PORT)
     if isinstance(port, bool) or not isinstance(port, int) or not (1 <= port <= 65535):
         print("warning: tls.port must be 1..65535, using %d" % DEFAULT_TLS_PORT,
               file=sys.stderr, flush=True)
         port = DEFAULT_TLS_PORT
-    out = {"enabled": bool(tls_raw.get("enabled", False)), "port": port}
+    out = {"enabled": bool(tls_raw.get("enabled", True)), "port": port}
     for field in ("cert", "key", "spki", "fp"):
         val = tls_raw.get(field)
         if isinstance(val, str) and val:

--- a/app/lib/SettingsContext.tsx
+++ b/app/lib/SettingsContext.tsx
@@ -10,6 +10,7 @@ import React, {
 import { AppState, AppStateStatus } from 'react-native';
 
 import { pingMatchesBox } from './api';
+import { readTlsAdvert } from './boxDiscovery';
 import { resolveTlsPin } from './boxTlsPair';
 import { getPref } from './prefs';
 import { isAllowedPairHost } from './pairLink';
@@ -327,6 +328,13 @@ type PingProbe = {
   ok: boolean;
   /** LAN IP reported by the agent (>= 2.3), for the Box.lastIp cache. */
   ip: string | null;
+  /**
+   * Advertised TLS pin fields (agent >= 2.9.85 with TLS on), for the auto-upgrade
+   * that pins a known plaintext box in place the moment it starts advertising
+   * TLS — no re-pair. `tls_fp` from a ping is a TOFU anchor (LAN, stops passive
+   * sniffing); the QR's fp is the stronger physical-presence one.
+   */
+  tls?: { tlsPort: number; fp: string };
 };
 
 /**
@@ -362,7 +370,14 @@ async function pingHost(
     const ip = body && typeof (body as { ip?: unknown }).ip === 'string'
       ? ((body as { ip: string }).ip || null)
       : null;
-    return { ok: true, ip };
+    const advert = body && typeof body === 'object'
+      ? readTlsAdvert(body as Record<string, unknown>)
+      : {};
+    const tls =
+      typeof advert.tlsPort === 'number' && advert.fp
+        ? { tlsPort: advert.tlsPort, fp: advert.fp }
+        : undefined;
+    return { ok: true, ip, tls };
   } catch {
     return { ok: false, ip: null };
   } finally {
@@ -384,6 +399,10 @@ async function pingBox(box: Box, timeoutMs: number): Promise<PingProbe> {
   }
   return primary;
 }
+
+/** Min gap between TLS auto-upgrade attempts for a box that advertises TLS but
+ *  hasn't verified yet (a verified box flips to secure and is skipped). */
+const TLS_UPGRADE_COOLDOWN_MS = 60_000;
 
 /**
  * Periodically pings every box's /api/ping and reports reachable per id.
@@ -409,6 +428,10 @@ export function useBoxOnlineStatus(
 
   // Per-id in-flight guard so a slow box doesn't stack pings.
   const inFlight = useRef<Set<string>>(new Set());
+  // Last TLS auto-upgrade attempt per box id, so a box that advertises TLS but
+  // won't verify isn't re-resolved every tick (a box that verifies flips to
+  // secure and is skipped thereafter).
+  const upgradeAt = useRef<Map<string, number>>(new Map());
   const mounted = useRef(true);
 
   // Prune status entries for boxes that no longer exist.
@@ -468,6 +491,36 @@ export function useBoxOnlineStatus(
                 cur.lastIp !== probe.ip
               ) {
                 void updateBox(box.id, { lastIp: probe.ip });
+              }
+            }
+            // TLS AUTO-UPGRADE (turnkey): a KNOWN plaintext box that starts
+            // advertising TLS is pinned IN PLACE — no re-pair. Resolve the pin
+            // from the advertised fp (fetch cert over plaintext, verify
+            // SHA-256(DER)==fp, derive the modulus); on success store
+            // secure/tlsPort/fp/pinModulus so every request switches to the pinned
+            // transport and the lock turns green. Skipped once secure; throttled so
+            // a box that advertises TLS but won't verify isn't re-resolved each tick.
+            if (probe.ok && probe.tls && !box.secure) {
+              const now = Date.now();
+              if (now - (upgradeAt.current.get(box.id) ?? 0) >= TLS_UPGRADE_COOLDOWN_MS) {
+                upgradeAt.current.set(box.id, now);
+                const addr = probe.ip && isValidLanIp(probe.ip) ? probe.ip : box.host;
+                void resolveTlsPin(addr, box.port, probe.tls.tlsPort, probe.tls.fp)
+                  .then((pin) => {
+                    if (!mounted.current || !pin) return;
+                    const cur = boxesRef.current.find((b) => b.id === box.id);
+                    // Re-read: don't pin onto a box the user re-targeted mid-flight,
+                    // and don't clobber a pin that landed by another path.
+                    if (cur && !cur.secure && cur.host === box.host && cur.port === box.port) {
+                      void updateBox(box.id, {
+                        secure: true,
+                        tlsPort: pin.tlsPort,
+                        fp: pin.fp,
+                        pinModulus: pin.pinModulus,
+                      });
+                    }
+                  })
+                  .catch(() => {});
               }
             }
           })

--- a/app/lib/boxDiscovery.ts
+++ b/app/lib/boxDiscovery.ts
@@ -62,7 +62,7 @@ export type FoundBox = {
 };
 
 /** Extract + validate a box's advertised TLS pin fields from a ping/UDP reply. */
-function readTlsAdvert(d: Record<string, unknown>): { tlsPort?: number; fp?: string } {
+export function readTlsAdvert(d: Record<string, unknown>): { tlsPort?: number; fp?: string } {
   const p = d.tls_port;
   const f = typeof d.tls_fp === 'string' ? d.tls_fp.toLowerCase() : '';
   if (typeof p === 'number' && Number.isInteger(p) && p >= 1 && p <= 65535 && /^[0-9a-f]{64}$/.test(f)) {

--- a/tests/test_tls_cert.py
+++ b/tests/test_tls_cert.py
@@ -65,8 +65,9 @@ def _san(cert_pem):
 
 
 def test_parse_tls():
-    # absent -> None
-    check(cs._parse_tls({}) is None, "no tls block -> None")
+    # DEFAULT-ON (2.9.88): an absent tls block enables TLS on the default port.
+    check(cs._parse_tls({}) == {"enabled": True, "port": cs.DEFAULT_TLS_PORT},
+          "no tls block -> default ON", cs._parse_tls({}))
     # enabled + explicit port
     got = cs._parse_tls({"tls": {"enabled": True, "port": 9443}})
     check(got == {"enabled": True, "port": 9443}, "enabled+port parsed", got)
@@ -74,12 +75,19 @@ def test_parse_tls():
     got = cs._parse_tls({"tls": {"enabled": True}})
     check(got and got["port"] == cs.DEFAULT_TLS_PORT,
           "default port applied", got)
-    # enabled defaults false
+    # enabled defaults TRUE within a block too (an empty block means on)
     got = cs._parse_tls({"tls": {}})
+    check(got == {"enabled": True, "port": cs.DEFAULT_TLS_PORT},
+          "enabled defaults True", got)
+    # OPT-OUT: explicit enabled:false is respected
+    got = cs._parse_tls({"tls": {"enabled": False}})
     check(got == {"enabled": False, "port": cs.DEFAULT_TLS_PORT},
-          "enabled defaults False", got)
-    # DEGRADE CLOSED: bad types never raise, never enable
-    check(cs._parse_tls({"tls": 5}) is None, "non-dict tls -> None (no raise)")
+          "enabled:false respected (opt-out)", got)
+    # DEGRADE CLOSED for TYPES: a non-dict tls block never raises; it falls back to
+    # the default-on config (TLS is additive — a garbled block should not silently
+    # DISABLE the encryption a plain box now gets).
+    check(cs._parse_tls({"tls": 5}) == {"enabled": True, "port": cs.DEFAULT_TLS_PORT},
+          "non-dict tls -> default ON (no raise)", cs._parse_tls({"tls": 5}))
     got = cs._parse_tls({"tls": {"enabled": True, "port": "nope"}})
     check(got and got["port"] == cs.DEFAULT_TLS_PORT,
           "bad port falls back to default (no raise)", got)


### PR DESCRIPTION
Agent 2.9.88 flips TLS to **on by default** + the app **auto-pins** a known plaintext box the moment it advertises TLS — so encryption + the green lock happen with no config edit and no re-pair.

## Agent (2.9.88) — TLS on by default
- `_parse_tls`: absent/malformed `tls` block ⇒ enabled. Box auto-mints a self-signed cert + serves HTTPS on 8788 **alongside** untouched plaintext 8787 (dual-listen, never flips).
- Net-additive + backward-compatible: old apps ignore the advert, keep 8787; no-openssl degrades closed to plaintext. Opt out: `"tls": {"enabled": false}`.
- Verified live on lenovodesktop: wiped tls config → auto-enabled + persisted a stable cert; 8787 still answers.

## App — auto-upgrade
- Online-status poll sees a known plaintext box advertise `tls_fp` → resolve pin in place (cert over plaintext, verify SHA-256(DER)==fp, derive modulus) → store secure/tlsPort/fp/pinModulus → green lock, **no re-pair**.
- Guarded: skip once secure, 60s throttle, degrade-closed. Ping fp = TOFU (LAN); QR fp = physical-presence.

## Won't lock anyone out
Plaintext never removed. Not updating ⇒ no change. Updating ⇒ encryption **added** beside plaintext. Only a deliberately-pinned box (new QR pair / auto-upgrade) is encrypted-only, by design, on the LAN where 8788 works.

## Ships
Agent 2.9.88 now (box-update). App auto-upgrade rides 2.9.50 after 2.9.49 clears App Store review.

tsc clean; TLS suites + app fast suite (462) green; `test_parse_tls` updated for default-on + opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)