### PR TITLE
fix(release): self-verification checked the key it had just signed with

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,17 @@ jobs:
       - name: Installer CLI + token-redaction pins
         run: bash tests/test_installer_cli.sh install.sh
 
+      # The release scripts used to "self-verify" a signature against a pubkey
+      # derived from the key that had just signed it — true by construction for
+      # ANY key, so it could never catch the one failure it claimed to prevent.
+      # A wrong or rotated key passed, uploaded, and was then refused on every
+      # user's box AFTER the release went public. They now check the keys
+      # embedded in install.sh, which is what a box actually trusts. Includes a
+      # control that runs the pre-fix sequence and asserts it ACCEPTS a key no
+      # box would.
+      - name: Release signing verifies the keys a box trusts
+        run: python3 tests/test_release_signing.py
+
       # Injected actions: buttons the agent offers only when the box can really
       # perform them ("a dead button costs more trust than a missing one"), so
       # every gate is asserted in BOTH directions. Covers the Bluetooth pairing

--- a/scripts/release-agent.sh
+++ b/scripts/release-agent.sh
@@ -155,15 +155,30 @@ cat "$tmp/SHA256SUMS"
 echo "==> signing SHA256SUMS with $key (via $ossl)"
 "$ossl" pkeyutl -sign -inkey "$key" -rawin -in "$tmp/SHA256SUMS" -out "$tmp/SHA256SUMS.sig"
 
-# Self-verify with the public half before uploading — never publish a signature
-# install.sh would reject.
-"$ossl" pkey -in "$key" -pubout -out "$tmp/pub.pem"
-if ! "$ossl" pkeyutl -verify -pubin -inkey "$tmp/pub.pem" -rawin \
-        -in "$tmp/SHA256SUMS" -sigfile "$tmp/SHA256SUMS.sig" >/dev/null 2>&1; then
-    echo "error: self-verification failed — not uploading" >&2
-    exit 1
-fi
-echo "    signature self-verified OK"
+# Verify against the keys A BOX ACTUALLY TRUSTS before uploading.
+#
+# This used to derive the public half from "$key" itself and verify against
+# that, which succeeds by construction for ANY key — so it could never detect
+# the one thing it claimed to ("never publish a signature install.sh would
+# reject"). Signing with a wrong or rotated key passed, uploaded, and failed on
+# every user's box after the release was public. See scripts/release-keys.sh.
+. "$here/release-keys.sh"
+# `|| _rc=$?` is load-bearing: both scripts run under `set -e`, so calling the
+# function bare would abort the moment it returns non-zero and the case below
+# would never print WHY. Measured: the first version of this exited 1 silently.
+_rc=0
+verify_against_installer "$root/install.sh" \
+    "$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig" "$ossl" || _rc=$?
+case "$_rc" in
+    0) echo "    signature verifies against the key embedded in install.sh (key #$RELEASE_KEY_MATCHED)" ;;
+    1) echo "error: BOTH keys embedded in install.sh reject this signature." >&2
+       echo "       Every box would refuse this release. Not uploading." >&2
+       exit 1 ;;
+    *) echo "error: could not verify against install.sh's embedded keys." >&2
+       echo "       Publishing something unverifiable is exactly the failure" >&2
+       echo "       this check exists to prevent. Not uploading." >&2
+       exit 1 ;;
+esac
 
 # Release notes = the matching section of agent/CHANGELOG.md.
 #

--- a/scripts/release-keys.sh
+++ b/scripts/release-keys.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# release-keys.sh — verify a release signature against the keys A BOX ACTUALLY
+# TRUSTS, i.e. the RELEASE_PUBKEY_PEM / _BACKUP blocks embedded in install.sh.
+#
+# WHY THIS EXISTS. release-agent.sh and sign-release.sh both used to "self-
+# verify" like this:
+#
+#     openssl pkey -in "$key" -pubout -out pub.pem      # <- from the SIGNING key
+#     openssl pkeyutl -verify -pubin -inkey pub.pem ...
+#
+# That derives the public half from the very key that just produced the
+# signature, so it succeeds BY CONSTRUCTION for any key whatsoever. It cannot
+# detect the one failure it claimed to ("never publish a signature install.sh
+# would reject"): sign with a wrong or rotated key and it passes, uploads
+# cleanly, and is then rejected on EVERY user's box — after the release is
+# public, which is the worst possible moment to find out.
+#
+# The accept rule below is install.sh's verify_release_sig, deliberately
+# reproduced rather than approximated: a good signature from EITHER key is
+# authentic, and the verdict is taken from openssl's OUTPUT STRING, not its exit
+# code, because that is what the box does.
+#
+# Sourced, not executed:  . "$(dirname "$0")/release-keys.sh"
+
+# Extract the two embedded PEM blocks from an install.sh.
+# Python, not sed: release-agent.sh already documents BSD/GNU sed drift biting
+# this repo, and this must not be the place it bites next.
+release_pubkeys() {   # $1 = path to install.sh; prints PEMs separated by a NUL-ish marker
+    python3 - "$1" <<'PY'
+import re, sys
+src = open(sys.argv[1]).read()
+pat = r"^RELEASE_PUBKEY_PEM(?:_BACKUP)?='(-----BEGIN PUBLIC KEY-----.*?-----END PUBLIC KEY-----)'"
+for m in re.finditer(pat, src, re.MULTILINE | re.DOTALL):
+    print(m.group(1))
+    print("---KEYSEP---")
+PY
+}
+
+# verify_against_installer <installer> <sums> <sig> <openssl>
+#   0 = a box would ACCEPT this signature
+#   1 = both embedded keys REJECT it  (never publish)
+#   2 = could not check               (never publish either — see below)
+#
+# The asymmetry with install.sh is deliberate. A BOX treats "cannot check" as
+# degrade-to-checksums, which is right for a machine on an ancient openssl. On
+# the RELEASE side, publishing something we were unable to verify is precisely
+# the failure this function exists to prevent, so the caller must abort on 2 as
+# well as 1.
+verify_against_installer() {
+    local installer="$1" sums="$2" sig="$3" ossl="${4:-openssl}"
+    local keys tmpd pub out saw_fail=0 n=0
+
+    [ -r "$installer" ] || { echo "release-keys: cannot read $installer" >&2; return 2; }
+    keys="$(release_pubkeys "$installer")" || {
+        echo "release-keys: failed to parse keys out of $installer" >&2; return 2; }
+
+    tmpd="$(mktemp -d)" || return 2
+    # Split on the marker and try each key.
+    while IFS= read -r -d '' pub; do
+        pub="$(printf '%s' "$pub" | sed -e 's/^[[:space:]]*$//' )"
+        [ -n "$(printf '%s' "$pub" | tr -d '[:space:]')" ] || continue
+        n=$((n + 1))
+        printf '%s\n' "$pub" > "$tmpd/k.pub"
+        out="$("$ossl" pkeyutl -verify -pubin -inkey "$tmpd/k.pub" -rawin \
+                -in "$sums" -sigfile "$sig" 2>&1 || true)"
+        if printf '%s' "$out" | grep -qi 'Verified Successfully'; then
+            rm -rf "$tmpd"
+            RELEASE_KEY_MATCHED="$n"     # 1 = primary, 2 = backup
+            return 0
+        elif printf '%s' "$out" | grep -qi 'Verification Failure'; then
+            saw_fail=1
+        fi
+    done < <(printf '%s' "$keys" | awk 'BEGIN{RS="---KEYSEP---\n"} NF{printf "%s%c", $0, 0}')
+    rm -rf "$tmpd"
+
+    # Zero keys found is a HARD failure, never "nothing to check, proceed" —
+    # otherwise a rename or reformat of the PEM block in install.sh silently
+    # restores the tautological no-op this whole file replaces.
+    if [ "$n" -eq 0 ]; then
+        echo "release-keys: no RELEASE_PUBKEY_PEM blocks found in $installer" >&2
+        return 2
+    fi
+    [ "$saw_fail" -eq 1 ] && return 1 || return 2
+}

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -41,17 +41,34 @@ gh release download "$tag" --repo "$REPO" --pattern SHA256SUMS --dir "$tmp" --cl
 echo "==> signing with $key (via $ossl)"
 "$ossl" pkeyutl -sign -inkey "$key" -rawin -in "$tmp/SHA256SUMS" -out "$tmp/SHA256SUMS.sig"
 
-# Sanity: verify our own signature with the public half before uploading, so we
-# never publish a signature install.sh would reject.
-"$ossl" pkey -in "$key" -pubout -out "$tmp/pub.pem"
-if ! "$ossl" pkeyutl -verify -pubin -inkey "$tmp/pub.pem" -rawin \
-        -in "$tmp/SHA256SUMS" -sigfile "$tmp/SHA256SUMS.sig" >/dev/null 2>&1; then
-    echo "error: self-verification failed — not uploading" >&2
-    exit 1
-fi
+# Verify against the keys A BOX ACTUALLY TRUSTS before uploading.
+#
+# This used to derive the public half from "$key" itself, which succeeds by
+# construction for any key and therefore could never catch a wrong or rotated
+# one — the failure it claimed to prevent. See scripts/release-keys.sh.
+here="$(cd "$(dirname "$0")" && pwd)"
+root="$(cd "$here/.." && pwd)"
+. "$here/release-keys.sh"
+# `|| _rc=$?` is load-bearing: both scripts run under `set -e`, so calling the
+# function bare would abort the moment it returns non-zero and the case below
+# would never print WHY. Measured: the first version of this exited 1 silently.
+_rc=0
+verify_against_installer "$root/install.sh" \
+    "$tmp/SHA256SUMS" "$tmp/SHA256SUMS.sig" "$ossl" || _rc=$?
+case "$_rc" in
+    0) echo "    verifies against the key embedded in install.sh (key #$RELEASE_KEY_MATCHED)" ;;
+    1) echo "error: BOTH keys embedded in install.sh reject this signature." >&2
+       echo "       Every box would refuse it. Not uploading." >&2
+       exit 1 ;;
+    *) echo "error: could not verify against install.sh's embedded keys." >&2
+       echo "       Publishing something unverifiable is the failure this check" >&2
+       echo "       exists to prevent. Not uploading." >&2
+       exit 1 ;;
+esac
 
 echo "==> uploading SHA256SUMS.sig to $tag"
 gh release upload "$tag" "$tmp/SHA256SUMS.sig" --repo "$REPO" --clobber
 
 echo "OK: signed + uploaded SHA256SUMS.sig for $tag"
-echo "    (verify the embedded key matches: openssl pkey -in $key -pubout)"
+echo "    (checked against install.sh's embedded release key, not against \$key —"
+echo "     so a wrong or rotated key aborts above instead of shipping.)"

--- a/tests/test_release_signing.py
+++ b/tests/test_release_signing.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""The release self-verification checks the keys a BOX trusts, not its own.
+
+Run: python3 tests/test_release_signing.py
+
+WHY THIS EXISTS. scripts/release-agent.sh and scripts/sign-release.sh both did:
+
+    openssl pkey -in "$key" -pubout -out pub.pem     # from the SIGNING key
+    openssl pkeyutl -verify -pubin -inkey pub.pem ...
+
+That derives the public half from the very key that just produced the signature,
+so it succeeds BY CONSTRUCTION for any key. It could never detect the single
+failure it claimed to prevent -- "never publish a signature install.sh would
+reject" -- because it never consulted install.sh's keys at all. Sign with a
+wrong or rotated key and it passed, uploaded cleanly, and was then refused by
+verify_release_sig() on EVERY user's box, after the release was public.
+
+The control below is the point of this suite: it runs the PRE-FIX sequence and
+asserts it PASSES against a key no box trusts. A guard is only proven once you
+have watched the thing it replaced fail to notice.
+
+Pure stdlib, no pytest. Needs an openssl with Ed25519 `-rawin` (CI has OpenSSL 3).
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+INSTALLER = os.path.join(ROOT, "install.sh")
+HELPER = os.path.join(ROOT, "scripts", "release-keys.sh")
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _openssl():
+    """An openssl that can do Ed25519 one-shot signing, or None."""
+    for cand in ("openssl", "/opt/homebrew/opt/openssl@3/bin/openssl",
+                 "/usr/local/opt/openssl@3/bin/openssl"):
+        exe = shutil.which(cand) if os.sep not in cand else (
+            cand if os.access(cand, os.X_OK) else None)
+        if not exe:
+            continue
+        r = subprocess.run([exe, "pkeyutl", "-help"], capture_output=True, text=True)
+        if "-rawin" in (r.stdout + r.stderr):
+            return exe
+    return None
+
+
+OSSL = _openssl()
+
+
+def _run_helper(installer, sums, sig):
+    """Call verify_against_installer and return its numeric verdict."""
+    script = (
+        '. "%s"\n'
+        'verify_against_installer "%s" "%s" "%s" "%s"\n'
+        'echo "rc=$?"\n' % (HELPER, installer, sums, sig, OSSL)
+    )
+    r = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    for line in r.stdout.splitlines():
+        if line.startswith("rc="):
+            return int(line[3:])
+    return -1
+
+
+def main():
+    if OSSL is None:
+        # Never silently skip: a "green" run that tested nothing is the exact
+        # failure mode this repo has been bitten by.
+        print("FAILED: no openssl with Ed25519 -rawin available")
+        sys.exit(1)
+
+    tmp = tempfile.mkdtemp(prefix="couchside-signing-")
+    try:
+        key = os.path.join(tmp, "throwaway.key")
+        sums = os.path.join(tmp, "SHA256SUMS")
+        sig = os.path.join(tmp, "SHA256SUMS.sig")
+        subprocess.run([OSSL, "genpkey", "-algorithm", "ED25519", "-out", key],
+                       check=True, capture_output=True)
+        with open(sums, "w") as f:
+            f.write("deadbeef  couchsided.py\n")
+        subprocess.run([OSSL, "pkeyutl", "-sign", "-inkey", key, "-rawin",
+                        "-in", sums, "-out", sig], check=True, capture_output=True)
+
+        pub = os.path.join(tmp, "throwaway.pub")
+        subprocess.run([OSSL, "pkey", "-in", key, "-pubout", "-out", pub],
+                       check=True, capture_output=True)
+        pub_pem = open(pub).read().strip()
+
+        print("the real install.sh REJECTS a key no box trusts")
+        check("throwaway-signed sums vs the shipped keys -> 1 (reject)",
+              _run_helper(INSTALLER, sums, sig), 1)
+
+        print("an installer embedding that key ACCEPTS it")
+        fake = os.path.join(tmp, "fake-install.sh")
+        with open(fake, "w") as f:
+            f.write("RELEASE_PUBKEY_PEM='%s'\n" % pub_pem)
+        check("matching embedded key -> 0 (accept)",
+              _run_helper(fake, sums, sig), 0)
+
+        print("either key satisfies it (install.sh's own rule)")
+        fake2 = os.path.join(tmp, "fake-backup.sh")
+        other = os.path.join(tmp, "other.key")
+        otherpub = os.path.join(tmp, "other.pub")
+        subprocess.run([OSSL, "genpkey", "-algorithm", "ED25519", "-out", other],
+                       check=True, capture_output=True)
+        subprocess.run([OSSL, "pkey", "-in", other, "-pubout", "-out", otherpub],
+                       check=True, capture_output=True)
+        with open(fake2, "w") as f:
+            f.write("RELEASE_PUBKEY_PEM='%s'\n" % open(otherpub).read().strip())
+            f.write("RELEASE_PUBKEY_PEM_BACKUP='%s'\n" % pub_pem)
+        check("signature matching only the BACKUP key -> 0 (accept)",
+              _run_helper(fake2, sums, sig), 0)
+
+        print("fail closed")
+        nokeys = os.path.join(tmp, "nokeys.sh")
+        with open(nokeys, "w") as f:
+            f.write("# an installer with no embedded keys at all\n")
+        check("no embedded keys -> 2 (hard abort, never 'nothing to check')",
+              _run_helper(nokeys, sums, sig), 2)
+        check("unreadable installer -> 2",
+              _run_helper(os.path.join(tmp, "does-not-exist.sh"), sums, sig), 2)
+
+        # ---- THE CONTROL -------------------------------------------------
+        # Reproduce the pre-fix self-check and watch it accept a key that every
+        # box would refuse. Without this, the assertions above only show the new
+        # code working; they do not show that the old code was broken.
+        print("control: the PRE-FIX self-check accepts a key no box trusts")
+        r = subprocess.run(
+            [OSSL, "pkeyutl", "-verify", "-pubin", "-inkey", pub, "-rawin",
+             "-in", sums, "-sigfile", sig],
+            capture_output=True, text=True)
+        prefix_ok = "Verified Successfully" in (r.stdout + r.stderr)
+        check("pre-fix check PASSES the throwaway key (the bug)", prefix_ok, True)
+        check("...while a real box REJECTS the same signature",
+              _run_helper(INSTALLER, sums, sig), 1)
+
+        # ---- wiring pins (weaker evidence; labelled as such) --------------
+        print("wiring (textual pins, not behaviour)")
+        for name in ("release-agent.sh", "sign-release.sh"):
+            src = open(os.path.join(ROOT, "scripts", name)).read()
+            check("%s sources release-keys.sh" % name,
+                  "release-keys.sh" in src, True)
+            check("%s calls verify_against_installer" % name,
+                  "verify_against_installer" in src, True)
+            check("%s no longer derives a pubkey from the signing key" % name,
+                  'pkey -in "$key" -pubout' in src, False)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print("FAILED: %s" % ", ".join(FAILURES))
+        sys.exit(1)
+    print("all release-signing tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## The bug

Both release scripts did:

```sh
openssl pkey -in "$key" -pubout -out pub.pem     # <- from the SIGNING key
openssl pkeyutl -verify -pubin -inkey pub.pem ...
```

That derives the public half from the very key that produced the signature, so it succeeds **by construction for any key**. It could never detect the single thing its comment claimed — *"never publish a signature install.sh would reject"* — because it never consulted `install.sh`'s keys at all.

Sign with a wrong or rotated key and it passed, uploaded cleanly, and was then refused by `verify_release_sig()` on **every user's box** — after the release was public, which is the worst possible moment to find out.

## The fix

New `scripts/release-keys.sh` extracts the `RELEASE_PUBKEY_PEM` / `_BACKUP` blocks from `install.sh` and verifies against those, **reproducing install.sh's own accept rule** rather than approximating it: either key is authentic, and the verdict comes from openssl's *output string*, not its exit code, because that's what a box does.

Two properties the old check didn't have:

- **"Could not verify" aborts.** A box degrading to checksums is right for a machine on an ancient openssl; publishing something we couldn't verify is exactly the failure being fixed. The asymmetry is commented.
- **Zero keys found is a hard abort**, never "nothing to check, proceed" — otherwise a rename or reformat of the PEM block silently restores the tautological no-op.

Extraction is `python3`, not `sed`: `release-agent.sh` already documents BSD/GNU sed drift biting this repo.

> `|| _rc=$?` is load-bearing. Both scripts run under `set -e`, so calling the function bare aborted *before* the `case` could print why. Measured: my first version exited 1 **silently**, which for an operator is nearly as bad as not aborting at all.

## Verified

End-to-end with a throwaway key against the real script:

```
EXIT: 1
error: BOTH keys embedded in install.sh reject this signature.
       Every box would refuse this release. Not uploading.

gh invocations during a refused run: (none — nothing was published)
```

That last line is from a `gh` stub that logs every invocation — the only rigorous way to prove nothing shipped.

`tests/test_release_signing.py` covers accept / reject / either-key / zero-keys / unreadable, and carries the **control**: it runs the pre-fix sequence and asserts it *passes* the throwaway key while a real box rejects the same signature.

Full suite **83/83**.

## Not verified

**The accept path through the real script** — it needs the offline maintainer key, which by design exists only on your machine. First observation is the next real release; the expected new line is:

```
signature verifies against the key embedded in install.sh (key #1)
```

If that line doesn't appear, stop and investigate before publishing.

## Merge order

This should land **before** the release carrying #475 and #476 — a signed release is how those reach boxes, and this is the guard on that step. Only overlap with #476 is one `ci.yml` step in a different region (a rebase, not a conflict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)