### PR TITLE
docs(changelog): bundle 2.9.92 note into 2.9.93 release notes

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -28,6 +28,10 @@ the Light card and the rings actually light up, and stay lit across reboots. (Ef
 buttons show as a solid colour on the rings for now — the driver's own animations
 aren't safely controllable yet.) Other boxes are unaffected.
 
+Also in this update: switching between your game lists (Steam Link and your
+uninstalled-games list) is quicker — the box no longer re-reads a multi-megabyte
+Steam file each time — plus a small pairing-robustness fix.
+
 ## 2.9.92
 
 **Your game lists stop re-reading a big file every time you look at them.** The box


### PR DESCRIPTION
Boxes on 2.9.91 (current served) jump to 2.9.93, so they also get 2.9.92. Adds a brief line to the 2.9.93 section so the published "What's new" covers everything a skipping box receives (per the changelog rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)