### PR TITLE
feat(app): Rainbow River + Heartbeat light-show presets

### DIFF
--- a/app/components/StripLightCard.tsx
+++ b/app/components/StripLightCard.tsx
@@ -467,6 +467,38 @@ export function StripLightCard() {
       }
       return;
     }
+    // GENERATOR presets sized to THIS strip, then loaded into the editor so they
+    // can be tweaked + re-saved. `playGen` plays the loop on the box and shows it.
+    const playGen = (frames: (Rgb | null)[][], holds: number[]) => {
+      setEffect('manual'); setBright(p.brightness);
+      setSeqFrames(frames); setFrameHold(holds); setSelFrame(0);
+      setFrame(frames[0].map((c) => c));
+      setCellBright(frames[0].map((c) => (c ? 100 : 0)));
+      if (agentMode && agentStrip) {
+        void api.setStripSequence(settings, agentStrip.prefix, {
+          frames, holdMs: holds[0] ?? 120, holds, loop: true, brightness: p.brightness,
+        }).then(() => poll.refresh()).catch(() => {});
+      }
+    };
+    // Rainbow River: a full-spectrum gradient that flows around the strip — one
+    // frame per shift step (n frames for an n-LED strip = a seamless loop).
+    if (p.generator === 'rainbowflow') {
+      const n = orderedLeds.length;
+      const frames = Array.from({ length: n }, (_, s) =>
+        orderedLeds.map((_, i) => hueToRgb((((i + s) / n) * 360) % 360)));
+      playGen(frames, frames.map(() => 80));
+      return;
+    }
+    // Heartbeat: two quick red pulses then a long dark rest (per-frame timing is
+    // what sells it — uniform timing would just look like blinking).
+    if (p.generator === 'heartbeat') {
+      const R: Rgb = { r: 255, g: 0, b: 0 };
+      const red = orderedLeds.map(() => ({ ...R }));
+      const off = orderedLeds.map(() => null);
+      playGen([red, off, orderedLeds.map(() => ({ ...R })), off.slice()],
+        [150, 120, 150, 800]);
+      return;
+    }
     // A painted PATTERN preset: enter manual mode, then repaint every LED.
     if (p.pattern && p.pattern.length) {
       setEffect('manual'); setBright(p.brightness);

--- a/app/lib/ledPresets.ts
+++ b/app/lib/ledPresets.ts
@@ -36,9 +36,10 @@ export type LedPreset = {
   /** A per-LED painted pattern (effect==='manual' only): one colour per strip
       node, null = off. Applying it repaints every LED. */
   pattern?: (Rgb | null)[];
-  /** A built-in that GENERATES a timed sequence sized to the strip when applied
-      (e.g. 'police' = red/blue halves alternating). Overrides effect/pattern. */
-  generator?: 'police';
+  /** A built-in that GENERATES a timed sequence sized to the strip when applied:
+      'police' (red/blue halves), 'rainbowflow' (a spectrum flowing around the
+      strip), 'heartbeat' (two red pulses + a long rest). Overrides effect/pattern. */
+  generator?: 'police' | 'rainbowflow' | 'heartbeat';
   /** A hand-built TIMED SEQUENCE (from the N-frame editor): per-LED colour frames
       plus one hold (ms) per frame. Applying it plays the loop on the box via
       /api/leds/sequence. Overrides effect/pattern/generator. */
@@ -51,6 +52,10 @@ const DEFAULTS: LedPreset[] = [
     color: { r: 255, g: 0, b: 0 }, speed: 80, brightness: 100 },
   { id: 'seed-police', label: 'Police', effect: 'manual',
     color: null, speed: 85, brightness: 100, generator: 'police' },
+  { id: 'seed-rainbowflow', label: 'Rainbow River', effect: 'manual',
+    color: null, speed: 80, brightness: 100, generator: 'rainbowflow' },
+  { id: 'seed-heartbeat', label: 'Heartbeat', effect: 'manual',
+    color: { r: 255, g: 0, b: 0 }, speed: 50, brightness: 100, generator: 'heartbeat' },
   { id: 'seed-breathe-blue', label: 'Breathe Blue', effect: 'breathe',
     color: { r: 0, g: 80, b: 255 }, speed: 35, brightness: 90 },
   { id: 'seed-rainbow', label: 'Rainbow', effect: 'rainbow',
@@ -130,7 +135,8 @@ function normalize(raw: unknown): LedPreset[] {
       pattern: Array.isArray(p.pattern)
         ? (p.pattern as unknown[]).map((c) => (isRgb(c) ? { r: c.r, g: c.g, b: c.b } : null))
         : undefined,
-      generator: p.generator === 'police' ? 'police' : undefined,
+      generator: (p.generator === 'police' || p.generator === 'rainbowflow'
+        || p.generator === 'heartbeat') ? p.generator : undefined,
       sequence: normalizeSequence(p.sequence),
     });
     if (out.length >= PRESET_MAX) break;


### PR DESCRIPTION
## What

Two built-in strip presets that showcase the sequence engine, implemented as strip-**sized** generators (like the existing Police preset) so they fit any strip length:

- **Rainbow River** — a full-spectrum gradient that flows around the strip (one frame per LED, 80 ms each) — a seamless rotating rainbow.
- **Heartbeat** — two quick red pulses then a long dark rest, holds `[150, 120, 150, 800]`. Showcases **per-frame timing** — uniform timing would just look like blinking.

Applying either builds frames sized to the connected strip, plays the loop on the box, and loads it into the editor so it can be tweaked + re-saved. New `DEFAULTS` seeds merge into an existing preset library on next load, so they appear even on a build that already has presets.

## Verified

In the web harness by pressing the preset chips against the mock 8-LED strip:
- Rainbow River → `frames: 8, holds: [80×8], loop` 
- Heartbeat → `frames: 4, holds: [150,120,150,800], loop`
- `tsc --noEmit` clean.

## Note

These generators are strip-only; like Police, they also appear in the OpenRGB card's shared preset list where they no-op. Pre-existing behavior — worth unifying later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)