### PR TITLE
release: app 2.9.50 — TLS auto-upgrade + rejection cleanup

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.49",
+    "version": "2.9.50",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",

--- a/app/changelogs/whatsnew-en-US.txt
+++ b/app/changelogs/whatsnew-en-US.txt
@@ -1,5 +1,1 @@
-A much faster remote screen in Game Mode: in Steam Big Picture, the remote viewer no longer hangs for several seconds before the first picture — it shows the live preview right away, in about a second. Desktop sessions still stream smooth video.
-
-Added TLS encryption with certificate pinning for the connection to your box, so a box that enables it keeps your traffic and access token off your network. A lock badge shows when it's on.
-
-Plus reliability fixes and polish.
+Encryption now turns on by itself. Once your box has the latest update, the app detects its encrypted connection and locks onto it automatically — the green lock appears on your boxes with no re-pairing needed. Plus reliability fixes and polish.


### PR DESCRIPTION
App-only. TLS auto-upgrade (pin known boxes in place, no re-pair) + fire-and-forget rejection cleanup. Agent 2.9.88 already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)