### PR TITLE
feat: strip effects (circle/comet/wipe/twinkle) + timed sequence engine + Police preset (agent 2.9.90)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.90
+
+**More ways to light up your strip.** If your box has an addressable RGB strip —
+like a Steam Machine's — it can now run a bunch of new looks: a one-way "circle"
+chase that wraps around, a comet with a fading tail, a colour wipe, and a twinkle,
+each with a direction control. It also gained **custom timed sequences** — the box
+plays a series of frames you set on a loop, which is what powers new presets like a
+red/blue "Police" flasher and (soon) a build-your-own pattern editor. These show up
+in the app's Light card once your app updates too.
+
 ## 2.9.89
 
 **Your light strip stops reverting.** If your box has an addressable RGB strip —

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.89"
+VERSION = "2.9.90"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4621,7 +4621,7 @@ _LED_STATE_CONF = os.path.expanduser("~/.config/couchside/leds.json")
 # Frozen allowlist of effect ids (looked up, never interpolated). 'solid'/'off'
 # are one-shot (no animation); the rest animate on the render thread.
 _LED_EFFECTS = ("solid", "off", "breathe", "pulse", "rainbow", "strobe",
-                "scanner", "manual")
+                "scanner", "manual", "circle", "comet", "wipe", "twinkle")
 _LED_STATIC = frozenset(("solid", "off"))
 
 _FX_TICK = 0.033                 # ~30 fps render cadence
@@ -4833,21 +4833,24 @@ def apply_led_effect(name, effect, color, speed, brightness):
 
 def _validate_effect_body(req):
     """Shape check for POST /api/leds/effect. Returns
-    (effect, color|None, speed|None, brightness|None, error|None). Rejects, never
-    sanitises."""
+    (effect, color|None, speed|None, brightness|None, reverse:bool, error|None).
+    Rejects, never sanitises."""
     effect = req.get("effect")
     if effect not in _LED_EFFECTS:
-        return None, None, None, None, "unknown effect"
+        return None, None, None, None, False, "unknown effect"
     color = req.get("color")
     if color is not None and not _is_rgb_triple(color):
-        return None, None, None, None, "color must be {r,g,b} ints 0-255"
+        return None, None, None, None, False, "color must be {r,g,b} ints 0-255"
     speed = req.get("speed")
     if speed is not None and not _is_pct(speed, 1):
-        return None, None, None, None, "speed must be an int 1-100"
+        return None, None, None, None, False, "speed must be an int 1-100"
     brightness = req.get("brightness")
     if brightness is not None and not _is_pct(brightness):
-        return None, None, None, None, "brightness must be an int 0-100"
-    return effect, color, speed, brightness, None
+        return None, None, None, None, False, "brightness must be an int 0-100"
+    reverse = req.get("reverse")
+    if reverse is not None and not isinstance(reverse, bool):
+        return None, None, None, None, False, "reverse must be a boolean"
+    return effect, color, speed, brightness, bool(reverse), None
 
 
 def _led_restore():
@@ -4861,18 +4864,34 @@ def _led_restore():
         if not isinstance(st, dict):
             continue
         effect = st.get("effect")
+        # A custom sequence isn't a plain effect id -> re-arm it via its own path.
+        if effect == "sequence" and name.startswith("strip:"):
+            prefix = name[len("strip:"):]
+            frames = st.get("frames")
+            hold = st.get("hold_ms")
+            if (prefix in strips and isinstance(frames, list) and frames
+                    and isinstance(hold, int) and not isinstance(hold, bool)):
+                try:
+                    apply_strip_sequence(
+                        prefix, frames[:_SEQ_MAX_FRAMES], min(60000, max(30, hold)),
+                        st.get("brightness") if _is_pct(st.get("brightness")) else 100,
+                        bool(st.get("loop", True)))
+                except OSError:
+                    pass
+            continue
         if effect not in _LED_EFFECTS:
             continue
         color = st.get("color") if _is_rgb_triple(st.get("color")) else None
         speed = st.get("speed") if _is_pct(st.get("speed"), 1) else 50
         brightness = st.get("brightness") if _is_pct(st.get("brightness")) else 100
+        reverse = bool(st.get("reverse"))
         try:
             if name.startswith("strip:"):
                 # A persisted strip (firmware effect): re-arm the whole strip so a
                 # reboot brings back the night-rider without the phone.
                 prefix = name[len("strip:"):]
                 if prefix in strips:
-                    apply_strip_effect(prefix, effect, color, speed, brightness)
+                    apply_strip_effect(prefix, effect, color, speed, brightness, reverse)
             elif name in live:
                 apply_led_effect(name, effect, color, speed, brightness)
         except OSError:
@@ -4910,6 +4929,10 @@ def _led_reconcile():
         effect = st.get("effect")
         if effect not in _LED_EFFECTS:
             continue
+        if effect in _STRIP_SEQ_EFFECTS:
+            continue  # agent-rendered: the render thread re-writes it every frame,
+                      # so it self-heals a reset without a reconcile re-arm (which
+                      # would restart the animation with a visible jump).
         members = strips.get(name[len("strip:"):])
         if not members:
             continue
@@ -4974,6 +4997,10 @@ _STRIP_HW_MAP = {"scanner": "patrol", "breathe": "breath", "rainbow": "rainbow",
                  "manual": "manual", "off": "off"}
 # effects whose look depends on the picked colour (set multi_intensity first).
 _STRIP_COLOUR_FX = ("scanner", "breathe", "pulse", "strobe", "solid")
+# Strip effects the AGENT renders per-LED (no firmware effect exists for them):
+# a one-way "circle"/comet the render thread sweeps + wraps. These are looked up
+# like any effect id; the agent owns every frame (fixed-literal writers, §3).
+_STRIP_SEQ_EFFECTS = ("circle", "comet", "wipe", "twinkle")
 
 
 def _led_strips(names=None):
@@ -5019,13 +5046,184 @@ def _strip_public(prefix, members):
             "hw_effects": _strip_hw_effects(members[0])}
 
 
-def apply_strip_effect(prefix, effect, color, speed, brightness):
+# ---- Agent-rendered strip animations (circle/comet + future custom sequences) --
+# Some looks have NO firmware effect -- a one-way "circle"/comet that runs off one
+# end and restarts at the other. The AGENT renders those per-LED on this thread,
+# same discipline as _fx_loop: fixed-literal writers, and the client only picks an
+# allowlisted effect id + range-checked colour/speed/brightness (validated frame
+# DATA for custom sequences comes later). ONE animation per strip. The thread
+# writes ~30x/s, so a Steam reset self-heals within a frame (the reconciler skips
+# these); persisted like any strip effect, so a reboot re-arms it.
+_SEQ_TICK = 0.033                # ~30 fps
+_SEQ_LOCK = threading.RLock()
+_SEQ_ACTIVE = {}                 # prefix -> spec (members/effect/color/speed/brightness/t0/raws)
+_SEQ_THREAD = [None]
+_SEQ_TAIL = 3                    # comet head + fading-tail length
+
+
+def _seq_period(speed):
+    """Speed 1..100 -> seconds for one full lap around the strip (higher = faster).
+    100 -> ~0.5s (snappy), 55 -> ~2s, 25 -> ~3.1s, 1 -> ~4s."""
+    s = speed if _is_pct(speed, 1) else 50
+    return 4.0 - (s / 100.0) * 3.5
+
+
+def _seq_frame_sweep(n, t, period, color, tail, reverse=False):
+    """A bright head + a `tail`-LED fading trail sweeping ONE direction and WRAPPING.
+    Short tail = a "circle" dot; long tail = a comet. reverse -> the other way; the
+    tail always trails BEHIND the head's motion."""
+    frame = [None] * n
+    d = -1 if reverse else 1
+    head = (t / period) * n * d
+    for k in range(min(tail, n)):
+        pos = int(head - d * k) % n
+        frac = 1.0 - (k / float(tail))               # head brightest, tail fades
+        frame[pos] = {"r": int(color["r"] * frac),
+                      "g": int(color["g"] * frac),
+                      "b": int(color["b"] * frac)}
+    return frame
+
+
+# circle keeps its old name for callers/tests; it's a short-tail sweep.
+def _seq_frame_circle(n, t, period, color):
+    return _seq_frame_sweep(n, t, period, color, _SEQ_TAIL)
+
+
+def _seq_frame_wipe(n, t, period, color, reverse=False):
+    """Fill the strip one direction over the first half of the period, then clear it
+    over the second half -- a repeating colour wipe. reverse -> from the other end."""
+    frame = [None] * n
+    phase = (t % period) / period                    # 0..1
+    if phase < 0.5:
+        upto = int((phase / 0.5) * n + 0.5)          # filling
+        idxs = range(min(upto, n)) if not reverse else range(max(0, n - upto), n)
+    else:
+        frm = int(((phase - 0.5) / 0.5) * n + 0.5)   # clearing
+        idxs = range(min(frm, n), n) if not reverse else range(0, max(0, n - frm))
+    for i in idxs:
+        frame[i] = color
+    return frame
+
+
+def _seq_frame_twinkle(n, t, period, color):
+    """Each LED sparkles in `color` on its own index-derived phase (no RNG state):
+    a sharpened sine -> mostly dim with occasional bright pops = a twinkle."""
+    frame = [None] * n
+    for i in range(n):
+        ph = (i * 0.6180339887) % 1.0                # golden-ratio spread of phases
+        f = 0.5 + 0.5 * math.sin(2 * math.pi * ((t / (period * 0.5)) + ph))
+        f = f * f * f                                # sharpen: dim base, rare pops
+        if f > 0.06:
+            frame[i] = {"r": int(color["r"] * f),
+                        "g": int(color["g"] * f),
+                        "b": int(color["b"] * f)}
+    return frame
+
+
+def _seq_render(spec, now):
+    """Write ONE frame of `spec` to its strip via the fixed-literal writers."""
+    members = spec["members"]
+    n = len(members)
+    t = now - spec["t0"]
+    e = spec["effect"]
+    period = _seq_period(spec["speed"])
+    color = spec["color"]
+    rev = bool(spec.get("reverse"))
+    if e == "circle":
+        frame = _seq_frame_sweep(n, t, period, color, _SEQ_TAIL, rev)
+    elif e == "comet":
+        frame = _seq_frame_sweep(n, t, period, color, max(4, n // 2), rev)
+    elif e == "wipe":
+        frame = _seq_frame_wipe(n, t, period, color, rev)
+    elif e == "twinkle":
+        frame = _seq_frame_twinkle(n, t, period, color)
+    elif e == "sequence":
+        # A custom TIMED sequence: a list of per-LED frames (already normalized to n
+        # members at validation) shown `hold_ms` each. loop -> wrap; else hold the
+        # last frame. This is what the app's alternate-colour feature builds (2
+        # frames) and the future editor builds (N frames).
+        frames = spec.get("frames") or []
+        if not frames:
+            return
+        hold = max(0.03, spec.get("hold_ms", 500) / 1000.0)
+        step = int(t / hold)
+        idx = (step % len(frames)) if spec.get("loop", True) else min(step, len(frames) - 1)
+        frame = frames[idx]
+    else:
+        return
+    bmax = spec["brightness"]
+    for i, name in enumerate(members):
+        raw = spec["raws"].get(name)
+        if not raw:
+            continue
+        c = frame[i]
+        try:
+            if c is not None and raw.get("rgb"):
+                _led_write_color(name, raw, c)
+                _led_write(name, "brightness",
+                           str(int(bmax / 100.0 * raw["max_brightness"] + 0.5)))
+            else:
+                _led_write(name, "brightness", "0")
+        except OSError:
+            pass
+
+
+def _seq_loop():
+    """Render every active agent strip animation until none remain (or shutdown)."""
+    while not _FX_STOP.is_set():
+        with _SEQ_LOCK:
+            active = list(_SEQ_ACTIVE.values())
+        if not active:
+            return
+        now = time.monotonic()
+        for spec in active:
+            _seq_render(spec, now)
+        _FX_STOP.wait(_SEQ_TICK)
+
+
+def _seq_ensure_thread():
+    with _SEQ_LOCK:
+        th = _SEQ_THREAD[0]
+        if th is None or not th.is_alive():
+            _SEQ_THREAD[0] = threading.Thread(target=_seq_loop, daemon=True,
+                                              name="led-seq")
+            _SEQ_THREAD[0].start()
+
+
+def _seq_start(prefix, members, effect, color, speed, brightness, reverse=False):
+    """Begin an agent-rendered animation on the strip: flip every member to manual
+    (so the firmware isn't also animating), register the spec, start the thread."""
+    raws = {n: _read_led_raw(n) for n in members}
+    for n in members:
+        try:
+            _led_write(n, "effect", "manual")
+        except OSError:
+            pass
+    with _SEQ_LOCK:
+        _SEQ_ACTIVE[prefix] = {
+            "members": members, "effect": effect,
+            "color": color or {"r": 255, "g": 0, "b": 0},
+            "speed": speed if _is_pct(speed, 1) else 50,
+            "brightness": brightness if _is_pct(brightness) else 100,
+            "reverse": bool(reverse),
+            "t0": time.monotonic(), "raws": raws}
+    _seq_ensure_thread()
+
+
+def _seq_stop(prefix):
+    """Stop any agent animation on `prefix` (leaves its last frame lit)."""
+    with _SEQ_LOCK:
+        _SEQ_ACTIVE.pop(prefix, None)
+
+
+def apply_strip_effect(prefix, effect, color, speed, brightness, reverse=False):
     """Set an addressable strip to a FIRMWARE effect (or a manual solid/off).
 
     Returns {"ok":True,"active":..} | {"ok":False,"status":..} | None(->404).
     The heavy lifting is the driver's: for a hardware effect we set the base
     colour/brightness then write `effect`=<firmware name> + `delay`, and the strip
-    animates itself. `solid` paints every LED (effect=manual); `off` zeroes them."""
+    animates itself. `solid` paints every LED (effect=manual); `off` zeroes them.
+    `reverse` only affects the agent-rendered sweeps (circle/comet/wipe)."""
     if effect not in _LED_EFFECTS:
         return {"ok": False, "status": 400, "error": "unknown effect"}
     if not isinstance(prefix, str):
@@ -5045,6 +5243,25 @@ def apply_strip_effect(prefix, effect, color, speed, brightness):
 
     def _bval(raw):
         return str(int(b / 100 * raw["max_brightness"] + 0.5))
+
+    # Agent-rendered animation (no firmware effect for it -- a one-way "circle"):
+    # the render thread drives per-LED frames. Supersedes per-LED paints; persisted
+    # so a reboot re-arms it via _seq_start again.
+    if effect in _STRIP_SEQ_EFFECTS:
+        rev = bool(reverse)
+        _seq_start(prefix, members, effect, col, sp, b, rev)
+        with _FX_LOCK:
+            for m in members:
+                _LED_PERSIST.pop(m, None)
+            _LED_PERSIST["strip:" + prefix] = {"effect": effect, "color": col,
+                                               "speed": sp, "brightness": b,
+                                               "reverse": rev}
+        _led_state_save()
+        return {"ok": True, "strip": prefix,
+                "active": {"effect": effect, "color": col, "speed": sp,
+                           "brightness": b, "reverse": rev}}
+    # A firmware / manual effect supersedes any running agent animation here.
+    _seq_stop(prefix)
 
     try:
         if effect == "off":
@@ -5104,6 +5321,85 @@ def apply_strip_effect(prefix, effect, color, speed, brightness):
     _led_state_save()
     return {"ok": True, "strip": prefix,
             "active": {"effect": effect, "color": col, "speed": sp, "brightness": b}}
+
+
+_SEQ_MAX_FRAMES = 64          # cap on a custom sequence's frame count (bounds memory)
+
+
+def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True):
+    """Play a custom TIMED SEQUENCE of per-LED frames on the strip (agent-rendered):
+    the general form behind the app's alternate-colour feature (2 frames) and the
+    future editor (N frames). `frames` is validated per-LED colour DATA; the render
+    thread owns every write (fixed literals, §3). Persisted -> re-arms on reboot.
+    Returns {"ok":True,..} | None (-> 404)."""
+    if not isinstance(prefix, str):
+        return None
+    members = _led_strips().get(prefix)
+    if not members:
+        return None
+    raws = {n: _read_led_raw(n) for n in members}
+    if not all(r and r["writable"] for r in raws.values()):
+        return None
+    b = brightness if _is_pct(brightness) else 100
+    n = len(members)
+    # Normalize each frame to EXACTLY the member count (pad short with off, drop
+    # extra), keeping only valid RGB triples -- nothing client-shaped reaches a write.
+    norm = [[(fr[i] if i < len(fr) and _is_rgb_triple(fr[i]) else None)
+             for i in range(n)] for fr in frames]
+    for name in members:
+        try:
+            _led_write(name, "effect", "manual")
+        except OSError:
+            pass
+    with _SEQ_LOCK:
+        _SEQ_ACTIVE[prefix] = {
+            "members": members, "effect": "sequence", "frames": norm,
+            "hold_ms": int(hold_ms), "loop": bool(loop), "brightness": b,
+            "color": {"r": 255, "g": 255, "b": 255}, "speed": 50,
+            "t0": time.monotonic(), "raws": raws}
+    _seq_ensure_thread()
+    with _FX_LOCK:
+        for m in members:
+            _LED_PERSIST.pop(m, None)
+        _LED_PERSIST["strip:" + prefix] = {"effect": "sequence", "frames": norm,
+                                           "hold_ms": int(hold_ms), "loop": bool(loop),
+                                           "brightness": b}
+    _led_state_save()
+    return {"ok": True, "strip": prefix,
+            "active": {"effect": "sequence", "frames": len(norm),
+                       "hold_ms": int(hold_ms), "loop": bool(loop), "brightness": b}}
+
+
+def _validate_sequence_body(req):
+    """Shape-check POST /api/leds/sequence. Returns
+    (frames, hold_ms, brightness|None, loop, error|None). Rejects, never sanitises."""
+    frames = req.get("frames")
+    if not isinstance(frames, list) or not (1 <= len(frames) <= _SEQ_MAX_FRAMES):
+        return None, None, None, None, \
+            "frames must be a list of 1..%d frames" % _SEQ_MAX_FRAMES
+    out = []
+    for fr in frames:
+        if not isinstance(fr, list) or len(fr) > 512:
+            return None, None, None, None, "each frame is a list of <=512 colours"
+        row = []
+        for c in fr:
+            if c is None:
+                row.append(None)
+            elif _is_rgb_triple(c):
+                row.append(c)
+            else:
+                return None, None, None, None, "frame colours must be {r,g,b} ints or null"
+        out.append(row)
+    hold_ms = req.get("hold_ms", 500)
+    if isinstance(hold_ms, bool) or not isinstance(hold_ms, int) or not (30 <= hold_ms <= 60000):
+        return None, None, None, None, "hold_ms must be an int 30..60000"
+    brightness = req.get("brightness")
+    if brightness is not None and not _is_pct(brightness):
+        return None, None, None, None, "brightness must be an int 0-100"
+    loop = req.get("loop", True)
+    if not isinstance(loop, bool):
+        return None, None, None, None, "loop must be a boolean"
+    return out, hold_ms, brightness, loop, None
 
 
 # ---- OpenRGB backend (cap: openrgb) -----------------------------------------
@@ -19708,6 +20004,42 @@ class Handler(BaseHTTPRequestHandler):
                            res, started)
                 return
 
+            if path == "/api/leds/sequence":
+                # Play a custom TIMED sequence on a STRIP: the client sends `frames`
+                # (per-LED colour DATA, each validated to {r,g,b}|null), `hold_ms`,
+                # `loop`. SAME allowlist discipline as the paint path -- the client
+                # provides colour DATA the agent renders via fixed-literal writers;
+                # the strip PREFIX is looked up in the live listdir, never interpolated.
+                try:
+                    req = json.loads(body.decode("utf-8")) if body else {}
+                    if not isinstance(req, dict):
+                        raise ValueError("body must be a JSON object")
+                except (ValueError, TypeError, UnicodeDecodeError):
+                    self._send(400, {"error": "body must be a JSON object"}, started)
+                    return
+                strip_name = req.get("strip")
+                frames, hold_ms, brightness, loop, verr = _validate_sequence_body(req)
+                if verr is not None:
+                    self._send(400, {"error": verr}, started)
+                    return
+                if self.mock:
+                    ms = _led_strips([l["name"] for l in MOCK_LEDS if l["writable"]])
+                    if not isinstance(strip_name, str) or strip_name not in ms:
+                        self._send(404, {"error": "unknown strip"}, started)
+                        return
+                    _MOCK_FX["strip:" + strip_name] = {
+                        "effect": "sequence", "frames": len(frames), "hold_ms": hold_ms,
+                        "loop": loop, "brightness": brightness if brightness is not None else 100}
+                    self._send(200, {"ok": True, "strip": strip_name,
+                                     "active": _MOCK_FX["strip:" + strip_name]}, started)
+                    return
+                res = apply_strip_sequence(strip_name, frames, hold_ms, brightness, loop)
+                if res is None:
+                    self._send(404, {"error": "unknown strip"}, started)
+                    return
+                self._send(200, res, started)
+                return
+
             if path == "/api/leds/effect":
                 # Start/replace an animated effect (breathe/pulse/rainbow/strobe/
                 # scanner) or a solid/off on an LED. SAME allowlist shape as
@@ -19724,7 +20056,7 @@ class Handler(BaseHTTPRequestHandler):
                                started)
                     return
                 led_name = req.get("led")
-                effect, color, speed, brightness, verr = _validate_effect_body(req)
+                effect, color, speed, brightness, reverse, verr = _validate_effect_body(req)
                 if verr is not None:
                     self._send(400, {"error": verr}, started)
                     return
@@ -19752,7 +20084,7 @@ class Handler(BaseHTTPRequestHandler):
                         self._send(200, {"ok": True, "strip": strip_name,
                                          "active": _MOCK_FX.get(key)}, started)
                         return
-                    res = apply_strip_effect(strip_name, effect, color, speed, brightness)
+                    res = apply_strip_effect(strip_name, effect, color, speed, brightness, reverse)
                     if res is None:
                         self._send(404, {"error": "unknown strip"}, started)
                         return
@@ -19807,7 +20139,7 @@ class Handler(BaseHTTPRequestHandler):
                                started)
                     return
                 device = req.get("device")
-                effect, color, speed, brightness, verr = _validate_effect_body(req)
+                effect, color, speed, brightness, reverse, verr = _validate_effect_body(req)
                 if verr is not None:
                     self._send(400, {"error": verr}, started)
                     return

--- a/app/components/RgbLedCard.tsx
+++ b/app/components/RgbLedCard.tsx
@@ -60,6 +60,11 @@ const EFFECT_META: Record<LedEffect, { label: string; usesColor: boolean }> = {
   scanner: { label: 'Scanner', usesColor: true },
   // `manual` is a strip-only concept; filtered out of this single-LED card below.
   manual: { label: 'Manual', usesColor: true },
+  // Strip-only agent animations; filtered out of this mono card (not in MONO_EFFECTS).
+  circle: { label: 'Circle', usesColor: true },
+  comet: { label: 'Comet', usesColor: true },
+  wipe: { label: 'Wipe', usesColor: true },
+  twinkle: { label: 'Twinkle', usesColor: true },
 };
 /** A mono LED can't show colour, so only these effects make sense on one. */
 const MONO_EFFECTS: LedEffect[] = ['solid', 'off', 'breathe', 'pulse', 'strobe'];

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -35,12 +35,18 @@ import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const POLL_MS = 15000;
 
-type StripEffect = 'solid' | 'off' | 'manual' | 'scanner' | 'rainbow' | 'breathe';
+type StripEffect =
+  | 'solid' | 'off' | 'manual' | 'scanner' | 'rainbow' | 'breathe'
+  | 'circle' | 'comet' | 'wipe' | 'twinkle';
 const EFFECTS: { id: StripEffect; label: string }[] = [
   { id: 'solid', label: 'Solid' },
   { id: 'manual', label: 'Manual' },
   { id: 'off', label: 'Off' },
   { id: 'scanner', label: 'Scanner' },
+  { id: 'circle', label: 'Circle' },
+  { id: 'comet', label: 'Comet' },
+  { id: 'wipe', label: 'Wipe' },
+  { id: 'twinkle', label: 'Twinkle' },
   { id: 'rainbow', label: 'Rainbow' },
   { id: 'breathe', label: 'Breathe' },
 ];
@@ -49,6 +55,15 @@ const SPEEDS = [
   { label: 'Med', pct: 55, ms: 90 },
   { label: 'Fast', pct: 90, ms: 55 },
 ];
+// Brightness levels a tap on a single LED cycles UP through, then off:
+// off -> 35 -> 70 -> 100 -> off.
+const CELL_STEPS = [35, 70, 100];
+/** The next per-LED brightness for a tap: up a step, or off past the top. */
+function nextCellBrightness(cur: number): number {
+  if (cur <= 0) return CELL_STEPS[0];
+  const idx = CELL_STEPS.findIndex((s) => cur <= s);
+  return idx < 0 || idx >= CELL_STEPS.length - 1 ? 0 : CELL_STEPS[idx + 1];
+}
 const scale = (c: Rgb, f: number): Rgb => ({
   r: Math.round(c.r * f), g: Math.round(c.g * f), b: Math.round(c.b * f),
 });
@@ -93,7 +108,12 @@ export function StripLightCard() {
   const [hue, setHue] = useState(0);
   const [bright, setBright] = useState(100);
   const [speedPct, setSpeedPct] = useState(55);
+  // Sweep direction for the agent-rendered directional effects (circle/comet/wipe).
+  const [reverse, setReverse] = useState(false);
   const [frame, setFrame] = useState<(Rgb | null)[]>([]);
+  // Per-LED brightness % (0 = off). A tap on a cell cycles it up the CELL_STEPS
+  // then off, so you can dial each LED's level (and turn it off) by tapping.
+  const [cellBright, setCellBright] = useState<number[]>([]);
   const [busy, setBusy] = useState(false);
   // Pending "name this preset" prompt: the auto label + a builder that turns the
   // typed name into the full preset to save.
@@ -123,6 +143,7 @@ export function StripLightCard() {
     if (seeded.current === strip.key) return;
     seeded.current = strip.key;
     setFrame(displayLeds(strip).map((l) => (l.brightness_pct > 0 ? l.color : null)));
+    setCellBright(displayLeds(strip).map((l) => l.brightness_pct));
     const a = strip && poll.data?.active?.[`strip:${agentStrip?.prefix}`];
     if (a) { setEffect(a.effect as StripEffect); setBright(a.brightness); if (a.color) setHue(rgbToHue(a.color)); }
     else {
@@ -161,7 +182,8 @@ export function StripLightCard() {
   // Steam Machine so the row matches the strip).
   const orderedLeds = displayLeds(strip);
   const color = hueToRgb(hue);
-  const animated = effect === 'scanner' || effect === 'rainbow' || effect === 'breathe';
+  const AGENT_ANIMATED = ['scanner', 'rainbow', 'breathe', 'circle', 'comet', 'wipe', 'twinkle'];
+  const animated = AGENT_ANIMATED.includes(effect);
   const shown = agentMode
     ? EFFECTS
     : EFFECTS.filter((e) => e.id === 'solid' || e.id === 'off' || e.id === 'scanner');
@@ -174,7 +196,7 @@ export function StripLightCard() {
       setBusy(true);
       try {
         await api.setStripEffect(settings, agentStrip.prefix, {
-          effect: e as LedEffect, brightness: Math.round(bright),
+          effect: e as LedEffect, brightness: Math.round(bright), reverse,
           ...(animated || e !== 'off' ? { speed: Math.round(speedPct) } : {}),
           ...(e === 'rainbow' ? {} : { color }),
         });
@@ -191,11 +213,17 @@ export function StripLightCard() {
 
   /** Re-apply the current colour/brightness — for a solid strip, or to re-arm an
    *  agent effect with the tweaked colour/speed (slider/speed commit). */
-  const reapply = () => {
+  // speedOverride: a speed CHIP sets state + re-applies in one tick, so it must
+  // pass the new value explicitly — reading speedPct here would send the PREVIOUS
+  // speed (stale closure: setSpeedPct hasn't re-rendered yet). Sliders re-render on
+  // each onChange before onCommit, so they call reapply() with no arg (current).
+  const reapply = (over?: { speed?: number; reverse?: boolean }) => {
     if (agentMode && agentStrip && effect !== 'off') {
       void api.setStripEffect(settings, agentStrip.prefix, {
         effect: effect as LedEffect, brightness: Math.round(bright),
-        speed: Math.round(speedPct), ...(effect === 'rainbow' ? {} : { color }),
+        speed: Math.round(over?.speed ?? speedPct),
+        reverse: over?.reverse ?? reverse,
+        ...(effect === 'rainbow' ? {} : { color }),
       }).catch(() => {});
       return;
     }
@@ -206,11 +234,24 @@ export function StripLightCard() {
     }
   };
 
-  /** Paint one cell — a per-LED customizer (best in Solid). */
+  /** Tap one LED to cycle its brightness up a step, then off — a per-LED dimmer.
+   *  Keeps the cell's own colour if it's already lit; a first tap on an off cell
+   *  uses the current picker colour. */
   const paintCell = (i: number) => {
     hapticLight();
-    void api.setLed(settings, orderedLeds[i].name, { color, brightness: Math.round(bright) }).catch(() => {});
-    setFrame((f) => { const c = f.slice(); c[i] = color; return c; });
+    const cur = cellBright[i] ?? (frame[i] ? 100 : 0);
+    const next = nextCellBrightness(cur);
+    const name = orderedLeds[i].name;
+    if (next > 0) {
+      const cellColor = frame[i] ?? color;   // keep this LED's colour if already lit
+      void api.setLed(settings, name, { color: cellColor, brightness: next }).catch(() => {});
+      setFrame((f) => { const c = f.slice(); c[i] = cellColor; return c; });
+      setCellBright((b) => { const c = b.slice(); c[i] = next; return c; });
+    } else {
+      void api.setLed(settings, name, { brightness: 0 }).catch(() => {});
+      setFrame((f) => { const c = f.slice(); c[i] = null; return c; });
+      setCellBright((b) => { const c = b.slice(); c[i] = 0; return c; });
+    }
   };
 
   /** Coerce any saved preset effect to one the strip runs. */
@@ -221,6 +262,25 @@ export function StripLightCard() {
 
   const applyPreset = (p: LedPreset) => {
     hapticLight();
+    // A GENERATOR preset (Police): build a strip-sized timed sequence + play it on
+    // the box (red/blue halves alternating -> a police bar).
+    if (p.generator === 'police') {
+      setBright(p.brightness);
+      const n = orderedLeds.length;
+      const R: Rgb = { r: 255, g: 0, b: 0 };
+      const B: Rgb = { r: 0, g: 40, b: 255 };
+      const half = Math.ceil(n / 2);
+      const A = orderedLeds.map((_, i) => (i < half ? R : null));
+      const Bf = orderedLeds.map((_, i) => (i >= half ? B : null));
+      setFrame(A);   // preview one flash in the grid
+      if (agentMode && agentStrip) {
+        const holdMs = Math.max(90, 600 - p.speed * 5);   // faster preset = quicker flash
+        void api.setStripSequence(settings, agentStrip.prefix, {
+          frames: [A, Bf], holdMs, loop: true, brightness: p.brightness,
+        }).then(() => poll.refresh()).catch(() => {});
+      }
+      return;
+    }
     // A painted PATTERN preset: enter manual mode, then repaint every LED.
     if (p.pattern && p.pattern.length) {
       setEffect('manual'); setBright(p.brightness);
@@ -311,12 +371,15 @@ export function StripLightCard() {
       <View style={styles.strip}>
         {orderedLeds.map((l, i) => {
           const c = frame[i] ?? null;
+          const bpct = cellBright[i] ?? (c ? 100 : 0);
+          const shown = c && bpct > 0 ? scale(c, bpct / 100) : null;   // dim by level
           return (
             <Pressable
               key={l.name} onPress={() => paintCell(i)} style={styles.cellWrap}
-              accessibilityRole="button" accessibilityLabel={`Paint LED ${i}`}>
+              accessibilityRole="button"
+              accessibilityLabel={`LED ${i}, ${bpct > 0 ? `${bpct}%` : 'off'} — tap to change`}>
               {({ pressed }) => (
-                <View style={[styles.cell, { backgroundColor: c ? cssRgb(c) : t.card },
+                <View style={[styles.cell, { backgroundColor: shown ? cssRgb(shown) : t.card },
                   pressed && styles.pressed]} />
               )}
             </Pressable>
@@ -350,11 +413,33 @@ export function StripLightCard() {
               const on = speedPct === s.pct;
               return (
                 <Pressable
-                  key={s.label} onPress={() => { hapticLight(); setSpeedPct(s.pct); if (agentMode) reapply(); }}
+                  key={s.label} onPress={() => { hapticLight(); setSpeedPct(s.pct); if (agentMode) reapply({ speed: s.pct }); }}
                   accessibilityRole="button" accessibilityState={{ selected: on }}
                   accessibilityLabel={`Speed ${s.label}`}
                   style={({ pressed }) => [styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
                   <Text style={[styles.chipText, on && styles.chipTextOn]}>{s.label}</Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </>
+      )}
+
+      {/* DIRECTION — only the agent-rendered sweeps have a direction. */}
+      {agentMode && (['circle', 'comet', 'wipe'] as StripEffect[]).includes(effect) && (
+        <>
+          <Text style={styles.sectionLabel}>DIRECTION</Text>
+          <View style={styles.chipRow}>
+            {[{ label: '→', rev: false }, { label: '←', rev: true }].map((d) => {
+              const on = reverse === d.rev;
+              return (
+                <Pressable
+                  key={d.label}
+                  onPress={() => { hapticLight(); setReverse(d.rev); reapply({ reverse: d.rev }); }}
+                  accessibilityRole="button" accessibilityState={{ selected: on }}
+                  accessibilityLabel={d.rev ? 'Direction reverse' : 'Direction forward'}
+                  style={({ pressed }) => [styles.chip, on && styles.chipOn, pressed && styles.pressed]}>
+                  <Text style={[styles.chipText, on && styles.chipTextOn]}>{d.label}</Text>
                 </Pressable>
               );
             })}
@@ -370,7 +455,7 @@ export function StripLightCard() {
             <View style={[styles.swatchPreview, { backgroundColor: cssRgb(color) }]} />
           </View>
           <TrackSlider
-            value={hue} min={0} max={360} onChange={setHue} onCommit={reapply}
+            value={hue} min={0} max={360} onChange={setHue} onCommit={() => reapply()}
             thumbColor={cssRgb(color)} accessibilityLabel="Strip colour hue"
             renderTrack={() => (
               <View style={styles.hueFill}>
@@ -386,7 +471,7 @@ export function StripLightCard() {
         <>
           <Text style={styles.sectionLabel}>BRIGHTNESS</Text>
           <TrackSlider
-            value={bright} min={0} max={100} onChange={setBright} onCommit={reapply}
+            value={bright} min={0} max={100} onChange={setBright} onCommit={() => reapply()}
             thumbColor={t.text} accessibilityLabel="Strip brightness"
             renderTrack={(pct) => (
               <View style={styles.brightTrack}>

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -487,7 +487,12 @@ export type LedEffect =
   | 'solid' | 'off' | 'breathe' | 'pulse' | 'rainbow' | 'strobe' | 'scanner'
   // `manual` = a per-LED painted pattern on a strip (agent >= 2.9.85); the
   // colours stick because the agent puts each node in the driver's manual mode.
-  | 'manual';
+  | 'manual'
+  // Agent-rendered strip animations (agent >= 2.9.90): the box renders them per-LED,
+  // so they survive the phone closing like the firmware effects. `circle` = a dot
+  // that wraps; `comet` = a long fading trail; `wipe` = fill one way then clear;
+  // `twinkle` = random sparkle in the picked colour.
+  | 'circle' | 'comet' | 'wipe' | 'twinkle';
 
 /** The effect currently running on an LED (from GET /api/leds `active`). Absent
     for an LED showing a plain solid colour (that's read from LedInfo instead). */
@@ -2763,11 +2768,39 @@ export const api = {
   setStripEffect(
     settings: ConnSettings,
     strip: string,
-    patch: { effect: LedEffect; color?: Rgb; speed?: number; brightness?: number },
+    patch: {
+      effect: LedEffect; color?: Rgb; speed?: number; brightness?: number;
+      // Reverse the sweep direction (agent-rendered circle/comet/wipe only;
+      // agent >= 2.9.90). Ignored by firmware effects + older agents.
+      reverse?: boolean;
+    },
   ): Promise<boolean> {
     return request<{ ok: boolean }>(settings, '/api/leds/effect', {
       method: 'POST',
       body: { strip, ...patch },
+    })
+      .then((r) => !!r?.ok)
+      .catch(() => false);
+  },
+
+  /**
+   * Play a custom TIMED sequence on a strip (agent >= 2.9.90): a list of per-LED
+   * frames shown `holdMs` each, looping — what the alternate-colour feature and the
+   * Police preset build. Agent-rendered, so it survives the phone closing. Older
+   * agents 404/400 -> resolves false and the caller degrades.
+   */
+  setStripSequence(
+    settings: ConnSettings,
+    strip: string,
+    seq: { frames: (Rgb | null)[][]; holdMs: number; loop?: boolean; brightness?: number },
+  ): Promise<boolean> {
+    return request<{ ok: boolean }>(settings, '/api/leds/sequence', {
+      method: 'POST',
+      body: {
+        strip, frames: seq.frames, hold_ms: Math.round(seq.holdMs),
+        loop: seq.loop ?? true,
+        ...(seq.brightness != null ? { brightness: Math.round(seq.brightness) } : {}),
+      },
     })
       .then((r) => !!r?.ok)
       .catch(() => false);

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -36,12 +36,17 @@ export type LedPreset = {
   /** A per-LED painted pattern (effect==='manual' only): one colour per strip
       node, null = off. Applying it repaints every LED. */
   pattern?: (Rgb | null)[];
+  /** A built-in that GENERATES a timed sequence sized to the strip when applied
+      (e.g. 'police' = red/blue halves alternating). Overrides effect/pattern. */
+  generator?: 'police';
 };
 
 /** Seeded once when the library is empty. "Night Rider" is the owner's example. */
 const DEFAULTS: LedPreset[] = [
   { id: 'seed-nightrider', label: 'Night Rider', effect: 'scanner',
     color: { r: 255, g: 0, b: 0 }, speed: 80, brightness: 100 },
+  { id: 'seed-police', label: 'Police', effect: 'manual',
+    color: null, speed: 85, brightness: 100, generator: 'police' },
   { id: 'seed-breathe-blue', label: 'Breathe Blue', effect: 'breathe',
     color: { r: 0, g: 80, b: 255 }, speed: 35, brightness: 90 },
   { id: 'seed-rainbow', label: 'Rainbow', effect: 'rainbow',
@@ -105,6 +110,7 @@ function normalize(raw: unknown): LedPreset[] {
       pattern: Array.isArray(p.pattern)
         ? (p.pattern as unknown[]).map((c) => (isRgb(c) ? { r: c.r, g: c.g, b: c.b } : null))
         : undefined,
+      generator: p.generator === 'police' ? 'police' : undefined,
     });
     if (out.length >= PRESET_MAX) break;
   }
@@ -125,6 +131,15 @@ export async function loadPresets(): Promise<void> {
     }
     presets = normalize(parsed);
     if (presets.length > 0) {
+      // Add any BUILT-IN seed the stored library predates (e.g. Police, added
+      // later) without wiping the user's own presets. (Simple id-merge; a built-in
+      // the user deleted can reappear — acceptable for now.)
+      const have = new Set(presets.map((p) => p.id));
+      const missing = DEFAULTS.filter((d) => !have.has(d.id));
+      if (missing.length) {
+        presets = [...presets, ...missing].slice(0, PRESET_MAX);
+        void storageSet(KEY, JSON.stringify(presets));
+      }
       emit();
       return;
     }

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -98,20 +98,22 @@ def _reset_engine():
 
 def test_validate_effect_body():
     print("effect body validation (reject, don't sanitise)")
-    e, c, s, b, err = cs._validate_effect_body({"effect": "breathe"})
-    check(err is None and e == "breathe", "accepts a bare known effect")
-    e, c, s, b, err = cs._validate_effect_body(
-        {"effect": "rainbow", "speed": 80, "brightness": 40,
-         "color": {"r": 1, "g": 2, "b": 3}})
-    check(err is None and s == 80 and b == 40 and c == {"r": 1, "g": 2, "b": 3},
-          "accepts full valid params")
+    e, c, s, b, rev, err = cs._validate_effect_body({"effect": "breathe"})
+    check(err is None and e == "breathe" and rev is False,
+          "accepts a bare known effect (reverse defaults False)")
+    e, c, s, b, rev, err = cs._validate_effect_body(
+        {"effect": "circle", "speed": 80, "brightness": 40,
+         "color": {"r": 1, "g": 2, "b": 3}, "reverse": True})
+    check(err is None and s == 80 and b == 40 and c == {"r": 1, "g": 2, "b": 3}
+          and rev is True, "accepts full valid params incl. reverse")
     bad = [{"effect": "nope"}, {"effect": "breathe", "speed": 0},
            {"effect": "breathe", "speed": 101}, {"effect": "breathe", "speed": True},
            {"effect": "breathe", "brightness": -1}, {"effect": "breathe", "brightness": 101},
            {"effect": "breathe", "color": {"r": 256, "g": 0, "b": 0}},
-           {"effect": "breathe", "color": [1, 2, 3]}, {}]
+           {"effect": "breathe", "color": [1, 2, 3]},
+           {"effect": "breathe", "reverse": "yes"}, {}]
     for body in bad:
-        _, _, _, _, err = cs._validate_effect_body(body)
+        _, _, _, _, _, err = cs._validate_effect_body(body)
         check(err is not None, "rejects %s" % body)
 
 

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -276,6 +276,125 @@ def test_strip_effect_clears_stale_per_led_persist():
         restore()
 
 
+def test_circle_starts_agent_animation():
+    print("circle: agent-rendered -> registers a sequence, flips members to manual")
+    writes = []
+    restore = _install(writes)
+    saved_thread, saved_save = cs._seq_ensure_thread, cs._led_state_save
+    try:
+        cs._seq_ensure_thread = lambda: None      # don't spawn the render thread
+        cs._led_state_save = lambda: None
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        with cs._FX_LOCK:
+            cs._LED_PERSIST.clear()
+        res = cs.apply_strip_effect("valve-leds", "circle",
+                                    {"r": 0, "g": 200, "b": 255}, 70, 90)
+        check(res and res.get("ok") and res["active"]["effect"] == "circle",
+              "circle accepted, active reports it")
+        check("valve-leds" in cs._SEQ_ACTIVE, "agent sequence registered for the strip")
+        check(all((("valve-leds[%d]" % i), "effect", "manual") in writes
+                  for i in range(_N)), "every member flipped to manual")
+        check(cs._LED_PERSIST.get("strip:valve-leds", {}).get("effect") == "circle",
+              "circle persisted so a reboot re-arms it")
+        # a firmware effect supersedes the running agent animation
+        cs.apply_strip_effect("valve-leds", "scanner", {"r": 255, "g": 0, "b": 0}, 70, 100)
+        check("valve-leds" not in cs._SEQ_ACTIVE, "scanner stops the agent sequence")
+    finally:
+        cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        restore()
+
+
+def test_circle_frame_sweeps_and_wraps():
+    print("circle frame: a head that advances one direction and wraps")
+    n, period, col = 8, 4.0, {"r": 255, "g": 0, "b": 0}
+    f0 = cs._seq_frame_circle(n, 0.0, period, col)
+    check(f0[0] is not None and f0[0]["r"] == 255, "bright head at index 0 at t=0")
+    check(sum(1 for c in f0 if c is not None) <= cs._SEQ_TAIL, "only head + tail lit")
+    fq = cs._seq_frame_circle(n, period / n * 2, period, col)
+    check(fq[2] is not None and fq[2]["r"] == 255, "head advanced to index 2")
+    fw = cs._seq_frame_circle(n, period * (n - 0.01) / n, period, col)
+    check(fw[n - 1] is not None, "head reaches the last LED before wrapping to 0")
+
+
+def test_reconcile_skips_agent_effects():
+    print("reconcile SKIPS agent-rendered effects (they self-heal each frame)")
+    writes = []
+    restore = _install(writes)
+    saved_load = cs._led_state_load
+    try:
+        cs._led_state_load = lambda: {"strip:valve-leds": {
+            "effect": "circle", "color": {"r": 255, "g": 0, "b": 0},
+            "speed": 55, "brightness": 100}}
+        base = cs._led_read_attr
+        cs._led_read_attr = lambda nm, a: ("normal" if a == "effect" else base(nm, a))
+        writes.clear()
+        cs._led_reconcile()
+        check(not any(w[1] == "effect" for w in writes),
+              "circle is not re-armed by the reconciler (render thread owns it)")
+    finally:
+        cs._led_state_load = saved_load
+        restore()
+
+
+def test_sequence_validation():
+    print("sequence body validation (reject, don't sanitise)")
+    good = {"frames": [[{"r": 255, "g": 0, "b": 0}, None], [None, {"r": 0, "g": 0, "b": 255}]],
+            "hold_ms": 400, "loop": True, "brightness": 90}
+    frames, hold, br, loop, err = cs._validate_sequence_body(good)
+    check(err is None and len(frames) == 2 and hold == 400 and loop is True and br == 90,
+          "accepts a valid 2-frame sequence")
+    bad = [
+        {"frames": []},                                  # empty
+        {"frames": [[{"r": 256, "g": 0, "b": 0}]]},      # bad colour
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "hold_ms": 10},    # hold too small
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "hold_ms": 999999},  # hold too big
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "loop": "yes"},    # loop not bool
+        {"frames": "nope"},                              # frames not a list
+        {"frames": [["red"]]},                           # colour not {r,g,b}|null
+    ]
+    for b in bad:
+        _, _, _, _, err = cs._validate_sequence_body(b)
+        check(err is not None, "rejects %s" % (list(b)[:1]))
+
+
+def test_sequence_starts_and_persists():
+    print("apply_strip_sequence: registers a sequence, normalizes frames, persists")
+    writes = []
+    restore = _install(writes)
+    saved_thread, saved_save = cs._seq_ensure_thread, cs._led_state_save
+    try:
+        cs._seq_ensure_thread = lambda: None
+        cs._led_state_save = lambda: None
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        with cs._FX_LOCK:
+            cs._LED_PERSIST.clear()
+        # frames SHORTER than the 5-member strip -> normalized (padded with off)
+        A = [{"r": 255, "g": 0, "b": 0}, {"r": 255, "g": 0, "b": 0}]
+        B = [None, None, {"r": 0, "g": 0, "b": 255}]
+        res = cs.apply_strip_sequence("valve-leds", [A, B], 400, 90, True)
+        check(res and res.get("ok") and res["active"]["frames"] == 2,
+              "sequence accepted")
+        spec = cs._SEQ_ACTIVE.get("valve-leds")
+        check(spec and spec["effect"] == "sequence" and len(spec["frames"]) == 2,
+              "registered as a 2-frame sequence")
+        check(spec and all(len(fr) == _N for fr in spec["frames"]),
+              "every frame normalized to the member count (%d)" % _N)
+        check(all((("valve-leds[%d]" % i), "effect", "manual") in writes for i in range(_N)),
+              "members flipped to manual")
+        p = cs._LED_PERSIST.get("strip:valve-leds", {})
+        check(p.get("effect") == "sequence" and p.get("hold_ms") == 400,
+              "sequence persisted for reboot re-arm")
+    finally:
+        cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        restore()
+
+
 if __name__ == "__main__":
     test_detect_strip()
     test_allowlist_unknown_prefix()
@@ -288,6 +407,11 @@ if __name__ == "__main__":
     test_strips_in_payload()
     test_reconcile_reapplies_only_on_drift()
     test_strip_effect_clears_stale_per_led_persist()
+    test_circle_starts_agent_animation()
+    test_circle_frame_sweeps_and_wraps()
+    test_reconcile_skips_agent_effects()
+    test_sequence_validation()
+    test_sequence_starts_and_persists()
     print()
     if _fail:
         print("FAILED: %d" % len(_fail))


### PR DESCRIPTION
Agent-rendered strip animations + a general timed-sequence engine (POST /api/leds/sequence), persisted/re-armed, reconciler-skipped. App: effect chips + direction toggle + per-LED brightness tapping + speed-chip fix + api.setStripSequence + built-in Police preset. All hardware-verified on the steamdeck. Agent 2.9.90 ships via box-update; app rides the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)