### PR TITLE
fix(installer): CLI restarts used an argv sudoers does not grant, so they failed silently

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1697,6 +1697,31 @@ DAEMON="${DIR}/couchsided.py"
 # with nothing else. Turning it on did nothing, and status then said "on".
 CFG="/var/lib/couchside/config.json"
 
+# Restart the agent so a config edit actually TAKES EFFECT.
+#
+# The argv here is not free-form: the sudoers grant install.sh writes is
+# EXACT-argument, allowing only
+#     /usr/bin/systemctl restart --no-block couchside.service
+# (spelled as a passwordless rule in the sudoers block above -- deliberately not
+# quoted verbatim here, because tests/test_readme_sudo_grants.py counts those
+# rules textually and a comment that looks like one is counted as a real grant),
+# so `sudo systemctl restart couchside` (what these verbs used to run) does
+# NOT match it, demands a password, and with 2>/dev/null attached fails
+# SILENTLY. Measured on a real box 2026-08-16: `couchside allow-launchers on`
+# wrote the config correctly, reported success, and the agent went on serving
+# the old value because the restart never happened. Same for allow-updates and
+# tls, where `tls off` left HTTPS up while telling the user it was off.
+#
+# -n so it can never hang waiting on a password, the granted argv verbatim, and
+# a LOUD message when neither path works -- the silence is what hid this.
+_restart_agent() {
+    sudo -n systemctl restart --no-block couchside.service 2>/dev/null && return 0
+    systemctl --user restart couchside 2>/dev/null && return 0
+    echo "warning: could not restart the agent, so this change is NOT live yet." >&2
+    echo "         Run:  sudo systemctl restart couchside" >&2
+    return 1
+}
+
 case "${1:-help}" in
   update|upgrade)
     yes=0; force=0
@@ -1821,8 +1846,7 @@ tmp = p + ".tmp"
 with open(tmp, "w") as f: json.dump(d, f, indent=2)
 os.replace(tmp, p)
 PY
-        sudo systemctl restart couchside 2>/dev/null \
-          || systemctl --user restart couchside 2>/dev/null || true
+        _restart_agent
         echo "App-triggered updates: ${2}"
         ;;
       ""|status)
@@ -1915,8 +1939,7 @@ tmp = p + ".tmp"
 with open(tmp, "w") as f: json.dump(d, f, indent=2)
 os.replace(tmp, p)
 PY
-        sudo systemctl restart couchside 2>/dev/null \
-          || systemctl --user restart couchside 2>/dev/null || true
+        _restart_agent
         echo "App-created launchers: ${2}  (${CFG})"
         ;;
       ""|status)
@@ -1955,8 +1978,7 @@ PY
     sudo chown "$(id -un)" "$TOKEN_FILE"
     # Restart so the auth gate compares against the NEW token (the agent loads
     # it at startup; without this the old token would still authorize).
-    sudo systemctl restart couchside 2>/dev/null \
-      || systemctl --user restart couchside 2>/dev/null || true
+    _restart_agent
     echo "New token minted. Old pairings are now invalid."
     echo "Show the new pairing QR on this box's screen with:  couchside pair"
     ;;
@@ -1992,8 +2014,7 @@ tmp = p + ".tmp"
 with open(tmp, "w") as f: json.dump(d, f, indent=2)
 os.replace(tmp, p)
 PY
-        sudo systemctl restart couchside 2>/dev/null \
-          || systemctl --user restart couchside 2>/dev/null || true
+        _restart_agent
         echo "TLS (HTTPS listener): ${2}"
         ;;
       status)

--- a/tests/test_installer_cli.sh
+++ b/tests/test_installer_cli.sh
@@ -55,7 +55,10 @@ lines=$(nt | wc -l | tr -d ' ')
 grep -q '^  new-token)$' "$tmp"; check "new-token subcommand exists" $?
 nt | grep -q "Continue? \[y/N\]"
 check "confirms before rotating" $?
-nt | grep -q 'systemctl restart couchside'
+# Via the shared helper since 2026-08-16 — the hand-rolled `sudo systemctl
+# restart couchside` this used to look for did not match the sudoers grant and
+# failed silently, which for new-token means the OLD token keeps authorizing.
+nt | grep -q '_restart_agent'
 check "restarts the agent (old token must stop authorizing)" $?
 nt | grep -q 'chmod 600'
 check "token file mode stays 600" $?
@@ -76,6 +79,32 @@ check "status reads the LIVE advert, not just config" $?
 tl | grep -q 'FAILS'
 check "off warns that pinned phones fail closed" $?
 rm -f "$tmp"
+
+echo "CLI restarts the agent with the argv sudoers actually grants"
+# The grant install.sh writes is EXACT-argument. A verb that restarts with any
+# other argv needs a password, and with 2>/dev/null attached it fails SILENTLY —
+# measured on a real box 2026-08-16: the config was written, success reported,
+# and the agent kept serving the old value. These two pins tie the CLI to the
+# rule; if either side is edited alone, this goes red.
+GRANT='systemctl restart --no-block couchside.service'
+grep -q "NOPASSWD: /usr/bin/$GRANT" "$SRC"
+check "install.sh still grants exactly '$GRANT'" $?
+tmp2="$(mktemp)"
+awk '/^cat > "\$CLI" <<'"'"'CLIEOF'"'"'$/{f=1;next} /^CLIEOF$/{f=0} f' "$SRC" > "$tmp2"
+# Every restart must go through the one helper...
+grep -q '^_restart_agent()' "$tmp2"
+check "CLI defines a single _restart_agent helper" $?
+# ...which uses -n (never hangs on a prompt) and the granted argv verbatim.
+grep -q "sudo -n $GRANT" "$tmp2"
+check "the helper uses -n and the granted argv verbatim" $?
+# No verb may hand-roll its own restart. Exclude comment/echo lines: the helper
+# deliberately NAMES the old broken form to explain it, and prints it as a hint.
+handrolled=$(grep -n 'sudo systemctl restart' "$tmp2" | grep -vE '^\s*[0-9]+:\s*#' | grep -vc 'echo')
+check "no verb hand-rolls a restart (found $handrolled)" "$handrolled"
+# Silence is what hid this: a failed restart must SAY so.
+grep -q 'NOT live yet' "$tmp2"
+check "a failed restart warns instead of '|| true'" $?
+rm -f "$tmp2"
 
 echo "firewall opens the TLS port"
 grep -q 'firewall-cmd --add-port="${TLS_PORT}/tcp" --permanent' "$SRC"


### PR DESCRIPTION
## Found on hardware, verifying #476

Installed the merged CLI on the Legion Go to check #476's box-side claim. The fix made `couchside allow-launchers on` write the right config — **and the setting still didn't take effect.** The write was never the only problem.

The sudoers grant `install.sh` writes is exact-argument, allowing only:

```
/usr/bin/systemctl restart --no-block couchside.service
```

All four CLI verbs ran:

```sh
sudo systemctl restart couchside 2>/dev/null || systemctl --user restart couchside 2>/dev/null || true
```

That doesn't match, so it demands a password. Non-interactively it fails, `2>/dev/null` eats the message, the `--user` fallback is inactive on a system-service box, and `|| true` swallows the rest.

## Measured, both states

Through the same API the app reads (`GET /api/launchers` → `create_enabled`), on a real Legion Go:

```
before fix:  False -> [allow-launchers on] -> False          <- config written, agent never reloaded
after fix:   False -> [on] -> True -> [off] -> False
```

Affects `allow-updates`, `allow-system-updates`, `allow-launchers` and `tls` alike. For **`tls off` it's worse than cosmetic**: the user is told HTTPS is off while the agent keeps serving it.

## The fix

One `_restart_agent` helper owns it: `sudo -n` so it can never hang on a prompt, the granted argv verbatim, and a **loud** warning naming the manual command when neither path works. The silence is what hid this.

`install.sh`'s own internal restart (~line 927) already used the correct form — only the CLI had drifted from it.

## Pins

`tests/test_installer_cli.sh` now ties the CLI to the rule from **both** sides: the grant text, the helper's argv, no hand-rolled restarts, and the warning. **Mutation-checked in both directions** — reverting one verb, and editing the sudoers grant alone, each turn it red.

## Two self-inflicted traps worth recording

- The `new-token` pin greped for the old literal and had to move to the helper.
- My explanatory comment quoted a sudoers rule verbatim, and `test_readme_sudo_grants.py` counted it as a **tenth real grant** — the same "a textual guard cannot tell code from prose" failure that made the `or True` guard use AST. Comment reworded rather than the counter weakened.

## Also resolves KI-062

The Legion Go has the Decky plugin present *and* runs the system `couchside.service`, whose unit carries `--config /var/lib/couchside/config.json`. So a real Decky box reads the state config — #476 is simply **correct** there, not "consistently wrong" as that PR hedged.

## Verified

- Full suite **84/84**.
- Hardware round-trip above; agent healthy across two restarts (`/api/ping` OK, `tls status` still honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)