### PR TITLE
fix(agent): reconcile RGB strip so a session switch/reboot can't revert it (2.9.89)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.89
+
+**Your light strip stops reverting.** If your box has an addressable RGB strip —
+like a Steam Machine's — switching between Game Mode and the desktop, or restarting,
+used to knock the strip back to its factory default and undo your effect. The box
+now notices when something resets the strip and re-applies your effect within a few
+seconds, so your night-rider (or whatever you set) stays put. Also cleans up a case
+where a saved strip effect and older hand-painted colours could fight each other.
+
 ## 2.9.88
 
 **Encryption, on by default.** Your box now protects its connection automatically.

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.88"
+VERSION = "2.9.89"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4610,8 +4610,12 @@ def _validate_led_body(req):
 #
 # The active effect (and a plain solid colour) is persisted to
 # ~/.config/couchside/leds.json and re-applied at startup, so a reboot restores
-# it instead of reverting to the firmware default -- the agent is a systemd
-# *user* service, so the restore runs on login.
+# it instead of reverting to the firmware default. The agent is a systemd SYSTEM
+# service, so it does NOT restart on a gamescope<->desktop switch -- and Steam
+# re-initializes the valve-leds on that switch, silently reverting our effect. So
+# _led_restore_worker also runs a background RECONCILER that re-asserts the strip's
+# effect whenever the live hardware drifts from what we set (session switch, boot
+# race, or anything else that resets the strip).
 _LED_STATE_CONF = os.path.expanduser("~/.config/couchside/leds.json")
 
 # Frozen allowlist of effect ids (looked up, never interpolated). 'solid'/'off'
@@ -4728,6 +4732,11 @@ def _fx_note_static(name, res):
     persist it as a solid so a reboot restores the colour."""
     _fx_stop(name)
     with _FX_LOCK:
+        # Painting one LED supersedes any whole-strip effect it belongs to -- drop
+        # that strip's persist so the two modes can't both restore + fight.
+        m = _STRIP_RE.match(name)
+        if m:
+            _LED_PERSIST.pop("strip:" + m.group(1), None)
         _LED_PERSIST[name] = {"effect": "solid", "color": res.get("color"),
                               "brightness": res.get("brightness_pct"), "speed": 50}
     _led_state_save()
@@ -4870,15 +4879,74 @@ def _led_restore():
             pass
 
 
+# The reconciler re-checks each strip's hardware effect this often. Cheap (one
+# sysfs read per strip) and only WRITES on a real mismatch -> never flickers, never
+# fights a steady strip.
+_LED_RECONCILE_INTERVAL_S = 4.0
+
+
+def _led_desired_hw_effect(effect, member):
+    """The firmware `effect` value apply_strip_effect() would write for our effect
+    id on this strip: the mapped name IF the device publishes it, else the manual/
+    off fallback. Read-only -- used to tell whether the live strip drifted from us."""
+    fw = _STRIP_HW_MAP.get(effect)
+    if fw and fw in _strip_hw_effects(member):
+        return fw
+    return "off" if effect == "off" else "manual"
+
+
+def _led_reconcile():
+    """Re-assert each persisted STRIP effect IF the live hardware drifted from it.
+
+    The agent is a systemd SYSTEM service, so a gamescope<->desktop switch (Steam
+    re-inits the valve-leds back to its own default) never restarts us and the
+    one-shot startup restore never re-runs -- the strip silently reverts. This
+    reads ONE `effect` attr per strip and re-applies ONLY on a mismatch, so a
+    steady strip is never rewritten (no flicker, no fight with a stable state)."""
+    strips = _led_strips()
+    for name, st in _led_state_load().items():
+        if not name.startswith("strip:") or not isinstance(st, dict):
+            continue
+        effect = st.get("effect")
+        if effect not in _LED_EFFECTS:
+            continue
+        members = strips.get(name[len("strip:"):])
+        if not members:
+            continue
+        try:
+            cur = _led_read_attr(members[0], "effect")
+        except OSError:
+            continue
+        if cur == _led_desired_hw_effect(effect, members[0]):
+            continue
+        color = st.get("color") if _is_rgb_triple(st.get("color")) else None
+        speed = st.get("speed") if _is_pct(st.get("speed"), 1) else 50
+        brightness = st.get("brightness") if _is_pct(st.get("brightness")) else 100
+        try:
+            apply_strip_effect(name[len("strip:"):], effect, color, speed, brightness)
+            print("[led] reconciled %s (hw effect was %r)" % (name, cur), flush=True)
+        except OSError:
+            pass
+
+
 def _led_restore_worker():
-    """Startup thread: wait for the OS/Steam to finish its own LED init, then
-    restore. One retry covers the boot race where the LED node appears late."""
+    """Startup: wait out the OS/Steam LED init, restore once, THEN keep reconciling.
+    Because the agent is a SYSTEM service a session switch never restarts us, so a
+    periodic drift check is what re-asserts our effect after Steam resets the strip.
+    The two initial delays cover the boot race where the node / Steam init lands
+    late. Runs on a daemon thread; the reconcile loop lives for the process."""
     for delay in (2.0, 6.0):
         time.sleep(delay)
         try:
             if _list_led_names():
                 _led_restore()
-                return
+                break
+        except OSError:
+            pass
+    while not _FX_STOP.is_set():
+        time.sleep(_LED_RECONCILE_INTERVAL_S)
+        try:
+            _led_reconcile()
         except OSError:
             pass
 
@@ -5026,6 +5094,11 @@ def apply_strip_effect(prefix, effect, color, speed, brightness):
         return {"ok": False, "status": 500, "error": str(e) or "strip write failed"}
 
     with _FX_LOCK:
+        # A whole-strip effect supersedes any per-LED paints on this strip: drop
+        # their persists so a restore/reconcile can never re-apply a conflicting
+        # mix (the "weird" state -- a scanner + stale solids fighting each other).
+        for m in members:
+            _LED_PERSIST.pop(m, None)
         _LED_PERSIST["strip:" + prefix] = {"effect": effect, "color": col,
                                            "speed": sp, "brightness": b}
     _led_state_save()

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -226,6 +226,56 @@ def test_strips_in_payload():
     check(vs and "patrol" in vs["hw_effects"], "hw_effects advertised (patrol)")
 
 
+def test_reconcile_reapplies_only_on_drift():
+    print("reconcile re-arms the strip ONLY when the hw effect drifted (Steam reset)")
+    writes = []
+    restore = _install(writes)
+    saved_load = cs._led_state_load
+    try:
+        # persisted desired = scanner (which wants firmware `patrol`)
+        cs._led_state_load = lambda: {"strip:valve-leds": {
+            "effect": "scanner", "color": {"r": 255, "g": 0, "b": 0},
+            "speed": 55, "brightness": 100}}
+        base_read = cs._led_read_attr
+        hw = {"effect": "patrol"}                 # the live hardware effect
+        cs._led_read_attr = lambda n, a: (hw["effect"] if a == "effect"
+                                          else base_read(n, a))
+        # (a) steady: hw already patrol -> reconcile must write nothing
+        writes.clear()
+        cs._led_reconcile()
+        check(not any(w[1] == "effect" for w in writes),
+              "steady strip (already patrol) is NOT rewritten")
+        # (b) drifted: Steam reset the strip to 'normal' -> reconcile re-arms patrol
+        hw["effect"] = "normal"
+        writes.clear()
+        cs._led_reconcile()
+        check(any(w == ("valve-leds[0]", "effect", "patrol") for w in writes),
+              "drifted strip re-armed to patrol")
+    finally:
+        cs._led_state_load = saved_load
+        restore()
+
+
+def test_strip_effect_clears_stale_per_led_persist():
+    print("a whole-strip effect drops stale per-LED persists (no conflicting restore)")
+    writes = []
+    restore = _install(writes)
+    saved_save = cs._led_state_save
+    try:
+        cs._led_state_save = lambda: None         # don't touch disk
+        with cs._FX_LOCK:
+            cs._LED_PERSIST.clear()
+            cs._LED_PERSIST["valve-leds[2]"] = {"effect": "solid",
+                "color": {"r": 0, "g": 0, "b": 255}, "brightness": 90, "speed": 50}
+        cs.apply_strip_effect("valve-leds", "scanner", {"r": 255, "g": 0, "b": 0}, 70, 100)
+        check("valve-leds[2]" not in cs._LED_PERSIST,
+              "stale per-LED persist cleared by the strip effect")
+        check("strip:valve-leds" in cs._LED_PERSIST, "strip effect persisted")
+    finally:
+        cs._led_state_save = saved_save
+        restore()
+
+
 if __name__ == "__main__":
     test_detect_strip()
     test_allowlist_unknown_prefix()
@@ -236,6 +286,8 @@ if __name__ == "__main__":
     test_paint_auto_switches_to_manual()
     test_delay_maps_speed()
     test_strips_in_payload()
+    test_reconcile_reapplies_only_on_drift()
+    test_strip_effect_clears_stale_per_led_persist()
     print()
     if _fail:
         print("FAILED: %d" % len(_fail))


### PR DESCRIPTION
Root cause: system service (never restarts on session switch) + one-shot startup LED restore -> Steam re-inits the strip on a gamescope<->desktop switch/boot and couchside never re-applies. Fix: a 4s reconciler that re-asserts the strip effect ONLY when the live hardware drifted. + mixed-persist cleanup. Verified on the real Steam Machine (simulated reset -> reconciled to patrol in ~6s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)