### PR TITLE
fix(agent): control the Legion Go S thumbstick-ring RGB (2.9.93)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.93
+
+**Legion Go S thumbstick lighting now works from the app.** The Go S drives its
+joystick-ring RGB through a special mode that turns the lights OFF the instant any
+setting is written — so the app would "set a colour" and the rings would just stay
+dark. The box now speaks that driver's language: pick a colour and brightness from
+the Light card and the rings actually light up, and stay lit across reboots. (Effect
+buttons show as a solid colour on the rings for now — the driver's own animations
+aren't safely controllable yet.) Other boxes are unaffected.
+
 ## 2.9.92
 
 **Your game lists stop re-reading a big file every time you look at them.** The box

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.92"
+VERSION = "2.9.93"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4400,10 +4400,23 @@ def _read_led_raw(name):
     color = _led_color_from_intensity(mi, index, maxint, maxb) if rgb else None
     writable = _led_access_w(name, "brightness") and (
         (not rgb) or _led_access_w(name, "multi_intensity"))
+    # Some HID RGB drivers gate output behind an `enabled` flag AND flip it back to
+    # false whenever any OTHER attr is written -- the Lenovo Legion Go S thumbstick
+    # rings (node `go_s:rgb:joystick_rings`, driver hid_lenovo_go_s) do exactly this,
+    # so a colour write "succeeds" yet the rings stay dark. Such a node also carries a
+    # `mode` (custom = manual colour, dynamic = firmware effect) -- REQUIRED here so a
+    # valve-leds strip node (which also has `enabled` but no `mode`) is NOT mistaken
+    # for one. When gated: set mode first + re-assert `enabled` LAST. `enable_on` is
+    # the truthy token the device itself lists in enabled_index (looked up, not
+    # trusted); None on every ordinary LED, so the gated path is dead code for them.
+    enable_on = None
+    if _led_access_w(name, "mode") and _led_access_w(name, "enabled"):
+        toks = (_led_read_attr(name, "enabled_index") or "").split()
+        enable_on = next((t for t in toks if t.lower() in ("true", "1", "on", "enabled")), None)
     return {"name": name, "desc": name, "rgb": rgb,
             "notable": _led_notable(name, rgb), "writable": writable,
             "max_brightness": maxb, "brightness": cur, "index": index,
-            "maxint": maxint, "color": color}
+            "maxint": maxint, "color": color, "enable_on": enable_on}
 
 
 def _led_public(raw):
@@ -4486,9 +4499,10 @@ def _led_realpath_ok(name):
 def _led_write(name, attr, value):
     """Write to the FIXED-literal attribute `attr` of LED `name`. attr is NEVER
     client input -- the only literals ever passed are 'brightness',
-    'multi_intensity', 'trigger' (set_led) and 'effect', 'enabled', 'delay'
-    (the valve-leds hardware-effect strip path). The effect VALUE is validated
-    against the device's own effect_index before it reaches here."""
+    'multi_intensity', 'trigger' (set_led), 'effect', 'enabled', 'delay'
+    (the valve-leds hardware-effect strip path), and 'mode' (fixed 'custom') +
+    'enabled' (the truthy token the device lists) for the gated Lenovo go_s rings.
+    The effect VALUE is validated against the device's own effect_index first."""
     with open(os.path.join(_LEDS_ROOT, name, attr), "w") as f:
         f.write(value)
 
@@ -4551,6 +4565,14 @@ def set_led(name, brightness, color):
                 _led_write(name, "effect", "manual")
             except OSError:
                 pass
+        if raw.get("enable_on"):
+            # Gated go_s rings: manual colour only shows in mode=custom (dynamic runs
+            # the firmware effect and ignores multi_intensity). Set it BEFORE the
+            # colour; `enabled` is re-asserted last below.
+            try:
+                _led_write(name, "mode", "custom")
+            except OSError:
+                pass
         if color is not None:
             _led_write_color(name, raw, color)
         if brightness is not None:
@@ -4559,6 +4581,13 @@ def set_led(name, brightness, color):
             # OFF. int(x + 0.5) sends the midpoint to ON.
             _led_write(name, "brightness",
                        str(int(brightness / 100 * raw["max_brightness"] + 0.5)))
+        if raw.get("enable_on"):
+            # LAST: every attr write above flips this driver's `enabled` back to
+            # false, so re-assert it or the rings stay dark (the whole bug).
+            try:
+                _led_write(name, "enabled", raw["enable_on"])
+            except OSError:
+                pass
     except OSError as e:
         return {"ok": False, "status": 500,
                 "error": (str(e) or "led write failed")}
@@ -4822,6 +4851,10 @@ def apply_led_effect(name, effect, color, speed, brightness):
         params["color"] = raw["color"] or (
             {"r": 255, "g": 0, "b": 0} if effect == "scanner"
             else {"r": 255, "g": 255, "b": 255})
+    if raw.get("enable_on"):
+        # Gated go_s rings can't be driven by the software frame writer (every tick
+        # would flip `enabled` off) -- use the firmware's own effect instead.
+        return _apply_gated_effect(name, raw, effect, params)
     _fx_start(name, raw, effect, params)
     with _FX_LOCK:
         _LED_PERSIST[name] = dict(params, effect=effect)
@@ -4829,6 +4862,23 @@ def apply_led_effect(name, effect, color, speed, brightness):
     return {"ok": True, "led": name,
             "active": {"effect": effect, "color": params["color"],
                        "speed": params["speed"], "brightness": params["brightness"]}}
+
+
+def _apply_gated_effect(name, raw, effect, params):
+    """Animated effect on a gated HID LED (Lenovo go_s rings). Two dead ends here:
+    the software frame writer can't drive it (every tick flips `enabled` off), and
+    forcing the firmware's OWN animation is UNSAFE -- writing `mode=dynamic` to the
+    hid_lenovo_go_s driver BLOCKS FOREVER (measured on real hardware; it hung a
+    request thread and took the agent down). So an effect just shows its colour as a
+    STATIC light via the reliable mode=custom path -- the rings light instead of
+    going dark or hanging. (A future software renderer could re-arm `enabled` per
+    frame in custom mode, but that is not this.)"""
+    res = set_led(name, params["brightness"], params["color"])
+    if not res or not res.get("ok"):
+        return res if res else None
+    _fx_note_static(name, res)
+    return {"ok": True, "active": None, "led": name,
+            "brightness_pct": res.get("brightness_pct"), "color": res.get("color")}
 
 
 def _validate_effect_body(req):

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -52,6 +52,13 @@ _FAKE = {
         "notable": True, "writable": False, "max_brightness": 255,
         "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
         "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}},
+    # A GATED HID RGB LED (Lenovo Legion Go S thumbstick rings): `enable_on` set ->
+    # the mode=custom-first / enabled-last sequencing path.
+    "go_s:rgb:joystick_rings": {"name": "go_s:rgb:joystick_rings",
+        "desc": "go_s:rgb:joystick_rings", "rgb": True, "notable": True,
+        "writable": True, "max_brightness": 100, "index": ["red", "green", "blue"],
+        "maxint": [100, 100, 100], "brightness": 100, "color": {"r": 0, "g": 0, "b": 0},
+        "enable_on": "true"},
 }
 
 
@@ -236,6 +243,60 @@ def test_persistence_restore_revalidates():
         restore()
 
 
+def test_gated_go_s_led():
+    print("gated go_s rings: mode=custom first, enabled LAST; effects fall back to solid")
+    G = "go_s:rgb:joystick_rings"
+    writes = []
+    restore = _install_fake(writes)
+    try:
+        # SOLID colour: mode=custom BEFORE the colour, enabled=true is the LAST write
+        writes.clear()
+        res = cs.set_led(G, 80, {"r": 255, "g": 0, "b": 0})
+        check(res and res.get("ok"), "gated set_led accepted")
+        gw = [w for w in writes if w[0] == G]
+        attrs = [w[1] for w in gw]
+        check((G, "mode", "custom") in writes, "mode set to custom")
+        check("mode" in attrs and "multi_intensity" in attrs
+              and attrs.index("mode") < attrs.index("multi_intensity"),
+              "mode=custom written before the colour")
+        check(attrs and attrs[-1] == "enabled" and gw[-1] == (G, "enabled", "true"),
+              "enabled=true is the LAST write")
+
+        # NEVER write mode=dynamic: that write BLOCKS FOREVER on the real driver.
+        check(not any(w == (G, "mode", "dynamic") for w in writes),
+              "solid path never writes the unsafe mode=dynamic")
+
+        # ANY animated effect -> static-colour fallback (mode=custom, enabled last),
+        # NOT the firmware-effect route and NOT the software render thread.
+        for eff, col in (("rainbow", None), ("pulse", {"r": 0, "g": 255, "b": 0})):
+            _reset_engine()
+            writes.clear()
+            res = cs.apply_led_effect(G, eff, col, 60, 100)
+            check(res and res.get("ok") and res.get("active") is None,
+                  "gated %s falls back to a solid (no live effect)" % eff)
+            check((G, "mode", "custom") in writes
+                  and not any(w == (G, "mode", "dynamic") for w in writes)
+                  and not any(w[1] == "effect" for w in writes if w[0] == G),
+                  "%s -> mode=custom only, no effect / no mode=dynamic write" % eff)
+            check([w[1] for w in writes if w[0] == G][-1] == "enabled",
+                  "%s fallback arms enabled LAST" % eff)
+            check(G not in cs._FX_ACTIVE, "%s does not start the render thread" % eff)
+    finally:
+        restore()
+
+
+def test_normal_led_not_gated():
+    print("a plain LED is untouched by the gated path (no mode/enabled writes)")
+    writes = []
+    restore = _install_fake(writes)
+    try:
+        cs.set_led("multicolor:front", 50, {"r": 10, "g": 20, "b": 30})
+        check(not any(w[1] in ("mode", "enabled") for w in writes),
+              "no mode/enabled written for a plain LED")
+    finally:
+        restore()
+
+
 def test_mock_effect_observable():
     print("mock: selecting an effect moves GET /api/leds `active` (observe both)")
     saved = dict(cs._MOCK_FX)
@@ -262,6 +323,8 @@ if __name__ == "__main__":
     test_allowlist_effect()
     test_animate_then_solid_lifecycle()
     test_persistence_restore_revalidates()
+    test_gated_go_s_led()
+    test_normal_led_not_gated()
     test_mock_effect_observable()
     print()
     if _fail:


### PR DESCRIPTION
## The bug

The Legion Go S drives its joystick-ring RGB through the `hid_lenovo_go_s` driver. Its `go_s:rgb:joystick_rings` node gates output behind an `enabled` flag **and flips it back to false whenever any other attr is written** — so the agent would set a colour and *silently disable the LED*, leaving the rings dark. The app "worked" (200 OK) but nothing lit.

## The fix

Detect this gated node — it exposes **both** `enabled` **and** `mode` (a valve-leds strip node has `enabled` but no `mode`, so it's not mistaken for one). For a gated node:
- write `mode=custom` **before** the colour (manual colour only shows in custom mode), and
- re-assert `enabled` **last**, after every colour/brightness write.

Effects fall back to a **static colour** on these rings. The firmware-effect route (`mode=dynamic`) is **deliberately not used**: writing `mode=dynamic` to this driver **blocks forever** — measured on real hardware, it hung a request thread and took the agent down. The code never writes it, and a test asserts that.

## Allowlist (§3)

Only fixed-literal attrs: `mode` is a fixed `'custom'`; `enabled` is the truthy token the device itself lists in `enabled_index` (looked up, not trusted). Gated behaviour triggers only when a node has both `enabled` and `mode`, so valve-leds strips and every ordinary LED are untouched.

## Verified

- **Real Legion Go S (10.1.1.195):** solid colour via `/api/leds/set` lights the rings (`enabled=true, mode=custom`, correct `multi_intensity`); an effect via `/api/leds/effect` falls back to solid and the agent stays alive (no hang).
- **Unit tests:** mode-first / enabled-last ordering, solid fallback, `mode=dynamic` is **never** written, plain LED unaffected. `test_led_effects` + `test_led_strip` + `test_led_control` + `test_protocol_parity` green.

Agent 2.9.93; unreleased (rides the next agent release alongside 2.9.92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)