### PR TITLE
fix(tests): a caps assertion that asserted nothing, and a guard for the class

### DIFF
--- a/tests/test_ci_wiring.py
+++ b/tests/test_ci_wiring.py
@@ -26,6 +26,7 @@ substring search for the filename in the workflow — because anything cleverer
 (parsing the YAML, resolving shell) has its own way of being wrong, and the
 failure mode of dumb-and-textual is a false alarm, not a false pass.
 """
+import ast
 import os
 import re
 import sys
@@ -107,6 +108,46 @@ for fn in sorted(os.listdir(WORKFLOWS)):
 for b in bad_names:
     print("  FAIL  %s" % b)
 check("no unquoted colon-space in a step name", bad_names, [])
+
+
+# A guard that cannot fail is the same class of bug as a suite that never runs,
+# so it belongs in this file. An assertion of the form `check(<expr> or True, …)`
+# is unconditionally true; found live in tests/test_steam_menus.py, where
+# "caps dict is built at boot" stayed GREEN with set_caps() stubbed out entirely
+# (measured 2026-08-16, both states). The author neutered a real failure instead
+# of fixing it — CAPS is {} until set_caps() runs.
+#
+# AST, not a regex, and the first attempt here is exactly why: a textual scan
+# cannot tell code from prose, so it flagged this very comment, its own check()
+# call below, and the docstring in test_steam_menus.py that quotes the old line
+# to explain it. Parsing matches real call sites only. It also stays narrow by
+# construction — the legitimate stub idiom `lambda n: (seen.append(n) or True)`
+# in tests/test_flatpak_update.py is not a check() argument, so it never matches.
+print()
+print("no assertion is neutered with `or True`")
+neutered = []
+for fn in sorted(f for f in os.listdir(TESTS) if f.endswith(".py")):
+    path = os.path.join(TESTS, fn)
+    with open(path) as f:
+        try:
+            tree = ast.parse(f.read(), filename=fn)
+        except SyntaxError as e:            # a suite that cannot parse is its own failure
+            neutered.append("%s: does not parse (%s)" % (fn, e))
+            continue
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "check"):
+            continue
+        for arg in node.args:
+            # `X or True` — a BoolOp whose last operand is the literal True.
+            if (isinstance(arg, ast.BoolOp) and isinstance(arg.op, ast.Or)
+                    and isinstance(arg.values[-1], ast.Constant)
+                    and arg.values[-1].value is True):
+                neutered.append("%s:%d  check(... or True, ...)" % (fn, node.lineno))
+for n in neutered:
+    print("  FAIL  %s" % n)
+check("no check(... or True ...) in tests/", neutered, [])
 
 print()
 if FAILURES:

--- a/tests/test_steam_menus.py
+++ b/tests/test_steam_menus.py
@@ -122,14 +122,46 @@ def test_available_gate():
 
 
 def test_caps_key_registered():
+    """The caps key, asserted against the RUNTIME dict rather than the source.
+
+    This test used to open with
+
+        check("steammenus" in cs.CAPS or True, "caps dict is built at boot")
+
+    `X or True` is unconditionally true, so it asserted nothing: it stayed green
+    with CAPS empty, with set_caps() never called, and with the key deleted
+    outright. The cause is visible one line up — CAPS is `{}` until set_caps()
+    runs (agent/couchsided.py: CAPS is initialised empty and populated there),
+    so the honest assertion failed and was neutered instead of fixed.
+
+    The other two checks grepped AGENT's source text for the literal wiring,
+    which §11.1 rules out ("test the thing; don't grep for it") — a rename of
+    `safe` or a reflow of that dict would fail them while the behaviour was
+    perfect, and, worse, they pass whenever the string exists even if the key
+    never reaches CAPS. All three are now runtime assertions on both branches.
+    """
     print("caps key")
-    check("steammenus" in cs.CAPS or True, "caps dict is built at boot")
-    # The mock tuple is the off-box contract the app develops against.
-    src = open(AGENT).read()
-    check('"steammenus")' in src or '"steammenus",' in src,
-          "steammenus present in the mock all-true caps tuple")
-    check('"steammenus": safe(steammenus_available)' in src,
-          "steammenus wired into the real CAPS dict")
+    orig_caps = dict(cs.CAPS)
+    orig_root = cs._steam_root
+    try:
+        # The mock tuple is the off-box contract the app develops against.
+        cs.set_caps(mock=True)
+        check(cs.CAPS.get("steammenus") is True,
+              "mock caps advertise steammenus")
+        # The real dict must COMPUTE the key from the probe, not hardcode it —
+        # so assert both directions. A key wired to a constant passes the first
+        # of these and fails the second.
+        cs._steam_root = lambda: None
+        cs.set_caps(mock=False)
+        check(cs.CAPS.get("steammenus") is False,
+              "real caps: no Steam -> steammenus False")
+        cs._steam_root = lambda: "/home/u/.local/share/Steam"
+        cs.set_caps(mock=False)
+        check(cs.CAPS.get("steammenus") is True,
+              "real caps: Steam present -> steammenus True")
+    finally:
+        cs._steam_root = orig_root
+        cs.CAPS = orig_caps
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The bug

`tests/test_steam_menus.py` opened with:

```python
check("steammenus" in cs.CAPS or True, "caps dict is built at boot")
```

`X or True` is unconditionally true — it asserted nothing.

**Measured, both states.** With `set_caps()` stubbed to return before it builds `CAPS` — precisely the condition that label claims to verify — the old suite exited **0 with zero failures**. The new one reports 3.

```
MUTATION: set_caps returns before building CAPS (all source strings intact)
  OLD test   exit=0  0 FAIL(s)     <- blind
  NEW test   exit=1  3 FAIL(s)
```

Cause is one line up: `CAPS` is `{}` until `set_caps()` runs, so the honest assertion failed and was neutered instead of fixed.

## The other two checks in that function

They grepped `AGENT`'s source text for the literal wiring, which §11.1 rules out. In fairness they *do* catch a source-level removal — a control confirmed the old suite failed when `"steammenus"` was deleted from the mock tuple. But they are blind to any behavioural break that leaves the strings intact, which is exactly the mutation above.

All three are now runtime assertions: the mock tuple via `set_caps(mock=True)`, and the real dict in **both directions** via a stubbed `_steam_root`, so a key wired to a constant passes the first and fails the second. `set_caps(mock=False)` costs 0.009s and eight suites already call it.

## Class fix

`tests/test_ci_wiring.py` — the file whose whole reason for existing is guards that do not guard — now rejects `check(<expr> or True, ...)` across `tests/`.

**AST, not a regex, and the first attempt is why.** A textual scan cannot tell code from prose: it flagged its own explanatory comment, its own `check()` call, and the docstring in `test_steam_menus.py` that quotes the old line to explain it. Parsing matches real call sites only, and by construction leaves the legitimate stub idiom `lambda n: (seen.append(n) or True)` in `test_flatpak_update.py` alone.

## Verified

- Full suite **82/82 green**.
- Guard passes on a clean tree; **fails** on a re-injected `or True`; does **not** flag the flatpak lambda.
- Both mutations above run and reported.

## Not verified / not applicable

- No agent code touched, no response shapes involved, no hardware needed.
- No CI change — both files are already wired.
- The sweep for this pattern found only the one instance; the four incompatible `check()` signatures across the suite are a separate, larger finding recorded in the audit doc, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)