### PR TITLE
chore(app): record shipped build numbers (ios 180 / android 97)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "179",
+      "buildNumber": "180",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 96
+      "versionCode": 97
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
EAS autoIncrement bumped these for the 2.9.50 builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)