### PR TITLE
fix(installer): an optional add-on's sudo aborted the whole app-triggered update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -596,6 +596,16 @@ jobs:
       - name: Installer CLI + token-redaction pins
         run: bash tests/test_installer_cli.sh install.sh
 
+      # An OPTIONAL step must never abort an app-triggered update. install.sh
+      # runs `set -euo pipefail` and the phone runs it DETACHED, so on a box
+      # whose user has a sudo password there is no tty and no root — an
+      # unguarded sudo in an optional step killed the whole run BEFORE the
+      # service restart, leaving the new agent on disk and the old one serving
+      # (KI-064, observed on a real Legion Go). Drives the seed block with a
+      # sudo that cannot prompt and asserts the run continues.
+      - name: Optional steps cannot abort a no-root update
+        run: bash tests/test_update_no_root.sh install.sh
+
       # The release scripts used to "self-verify" a signature against a pubkey
       # derived from the key that had just signed it — true by construction for
       # ANY key, so it could never catch the one failure it claimed to prevent.

--- a/install.sh
+++ b/install.sh
@@ -827,13 +827,39 @@ fi
 # match (or no file), no install, and the agent fetches + verifies at flash time
 # instead. Dropped root-owned at the fixed path the agent reads for Setup ->
 # Utilities flashing.
+# Can we get root at all? Computed HERE rather than at the fast-path gate below,
+# because the OPTIONAL steps between here and there must be able to ask. A
+# detached app-triggered update has no tty and, on a box whose user has a sudo
+# password, no way to become root -- and under `set -e` an unguarded sudo in an
+# optional step aborts the WHOLE update before the service is ever restarted.
+CAN_PRIVILEGE=0
+if sudo -n true 2>/dev/null; then
+    CAN_PRIVILEGE=1                       # passwordless sudo (e.g. a fresh Deck)
+elif { true < /dev/tty; } 2>/dev/null; then
+    CAN_PRIVILEGE=1                       # a terminal we can prompt on
+fi
+
 if [ -f "$WORK_DIR/$OPENPUCK_FW_NAME" ]; then
     openpuck_got="$( { command -v sha256sum >/dev/null 2>&1 \
         && sha256sum "$WORK_DIR/$OPENPUCK_FW_NAME" \
         || shasum -a 256 "$WORK_DIR/$OPENPUCK_FW_NAME"; } | cut -d' ' -f1)"
-    if [ "$openpuck_got" = "$OPENPUCK_FW_SHA256" ]; then
-        sudo install -d -m 0755 "$(dirname "$OPENPUCK_FW_DEST")"
-        sudo install -m 0644 -o root -g root "$WORK_DIR/$OPENPUCK_FW_NAME" "$OPENPUCK_FW_DEST"
+    if [ "$openpuck_got" != "$OPENPUCK_FW_SHA256" ]; then
+        note "OpenPuck firmware sha256 mismatch — skipping seed (agent fetches at flash time)."
+    elif [ "$CAN_PRIVILEGE" -eq 0 ]; then
+        # KI-064: this seed is OPTIONAL and sits BEFORE the detached-update
+        # fast-path below, so its sudo must never be able to abort the run.
+        # Under `set -e` it did exactly that -- an app-triggered update on a
+        # password-sudo box died here with "a terminal is required to read the
+        # password", leaving the new agent on disk and the OLD one still
+        # serving (observed on a Legion Go, 2026-08-16). Skipping is a
+        # SUPPORTED outcome: the agent fetches + verifies this firmware at
+        # flash time whenever the seed is absent.
+        note "no way to get root here — skipping the OpenPuck seed (agent fetches at flash time)."
+    else
+        sudo install -d -m 0755 "$(dirname "$OPENPUCK_FW_DEST")" \
+            || note "OpenPuck seed dir failed — skipping (agent fetches at flash time)."
+        sudo install -m 0644 -o root -g root "$WORK_DIR/$OPENPUCK_FW_NAME" "$OPENPUCK_FW_DEST" \
+            || note "OpenPuck seed copy failed — skipping (agent fetches at flash time)."
         # AGPL-3.0: the notice (attribution + source offer) rides beside the binary;
         # it came through the signed SHA256SUMS gate above.
         if [ -f "$WORK_DIR/OPENPUCK-NOTICE.txt" ] \
@@ -843,8 +869,6 @@ if [ -f "$WORK_DIR/$OPENPUCK_FW_NAME" ]; then
                 "$(dirname "$OPENPUCK_FW_DEST")/OPENPUCK-NOTICE.txt"
         fi
         note "installed OpenPuck firmware seed ($OPENPUCK_FW_NAME)"
-    else
-        note "OpenPuck firmware sha256 mismatch — skipping seed (agent fetches at flash time)."
     fi
 fi
 # The aerial-screensaver player is optional: install only if wanted AND it
@@ -916,12 +940,6 @@ fi
 # Decky) -- so DON'T gate on "Decky absent", which wrongly skipped exactly that
 # box. A pure Decky setup leaves couchside.service INACTIVE (the plugin runs its
 # own copy), so is-active is false there and the fast-path correctly stands down.
-CAN_PRIVILEGE=0
-if sudo -n true 2>/dev/null; then
-    CAN_PRIVILEGE=1                       # passwordless sudo (e.g. a fresh Deck)
-elif { true < /dev/tty; } 2>/dev/null; then
-    CAN_PRIVILEGE=1                       # a terminal we can prompt on
-fi
 if [ "$CAN_PRIVILEGE" -eq 0 ] && [ -s "$TOKEN_FILE" ] \
    && systemctl is-active --quiet couchside.service 2>/dev/null; then
     if sudo -n systemctl restart --no-block couchside.service 2>/dev/null; then

--- a/tests/test_update_no_root.sh
+++ b/tests/test_update_no_root.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# An OPTIONAL step must never abort an app-triggered update (KI-064).
+#
+# install.sh runs `set -euo pipefail`. The phone's update runs it DETACHED, so on
+# a box whose desktop user has a sudo password there is no tty to type it into
+# and no way to become root. An unguarded `sudo` in an OPTIONAL step therefore
+# killed the whole run BEFORE the service restart, leaving the freshly-downloaded
+# agent on disk and the OLD one still serving. Observed on a real Legion Go
+# (2026-08-16): the OpenPuck firmware seed did exactly this.
+#
+# install.sh already had the right idea one screen further down -- the
+# CAN_PRIVILEGE fast-path, whose own comment cites the same stall on a Legion Go
+# S in 2026-07-23. The seed just ran BEFORE that gate could save it.
+#
+# These pins are textual (what lands on boxes is this text), plus one executable
+# check: the seed block is driven with a `sudo` that always fails, exactly as a
+# detached no-password run sees it, and must NOT abort.
+set -u
+SRC="${1:?usage: test_update_no_root.sh /path/to/install.sh}"
+fails=0
+check() { if [ "$2" -eq 0 ]; then echo "  PASS  $1"; else echo "  FAIL  $1"; fails=$((fails+1)); fi; }
+
+echo "the privilege probe is available to the optional steps"
+# The probe must be computed BEFORE the first optional sudo, not at the
+# fast-path gate -- that ordering is the whole bug.
+probe_line=$(grep -n '^CAN_PRIVILEGE=0' "$SRC" | head -1 | cut -d: -f1)
+seed_line=$(grep -n 'sudo install .*OPENPUCK_FW_DEST' "$SRC" | head -1 | cut -d: -f1)
+[ -n "$probe_line" ]; check "CAN_PRIVILEGE probe exists" $?
+[ -n "$probe_line" ] && [ -n "$seed_line" ] && [ "$probe_line" -lt "$seed_line" ]
+check "probe is computed BEFORE the optional seed (probe=$probe_line seed=$seed_line)" $?
+
+echo "the optional seed cannot abort the run"
+grep -q 'skipping the OpenPuck seed' "$SRC"
+check "seed skips (with a note) when root is unavailable" $?
+# Every sudo in the seed block must be non-fatal: gated on CAN_PRIVILEGE and
+# carrying its own || fallback.
+seed_block=$(awk '/^if \[ -f "\$WORK_DIR\/\$OPENPUCK_FW_NAME" \]; then/,/^fi$/' "$SRC")
+bare=$(printf '%s\n' "$seed_block" | grep -c 'sudo install' || true)
+guarded=$(printf '%s\n' "$seed_block" | grep -A1 'sudo install' | grep -c '|| note' || true)
+[ "$bare" -gt 0 ] && [ "$guarded" -ge 2 ]
+check "each sudo install in the seed has a || note fallback ($guarded/$bare)" $?
+
+echo "executable check: a sudo that cannot prompt must not kill the run"
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/bin"
+# Exactly what a detached run sees from a password-sudo box.
+cat > "$tmp/bin/sudo" <<'EOF'
+#!/bin/sh
+if [ "$1" = "-n" ] && [ "$2" = "true" ]; then exit 1; fi
+echo "sudo: a terminal is required to read the password" >&2
+echo "sudo: a password is required" >&2
+exit 1
+EOF
+chmod +x "$tmp/bin/sudo"
+# Drive ONLY the seed block, with the same strictness install.sh runs under.
+{
+  echo 'set -euo pipefail'
+  echo 'note() { echo "    $*"; }'
+  echo "OPENPUCK_FW_NAME=fw.uf2"
+  echo "OPENPUCK_FW_DEST=$tmp/dest/fw.uf2"
+  echo "WORK_DIR=$tmp/work"
+  # Make the sha match so we reach the sudo path rather than the mismatch note.
+  echo "OPENPUCK_FW_SHA256=\$( { command -v sha256sum >/dev/null 2>&1 && sha256sum $tmp/work/fw.uf2 || shasum -a 256 $tmp/work/fw.uf2; } | cut -d' ' -f1)"
+  awk '/^# Can we get root at all\?/,/^fi$/' "$SRC" | head -14   # the probe
+  awk '/^if \[ -f "\$WORK_DIR\/\$OPENPUCK_FW_NAME" \]; then/,/^fi$/' "$SRC"
+  echo 'echo REACHED_END'
+} > "$tmp/drive.sh"
+mkdir -p "$tmp/work"; echo firmware > "$tmp/work/fw.uf2"
+out="$(PATH="$tmp/bin:$PATH" bash "$tmp/drive.sh" 2>&1)"; rc=$?
+printf '%s\n' "$out" | grep -q REACHED_END
+check "the run CONTINUES past an unanswerable sudo (rc=$rc)" $?
+printf '%s\n' "$out" | grep -q 'skipping the OpenPuck seed'
+check "and says why, instead of failing silently" $?
+rm -rf "$tmp"
+
+echo
+if [ "$fails" -gt 0 ]; then echo "FAILED: $fails"; exit 1; fi
+echo "all no-root update pins passed"


### PR DESCRIPTION
## Found on hardware

Taking the 2.9.92 update on the Legion Go **through the app's own path** (`POST /api/update/apply`):

```
==> Installing daemon to /home/deck/.local/opt/couchside
sudo: a terminal is required to read the password
sudo: a password is required
```

`install.sh` runs `set -euo pipefail`, and the phone runs it **detached** — so on a box whose desktop user has a sudo password there's no tty and no root. The **optional** OpenPuck firmware seed called `sudo install` unguarded, so the run died there: *after* the signed agent was fetched, verified and written to disk, and *before* the service restart.

The box kept serving 2.9.91 with 2.9.92 sitting on disk.

## install.sh already knew about this

One screen further down is the `CAN_PRIVILEGE` fast-path, whose own comment cites **this exact stall on a Legion Go S in 2026-07-23** and restarts via the NOPASSWD grant instead. The seed just ran *before* the gate that would have saved it.

**Fix:** hoist the privilege probe above the optional steps and gate the seed on it, rather than duplicating the logic. Skipping is a *supported* outcome — the block's own comment says the agent fetches and verifies this firmware at flash time when the seed is absent — so it now notes and continues. Both `sudo` calls also carry `|| note` so a failure for any other reason can't abort an update either.

**An optional add-on must not be able to stop an agent update.**

## Blast radius, measured

A sudo password is the *recommended* posture, not an edge case:

| Box | sudo | |
|---|---|---|
| bazzite | passwordless | unaffected |
| steam-machine | needs password | **exposed** |
| Legion Go | needs password | **exposed** (where this was found) |

## Not introduced by 2.9.92

install.sh's execution path was verified byte-identical to the previously released one before publishing. This is the OpenPuck seeding path (2.9.77 era) and would have failed identically on any earlier app-triggered update.

## Test

`tests/test_update_no_root.sh` drives the seed block under `set -euo pipefail` with a sudo stub emitting the real *"a terminal is required"* failure.

**Control:** against the pre-fix shape the run **aborts (rc=1)** and says nothing; with the fix it continues and explains. Also pins that the probe is computed *before* the seed — that ordering is the bug.

install.sh only; agent VERSION unchanged at 2.9.92. Suite **85/85**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)