### PR TITLE
feat: per-frame timing for LED strip sequences + save-as-preset

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.91
+
+**Build your own light-strip animations, frame by frame.** Custom timed sequences
+can now hold each frame for a **different** length of time, so a pattern can linger
+on one look and flash quickly through others. This is what powers the app's new
+**frame-by-frame strip editor** — paint a look, capture it as a frame, set how long
+each frame plays, and the box loops them on its own (and remembers across reboots).
+Older sequences keep playing exactly as before. Show up in the app's Light card once
+your app updates too.
+
 ## 2.9.90
 
 **More ways to light up your strip.** If your box has an addressable RGB strip —

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.90"
+VERSION = "2.9.91"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4869,13 +4869,20 @@ def _led_restore():
             prefix = name[len("strip:"):]
             frames = st.get("frames")
             hold = st.get("hold_ms")
+            holds = st.get("holds")
             if (prefix in strips and isinstance(frames, list) and frames
                     and isinstance(hold, int) and not isinstance(hold, bool)):
+                fr = frames[:_SEQ_MAX_FRAMES]
+                # per-frame durations only if a clean int list matching the frames;
+                # apply_strip_sequence re-validates too (defence in depth).
+                hh = holds if (isinstance(holds, list) and len(holds) == len(fr)
+                               and all(isinstance(x, int) and not isinstance(x, bool)
+                                       for x in holds)) else None
                 try:
                     apply_strip_sequence(
-                        prefix, frames[:_SEQ_MAX_FRAMES], min(60000, max(30, hold)),
+                        prefix, fr, min(60000, max(30, hold)),
                         st.get("brightness") if _is_pct(st.get("brightness")) else 100,
-                        bool(st.get("loop", True)))
+                        bool(st.get("loop", True)), hh)
                 except OSError:
                     pass
             continue
@@ -5139,15 +5146,40 @@ def _seq_render(spec, now):
         frame = _seq_frame_twinkle(n, t, period, color)
     elif e == "sequence":
         # A custom TIMED sequence: a list of per-LED frames (already normalized to n
-        # members at validation) shown `hold_ms` each. loop -> wrap; else hold the
-        # last frame. This is what the app's alternate-colour feature builds (2
-        # frames) and the future editor builds (N frames).
+        # members at validation). With per-frame `holds` (one ms per frame) we walk a
+        # cumulative timeline; without them every frame shows for the uniform
+        # `hold_ms`. loop -> wrap; else hold the last frame. This is what the app's
+        # alternate-colour feature builds (2 frames) and the N-frame editor builds.
         frames = spec.get("frames") or []
         if not frames:
             return
-        hold = max(0.03, spec.get("hold_ms", 500) / 1000.0)
-        step = int(t / hold)
-        idx = (step % len(frames)) if spec.get("loop", True) else min(step, len(frames) - 1)
+        loop = spec.get("loop", True)
+        holds = spec.get("holds")
+        if holds and len(holds) == len(frames):
+            total = sum(holds) / 1000.0
+            if total <= 0:
+                idx = 0
+            elif loop:
+                tm = t % total
+                acc = 0.0
+                idx = len(frames) - 1
+                for j, h in enumerate(holds):
+                    acc += h / 1000.0
+                    if tm < acc:
+                        idx = j
+                        break
+            else:
+                acc = 0.0
+                idx = len(frames) - 1
+                for j, h in enumerate(holds):
+                    acc += h / 1000.0
+                    if t < acc:
+                        idx = j
+                        break
+        else:
+            hold = max(0.03, spec.get("hold_ms", 500) / 1000.0)
+            step = int(t / hold)
+            idx = (step % len(frames)) if loop else min(step, len(frames) - 1)
         frame = frames[idx]
     else:
         return
@@ -5326,12 +5358,13 @@ def apply_strip_effect(prefix, effect, color, speed, brightness, reverse=False):
 _SEQ_MAX_FRAMES = 64          # cap on a custom sequence's frame count (bounds memory)
 
 
-def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True):
+def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True, holds=None):
     """Play a custom TIMED SEQUENCE of per-LED frames on the strip (agent-rendered):
     the general form behind the app's alternate-colour feature (2 frames) and the
-    future editor (N frames). `frames` is validated per-LED colour DATA; the render
-    thread owns every write (fixed literals, §3). Persisted -> re-arms on reboot.
-    Returns {"ok":True,..} | None (-> 404)."""
+    N-frame editor. `frames` is validated per-LED colour DATA; the render thread
+    owns every write (fixed literals, §3). `holds` is an OPTIONAL per-frame duration
+    list (len == frames); absent -> every frame shows for the uniform `hold_ms`.
+    Persisted -> re-arms on reboot. Returns {"ok":True,..} | None (-> 404)."""
     if not isinstance(prefix, str):
         return None
     members = _led_strips().get(prefix)
@@ -5346,6 +5379,18 @@ def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True):
     # extra), keeping only valid RGB triples -- nothing client-shaped reaches a write.
     norm = [[(fr[i] if i < len(fr) and _is_rgb_triple(fr[i]) else None)
              for i in range(n)] for fr in frames]
+    # Optional per-frame durations: keep only a full, in-range int list (one per
+    # frame); anything else -> None (uniform hold_ms). Defensively re-validated here
+    # too, so a junk persist file / caller can never drive an out-of-range timeline.
+    hnorm = None
+    if isinstance(holds, list) and len(holds) == len(norm) and norm:
+        try:
+            cand = [min(60000, max(30, int(h))) for h in holds
+                    if not isinstance(h, bool)]
+            if len(cand) == len(norm):
+                hnorm = cand
+        except (TypeError, ValueError):
+            hnorm = None
     for name in members:
         try:
             _led_write(name, "effect", "manual")
@@ -5354,7 +5399,7 @@ def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True):
     with _SEQ_LOCK:
         _SEQ_ACTIVE[prefix] = {
             "members": members, "effect": "sequence", "frames": norm,
-            "hold_ms": int(hold_ms), "loop": bool(loop), "brightness": b,
+            "hold_ms": int(hold_ms), "holds": hnorm, "loop": bool(loop), "brightness": b,
             "color": {"r": 255, "g": 255, "b": 255}, "speed": 50,
             "t0": time.monotonic(), "raws": raws}
     _seq_ensure_thread()
@@ -5362,25 +5407,30 @@ def apply_strip_sequence(prefix, frames, hold_ms, brightness, loop=True):
         for m in members:
             _LED_PERSIST.pop(m, None)
         _LED_PERSIST["strip:" + prefix] = {"effect": "sequence", "frames": norm,
-                                           "hold_ms": int(hold_ms), "loop": bool(loop),
-                                           "brightness": b}
+                                           "hold_ms": int(hold_ms), "holds": hnorm,
+                                           "loop": bool(loop), "brightness": b}
     _led_state_save()
-    return {"ok": True, "strip": prefix,
-            "active": {"effect": "sequence", "frames": len(norm),
-                       "hold_ms": int(hold_ms), "loop": bool(loop), "brightness": b}}
+    active = {"effect": "sequence", "frames": len(norm),
+              "hold_ms": int(hold_ms), "loop": bool(loop), "brightness": b}
+    if hnorm is not None:
+        active["holds"] = hnorm
+    return {"ok": True, "strip": prefix, "active": active}
 
 
 def _validate_sequence_body(req):
     """Shape-check POST /api/leds/sequence. Returns
-    (frames, hold_ms, brightness|None, loop, error|None). Rejects, never sanitises."""
+    (frames, hold_ms, holds, brightness|None, loop, error|None). Rejects, never
+    sanitises. `holds` is an OPTIONAL per-frame duration list (one int ms per
+    frame, len == frames); absent -> None and the uniform `hold_ms` governs every
+    frame. Old clients that omit it keep the uniform-cadence behaviour."""
     frames = req.get("frames")
     if not isinstance(frames, list) or not (1 <= len(frames) <= _SEQ_MAX_FRAMES):
-        return None, None, None, None, \
+        return None, None, None, None, None, \
             "frames must be a list of 1..%d frames" % _SEQ_MAX_FRAMES
     out = []
     for fr in frames:
         if not isinstance(fr, list) or len(fr) > 512:
-            return None, None, None, None, "each frame is a list of <=512 colours"
+            return None, None, None, None, None, "each frame is a list of <=512 colours"
         row = []
         for c in fr:
             if c is None:
@@ -5388,18 +5438,26 @@ def _validate_sequence_body(req):
             elif _is_rgb_triple(c):
                 row.append(c)
             else:
-                return None, None, None, None, "frame colours must be {r,g,b} ints or null"
+                return None, None, None, None, None, "frame colours must be {r,g,b} ints or null"
         out.append(row)
     hold_ms = req.get("hold_ms", 500)
     if isinstance(hold_ms, bool) or not isinstance(hold_ms, int) or not (30 <= hold_ms <= 60000):
-        return None, None, None, None, "hold_ms must be an int 30..60000"
+        return None, None, None, None, None, "hold_ms must be an int 30..60000"
+    holds = req.get("holds")
+    if holds is not None:
+        if not isinstance(holds, list) or len(holds) != len(out):
+            return None, None, None, None, None, \
+                "holds must be a list of one duration per frame"
+        for h in holds:
+            if isinstance(h, bool) or not isinstance(h, int) or not (30 <= h <= 60000):
+                return None, None, None, None, None, "each hold must be an int 30..60000"
     brightness = req.get("brightness")
     if brightness is not None and not _is_pct(brightness):
-        return None, None, None, None, "brightness must be an int 0-100"
+        return None, None, None, None, None, "brightness must be an int 0-100"
     loop = req.get("loop", True)
     if not isinstance(loop, bool):
-        return None, None, None, None, "loop must be a boolean"
-    return out, hold_ms, brightness, loop, None
+        return None, None, None, None, None, "loop must be a boolean"
+    return out, hold_ms, holds, brightness, loop, None
 
 
 # ---- OpenRGB backend (cap: openrgb) -----------------------------------------
@@ -20018,7 +20076,7 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "body must be a JSON object"}, started)
                     return
                 strip_name = req.get("strip")
-                frames, hold_ms, brightness, loop, verr = _validate_sequence_body(req)
+                frames, hold_ms, holds, brightness, loop, verr = _validate_sequence_body(req)
                 if verr is not None:
                     self._send(400, {"error": verr}, started)
                     return
@@ -20027,13 +20085,16 @@ class Handler(BaseHTTPRequestHandler):
                     if not isinstance(strip_name, str) or strip_name not in ms:
                         self._send(404, {"error": "unknown strip"}, started)
                         return
-                    _MOCK_FX["strip:" + strip_name] = {
+                    active = {
                         "effect": "sequence", "frames": len(frames), "hold_ms": hold_ms,
                         "loop": loop, "brightness": brightness if brightness is not None else 100}
+                    if holds is not None:
+                        active["holds"] = list(holds)
+                    _MOCK_FX["strip:" + strip_name] = active
                     self._send(200, {"ok": True, "strip": strip_name,
                                      "active": _MOCK_FX["strip:" + strip_name]}, started)
                     return
-                res = apply_strip_sequence(strip_name, frames, hold_ms, brightness, loop)
+                res = apply_strip_sequence(strip_name, frames, hold_ms, brightness, loop, holds)
                 if res is None:
                     self._send(404, {"error": "unknown strip"}, started)
                     return

--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -117,8 +117,12 @@ export function StripLightCard() {
   const [cycleMs, setCycleMs] = useState(500);    // ms between the two frames
   // N-FRAME EDITOR: captured frames (colours already baked with per-LED brightness).
   // >= 2 frames -> plays as a looping sequence on the box; tap a frame to load it
-  // back into the grid for editing/re-capture.
+  // back into the grid for editing/re-capture. `frameHold` holds one duration (ms)
+  // per frame (each frame can linger a different length); `selFrame` is the frame
+  // currently loaded for editing (its per-frame timer is shown).
   const [seqFrames, setSeqFrames] = useState<(Rgb | null)[][]>([]);
+  const [frameHold, setFrameHold] = useState<number[]>([]);
+  const [selFrame, setSelFrame] = useState<number | null>(null);
   const [frame, setFrame] = useState<(Rgb | null)[]>([]);
   // Per-LED brightness % (0 = off). A tap on a cell cycles it up the CELL_STEPS
   // then off, so you can dial each LED's level (and turn it off) by tapping.
@@ -312,20 +316,27 @@ export function StripLightCard() {
       return c && b > 0 ? scale(c as Rgb, b / 100) : null;
     });
 
-  /** Play a list of frames on the box as a looping sequence. */
-  const pushSeq = (fr: (Rgb | null)[][], ms: number) => {
+  /** Play a list of frames on the box as a looping sequence, each frame held for
+   *  its own duration (frameHold, one ms per frame). Older agents ignore `holds`
+   *  and fall back to the first frame's hold. */
+  const pushSeq = (fr: (Rgb | null)[][], holds: number[]) => {
     if (!agentMode || !agentStrip || fr.length < 1) return;
+    const hs = holds.slice(0, fr.length);
     void api.setStripSequence(settings, agentStrip.prefix, {
-      frames: fr, holdMs: ms, loop: true, brightness: 100,
+      frames: fr, holdMs: hs[0] ?? cycleMs, holds: hs, loop: true, brightness: 100,
     }).catch(() => {});
   };
 
-  /** Capture the current paint as a new frame; auto-play once there are >= 2. */
+  /** Capture the current paint as a new frame; auto-play once there are >= 2. The
+   *  new frame inherits the current global cadence (cycleMs) as its hold. */
   const addFrame = () => {
     hapticLight();
     const next = [...seqFrames, bakeCurrent()];
+    const holds = [...frameHold, cycleMs];
     setSeqFrames(next);
-    if (next.length >= 2) pushSeq(next, cycleMs);
+    setFrameHold(holds);
+    setSelFrame(next.length - 1);
+    if (next.length >= 2) pushSeq(next, holds);
   };
 
   /** Load a captured frame back into the grid so it can be tweaked + re-captured. */
@@ -333,6 +344,7 @@ export function StripLightCard() {
     hapticLight();
     const fr = seqFrames[i];
     if (!fr) return;
+    setSelFrame(i);
     setEffect('manual');
     setFrame(fr.map((c) => c));
     setCellBright(fr.map((c) => (c ? 100 : 0)));
@@ -341,9 +353,34 @@ export function StripLightCard() {
   const removeFrame = (i: number) => {
     hapticLight();
     const next = seqFrames.filter((_, k) => k !== i);
+    const holds = frameHold.filter((_, k) => k !== i);
     setSeqFrames(next);
-    if (next.length >= 2) pushSeq(next, cycleMs);
+    setFrameHold(holds);
+    setSelFrame((cur) => (cur == null ? null : cur === i ? null : cur > i ? cur - 1 : cur));
+    if (next.length >= 2) pushSeq(next, holds);
     else if (next.length === 1) applyMainPattern(next[0], next[0].map((c) => (c ? 100 : 0)));
+  };
+
+  /** Set every frame's hold to `ms` (the global "all frames" cadence). */
+  const setAllHolds = (ms: number) => {
+    const holds = seqFrames.map(() => ms);
+    setFrameHold(holds);
+    if (seqFrames.length >= 2) pushSeq(seqFrames, holds);
+  };
+
+  /** Override just the selected frame's hold (ms). */
+  const setFrameHoldAt = (i: number, ms: number, commit: boolean) => {
+    const holds = frameHold.map((h, k) => (k === i ? ms : h));
+    setFrameHold(holds);
+    if (commit && seqFrames.length >= 2) pushSeq(seqFrames, holds);
+  };
+
+  /** Wipe the captured sequence back to an empty editor. */
+  const clearSeq = () => {
+    hapticLight();
+    setSeqFrames([]);
+    setFrameHold([]);
+    setSelFrame(null);
   };
 
   /** Coerce any saved preset effect to one the strip runs. */
@@ -354,6 +391,24 @@ export function StripLightCard() {
 
   const applyPreset = (p: LedPreset) => {
     hapticLight();
+    // A hand-built SEQUENCE preset (N-frame editor): load it back into the editor
+    // (visible + re-editable) and play the loop on the box with its per-frame holds.
+    if (p.sequence && p.sequence.frames.length >= 2) {
+      setEffect('manual');
+      const frames = p.sequence.frames.map((f) => orderedLeds.map((_, i) => f[i] ?? null));
+      const holds = p.sequence.holds.slice(0, frames.length);
+      setSeqFrames(frames);
+      setFrameHold(holds);
+      setSelFrame(0);
+      setFrame(frames[0].map((c) => c));
+      setCellBright(frames[0].map((c) => (c ? 100 : 0)));
+      if (agentMode && agentStrip) {
+        void api.setStripSequence(settings, agentStrip.prefix, {
+          frames, holdMs: holds[0] ?? 500, holds, loop: p.sequence.loop ?? true, brightness: 100,
+        }).then(() => poll.refresh()).catch(() => {});
+      }
+      return;
+    }
     // A GENERATOR preset (Police): build a strip-sized timed sequence + play it on
     // the box (red/blue halves alternating -> a police bar).
     if (p.generator === 'police') {
@@ -426,6 +481,21 @@ export function StripLightCard() {
       build: (name) => ({
         label: name, effect: effect as LedEffect, color: usesColor ? color : null,
         speed: Math.round(speedPct), brightness: Math.round(bright),
+      }),
+    });
+  };
+
+  /** Save the current N-frame sequence (frames + per-frame holds) as a preset. */
+  const saveSequencePreset = () => {
+    hapticLight();
+    const frames = seqFrames.map((f) => f.map((c) => c ?? null));
+    const holds = frameHold.slice(0, frames.length).map((h) => Math.round(h));
+    setNamePrompt({
+      label: `Sequence ${frames.length}`,
+      build: (name) => ({
+        label: name, effect: 'manual', color: null,
+        speed: Math.round(speedPct), brightness: 100,
+        sequence: { frames, holds, loop: true },
       }),
     });
   };
@@ -633,7 +703,7 @@ export function StripLightCard() {
             </Text>
             <View style={{ flexDirection: 'row', gap: 6 }}>
               {seqFrames.length > 0 && (
-                <Pressable onPress={() => { hapticLight(); setSeqFrames([]); }}
+                <Pressable onPress={clearSeq}
                   accessibilityRole="button" accessibilityLabel="Clear sequence"
                   style={({ pressed }) => [styles.chip, pressed && styles.pressed]}>
                   <Text style={[styles.chipText, { color: t.textDim }]}>Clear</Text>
@@ -653,34 +723,66 @@ export function StripLightCard() {
                   <Pressable key={fi} onPress={() => loadFrame(fi)} onLongPress={() => removeFrame(fi)}
                     accessibilityRole="button"
                     accessibilityLabel={`Frame ${fi + 1} — tap to edit, hold to remove`}
-                    style={({ pressed }) => [styles.filmFrame, pressed && styles.pressed]}>
+                    style={({ pressed }) => [
+                      styles.filmFrame, selFrame === fi && styles.filmFrameSel, pressed && styles.pressed,
+                    ]}>
                     <View style={styles.filmRow}>
                       {fr.map((c, ci) => (
                         <View key={ci} style={{ flex: 1, backgroundColor: c ? cssRgb(c) : t.card }} />
                       ))}
                     </View>
-                    <Text style={styles.filmIdx}>{fi + 1}</Text>
+                    <Text style={[styles.filmIdx, selFrame === fi && { color: t.text }]}>
+                      {fi + 1} · {((frameHold[fi] ?? cycleMs) / 1000).toFixed(1)}s
+                    </Text>
                   </Pressable>
                 ))}
               </View>
               {seqFrames.length >= 2 && (
                 <>
+                  {/* PER-FRAME timer: overrides just the frame loaded in the grid. */}
+                  {selFrame != null && selFrame < seqFrames.length && (
+                    <>
+                      <View style={styles.sliderHeader}>
+                        <Text style={styles.sectionLabel}>THIS FRAME · {selFrame + 1}</Text>
+                        <Text style={{ color: t.text, fontSize: 12, fontFamily: mono }}>
+                          {((frameHold[selFrame] ?? cycleMs) / 1000).toFixed(2)}s
+                        </Text>
+                      </View>
+                      <TrackSlider
+                        value={frameHold[selFrame] ?? cycleMs} min={100} max={5000}
+                        onChange={(v) => setFrameHoldAt(selFrame, v, false)}
+                        onCommit={(v) => setFrameHoldAt(selFrame, v, true)}
+                        thumbColor={t.text} accessibilityLabel="This frame's hold time"
+                        renderTrack={(pct) => (
+                          <View style={styles.brightTrack}>
+                            <View style={[styles.brightFill, { width: `${pct * 100}%`, backgroundColor: t.text }]} />
+                          </View>
+                        )}
+                      />
+                    </>
+                  )}
+                  {/* GLOBAL cadence: applies one time to EVERY frame. */}
                   <View style={styles.sliderHeader}>
-                    <Text style={styles.sectionLabel}>FRAME EVERY</Text>
+                    <Text style={styles.sectionLabel}>ALL FRAMES</Text>
                     <Text style={{ color: t.textDim, fontSize: 12, fontFamily: mono }}>
                       {(cycleMs / 1000).toFixed(cycleMs < 1000 ? 2 : 1)}s
                     </Text>
                   </View>
                   <TrackSlider
                     value={cycleMs} min={100} max={3000} onChange={setCycleMs}
-                    onCommit={() => pushSeq(seqFrames, cycleMs)}
-                    thumbColor={t.text} accessibilityLabel="Sequence frame time"
+                    onCommit={(v) => setAllHolds(v)}
+                    thumbColor={t.textDim} accessibilityLabel="Cadence for every frame"
                     renderTrack={(pct) => (
                       <View style={styles.brightTrack}>
-                        <View style={[styles.brightFill, { width: `${pct * 100}%`, backgroundColor: t.text }]} />
+                        <View style={[styles.brightFill, { width: `${pct * 100}%`, backgroundColor: t.textDim }]} />
                       </View>
                     )}
                   />
+                  <Pressable onPress={saveSequencePreset}
+                    accessibilityRole="button" accessibilityLabel="Save this sequence as a preset"
+                    style={({ pressed }) => [styles.savePreset, { marginTop: 10, alignSelf: 'flex-start' }, pressed && styles.pressed]}>
+                    <Text style={styles.chipTextOn}>＋ Save as preset</Text>
+                  </Pressable>
                 </>
               )}
             </>
@@ -769,6 +871,7 @@ const makeStyles = (t: Palette) =>
       width: 68, borderRadius: 6, overflow: 'hidden',
       borderWidth: 1, borderColor: t.cardBorder, backgroundColor: t.card,
     },
+    filmFrameSel: { borderColor: t.blue, borderWidth: 2 },
     filmRow: { flexDirection: 'row', height: 22 },
     filmIdx: { color: t.textDim, fontSize: 10, textAlign: 'center', fontFamily: mono, paddingVertical: 1 },
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -2788,18 +2788,32 @@ export const api = {
    * frames shown `holdMs` each, looping — what the alternate-colour feature and the
    * Police preset build. Agent-rendered, so it survives the phone closing. Older
    * agents 404/400 -> resolves false and the caller degrades.
+   *
+   * `holds` (agent >= 2.9.91) is an OPTIONAL per-frame duration list (one ms per
+   * frame, len === frames): each frame can linger a different length of time. When
+   * omitted every frame shows for the uniform `holdMs`. Agents that predate it
+   * ignore `holds` and fall back to `holdMs`, so always send a sensible `holdMs`.
    */
   setStripSequence(
     settings: ConnSettings,
     strip: string,
-    seq: { frames: (Rgb | null)[][]; holdMs: number; loop?: boolean; brightness?: number },
+    seq: {
+      frames: (Rgb | null)[][]; holdMs: number; loop?: boolean;
+      brightness?: number; holds?: number[];
+    },
   ): Promise<boolean> {
+    // Only forward `holds` when it is a clean per-frame list (one entry per frame);
+    // otherwise let the box use the uniform holdMs.
+    const holds = Array.isArray(seq.holds) && seq.holds.length === seq.frames.length
+      ? seq.holds.map((h) => Math.round(h))
+      : undefined;
     return request<{ ok: boolean }>(settings, '/api/leds/sequence', {
       method: 'POST',
       body: {
         strip, frames: seq.frames, hold_ms: Math.round(seq.holdMs),
         loop: seq.loop ?? true,
         ...(seq.brightness != null ? { brightness: Math.round(seq.brightness) } : {}),
+        ...(holds ? { holds } : {}),
       },
     })
       .then((r) => !!r?.ok)

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -39,6 +39,10 @@ export type LedPreset = {
   /** A built-in that GENERATES a timed sequence sized to the strip when applied
       (e.g. 'police' = red/blue halves alternating). Overrides effect/pattern. */
   generator?: 'police';
+  /** A hand-built TIMED SEQUENCE (from the N-frame editor): per-LED colour frames
+      plus one hold (ms) per frame. Applying it plays the loop on the box via
+      /api/leds/sequence. Overrides effect/pattern/generator. */
+  sequence?: { frames: (Rgb | null)[][]; holds: number[]; loop?: boolean };
 };
 
 /** Seeded once when the library is empty. "Night Rider" is the owner's example. */
@@ -92,6 +96,22 @@ const isRgb = (c: unknown): c is Rgb =>
   !!c && typeof c === 'object' &&
   ['r', 'g', 'b'].every((k) => Number.isInteger((c as Record<string, unknown>)[k]));
 
+/** Coerce a stored `sequence` into a clean shape, or undefined if malformed. A
+ *  valid sequence has >= 2 colour frames and one hold (ms) per frame. */
+function normalizeSequence(raw: unknown): LedPreset['sequence'] {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const s = raw as Record<string, unknown>;
+  if (!Array.isArray(s.frames) || !Array.isArray(s.holds)) return undefined;
+  const frames = (s.frames as unknown[])
+    .filter((f) => Array.isArray(f))
+    .map((f) => (f as unknown[]).map((c) => (isRgb(c) ? { r: c.r, g: c.g, b: c.b } : null)));
+  const holds = (s.holds as unknown[]).map((h) => (typeof h === 'number' ? h : 0));
+  if (frames.length < 2 || holds.length !== frames.length || holds.some((h) => h <= 0)) {
+    return undefined;
+  }
+  return { frames, holds, loop: s.loop !== false };
+}
+
 /** Coerce a parsed value into a clean LedPreset[], dropping anything malformed. */
 function normalize(raw: unknown): LedPreset[] {
   if (!Array.isArray(raw)) return [];
@@ -111,6 +131,7 @@ function normalize(raw: unknown): LedPreset[] {
         ? (p.pattern as unknown[]).map((c) => (isRgb(c) ? { r: c.r, g: c.g, b: c.b } : null))
         : undefined,
       generator: p.generator === 'police' ? 'police' : undefined,
+      sequence: normalizeSequence(p.sequence),
     });
     if (out.length >= PRESET_MAX) break;
   }

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -343,9 +343,14 @@ def test_sequence_validation():
     print("sequence body validation (reject, don't sanitise)")
     good = {"frames": [[{"r": 255, "g": 0, "b": 0}, None], [None, {"r": 0, "g": 0, "b": 255}]],
             "hold_ms": 400, "loop": True, "brightness": 90}
-    frames, hold, br, loop, err = cs._validate_sequence_body(good)
-    check(err is None and len(frames) == 2 and hold == 400 and loop is True and br == 90,
-          "accepts a valid 2-frame sequence")
+    frames, hold, holds, br, loop, err = cs._validate_sequence_body(good)
+    check(err is None and len(frames) == 2 and hold == 400 and loop is True and br == 90
+          and holds is None, "accepts a valid 2-frame sequence (no per-frame holds)")
+    # per-frame holds: a valid list matching the frame count is accepted verbatim
+    withholds = dict(good, holds=[200, 800])
+    _, _, holds2, _, _, err = cs._validate_sequence_body(withholds)
+    check(err is None and holds2 == [200, 800],
+          "accepts per-frame holds matching the frame count")
     bad = [
         {"frames": []},                                  # empty
         {"frames": [[{"r": 256, "g": 0, "b": 0}]]},      # bad colour
@@ -354,9 +359,16 @@ def test_sequence_validation():
         {"frames": [[{"r": 1, "g": 2, "b": 3}]], "loop": "yes"},    # loop not bool
         {"frames": "nope"},                              # frames not a list
         {"frames": [["red"]]},                           # colour not {r,g,b}|null
+        # per-frame holds: wrong length, out of range, wrong type -> rejected
+        {"frames": [[{"r": 1, "g": 2, "b": 3}], [None]], "holds": [200]},  # len != frames
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "holds": [10]},           # hold too small
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "holds": [999999]},       # hold too big
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "holds": ["x"]},          # not an int
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "holds": [True]},         # bool not int
+        {"frames": [[{"r": 1, "g": 2, "b": 3}]], "holds": "nope"},         # not a list
     ]
     for b in bad:
-        _, _, _, _, err = cs._validate_sequence_body(b)
+        _, _, _, _, _, err = cs._validate_sequence_body(b)
         check(err is not None, "rejects %s" % (list(b)[:1]))
 
 
@@ -388,7 +400,110 @@ def test_sequence_starts_and_persists():
         p = cs._LED_PERSIST.get("strip:valve-leds", {})
         check(p.get("effect") == "sequence" and p.get("hold_ms") == 400,
               "sequence persisted for reboot re-arm")
+        check(p.get("holds") is None,
+              "no per-frame holds persisted when none supplied")
+        # now with per-frame holds -> stored on the spec AND persisted for re-arm
+        res = cs.apply_strip_sequence("valve-leds", [A, B], 500, 90, True, [150, 850])
+        check(res["active"].get("holds") == [150, 850], "per-frame holds echoed")
+        check(cs._SEQ_ACTIVE["valve-leds"].get("holds") == [150, 850],
+              "per-frame holds on the live spec")
+        check(cs._LED_PERSIST["strip:valve-leds"].get("holds") == [150, 850],
+              "per-frame holds persisted for reboot re-arm")
+        # a holds list that does NOT match the frame count is dropped (uniform hold)
+        res = cs.apply_strip_sequence("valve-leds", [A, B], 500, 90, True, [150])
+        check(res["active"].get("holds") is None and "holds" not in res["active"],
+              "mismatched holds length dropped -> uniform hold")
     finally:
+        cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        restore()
+
+
+def test_sequence_per_frame_holds_timeline():
+    print("per-frame holds: render walks a cumulative timeline (loop wraps)")
+    writes = []
+    restore = _install(writes)
+    saved_wc = cs._led_write_color
+    painted = {}
+    cs._led_write_color = lambda name, raw, c: painted.__setitem__(name, dict(c))
+    saved_thread, saved_save = cs._seq_ensure_thread, cs._led_state_save
+    try:
+        cs._seq_ensure_thread = lambda: None
+        cs._led_state_save = lambda: None
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        R = [{"r": 255, "g": 0, "b": 0}] * _N
+        G = [{"r": 0, "g": 255, "b": 0}] * _N
+        B = [{"r": 0, "g": 0, "b": 255}] * _N
+        # red 100ms, green 200ms, blue 300ms -> total 600ms, looping
+        cs.apply_strip_sequence("valve-leds", [R, G, B], 500, 100, True, [100, 200, 300])
+        spec = cs._SEQ_ACTIVE["valve-leds"]
+        m0 = spec["members"][0]
+
+        def frame_at(elapsed):
+            painted.clear()
+            spec["t0"] = 0.0            # so t == elapsed selects the frame at that time
+            cs._seq_render(spec, elapsed)
+            return painted.get(m0)
+
+        check(frame_at(0.05) == {"r": 255, "g": 0, "b": 0}, "t=50ms  -> frame 0 (red)")
+        check(frame_at(0.25) == {"r": 0, "g": 255, "b": 0}, "t=250ms -> frame 1 (green)")
+        check(frame_at(0.55) == {"r": 0, "g": 0, "b": 255}, "t=550ms -> frame 2 (blue)")
+        # loop wraps: 650ms == 50ms into the next cycle -> back to frame 0
+        check(frame_at(0.65) == {"r": 255, "g": 0, "b": 0}, "t=650ms -> wraps to frame 0")
+
+        # NON-LOOP: same holds, loop=False -> advances through, then HOLDS the last
+        # frame forever (never wraps). Observe both states at the SAME time points.
+        cs.apply_strip_sequence("valve-leds", [R, G, B], 500, 100, False, [100, 200, 300])
+        spec = cs._SEQ_ACTIVE["valve-leds"]
+        m0 = spec["members"][0]
+        check(frame_at(0.05) == {"r": 255, "g": 0, "b": 0}, "non-loop t=50ms  -> frame 0")
+        check(frame_at(0.25) == {"r": 0, "g": 255, "b": 0}, "non-loop t=250ms -> frame 1")
+        check(frame_at(0.55) == {"r": 0, "g": 0, "b": 255}, "non-loop t=550ms -> frame 2")
+        # past the 600ms total: clamps to the LAST frame (blue), does NOT wrap to red
+        check(frame_at(0.65) == {"r": 0, "g": 0, "b": 255}, "non-loop t=650ms -> clamps to last (blue)")
+        check(frame_at(5.0) == {"r": 0, "g": 0, "b": 255}, "non-loop far past end -> still last (blue)")
+    finally:
+        cs._led_write_color = saved_wc
+        cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        restore()
+
+
+def test_led_restore_rearms_per_frame_holds():
+    print("restore: a persisted sequence re-arms with its per-frame holds (revalidated)")
+    writes = []
+    restore = _install(writes)
+    saved_load = cs._led_state_load
+    saved_thread, saved_save = cs._seq_ensure_thread, cs._led_state_save
+    try:
+        cs._seq_ensure_thread = lambda: None
+        cs._led_state_save = lambda: None
+        R = [{"r": 255, "g": 0, "b": 0}] * _N
+        B = [{"r": 0, "g": 0, "b": 255}] * _N
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        cs._led_state_load = lambda: {"strip:valve-leds": {
+            "effect": "sequence", "frames": [R, B], "hold_ms": 500,
+            "holds": [120, 880], "loop": True, "brightness": 100}}
+        cs._led_restore()
+        spec = cs._SEQ_ACTIVE.get("valve-leds")
+        check(spec and spec["effect"] == "sequence" and spec.get("holds") == [120, 880],
+              "sequence re-armed WITH its per-frame holds")
+        # a junk holds list (wrong length) is ignored -> uniform hold, still re-arms
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        cs._led_state_load = lambda: {"strip:valve-leds": {
+            "effect": "sequence", "frames": [R, B], "hold_ms": 500,
+            "holds": [120], "loop": True, "brightness": 100}}
+        cs._led_restore()
+        spec = cs._SEQ_ACTIVE.get("valve-leds")
+        check(spec and spec.get("holds") is None,
+              "mismatched persisted holds dropped -> uniform hold (still re-arms)")
+    finally:
+        cs._led_state_load = saved_load
         cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
         with cs._SEQ_LOCK:
             cs._SEQ_ACTIVE.clear()
@@ -412,6 +527,8 @@ if __name__ == "__main__":
     test_reconcile_skips_agent_effects()
     test_sequence_validation()
     test_sequence_starts_and_persists()
+    test_sequence_per_frame_holds_timeline()
+    test_led_restore_rearms_per_frame_holds()
     print()
     if _fail:
         print("FAILED: %d" % len(_fail))


### PR DESCRIPTION
## What

**Agent 2.9.91** — `POST /api/leds/sequence` gains an optional **`holds`** list (one ms duration per frame). The render thread walks a cumulative timeline instead of a single uniform hold, so a sequence can linger on one frame and flash quickly through others.

**App** — the strip Light card's SEQUENCE editor (the N-frame editor) gains:
- a per-frame **THIS FRAME** timer (overrides just the selected frame),
- an **ALL FRAMES** cadence (sets every frame at once),
- filmstrip frame selection + per-frame ms labels,
- **Save as preset** — a new `LedPreset.sequence` (frames + per-frame holds), applied via `setStripSequence`.

## Safety / compatibility

- **§4 shape:** `holds` is only *added* to the active dict + persist record. `hold_ms` and every existing field stay. No response shape renamed/removed.
- **Backward-compat both directions (verified live):** omitting `holds` reproduces the old uniform behaviour exactly; an **older agent** that predates the field ignores it and plays uniform `hold_ms` (the app always sends a sane `hold_ms` alongside).
- **§3 reject-not-sanitise:** `holds` len must equal frames, each int 30..60000; rejected at `_validate_sequence_body`, defensively re-validated in `apply_strip_sequence`, and re-validated again on reboot restore (never trusts the persist file).

## Verified

- **Unit** (`tests/test_led_strip.py`): holds validation (accept + 6 reject cases), apply echo/persist/mismatch-drop, cumulative-timeline render observing frame selection **and** loop wrap, **non-loop clamp-to-last** (both states at the same `t`), reboot re-arm with holds. `led-effects` + `protocol-parity` green. App `tsc` clean.
- **Hardware — steamdeck (valve-leds strip):** holds `[100,100,1000]` over ~1.3 s rendered led0 **blue 16 / red 4 / green 3** — the long hold dominates while short frames still flash; the POST echoes `holds`.
- **Hardware — Bazzite (no strip, Python 3.14):** 2.9.91 runs clean (ping/status 200), unknown strip → `404`, bad `holds` → `400`, auth gate → `401`.
- **Adversarial diff review** (5 dimensions: correctness / allowlist-security / compat-shape / app-wiring / test-coverage): 4 clean, 1 confirmed gap (non-loop timeline untested) → fixed in this PR.

## Not verified

- The app filmstrip taps themselves on-device — exercise in the dev client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)