### PR TITLE
fix(app): catch remaining fire-and-forget rejections (deep-link, IAP, Steam review)

### DIFF
--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -926,9 +926,9 @@ function SetupBody() {
   const [price, setPrice] = useState<string | null>(null);
   useEffect(() => {
     let cancelled = false;
-    getProduct().then((p) => {
+    void getProduct().then((p) => {
       if (!cancelled && p?.displayPrice) setPrice(p.displayPrice);
-    });
+    }).catch(() => {});
     return () => {
       cancelled = true;
     };

--- a/app/app/installable.tsx
+++ b/app/app/installable.tsx
@@ -156,7 +156,7 @@ function GameSheet({
   useEffect(() => {
     let live = true;
     setReview(undefined);
-    void fetchSteamReview(appid).then((r) => { if (live) setReview(r); });
+    void fetchSteamReview(appid).then((r) => { if (live) setReview(r); }).catch(() => {});
     return () => { live = false; };
   }, [appid]);
 

--- a/app/lib/DeepLink.tsx
+++ b/app/lib/DeepLink.tsx
@@ -70,7 +70,7 @@ export function DeepLinkHandler() {
     let mounted = true;
     void Linking.getInitialURL().then((url) => {
       if (mounted) apply(url);
-    });
+    }).catch(() => {});
     const sub = Linking.addEventListener('url', (e) => apply(e.url));
     return () => {
       mounted = false;


### PR DESCRIPTION
Three effect-mount `.then()` promises had no `.catch()` → unhandled rejection (dev LogBox red-screen). Each now `.catch(() => {})`. Completes the 2.9.49 robustness pass; rides 2.9.50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)