### PR TITLE
docs(agent): changelog 2.9.92 leads with the change users actually feel

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -20,6 +20,13 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.92
 
+**Your game lists stop re-reading a big file every time you look at them.** The box
+kept the names for Steam Link and your uninstalled-games list in two separate
+caches that knocked each other over, so switching between those screens made it
+re-read a multi-megabyte Steam file each time — about a fifth of a second of work
+on a 1,500-game library, over and over. It now reads that file once and both
+screens share it. Same names, same lists; the box just stops doing the work twice.
+
 **Pairing is steadier against junk input.** If something on your network sent the
 pairing endpoint a malformed request, the box answered with a server error instead
 of a clean refusal. It now refuses cleanly, the way it always did for a wrong PIN.


### PR DESCRIPTION
The 2.9.92 section only mentioned the pairing fix — which no user will ever notice, since it changes the answer to a malformed request no shipped app sends.

The appinfo cache collapse (#481) is the one they'll actually feel: two caches with incompatible key shapes evicted each other, so alternating between the Steam Link list and the uninstalled-games list re-read a multi-MB Steam file every time. Measured **172 ms per parse** on a 1562-app library; six alternating calls went from ~1s to **0.2 ms**.

Led with rather than appended, per this file's own header: *"the top section must describe everything a user is getting"*. Written for the person holding the phone, not the commit log.

Verified the extractor picks up both paragraphs, and `VERSION=2.9.92` still matches its section so `release-agent.sh` won't abort.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)