### PR TITLE
fix(agent): pre-auth /api/pair/finish answered 500 on a non-object body (2.9.92)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,14 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.92
+
+**Pairing is steadier against junk input.** If something on your network sent the
+pairing endpoint a malformed request, the box answered with a server error instead
+of a clean refusal. It now refuses cleanly, the way it always did for a wrong PIN.
+Nothing about how you pair changes, and no PIN or token was ever exposed by this —
+the box was just giving an untidy answer to a question it should simply decline.
+
 ## 2.9.91
 
 **Build your own light-strip animations, frame by frame.** Custom timed sequences

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.91"
+VERSION = "2.9.92"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -18535,7 +18535,14 @@ def pair_pin_active():
 def pair_pin_check(pin):
     """Validate a submitted PIN. True (and burns the session) on match; raises
     ValueError with a user-facing reason on no-session / expired / locked /
-    wrong. A wrong guess counts toward the attempt cap."""
+    wrong. A wrong guess counts toward the attempt cap.
+
+    `pin` is UNTRUSTED and arrives from an unauthenticated route, so a non-string
+    is REJECTED rather than coerced (§3.6). It used to be `(pin or "").strip()`,
+    which raises AttributeError on any truthy non-string — `{"pin": 5}` and
+    `{"pin": 3.4}` both escaped the caller's except tuple and surfaced as a 500.
+    A falsy non-string (None, [], 0) happened to survive via the `or`, which is
+    why this was never noticed."""
     global PAIR_PIN
     with PAIR_PIN_LOCK:
         s = PAIR_PIN
@@ -18545,7 +18552,7 @@ def pair_pin_check(pin):
         if s["attempts"] >= PAIR_PIN_MAX_ATTEMPTS:
             PAIR_PIN = None
             raise ValueError("too many wrong PINs — start again")
-        if (pin or "").strip() != s["pin"]:
+        if not isinstance(pin, str) or pin.strip() != s["pin"]:
             s["attempts"] += 1
             raise ValueError("wrong PIN")
         PAIR_PIN = None                       # consume on success
@@ -19841,11 +19848,17 @@ class Handler(BaseHTTPRequestHandler):
                         pair_show_on_box(self.port)
                     self._send(200, {"ok": True, "ttl": ttl}, started)
                     return
+                # .get() stays OUTSIDE the try on purpose. It used to sit inside,
+                # so a body that PARSES but is not an object ([], "x", 5) raised
+                # AttributeError past this except tuple into the do_POST catch-all
+                # and answered 500 on a pre-auth route. Widening the tuple would
+                # have hidden it instead: any future AttributeError in the
+                # token-issuing block below would silently read as "no PIN sent".
                 try:
                     req = json.loads(pair_body.decode("utf-8")) if pair_body else {}
-                    submitted = req.get("pin")
                 except (ValueError, UnicodeDecodeError):
-                    submitted = None
+                    req = None
+                submitted = req.get("pin") if isinstance(req, dict) else None
                 try:
                     pair_pin_check(submitted)
                 except ValueError as e:

--- a/agent/win/couchsided-win.py
+++ b/agent/win/couchsided-win.py
@@ -4848,7 +4848,11 @@ def pair_pin_check(pin):
         if s["attempts"] >= PAIR_PIN_MAX_ATTEMPTS:
             PAIR_PIN = None
             raise ValueError("too many wrong PINs - start again")
-        if (pin or "").strip() != s["pin"]:
+        # Untrusted input from an unauthenticated route: REJECT a non-string
+        # rather than coerce it (§3.6). `(pin or "").strip()` raised
+        # AttributeError on any truthy non-string, which surfaced as a 500.
+        # Kept in lockstep with agent/couchsided.py pair_pin_check.
+        if not isinstance(pin, str) or pin.strip() != s["pin"]:
             s["attempts"] += 1
             raise ValueError("wrong PIN")
         PAIR_PIN = None                       # consume on success
@@ -5536,11 +5540,14 @@ class Handler(BaseHTTPRequestHandler):
                         pair_show_on_box(self.port)
                     self._send(200, {"ok": True, "ttl": ttl}, started)
                     return
+                # .get() OUTSIDE the try: a body that parses but is not an object
+                # ([], "x", 5) raised AttributeError past this tuple and answered
+                # 500 on a pre-auth route. Lockstep with agent/couchsided.py.
                 try:
                     req = json.loads(pair_body.decode("utf-8")) if pair_body else {}
-                    submitted = req.get("pin")
                 except (ValueError, UnicodeDecodeError):
-                    submitted = None
+                    req = None
+                submitted = req.get("pin") if isinstance(req, dict) else None
                 try:
                     pair_pin_check(submitted)
                 except ValueError as e:

--- a/tests/test_pair_page.py
+++ b/tests/test_pair_page.py
@@ -16,10 +16,14 @@ the one bug the design can ship: a tutorial that never hands off. It was proven
 end to end on a real box's CEF, but the page's structural half (it polls, and it
 reloads on active===true) is asserted here so a refactor can't quietly break it.
 """
+import http.client
 import importlib.util
+import json
 import os
 import sys
+import threading
 import time
+from http.server import ThreadingHTTPServer
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _spec = importlib.util.spec_from_file_location(
@@ -240,6 +244,138 @@ def test_box_pop_is_rate_limited():
         cs.pair_show_on_box_url = real
 
 
+# --- the two pre-auth POST routes, END TO END (KI-020) ---------------------
+# Everything above exercises pair_pin_start / pair_pin_check as FUNCTIONS. The
+# HTTP routes themselves had no coverage, which is what KI-020 recorded — and
+# they are two of only three unauthenticated routes on the agent, exactly the
+# surface §6 demands an unknown-input-rejection test for.
+#
+# The gap was not theoretical. `req.get("pin")` used to sit inside a try that
+# caught only parse errors, so a body that PARSES but is not an object ([], "x",
+# 5) raised AttributeError into the do_POST catch-all and answered 500. A dict
+# with a non-string pin ({"pin": 5}) escaped one frame deeper, in pair_pin_check.
+#
+# Server harness mirrors tests/test_upload.py:_server.
+
+TOKEN = "t0ken-for-pair-route-tests"
+
+
+def _server():
+    """Handler on a random loopback port. Returns (srv, port)."""
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = False
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), cs.Handler)
+    cs.Handler.port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _post(port, path, body=b""):
+    """POST with NO Authorization header — these routes are pre-auth by design."""
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("POST", path, body=body)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(data.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return resp.status, {}
+
+
+def _arm_pin():
+    """Force a fresh, live PIN session without popping the box screen."""
+    real = cs.pair_show_on_box_url
+    cs.pair_show_on_box_url = lambda url: None
+    try:
+        with cs.PAIR_PIN_LOCK:
+            cs.PAIR_PIN = None
+        pin, _ttl, _fresh = cs.pair_pin_start()
+        return pin
+    finally:
+        cs.pair_show_on_box_url = real
+
+
+def test_pair_routes_end_to_end():
+    print("pre-auth pair routes, end to end")
+    real_pop = cs.pair_show_on_box_url
+    cs.pair_show_on_box_url = lambda url: None      # never throw a page on a TV
+    srv, port = _server()
+    try:
+        # /start answers unauthenticated and hands back a TTL, no secret.
+        with cs._BOX_POP_LOCK:
+            cs._BOX_POP_AT[0] = 0.0
+        status, body = _post(port, "/api/pair/start")
+        check("start: 200 without any credential", status, 200)
+        check("start: returns a ttl", isinstance(body.get("ttl"), int), True)
+        check("start: hands back no token", "token" in body, False)
+
+        # The bug: bodies that PARSE but are not a {"pin": <str>} object. Every
+        # one of these answered 500 {"error": "AttributeError"} before the fix.
+        # Each burns an attempt, and the cap is 5 — so re-arm before EVERY case
+        # or the sixth assertion fails on "too many wrong PINs" instead.
+        malformed = [b"[]", b'"x"', b"5", b"null", b"true", b'{"pin": 5}',
+                     b'{"pin": {}}', b'{"pin": 3.4}', b'{"pin": []}',
+                     b"not json", b""]
+        bad_status, bad_err, leaked = set(), set(), []
+        for raw in malformed:
+            _arm_pin()
+            st, bd = _post(port, "/api/pair/finish", raw)
+            bad_status.add(st)
+            bad_err.add(bd.get("error"))
+            if "token" in bd:
+                leaked.append(raw)
+        check("malformed bodies: every one is 403", bad_status, {403})
+        check("malformed bodies: none 500s", 500 in bad_status, False)
+        check("malformed bodies: no AttributeError surfaces",
+              "AttributeError" in bad_err, False)
+        check("malformed bodies: no token ever returned", leaked, [])
+
+        # Wrong PIN: refused, and still no token.
+        _arm_pin()
+        st, bd = _post(port, "/api/pair/finish", b'{"pin": "000000"}')
+        check("wrong pin: 403", st, 403)
+        check("wrong pin: no token", "token" in bd, False)
+
+        # Control — the happy path still works after all of the above, so the
+        # refusals above are the route rejecting input, not the route being dead.
+        pin = _arm_pin()
+        st, bd = _post(port, "/api/pair/finish",
+                       json.dumps({"pin": pin}).encode())
+        check("correct pin: 200", st, 200)
+        check("correct pin: returns the token", bd.get("token"), TOKEN)
+
+        # And the session is single-use: replaying the same PIN is refused.
+        st, bd = _post(port, "/api/pair/finish",
+                       json.dumps({"pin": pin}).encode())
+        check("replayed pin: 403", st, 403)
+        check("replayed pin: no token", "token" in bd, False)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        cs.pair_show_on_box_url = real_pop
+        with cs.PAIR_PIN_LOCK:
+            cs.PAIR_PIN = None
+
+
+def test_pin_check_rejects_non_strings():
+    """Unit-level companion: the second edit site, reachable independently."""
+    print("pair_pin_check rejects non-string pins")
+    for bad in (5, 3.4, {}, [], None, object()):
+        _arm_pin()
+        try:
+            cs.pair_pin_check(bad)
+            check("non-string %r refused" % (bad,), "accepted", "ValueError")
+        except ValueError:
+            check("non-string %r -> ValueError" % type(bad).__name__, True, True)
+        except Exception as e:                      # the old failure mode
+            check("non-string %r -> ValueError (got %s)"
+                  % (type(bad).__name__, type(e).__name__), False, True)
+    with cs.PAIR_PIN_LOCK:
+        cs.PAIR_PIN = None
+
+
 if __name__ == "__main__":
     for fn in (test_loopback_gate,
                test_host_header_gate,
@@ -251,7 +387,9 @@ if __name__ == "__main__":
                test_pin_check_counts_attempts_and_caps,
                test_pin_check_is_single_use,
                test_pin_expiry_clears_the_session,
-               test_box_pop_is_rate_limited):
+               test_box_pop_is_rate_limited,
+               test_pair_routes_end_to_end,
+               test_pin_check_rejects_non_strings):
         fn()
     if FAILURES:
         print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))


### PR DESCRIPTION
## The bug

`POST /api/pair/finish` is one of only **three unauthenticated routes** on the agent. `req.get("pin")` sat *inside* a `try` that caught only parse errors, so a body that parses but isn't an object raised `AttributeError` past the handler into the `do_POST` catch-all:

```
[]   "x"   5   null   true   "not json"    ->  500 {"error": "AttributeError"}
```

And a dict with a non-string pin escaped one frame deeper, at `pair_pin_check`'s `(pin or "").strip()`:

```
{"pin": 5}   {"pin": 3.4}                  ->  500
```

A *falsy* non-string (`None`, `[]`, `0`) survived via the `or`, which is why this went unnoticed.

Not a privilege bug — no token leaked, no attempt burned — but it's the wrong answer on exactly the surface §6 most wants an unknown-input-rejection test for.

## The fix — two sites, both required

- **the route**: `.get()` moves *out* of the `try`, behind an `isinstance(dict)` guard
- **`pair_pin_check`**: reject a non-string rather than coerce it (§3.6)

A guard rather than a wider `except` tuple, deliberately. Widening doesn't fix `{"pin": 5}` at all, and it would keep `.get()` inside the `try` — so any future `AttributeError` in the token-issuing block below would silently read as "no PIN submitted".

**Behaviour delta is 500 → 403 only.** Non-string pins land on the existing `{"ok": false, "error": "wrong PIN"}` and burn an attempt exactly like a wrong guess (an empty body already did). No new status code, no response-shape change; the app only ever sends `{pin: string}`.

The Windows agent carried both sites verbatim — fixed in lockstep.

## Closes KI-020

The two pre-auth POST routes now have **end-to-end** coverage through a live `Handler`, not just at function level. That was the gap KI-020 recorded.

## Verified — both states

With the original code restored and the new test kept:
```
POST /api/pair/finish 500  x7
  FAIL  malformed bodies: every one is 403 (got {403, 500}, want {403})
  FAIL  malformed bodies: no AttributeError surfaces
  FAIL  non-string 'int' -> ValueError (got AttributeError)
```
With the fix: every malformed body 403, no `AttributeError`, no token ever returned, happy path and single-use replay still correct (control).

Also: both agents import cleanly; `mock_status` key set **byte-identical** before/after; full suite **82/82**.

## Not verified

- The Windows **route** end-to-end — parity is asserted at function level only (no Windows box in the loop).
- No hardware needed for anything in this PR; it's all loopback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)