### PR TITLE
fix(agent): Go S rings — effect=monocolor for solid + firmware effects (2.9.94)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,17 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.94
+
+**Legion Go S thumbstick lighting — colours and effects that actually stick.** The
+rings run whatever their firmware is set to, so just sending a colour left them
+spinning their factory rainbow. The box now switches them to a solid colour when you
+pick one, and can also run their built-in **rainbow** and **breathe** effects — all
+from the Light card, and it survives a reboot. (This finishes the half-done fix in
+2.9.93, which lit the rings but left the rainbow running.) Also included for boxes
+coming from an older version: quicker game-list switching and a pairing fix. Other
+boxes are unaffected.
+
 ## 2.9.93
 
 **Legion Go S thumbstick lighting now works from the app.** The Go S drives its

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -48,7 +48,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.93"
+VERSION = "2.9.94"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -4403,20 +4403,25 @@ def _read_led_raw(name):
     # Some HID RGB drivers gate output behind an `enabled` flag AND flip it back to
     # false whenever any OTHER attr is written -- the Lenovo Legion Go S thumbstick
     # rings (node `go_s:rgb:joystick_rings`, driver hid_lenovo_go_s) do exactly this,
-    # so a colour write "succeeds" yet the rings stay dark. Such a node also carries a
-    # `mode` (custom = manual colour, dynamic = firmware effect) -- REQUIRED here so a
-    # valve-leds strip node (which also has `enabled` but no `mode`) is NOT mistaken
-    # for one. When gated: set mode first + re-assert `enabled` LAST. `enable_on` is
-    # the truthy token the device itself lists in enabled_index (looked up, not
-    # trusted); None on every ordinary LED, so the gated path is dead code for them.
+    # so a colour write "succeeds" yet the rings stay dark. TWO more quirks (both
+    # confirmed on real hardware): the FIRMWARE runs whatever `effect` says --
+    # `monocolor` shows the manual colour, `rainbow`/`breathe` animate -- so a solid
+    # colour needs effect=monocolor (mode=custom alone leaves the last effect running);
+    # and writing `mode=dynamic` BLOCKS FOREVER, so we never do. Requiring `mode`
+    # (which a valve-leds strip node lacks despite having `enabled`) keeps a strip from
+    # being mistaken for one. `enable_on` is the truthy token the device lists in
+    # enabled_index (looked up, not trusted) -- None on every ordinary LED, so the gated
+    # path is dead code for them; `dev_effects` is the firmware effect allowlist.
     enable_on = None
     if _led_access_w(name, "mode") and _led_access_w(name, "enabled"):
         toks = (_led_read_attr(name, "enabled_index") or "").split()
         enable_on = next((t for t in toks if t.lower() in ("true", "1", "on", "enabled")), None)
+    dev_effects = tuple((_led_read_attr(name, "effect_index") or "").split()) if enable_on else ()
     return {"name": name, "desc": name, "rgb": rgb,
             "notable": _led_notable(name, rgb), "writable": writable,
             "max_brightness": maxb, "brightness": cur, "index": index,
-            "maxint": maxint, "color": color, "enable_on": enable_on}
+            "maxint": maxint, "color": color,
+            "enable_on": enable_on, "dev_effects": dev_effects}
 
 
 def _led_public(raw):
@@ -4566,11 +4571,14 @@ def set_led(name, brightness, color):
             except OSError:
                 pass
         if raw.get("enable_on"):
-            # Gated go_s rings: manual colour only shows in mode=custom (dynamic runs
-            # the firmware effect and ignores multi_intensity). Set it BEFORE the
-            # colour; `enabled` is re-asserted last below.
+            # Gated go_s rings: the firmware runs `effect`, so a SOLID colour needs
+            # effect=monocolor -- otherwise the last animation (e.g. the factory
+            # rainbow spin) keeps running and ignores the colour. Set mode=custom +
+            # effect=monocolor BEFORE the colour; `enabled` is re-asserted last below.
             try:
                 _led_write(name, "mode", "custom")
+                if "monocolor" in (raw.get("dev_effects") or ()):
+                    _led_write(name, "effect", "monocolor")
             except OSError:
                 pass
         if color is not None:
@@ -4864,21 +4872,48 @@ def apply_led_effect(name, effect, color, speed, brightness):
                        "speed": params["speed"], "brightness": params["brightness"]}}
 
 
+# Map an app effect id -> the go_s firmware effect that best matches it. The software
+# frame writer can't drive these rings (every tick flips `enabled` off), so the
+# FIRMWARE animates instead -- driven by the `effect` attr, NOT `mode=dynamic` (that
+# write BLOCKS FOREVER on hid_lenovo_go_s; never issued). A value not mapped here (or
+# not in the device's own effect_index) falls back to a solid colour via set_led.
+_GO_S_FX = {"rainbow": "rainbow", "breathe": "breathe",
+            "pulse": "breathe", "strobe": "breathe"}
+
+
 def _apply_gated_effect(name, raw, effect, params):
-    """Animated effect on a gated HID LED (Lenovo go_s rings). Two dead ends here:
-    the software frame writer can't drive it (every tick flips `enabled` off), and
-    forcing the firmware's OWN animation is UNSAFE -- writing `mode=dynamic` to the
-    hid_lenovo_go_s driver BLOCKS FOREVER (measured on real hardware; it hung a
-    request thread and took the agent down). So an effect just shows its colour as a
-    STATIC light via the reliable mode=custom path -- the rings light instead of
-    going dark or hanging. (A future software renderer could re-arm `enabled` per
-    frame in custom mode, but that is not this.)"""
-    res = set_led(name, params["brightness"], params["color"])
-    if not res or not res.get("ok"):
-        return res if res else None
-    _fx_note_static(name, res)
-    return {"ok": True, "active": None, "led": name,
-            "brightness_pct": res.get("brightness_pct"), "color": res.get("color")}
+    """Animated effect on a gated HID LED (Lenovo go_s rings). Route to the DEVICE's
+    own firmware effect via the `effect` attr when it lists a matching name (looked up
+    in effect_index, §3) -- it animates in hardware, no per-frame `enabled` re-arming
+    and no `mode=dynamic` (that hangs the driver). breathe carries the chosen colour;
+    rainbow ignores it. An effect the firmware has no analogue for (scanner) shows the
+    colour statically via set_led. Persisted -> re-armed on reboot."""
+    dev = raw.get("dev_effects") or ()
+    fw = _GO_S_FX.get(effect)
+    if not fw or fw not in dev:
+        # no firmware analogue -> solid colour (set_led writes effect=monocolor)
+        res = set_led(name, params["brightness"], params["color"])
+        if not res or not res.get("ok"):
+            return res if res else None
+        _fx_note_static(name, res)
+        return {"ok": True, "active": None, "led": name,
+                "brightness_pct": res.get("brightness_pct"), "color": res.get("color")}
+    b = str(int(params["brightness"] / 100 * raw["max_brightness"] + 0.5))
+    try:
+        _led_write(name, "mode", "custom")   # only writable mode; dynamic hangs
+        _led_write(name, "effect", fw)       # looked up in the device's effect_index
+        if fw == "breathe" and params["color"]:
+            _led_write_color(name, raw, params["color"])
+        _led_write(name, "brightness", b)
+        _led_write(name, "enabled", raw["enable_on"])   # LAST -- see set_led
+    except OSError as e:
+        return {"ok": False, "status": 500, "error": (str(e) or "led write failed")}
+    with _FX_LOCK:
+        _LED_PERSIST[name] = dict(params, effect=effect)
+    _led_state_save()
+    return {"ok": True, "led": name,
+            "active": {"effect": effect, "color": params["color"],
+                       "speed": params["speed"], "brightness": params["brightness"]}}
 
 
 def _validate_effect_body(req):

--- a/tests/test_led_effects.py
+++ b/tests/test_led_effects.py
@@ -52,13 +52,13 @@ _FAKE = {
         "notable": True, "writable": False, "max_brightness": 255,
         "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
         "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}},
-    # A GATED HID RGB LED (Lenovo Legion Go S thumbstick rings): `enable_on` set ->
-    # the mode=custom-first / enabled-last sequencing path.
+    # A GATED HID RGB LED (Lenovo Legion Go S thumbstick rings): `enable_on` set +
+    # a firmware `dev_effects` list -> the effect=monocolor / enabled-last path.
     "go_s:rgb:joystick_rings": {"name": "go_s:rgb:joystick_rings",
         "desc": "go_s:rgb:joystick_rings", "rgb": True, "notable": True,
         "writable": True, "max_brightness": 100, "index": ["red", "green", "blue"],
         "maxint": [100, 100, 100], "brightness": 100, "color": {"r": 0, "g": 0, "b": 0},
-        "enable_on": "true"},
+        "enable_on": "true", "dev_effects": ("monocolor", "breathe", "chroma", "rainbow")},
 }
 
 
@@ -244,43 +244,55 @@ def test_persistence_restore_revalidates():
 
 
 def test_gated_go_s_led():
-    print("gated go_s rings: mode=custom first, enabled LAST; effects fall back to solid")
+    print("gated go_s rings: effect=monocolor for solid, firmware effect for rainbow/breathe")
     G = "go_s:rgb:joystick_rings"
     writes = []
     restore = _install_fake(writes)
     try:
-        # SOLID colour: mode=custom BEFORE the colour, enabled=true is the LAST write
+        # SOLID colour: mode=custom + effect=monocolor BEFORE the colour (or the
+        # factory rainbow keeps running), enabled=true is the LAST write.
         writes.clear()
         res = cs.set_led(G, 80, {"r": 255, "g": 0, "b": 0})
         check(res and res.get("ok"), "gated set_led accepted")
         gw = [w for w in writes if w[0] == G]
         attrs = [w[1] for w in gw]
-        check((G, "mode", "custom") in writes, "mode set to custom")
-        check("mode" in attrs and "multi_intensity" in attrs
-              and attrs.index("mode") < attrs.index("multi_intensity"),
-              "mode=custom written before the colour")
-        check(attrs and attrs[-1] == "enabled" and gw[-1] == (G, "enabled", "true"),
-              "enabled=true is the LAST write")
-
-        # NEVER write mode=dynamic: that write BLOCKS FOREVER on the real driver.
+        check((G, "effect", "monocolor") in writes, "solid writes effect=monocolor")
+        check("effect" in attrs and "multi_intensity" in attrs
+              and attrs.index("effect") < attrs.index("multi_intensity"),
+              "effect=monocolor written before the colour")
+        check(gw and gw[-1] == (G, "enabled", "true"), "enabled=true is the LAST write")
         check(not any(w == (G, "mode", "dynamic") for w in writes),
-              "solid path never writes the unsafe mode=dynamic")
+              "solid never writes the unsafe mode=dynamic")
 
-        # ANY animated effect -> static-colour fallback (mode=custom, enabled last),
-        # NOT the firmware-effect route and NOT the software render thread.
-        for eff, col in (("rainbow", None), ("pulse", {"r": 0, "g": 255, "b": 0})):
+        # FIRMWARE effects: rainbow / breathe drive the device's own `effect` (looked
+        # up in effect_index), NOT the software render thread, NOT mode=dynamic.
+        for eff, fw, wants_color in (("rainbow", "rainbow", False),
+                                     ("breathe", "breathe", True),
+                                     ("pulse", "breathe", True)):
             _reset_engine()
             writes.clear()
-            res = cs.apply_led_effect(G, eff, col, 60, 100)
-            check(res and res.get("ok") and res.get("active") is None,
-                  "gated %s falls back to a solid (no live effect)" % eff)
-            check((G, "mode", "custom") in writes
-                  and not any(w == (G, "mode", "dynamic") for w in writes)
-                  and not any(w[1] == "effect" for w in writes if w[0] == G),
-                  "%s -> mode=custom only, no effect / no mode=dynamic write" % eff)
+            res = cs.apply_led_effect(G, eff, {"r": 0, "g": 255, "b": 0}, 60, 100)
+            check(res and res.get("ok") and res["active"]["effect"] == eff,
+                  "gated %s accepted as a live effect" % eff)
+            check((G, "effect", fw) in writes,
+                  "%s -> firmware effect=%s (looked up in effect_index)" % (eff, fw))
+            check(not any(w == (G, "mode", "dynamic") for w in writes),
+                  "%s never writes mode=dynamic" % eff)
+            check(any(w[0] == G and w[1] == "multi_intensity" for w in writes) == wants_color,
+                  "%s writes a colour only when it uses one" % eff)
             check([w[1] for w in writes if w[0] == G][-1] == "enabled",
-                  "%s fallback arms enabled LAST" % eff)
-            check(G not in cs._FX_ACTIVE, "%s does not start the render thread" % eff)
+                  "%s arms enabled LAST" % eff)
+            check(G not in cs._FX_ACTIVE, "%s does not start the software render thread" % eff)
+
+        # No firmware analogue (scanner) -> solid colour via effect=monocolor
+        _reset_engine()
+        writes.clear()
+        res = cs.apply_led_effect(G, "scanner", {"r": 255, "g": 0, "b": 0}, 50, 90)
+        check(res and res.get("ok") and res.get("active") is None,
+              "gated scanner falls back to a solid")
+        check((G, "effect", "monocolor") in writes
+              and not any(w in ((G, "effect", "rainbow"), (G, "effect", "breathe")) for w in writes),
+              "scanner -> effect=monocolor, not a firmware animation")
     finally:
         restore()
 


### PR DESCRIPTION
Corrects 2.9.93, which lit the rings but left them spinning the factory rainbow.

## What was wrong

The `hid_lenovo_go_s` firmware runs whatever the `effect` attr says. 2.9.93 wrote `mode=custom` + a colour but left `effect=rainbow`, so the rings kept spinning and **ignored the colour**. I'd verified the sysfs *write*, not the physical *light* — the evidence-rule miss this repo explicitly warns about.

## The corrected mechanism (all confirmed on the real Go S)

- **Solid colour** → write `effect=monocolor` before the colour (`set_led`).
- **Ring effects** → route `rainbow`/`breathe`/`pulse` to the device's own firmware effect via the `effect` attr (value looked up in `effect_index`, §3). Rainbow spins; breathe pulses the chosen colour. No analogue (scanner) → solid.
- `mode=dynamic` is still **never** written (it blocks the driver forever); `enabled` is still re-asserted **last**.

## Verified — through the agent, watching the physical rings

On 10.1.1.195, the owner confirmed each: **solid green ✓, spinning rainbow ✓, breathing blue ✓**. Agent stays alive on every path.

Unit tests assert `effect=monocolor` for solid, the firmware-effect route for rainbow/breathe (colour written only when the effect uses one), scanner→solid, `mode=dynamic` never written, plain LED untouched. `test_led_effects` + `test_led_strip` + `test_led_control` + `test_protocol_parity` green.

Agent 2.9.94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)