### PR TITLE
fix(installer): `couchside allow-launchers` was a dead switch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,17 @@ jobs:
       - name: Release signing verifies the keys a box trusts
         run: python3 tests/test_release_signing.py
 
+      # `couchside allow-launchers` gates POST /api/launchers, which runs a
+      # client-supplied argv — and it was a DEAD SWITCH: it wrote
+      # /etc/couchside/config.json while the agent reads the state config the
+      # unit names, so turning it on did nothing and status then said "on".
+      # Nothing caught that, and ALLOW_APP_LAUNCHERS had no coverage at all
+      # despite §6 requiring it. This drives the REAL CLI against a temp config,
+      # boots a live Handler, and asserts the route's answer actually changes —
+      # plus a control that reproduces the dead switch in the same run.
+      - name: Allow-launchers switch really gates the route
+        run: python3 tests/test_allow_launchers_switch.py
+
       # Injected actions: buttons the agent offers only when the box can really
       # perform them ("a dead button costs more trust than a missing one"), so
       # every gate is asserted in BOTH directions. Covers the Bluetooth pairing

--- a/install.sh
+++ b/install.sh
@@ -1687,6 +1687,15 @@ RELEASE_API="https://api.github.com/repos/emerytech/couchside/releases/latest"
 AGENT_VER_URL="https://github.com/emerytech/couchside/releases/latest/download/agent-version.txt"
 DIR="${HOME}/.local/opt/couchside"
 DAEMON="${DIR}/couchsided.py"
+# THE config the agent actually reads. The unit's ExecStart carries
+# `--config <this>` (install.sh CONFIG_FILE -> couchside.service), and
+# couchsided.py's load_config() opens exactly that path with no fallback.
+#
+# ONE variable for every verb that edits or REPORTS config, because the
+# alternative already failed: `allow-launchers` had the pre-2.9 /etc path
+# hardcoded, so the write and its own status grep agreed with each other and
+# with nothing else. Turning it on did nothing, and status then said "on".
+CFG="/var/lib/couchside/config.json"
 
 case "${1:-help}" in
   update|upgrade)
@@ -1797,10 +1806,10 @@ PY
     case "${2:-}" in
       on|off)
         val="false"; [ "$2" = "on" ] && val="true"
-        python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
+        python3 - "$val" "$CFG" <<'PY' || { echo "failed to update config" >&2; exit 1; }
 import json, os, sys
-p = "/var/lib/couchside/config.json"
 val = sys.argv[1] == "true"
+p = sys.argv[2]
 try:
     with open(p) as f: d = json.load(f)
     if not isinstance(d, dict): d = {}
@@ -1817,7 +1826,7 @@ PY
         echo "App-triggered updates: ${2}"
         ;;
       ""|status)
-        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' /var/lib/couchside/config.json 2>/dev/null \
+        grep -q '"allow_app_update"[[:space:]]*:[[:space:]]*true' "$CFG" 2>/dev/null \
           && echo "App-triggered updates: on" || echo "App-triggered updates: off"
         ;;
       *) echo "usage: couchside allow-updates on|off" >&2; exit 2 ;;
@@ -1886,10 +1895,15 @@ GRANT
     case "${2:-}" in
       on|off)
         val="false"; [ "$2" = "on" ] && val="true"
-        sudo python3 - "$val" <<'PY' || { echo "failed to update config" >&2; exit 1; }
+        # NO sudo, same as allow-updates above: the desktop user owns the state
+        # dir, and a sudo write would os.replace() the file into root ownership
+        # — after which the agent (which runs as that user) can no longer rewrite
+        # it, and every TV pairing / launcher edit 500s. This verb used to shell
+        # out with sudo AND at the wrong path; both halves are the fix.
+        python3 - "$val" "$CFG" <<'PY' || { echo "failed to update config" >&2; exit 1; }
 import json, os, sys
-p = "/etc/couchside/config.json"
 val = sys.argv[1] == "true"
+p = sys.argv[2]
 try:
     with open(p) as f: d = json.load(f)
     if not isinstance(d, dict): d = {}
@@ -1903,11 +1917,15 @@ os.replace(tmp, p)
 PY
         sudo systemctl restart couchside 2>/dev/null \
           || systemctl --user restart couchside 2>/dev/null || true
-        echo "App-created launchers: ${2}"
+        echo "App-created launchers: ${2}  (${CFG})"
         ;;
       ""|status)
-        grep -q '"allow_app_launchers"[[:space:]]*:[[:space:]]*true' /etc/couchside/config.json 2>/dev/null \
-          && echo "App-created launchers: on" || echo "App-created launchers: off"
+        # Print the file that was read. A status line that names its source
+        # cannot silently report on a config nothing loads, which is exactly
+        # how this verb lied for as long as it did.
+        grep -q '"allow_app_launchers"[[:space:]]*:[[:space:]]*true' "$CFG" 2>/dev/null \
+          && echo "App-created launchers: on  (${CFG})" \
+          || echo "App-created launchers: off  (${CFG})"
         ;;
       *) echo "usage: couchside allow-launchers on|off" >&2; exit 2 ;;
     esac
@@ -1946,8 +1964,7 @@ PY
     # On-wire encryption (agent >= 2.9.88 defaults ON: HTTPS beside plaintext,
     # dual-listen). This flips config.json's tls.enabled and restarts the
     # agent. Config lives in the user-owned state dir, so no sudo — same as
-    # allow-updates.
-    CFG="/var/lib/couchside/config.json"
+    # allow-updates. Uses the hoisted $CFG (one source of truth for all verbs).
     case "${2:-status}" in
       on|off)
         if [ "$2" = "off" ]; then

--- a/tests/test_allow_launchers_switch.py
+++ b/tests/test_allow_launchers_switch.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""`couchside allow-launchers` actually gates POST /api/launchers.
+
+Run: python3 tests/test_allow_launchers_switch.py
+
+WHY THIS EXISTS. The verb was a DEAD SWITCH. It wrote
+/etc/couchside/config.json while the unit the same installer generates runs the
+agent with `--config /var/lib/couchside/config.json` — and load_config() opens
+exactly that path, no fallback. So the write and the verb's own `status` grep
+agreed with each other and with nothing else: turning it ON did nothing, and
+status then reported "on". The sibling verbs (allow-updates, tls) were already
+correct, which is what made it invisible.
+
+Nothing caught it. tests/test_installer_cli.sh pins four unrelated properties;
+test_os_update.py and test_flatpak_update.py only use the string
+"allow-launchers)" as a range terminator while slicing a different block. And
+ALLOW_APP_LAUNCHERS had no coverage at all despite gating a route that runs a
+client-supplied argv — a §6 gap in its own right.
+
+So this suite asserts the END-TO-END property that was missing: drive the REAL
+CLI (extracted from install.sh, not a copy) against a temp config, boot a live
+Handler on that config, and prove the route's answer actually changes. Plus a
+CONTROL that re-runs the same flow against a copy pinned to the old /etc path
+and shows the switch doing nothing — the bug, reproduced, in the same run.
+
+Pure stdlib, no pytest.
+"""
+import http.client
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+from http.server import ThreadingHTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+INSTALLER = os.path.join(ROOT, "install.sh")
+
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+TOKEN = "t0ken-allow-launchers"
+# A config _parse_config ACCEPTS. `units` must be a non-empty list, and an
+# invalid config is not neutral here: load_config reads the opt-in flags first
+# and then falls back to built-in defaults, so a malformed fixture would still
+# pass these assertions while exercising the degraded path instead of the real
+# one. Keep this valid.
+VALID_CFG = {"units": [{"name": "couchside.service", "scope": "system"}],
+             "actions": {}}
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# --- extract the REAL CLI, so this tests what ships -------------------------
+
+def _extract_cli():
+    """The couchside CLI exactly as install.sh writes it to disk."""
+    src = open(INSTALLER).read()
+    m = re.search(r"^cat > \"\$CLI\" <<'CLIEOF'\n(.*?)^CLIEOF$",
+                  src, re.MULTILINE | re.DOTALL)
+    if not m:
+        raise SystemExit("could not find the CLI heredoc in install.sh")
+    return m.group(1)
+
+
+def _cli_pinned_to(cfg_path, body=None):
+    """Write the CLI to a temp file with its single CFG= line repointed at
+    `cfg_path`. Rewriting that ONE line is the whole point: it proves the
+    shipped CLI has exactly one config path and that everything follows it."""
+    body = _extract_cli() if body is None else body
+    out, n = re.subn(r'^CFG=.*$', 'CFG="%s"' % cfg_path, body, count=1,
+                     flags=re.MULTILINE)
+    if n != 1:
+        raise SystemExit("expected exactly one CFG= line in the CLI, found %d" % n)
+    fd, path = tempfile.mkstemp(prefix="couchside-cli-", suffix=".sh")
+    with os.fdopen(fd, "w") as f:
+        f.write(out)
+    os.chmod(path, 0o755)
+    return path
+
+
+def _stub_path(tmp):
+    """A PATH whose `sudo` and `systemctl` are no-ops, so the verb runs here."""
+    bindir = os.path.join(tmp, "bin")
+    os.makedirs(bindir, exist_ok=True)
+    # `sudo` must exec its arguments, not swallow them: the restart line is
+    # `sudo systemctl ...` and systemctl itself is stubbed true.
+    with open(os.path.join(bindir, "sudo"), "w") as f:
+        f.write('#!/bin/sh\nexec "$@"\n')
+    with open(os.path.join(bindir, "systemctl"), "w") as f:
+        f.write('#!/bin/sh\nexit 0\n')
+    for n in ("sudo", "systemctl"):
+        os.chmod(os.path.join(bindir, n), 0o755)
+    return bindir + os.pathsep + os.environ.get("PATH", "")
+
+
+def _run_verb(cli, tmp, *args):
+    return subprocess.run(["bash", cli, "allow-launchers", *args],
+                          capture_output=True, text=True,
+                          env={**os.environ, "PATH": _stub_path(tmp), "HOME": tmp})
+
+
+# --- live agent on that config ---------------------------------------------
+
+def _serve(cfg_path):
+    cs.load_config(cfg_path)
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = False
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), cs.Handler)
+    cs.Handler.port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _post_launcher(port, token=TOKEN, cmd=("/bin/true",), label="t"):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    headers = {"Content-Type": "application/json"}
+    if token is not None:
+        headers["Authorization"] = "Bearer " + token
+    body = json.dumps({"label": label, "cmd": list(cmd)}).encode()
+    conn.request("POST", "/api/launchers", body=body, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    return resp.status, data
+
+
+def _route_status(cfg_path):
+    srv, port = _serve(cfg_path)
+    try:
+        return _post_launcher(port)[0]
+    finally:
+        srv.shutdown()
+        srv.server_close()
+
+
+def _flag(cfg_path):
+    try:
+        with open(cfg_path) as f:
+            return json.load(f).get("allow_app_launchers")
+    except Exception:
+        return None
+
+
+# --- the tests --------------------------------------------------------------
+
+def test_cli_has_one_config_path():
+    print("the shipped CLI has exactly one config path")
+    body = _extract_cli()
+    check("exactly one CFG= definition", len(re.findall(r'^CFG=', body, re.M)), 1)
+    check("no /etc/couchside/config.json anywhere in the CLI",
+          "/etc/couchside/config.json" in body, False)
+    # The dead switch shelled out with sudo, which would re-root the file the
+    # agent must itself rewrite (see the allow-updates comment in install.sh).
+    blk = body[body.index("  allow-launchers)"):]
+    blk = blk[:blk.index("\n  new-token)")]
+    check("allow-launchers does not sudo the config write",
+          "sudo python3" in blk, False)
+
+
+def test_switch_actually_gates_the_route():
+    print("allow-launchers on|off changes what POST /api/launchers answers")
+    tmp = tempfile.mkdtemp(prefix="couchside-als-")
+    cfg = os.path.join(tmp, "config.json")
+    with open(cfg, "w") as f:
+        json.dump(VALID_CFG, f)
+    cli = _cli_pinned_to(cfg)
+    try:
+        r = _run_verb(cli, tmp, "on")
+        check("`on` exits 0", r.returncode, 0)
+        check("`on` writes the flag true", _flag(cfg), True)
+        check("`on` -> route accepts (200)", _route_status(cfg), 200)
+        # status must report the file it read, not a different one
+        s = _run_verb(cli, tmp, "status")
+        check("status says on", "on" in s.stdout, True)
+        check("status names the config it read", cfg in s.stdout, True)
+
+        r = _run_verb(cli, tmp, "off")
+        check("`off` exits 0", r.returncode, 0)
+        check("`off` writes the flag false", _flag(cfg), False)
+        check("`off` -> route refuses (403)", _route_status(cfg), 403)
+    finally:
+        os.unlink(cli)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_route_still_demands_auth_and_validates(     # §6, never covered before
+):
+    print("§6: the gated route still refuses bad credentials and bad input")
+    tmp = tempfile.mkdtemp(prefix="couchside-als-auth-")
+    cfg = os.path.join(tmp, "config.json")
+    with open(cfg, "w") as f:
+        json.dump({**VALID_CFG, "allow_app_launchers": True}, f)
+    srv, port = _serve(cfg)
+    try:
+        check("no bearer -> 401", _post_launcher(port, token=None)[0], 401)
+        check("wrong bearer -> 401", _post_launcher(port, token="nope")[0], 401)
+        st, _ = _post_launcher(port, cmd=())
+        check("empty argv -> 400", st, 400)
+        # A string where an argv LIST is required must be rejected, not split.
+        conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+        conn.request("POST", "/api/launchers",
+                     body=json.dumps({"label": "t", "cmd": "/bin/true"}).encode(),
+                     headers={"Authorization": "Bearer " + TOKEN,
+                              "Content-Type": "application/json"})
+        resp = conn.getresponse()
+        resp.read()          # drain before close, else the server logs a reset
+        st = resp.status
+        conn.close()
+        check("cmd as a string (not a list) -> 400", st, 400)
+    finally:
+        srv.shutdown()
+        srv.server_close()
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def test_control_the_old_switch_did_nothing():
+    """CONTROL (§11.2/§11.3): the bug, reproduced in this same run.
+
+    Same flow, but the CLI is pinned to the pre-fix /etc path while the agent
+    reads the state config — which is exactly the shipped mismatch. The state
+    config must come back BYTE-IDENTICAL and the route must keep refusing,
+    while the verb still cheerfully reports success.
+    """
+    print("control: the pre-fix verb wrote a config nothing reads")
+    tmp = tempfile.mkdtemp(prefix="couchside-als-ctl-")
+    state_cfg = os.path.join(tmp, "state", "config.json")
+    os.makedirs(os.path.dirname(state_cfg))
+    with open(state_cfg, "w") as f:
+        json.dump(VALID_CFG, f)
+    before = open(state_cfg, "rb").read()
+
+    stale_cfg = os.path.join(tmp, "etc", "config.json")   # the /etc stand-in
+    cli = _cli_pinned_to(stale_cfg)
+    try:
+        r = _run_verb(cli, tmp, "on")
+        check("pre-fix `on` still exits 0 (it looked like it worked)",
+              r.returncode, 0)
+        check("pre-fix `on` wrote its own file", _flag(stale_cfg), True)
+        check("...but the config the agent reads is UNTOUCHED",
+              open(state_cfg, "rb").read(), before)
+        check("...and the route still refuses (403)", _route_status(state_cfg), 403)
+    finally:
+        os.unlink(cli)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    for fn in (test_cli_has_one_config_path,
+               test_switch_actually_gates_the_route,
+               test_route_still_demands_auth_and_validates,
+               test_control_the_old_switch_did_nothing):
+        fn()
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        sys.exit(1)
+    print("all allow-launchers switch tests passed")


### PR DESCRIPTION
## The bug

The verb wrote `/etc/couchside/config.json` and its own `status` grepped the same path — but the unit the same installer generates runs the agent with `--config /var/lib/couchside/config.json`, and `load_config()` opens exactly that, no fallback.

So the write and the status line agreed with each other and with nothing else: **turning it on did nothing, and `status` then reported "on".**

That matters more than a cosmetic path bug. `ALLOW_APP_LAUNCHERS` gates `POST /api/launchers`, which runs a **client-supplied argv** as the desktop user — an operator's belief about its state is the entire point of the switch. The sibling verbs (`allow-updates`, `tls`) were already correct, which is what kept it invisible.

## Two changes, both required

1. **Path** → the state config the agent actually reads.
2. **Drop the `sudo`.** `allow-updates` carries the reason in a comment: the desktop user owns the state dir, and a sudo write `os.replace()`s the file into root ownership — after which the agent can no longer rewrite it and every TV pairing / launcher edit 500s. **Fixing only the path would have traded a dead switch for a worse bug.**

One hoisted `$CFG` now serves all three verbs, and `status` prints the file it read — a status line that names its source can't silently report on a config nothing loads.

## Tests

New `tests/test_allow_launchers_switch.py` drives the **real** CLI (extracted from `install.sh`, not a copy) against a temp config, boots a live `Handler` on it, and asserts the route's answer actually changes: `on` → 200, `off` → 403.

It also carries the **§6 coverage `ALLOW_APP_LAUNCHERS` never had** — 401 without a bearer, 401 with a wrong bearer, 400 on an empty argv, 400 on `cmd` as a string rather than a list.

And a **control**: the same flow with the CLI pinned to the old `/etc` path shows the state config coming back byte-identical and the route still refusing — the bug reproduced in the same run, while the verb still exits 0 and looks like it worked.

> Fixture note worth keeping: `units` must be non-empty or `_parse_config` rejects the config and `load_config` falls back to defaults — which *still honours the opt-in flags*. A malformed fixture would therefore have passed while exercising the degraded path instead of the real one. Caught and fixed during review of my own test.

## Verified

- New suite green; **full suite 83/83**; CI wiring guard green.

## Not verified

- **A real box's unit carrying `--config`** — asserted textually here only. Box check: `systemctl cat couchside.service | grep -- --config`, then `couchside allow-launchers on`, create a launcher from the phone (expect success), `off`, expect 403.
- **Decky boxes.** `couchside-decky/main.py` pins `/etc` and its unit has no `--config`, so a Decky agent may genuinely read `/etc`. That checkout is stale (bundles agent 2.8.3). This change makes the verb *consistently* wrong there rather than accidentally right — the same state `allow-updates` and `tls` are already in. Filed as an open question, deliberately not solved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)