### PR TITLE
Watch build-out: streaming remote for the Player (experimental, opt-in)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,6 +552,12 @@ jobs:
       - name: Unit tests (player tile)
         run: python3 tests/test_player_tile.py
 
+      # Free-URL tier (§5 tier 3): the agent urllib validator, the opt-in flag
+      # that ships OFF, and the tile scheme backstop. The allowlist proof for
+      # "a client makes the box browser open an arbitrary page".
+      - name: Unit tests (player free-URL tier)
+        run: python3 tests/test_player_open_url.py
+
       # Player routes. Drives a real Handler on loopback with STUB steam /
       # steamos-add-to-steam binaries that log every call, so "refused" and
       # "nothing ran" are two separate observations -- a test that only checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -568,6 +568,15 @@ jobs:
       - name: Unit tests (key chords)
         run: python3 tests/test_key_chords.py
 
+      # Spatial focus navigation (navup/navdown) — the d-pad's vertical step.
+      # These run agent-authored JS in the box's browser, so the guard that
+      # matters is that the op id only ever INDEXES a frozen script table, that
+      # the scripts carry no format placeholder a later edit could fill from a
+      # request, and that an unreachable browser is an error rather than a
+      # pretend success.
+      - name: Unit tests (player spatial nav)
+        run: python3 tests/test_player_nav.py
+
       # Player routes. Drives a real Handler on loopback with STUB steam /
       # steamos-add-to-steam binaries that log every call, so "refused" and
       # "nothing ran" are two separate observations -- a test that only checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,6 +558,16 @@ jobs:
       - name: Unit tests (player free-URL tier)
         run: python3 tests/test_player_open_url.py
 
+      # Named key chords on {t:'k'} — the Shift+Tab the Watch d-pad needs to
+      # walk a web page's focus ring backwards (netflix.com and youtube.com
+      # ignore arrow keys entirely). Pins that an unknown key NAME is refused
+      # rather than pattern-matched, that a non-string name cannot escape the
+      # caller's ValueError handling and kill the session, and that the hello
+      # frame advertises exactly the names the decoder accepts — the field a
+      # newer app relies on to avoid firing an unknown key at an older agent.
+      - name: Unit tests (key chords)
+        run: python3 tests/test_key_chords.py
+
       # Player routes. Drives a real Handler on loopback with STUB steam /
       # steamos-add-to-steam binaries that log every call, so "refused" and
       # "nothing ran" are two separate observations -- a test that only checked

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,17 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.95
+
+**Move around a streaming site from the couch.** The Watch screen's new on-screen
+d-pad can now step **backwards** through a page as well as forwards, so you can move
+between tiles on Netflix, YouTube and the rest without reaching for the trackpad.
+(Those sites navigate by focus ring rather than arrow keys — the box now speaks that
+too.) Also hardens the keyboard channel: a malformed key from a client is refused
+cleanly instead of dropping the remote's connection. Boxes coming from an older
+version also get the Legion Go S thumbstick lighting fixes, quicker game-list
+switching and a pairing fix; other boxes are unaffected.
+
 ## 2.9.94
 
 **Legion Go S thumbstick lighting — colours and effects that actually stick.** The

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -20,14 +20,16 @@ deciding whether to press "Update now" on a machine across the room.
 
 ## 2.9.95
 
-**Move around a streaming site from the couch.** The Watch screen's new on-screen
-d-pad can now step **backwards** through a page as well as forwards, so you can move
-between tiles on Netflix, YouTube and the rest without reaching for the trackpad.
-(Those sites navigate by focus ring rather than arrow keys — the box now speaks that
-too.) Also hardens the keyboard channel: a malformed key from a client is refused
-cleanly instead of dropping the remote's connection. Boxes coming from an older
-version also get the Legion Go S thumbstick lighting fixes, quicker game-list
-switching and a pairing fix; other boxes are unaffected.
+**Move around a streaming site from the couch.** The Watch screen's swipe pad now
+moves between tiles in **all four directions** on Netflix, YouTube and the rest —
+including in Game Mode, where the old key-based approach used to pop Steam's side
+menu instead of moving. Pages also open **properly sized for a TV** now (zoomed for
+the couch, adjustable from the app), and every service's home page is navigable —
+including the ones that used to ignore the pad entirely. Also hardens the keyboard
+channel: a malformed key from a client is refused cleanly instead of dropping the
+remote's connection. Boxes coming from an older version also get the Legion Go S
+thumbstick lighting fixes, quicker game-list switching and a pairing fix; other
+boxes are unaffected.
 
 ## 2.9.94
 

--- a/agent/couchside-player.sh
+++ b/agent/couchside-player.sh
@@ -39,9 +39,11 @@ LOG="$CACHE_DIR/player.log"
 # everything in it is treated as untrusted input: an id that is not a case arm
 # below exits non-zero and launches NOTHING.
 #
-# Adding a service means adding an arm here. There is deliberately no "custom
-# URL" arm: that tier is a separate, box-side-gated feature (see
-# docs/memory/project_media-player.md §5), not something the tile grants.
+# Adding a service means adding an arm here. The service table never grants a
+# "custom URL" — that is a SEPARATE, box-side-gated tier (project_media-player.md
+# §5 tier 3): the agent validates the raw URL with urllib and gates it behind an
+# opt-in flag, and the tile only opens what arrives in `url=`, backstopped by
+# validate_open_url() below (http/https, a host, nothing structural).
 # ---------------------------------------------------------------------------
 service_url() {
     case "$1" in
@@ -390,6 +392,7 @@ read_conf() {
     DEEP_PATH=""
     QUERY=""
     HUB=""
+    URL_RAW=""
     [ -f "$CONF" ] || return 0
     # Parse strictly: only these keys, only from `key=value` lines. Anything
     # else in the file is ignored rather than interpreted.
@@ -397,6 +400,7 @@ read_conf() {
     SERVICE=$(sed -n 's/^service=\(.*\)$/\1/p' "$CONF" | tail -1)
     DEEP_PATH=$(sed -n 's/^path=\(.*\)$/\1/p' "$CONF" | tail -1)
     QUERY=$(sed -n 's/^query=\(.*\)$/\1/p' "$CONF" | tail -1)
+    URL_RAW=$(sed -n 's/^url=\(.*\)$/\1/p' "$CONF" | tail -1)
 }
 
 # Build a SEARCH url: frozen prefix from the table + the encoded query.
@@ -448,11 +452,35 @@ build_url() {
     echo "${base%/}$path"
 }
 
+# Free-URL tier (project_media-player.md §5 tier 3) BACKSTOP. The AGENT does the
+# full urllib validation and gates the whole tier behind an opt-in flag; this is
+# defense-in-depth at the enforcement point. http/https only, a non-empty host,
+# no whitespace/control/backslash/quote. The URL only ever becomes --app=<url> to
+# the browser (an argv element) — it is NEVER handed to xdg-open/steam://openurl,
+# whose scheme re-dispatch is the actual RCE path.
+validate_open_url() {
+    local url="$1" rest host
+    case "$url" in
+        https://?*|http://?*) : ;;
+        *) log "refused: url scheme (http/https only)"; return 1 ;;
+    esac
+    case "$url" in
+        *[[:space:][:cntrl:]]*|*'\'*|*'"'*) log "refused: url whitespace/control"; return 1 ;;
+    esac
+    rest="${url#*://}"; host="${rest%%[/?#]*}"
+    [ -n "$host" ] || { log "refused: url has no host"; return 1; }
+    case "$host" in
+        *[!A-Za-z0-9.:_%[-]-]*) log "refused: url host chars"; return 1 ;;
+    esac
+    printf '%s' "$url"
+}
+
 # --- debug entry points, used by tests/test_player_tile.py -------------------
 # They exercise the real functions above; they do not reimplement them.
 case "${1:-}" in
     --print-ozone) pick_ozone; exit 0 ;;
     --print-url)   build_url "${2:-}" "${3:-}" || exit 1; exit 0 ;;
+    --print-open-url) validate_open_url "${2:-}" || exit 1; exit 0 ;;
     --print-search) build_search_url "${2:-}" "${3:-}" || exit 1; exit 0 ;;
     --print-hub)   write_hub && printf 'file://%s\n' "$HUB_FILE"; exit $? ;;
     --print-hosts) service_hosts "${2:-}" || exit 1; exit 0 ;;
@@ -489,6 +517,10 @@ if [ "${HUB:-}" = "1" ]; then
     # The hub is the tile's own page, so there is nothing to validate: it is
     # written here from the frozen table and lives inside the browser profile.
     if write_hub; then URL="file://$HUB_FILE"; else URL=""; fi
+elif [ -n "${URL_RAW:-}" ]; then
+    # Free-URL tier (§5 tier 3): the agent already validated + gated it; the tile
+    # backstops the scheme/host before opening. Wins over service/path/query.
+    URL="$(validate_open_url "$URL_RAW")" || URL=""
 elif [ -n "${QUERY:-}" ]; then
     URL="$(build_search_url "$SERVICE" "$QUERY")" || URL=""
 else

--- a/agent/couchside-player.sh
+++ b/agent/couchside-player.sh
@@ -329,10 +329,16 @@ BROWSER_KIND=""
 BROWSER_BIN=""
 
 resolve_browser() {
+    # Widevine may live under the SYSTEM flatpak tree or the USER one — the
+    # Steam Machine's polkit refuses system installs over SSH, so Chrome lands
+    # in ~/.local/share/flatpak there (first box to need this, 2026-08-17).
+    # `flatpak info` already answers for both scopes.
     if command -v flatpak >/dev/null 2>&1 \
        && flatpak info com.google.Chrome >/dev/null 2>&1 \
-       && [ -n "$(find /var/lib/flatpak/app/com.google.Chrome -name libwidevinecdm.so \
-                  -print -quit 2>/dev/null)" ]; then
+       && { [ -n "$(find /var/lib/flatpak/app/com.google.Chrome -name libwidevinecdm.so \
+                    -print -quit 2>/dev/null)" ] \
+          || [ -n "$(find "$HOME/.local/share/flatpak/app/com.google.Chrome" \
+                     -name libwidevinecdm.so -print -quit 2>/dev/null)" ]; }; then
         BROWSER_KIND="flatpak"
         BROWSER_BIN="com.google.Chrome"
         return 0

--- a/agent/couchside-player.sh
+++ b/agent/couchside-player.sh
@@ -399,6 +399,7 @@ read_conf() {
     QUERY=""
     HUB=""
     URL_RAW=""
+    UI_SCALE=""
     [ -f "$CONF" ] || return 0
     # Parse strictly: only these keys, only from `key=value` lines. Anything
     # else in the file is ignored rather than interpreted.
@@ -407,6 +408,15 @@ read_conf() {
     DEEP_PATH=$(sed -n 's/^path=\(.*\)$/\1/p' "$CONF" | tail -1)
     QUERY=$(sed -n 's/^query=\(.*\)$/\1/p' "$CONF" | tail -1)
     URL_RAW=$(sed -n 's/^url=\(.*\)$/\1/p' "$CONF" | tail -1)
+    # UI scale for --force-device-scale-factor. Written by the agent from its
+    # own display probe (4K TVs render desktop scale unusably small from the
+    # couch). LITERAL whitelist — this becomes an argv element, so anything
+    # not exactly one of these values is dropped, not passed through.
+    UI_SCALE=$(sed -n 's/^scale=\(.*\)$/\1/p' "$CONF" | tail -1)
+    case "$UI_SCALE" in
+        1|1.25|1.5|1.75|2) : ;;
+        *) UI_SCALE="" ;;
+    esac
 }
 
 # Build a SEARCH url: frozen prefix from the table + the encoded query.
@@ -597,6 +607,9 @@ CHROME_ARGS=(
     --start-fullscreen
     --app="$URL"
 )
+# Couch zoom: whitelisted in read_conf (a literal 1|1.25|1.5|1.75|2), so this
+# argv element can only ever be one of five fixed strings.
+[ -n "$UI_SCALE" ] && CHROME_ARGS+=(--force-device-scale-factor="$UI_SCALE")
 [ -n "$OZONE" ] && CHROME_ARGS=("$OZONE" "${CHROME_ARGS[@]}")
 
 if [ "$BROWSER_KIND" = "flatpak" ]; then

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -19,6 +19,7 @@ import errno
 import glob
 import hashlib
 import hmac
+import ipaddress
 import json
 import math
 import os
@@ -83,6 +84,12 @@ DEFAULT_TLS_PORT = 8788  # HTTPS listener when tls.enabled; plaintext stays on D
 #     "enabled": false,                             # default false (opt-in)
 #     "hold_ms": 1200,                              # 600..5000, default 1200
 #     "uniq": ""                                    # optional; pin to ONE pad (MAC)
+#   },
+#   "player": {                                     # optional; Couchside Player
+#     "custom_url": false                           # opt-in free-URL tier (§5);
+#                                                   # OFF by default. true lets the
+#                                                   # phone open ANY http(s) page on
+#                                                   # the box's browser (validated).
 #   }
 # }
 #
@@ -2849,16 +2856,19 @@ def _pl_conf_read():
     return service, path, query
 
 
-def _pl_conf_write(service, path, query="", hub=False):
-    """A deep-link path and a search query are mutually exclusive — the tile
-    treats a query as "open this service's search results", and writing both
-    would leave which one wins to reading order."""
+def _pl_conf_write(service, path, query="", hub=False, url=""):
+    """A deep-link path, a search query, and a free `url` are mutually exclusive
+    — the tile treats a query as "open this service's search results" and a url
+    as "open exactly this page", and writing more than one would leave which wins
+    to reading order. `url` is already validated by _pl_validate_open_url."""
     os.makedirs(os.path.dirname(PLAYER_CONF), exist_ok=True)
     with open(PLAYER_CONF, "w") as f:
         if hub:
             f.write("hub=1\n")
         f.write("service=%s\n" % service)
-        if query:
+        if url:
+            f.write("url=%s\n" % url)
+        elif query:
             f.write("query=%s\n" % query)
         elif path:
             f.write("path=%s\n" % path)
@@ -2895,6 +2905,100 @@ def _pl_validate_search(service, query):
     if PL_MOCK:
         return "https://example.invalid/%s?q=%s" % (service, len(query))
     return _pl_ask("--print-search", service, query)
+
+
+# ---------------------------------------------------------------------------
+# Free-URL tier (project_media-player.md §5, tier 3): open an ARBITRARY web page
+# on the box's player. A genuinely new primitive ("a client makes the box's
+# browser go somewhere"), so it SHIPS OFF and is gated behind a box-side config
+# flag — a default install never gains arbitrary navigation. Validation is
+# reject-never-sanitise (§3 rule 6); the URL only ever becomes an argv element to
+# the resolved browser binary (`--app=<url>`), NEVER xdg-open/steam://openurl
+# (those re-dispatch by scheme = arbitrary handler launch, the real RCE path).
+# ---------------------------------------------------------------------------
+_PL_URL_MAX = 2048
+# A small allowed port set: standard web + the LAN media servers this tier is
+# for (Plex 32400, Jellyfin 8096/8920, Home Assistant 8123, common alt-http).
+_PL_ALLOWED_PORTS = frozenset({80, 443, 8080, 8443, 8096, 8920, 8123, 32400})
+_PL_OPEN_MIN_INTERVAL_S = 2.0   # rate-limit (KI-019): a token holder can't strobe the TV
+_pl_last_open = [0.0]
+
+
+def _pl_custom_url_enabled():
+    """True only when the box owner opted into the free-URL tier
+    (config.json `"player": {"custom_url": true}`). Read FRESH from the config so
+    the edit + agent restart is the whole toggle. Degrade-closed (§3 rule 7): any
+    error, or the key absent/not exactly true, is OFF."""
+    if PL_MOCK:
+        return True
+    try:
+        with open(CONFIG_PATH) as f:
+            raw = json.load(f)
+    except (OSError, ValueError):
+        return False
+    p = raw.get("player")
+    return isinstance(p, dict) and p.get("custom_url") is True
+
+
+def _pl_host_is_lan(host):
+    """True for a loopback / RFC1918 / link-local IP, or a localhost-ish name —
+    the only hosts plain http is allowed to (the Plex/Jellyfin-on-the-LAN case)."""
+    try:
+        ip = ipaddress.ip_address(host)
+        return ip.is_loopback or ip.is_private or ip.is_link_local
+    except ValueError:
+        h = host.lower()
+        return (h == "localhost" or h.endswith(".local") or h.endswith(".lan")
+                or h.endswith(".home") or h.endswith(".internal"))
+
+
+def _pl_valid_host(host):
+    """host is a valid IP literal OR a DNS name (labels [A-Za-z0-9-], not
+    edge-hyphenated, 1..63 each, total <=253). ASCII only — IDN is rejected
+    upstream, not normalised."""
+    try:
+        ipaddress.ip_address(host)
+        return True
+    except ValueError:
+        pass
+    if not host or len(host) > 253:
+        return False
+    labels = host.split(".")
+    return all(re.fullmatch(r"(?!-)[A-Za-z0-9-]{1,63}(?<!-)", lbl) for lbl in labels)
+
+
+def _pl_validate_open_url(url):
+    """§5 tier-3 validation. Returns the URL string if allowed, else None. Reject,
+    never sanitise: https anywhere; http ONLY to a LAN host; no userinfo; a valid
+    host; a port from the small allowed set; no control chars or whitespace
+    anywhere; length-capped; ASCII-printable only (rejects IDN + control + space)."""
+    if not isinstance(url, str) or not url or len(url) > _PL_URL_MAX:
+        return None
+    # Every byte must be ASCII printable (0x21..0x7e): rejects whitespace,
+    # control bytes, and any non-ASCII (IDN) in ONE check, before parsing.
+    if any(not (0x21 <= ord(c) <= 0x7e) for c in url):
+        return None
+    try:
+        p = urlparse(url)
+    except ValueError:
+        return None
+    if p.scheme not in ("https", "http"):
+        return None
+    if p.username is not None or p.password is not None:
+        return None
+    host = p.hostname
+    if not host or not _pl_valid_host(host):
+        return None
+    lan = _pl_host_is_lan(host)
+    if p.scheme == "http" and not lan:
+        return None                                  # plaintext only on the LAN
+    try:
+        port = p.port
+    except ValueError:
+        return None
+    if port is not None and port not in _PL_ALLOWED_PORTS:
+        return None
+    return url
 
 
 def _pl_appid():
@@ -2966,6 +3070,7 @@ def player_info():
                 "service_urls": dict(_PLAYER_SERVICE_URLS),
                 "searchable": list(_PLAYER_SEARCHABLE),
                 "service_hosts": {k: list(v) for k, v in _PLAYER_SERVICE_HOSTS.items()},
+                "open_url": _pl_custom_url_enabled(),
                 "playback": player_playback(),
                 "seek_secs": list(PLAYER_SEEK_SECS)}
     service, path, query = _pl_conf_read()
@@ -2975,6 +3080,10 @@ def player_info():
             "service_urls": dict(_PLAYER_SERVICE_URLS),
             "searchable": list(_PLAYER_SEARCHABLE),
             "service_hosts": {k: list(v) for k, v in _PLAYER_SERVICE_HOSTS.items()},
+            # Free-URL tier availability (§5 tier 3): true only when the box owner
+            # set player.custom_url. Additive; an old app ignores it, a new one
+            # shows the "open any web link" field only when the box allows it.
+            "open_url": _pl_custom_url_enabled(),
             # Added field, never a shape change: null when nothing is playing
             # or the browser can't be reached, so an old app ignores it and a
             # new one hides the transport rather than showing a dead scrubber.
@@ -3021,17 +3130,40 @@ def _pl_relaunch(appid, was_running):
     threading.Thread(target=launch, daemon=True).start()
 
 
-def player_open(service, path="", query=""):
+def player_open(service, path="", query="", url=""):
     """Point the tile at an allowlisted service and launch it through Steam.
 
     With `query`, the tile opens that service's OWN search results instead —
     which is the whole of "search from the phone": nobody types a title on a TV
     with a d-pad. A query and a deep-link path are mutually exclusive.
 
-    Raises ValueError when the service/path/query is refused — the caller turns
-    that into a 404, and NOTHING is written or launched. Registration and the
-    fresh-registration double-fire run in a background thread so the POST
+    With `url` (the opt-in free-URL tier — the CALLER must have already checked
+    _pl_custom_url_enabled() + the rate limit), open exactly that page. The url is
+    validated HERE by _pl_validate_open_url and only ever becomes a `--app=<url>`
+    argv to the browser — never xdg-open (§5).
+
+    Raises ValueError when the service/path/query/url is refused — the caller
+    turns that into a 404, and NOTHING is written or launched. Registration and
+    the fresh-registration double-fire run in a background thread so the POST
     returns immediately; the app watches `running` flip via GET."""
+    if url:
+        valid = _pl_validate_open_url(url)
+        if valid is None:
+            raise ValueError("url rejected")
+        service, path, query, url = "netflix", "", "", valid
+        if PL_MOCK:
+            _PL_MOCK.update(running=True, service="", path="", query="", url=valid)
+            return {"ok": True, "running": True, "url": valid}
+        if not player_available():
+            raise RuntimeError("player not installed on this box")
+        with _PL_LOCK:
+            _pl_conf_write(service, "", "", url=valid)
+            was_running = _pl_running()
+            if was_running:
+                player_close()
+            appid = _pl_appid()
+        _pl_relaunch(appid, was_running)
+        return {"ok": True, "starting": True, "url": valid}
     if query:
         url = _pl_validate_search(service, query)
         if url is None:
@@ -20930,10 +21062,25 @@ class Handler(BaseHTTPRequestHandler):
                     self._send(400, {"error": "json body with op required"}, started)
                     return
                 if op == "open":
+                    open_url = req.get("url")
+                    if open_url is not None:
+                        # Free-URL tier (§5 tier 3): SHIPS OFF, gated behind a
+                        # box-side config flag, and rate-limited (KI-019) so a
+                        # token holder cannot strobe the TV. The url itself is
+                        # validated inside player_open (reject, never sanitise).
+                        if not _pl_custom_url_enabled():
+                            self._send(403, {"error": "custom URL not enabled on this box"}, started)
+                            return
+                        now = time.time()
+                        if now - _pl_last_open[0] < _PL_OPEN_MIN_INTERVAL_S:
+                            self._send(429, {"error": "slow down"}, started)
+                            return
+                        _pl_last_open[0] = now
                     try:
                         r = player_open(req.get("service"),
                                         req.get("path", ""),
-                                        req.get("query", ""))
+                                        req.get("query", ""),
+                                        open_url or "")
                     except ValueError:
                         # Deliberately does NOT echo the rejected value back.
                         self._send(404, {"error": "unknown service"}, started)

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3389,7 +3389,7 @@ PLAYER_JS_SEEK = {
 # Focus set this way is REAL focus, so the d-pad's OK button (a genuine uinput
 # Enter) activates whatever this landed on.
 _PL_JS_NAV_BODY = """(function(){
-  var DIR = %d;
+  var DX = %d, DY = %d;
   var a = document.activeElement;
   // MODAL SCOPING (measured on tv.apple.com): a signup <dialog> holds a focus
   // trap — focusing a tile behind it just gets stolen back. When a modal owns
@@ -3419,9 +3419,13 @@ _PL_JS_NAV_BODY = """(function(){
                  : {cx: innerWidth/2, cy: 0};
   var best = null, bestScore = Infinity;
   for (var j = 0; j < all.length; j++){
-    var c = all[j], dy = (c.cy - cur.cy) * DIR;
-    if (dy < 24) continue;
-    var score = dy + Math.abs(c.cx - cur.cx) * 2;
+    var c = all[j];
+    // Signed travel along the requested axis; distance across it is a penalty
+    // so a step stays in its row/column rather than jumping diagonally.
+    var fwd = DX ? (c.cx - cur.cx) * DX : (c.cy - cur.cy) * DY;
+    if (fwd < 24) continue;
+    var cross = DX ? Math.abs(c.cy - cur.cy) : Math.abs(c.cx - cur.cx);
+    var score = fwd + cross * 2;
     if (score < bestScore){ bestScore = score; best = c; }
   }
   if (!best) return false;
@@ -3434,8 +3438,16 @@ _PL_JS_NAV_BODY = """(function(){
 # this dict by op id; the direction is an agent-chosen literal, never a value
 # formatted out of the request body.
 PLAYER_JS_NAV = {
-    "navdown": _PL_JS_NAV_BODY % 1,
-    "navup": _PL_JS_NAV_BODY % -1,
+    "navdown": _PL_JS_NAV_BODY % (0, 1),
+    "navup": _PL_JS_NAV_BODY % (0, -1),
+    # Horizontal spatial steps. These exist because the obvious key answer —
+    # Tab / Shift+Tab — is Steam's OVERLAY HOTKEY: in Game Mode the tile is a
+    # Steam game, and a Shift+Tab from the d-pad opened the Steam side menu on
+    # the TV instead of walking focus (owner report, Steam Machine,
+    # 2026-08-18). CDP focus steps involve no keys at all, so there is nothing
+    # for Steam to intercept.
+    "navleft": _PL_JS_NAV_BODY % (-1, 0),
+    "navright": _PL_JS_NAV_BODY % (1, 0),
 }
 
 
@@ -21355,7 +21367,7 @@ class Handler(BaseHTTPRequestHandler):
                         self._send(409, {"error": str(e)}, started)
                         return
                     self._send(200, r, started)
-                elif op in ("navup", "navdown"):
+                elif op in ("navup", "navdown", "navleft", "navright"):
                     # Spatial focus step for the on-screen d-pad. Same frozen
                     # lookup as transport: the op id picks one of two scripts
                     # the agent wrote, and the direction is a literal baked in

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.94"
+VERSION = "2.9.95"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -14548,6 +14548,21 @@ DESKTOP_CHORDS = {
     "overview": (KEY_LEFTMETA, KEY_W),  # KWin "Overview" effect (Plasma 6)
 }
 
+# Generic key chords, not desktop-specific. Same press-in-order/release-in-
+# reverse expansion as DESKTOP_CHORDS; kept separate so the desktop cluster
+# stays a list of desktop actions.
+#
+# WHY shifttab EXISTS: measured on the reference box 2026-08-17 against the real
+# sites, with a control key in the same run — netflix.com and youtube.com IGNORE
+# arrow keys entirely (right/down moved nothing) and walk their focus ring on
+# TAB (focus went Mima -> pokemonRhyott on Netflix, "Skip navigation" -> "Search
+# with your voice" on YouTube). Arrow-key grid nav is a TV-APP behaviour, not a
+# web behaviour. So a couch d-pad driving a web page needs Tab to go forward and
+# Shift+Tab to go back; without this entry the ring could only ever advance.
+KEY_CHORDS = {
+    "shifttab": (KEY_LEFTSHIFT, KEY_TAB),
+}
+
 # All KEY_* codes the virtual keyboard may emit (declared at device create).
 # KEY_LEFTCTRL is included for the Ctrl+V paste chord even though no char maps
 # to it, else the uinput device won't declare the capability and emit fails.
@@ -14555,6 +14570,7 @@ KEYBOARD_CODES = sorted(
     {code for code, _shift in CHAR_KEYMAP.values()}
     | set(SPECIAL_KEYS.values())
     | {c for codes in DESKTOP_CHORDS.values() for c in codes}
+    | {c for codes in KEY_CHORDS.values() for c in codes}
     | {KEY_LEFTSHIFT, KEY_LEFTCTRL, KEY_LEFTALT}
 )
 
@@ -15066,12 +15082,23 @@ def keyboard_events(msg):
         return _type_events(text)
     if t == "k":
         key = msg.get("key")
+        # A non-string name can never be a table entry, and an UNHASHABLE one (a
+        # JSON object or array) raises TypeError out of the `in` tests below —
+        # which escapes the caller's `except ValueError` and takes the session
+        # thread with it. Refuse it as the unknown key it is: reject, don't
+        # sanitise (§3.6), and fail closed (§7).
+        if not isinstance(key, str):
+            raise ValueError("key must be a string")
         if key in SPECIAL_KEYS:
             code = SPECIAL_KEYS[key]
             return [(EV_KEY, code, 1), (EV_KEY, code, 0)]
         if key in DESKTOP_CHORDS:
             codes = DESKTOP_CHORDS[key]
             # Press in order, release in reverse (modifiers wrap the base key).
+            return ([(EV_KEY, c, 1) for c in codes]
+                    + [(EV_KEY, c, 0) for c in reversed(codes)])
+        if key in KEY_CHORDS:
+            codes = KEY_CHORDS[key]
             return ([(EV_KEY, c, 1) for c in codes]
                     + [(EV_KEY, c, 0) for c in reversed(codes)])
         raise ValueError("unknown special key %r" % (key,))
@@ -18350,8 +18377,16 @@ def _make_holder(entry, mock):
     entry["held"] = True
     entry["requested"] = False
     dev = entry["device"].name if entry.get("device") is not None else "keyboard only"
+    # `keys` is ADDITIVE (see CLAUDE.md §4): it lets a client discover which
+    # named keys/chords this agent accepts instead of guessing from a version
+    # number. It matters because an unknown key name raises in keyboard_events
+    # and CLOSES the session — so a client that blind-fired a newer name would
+    # kill its own socket against an older agent. Old clients ignore the field.
     _wsend_json(entry, {"t": "hello", "dev": dev,
-                        "text": _text_caps(mock)})
+                        "text": _text_caps(mock),
+                        "keys": sorted(set(SPECIAL_KEYS)
+                                       | set(DESKTOP_CHORDS)
+                                       | set(KEY_CHORDS))})
     for slot, factory in (("mouse", MockMouse if mock else UInputMouse),
                           ("keyboard", MockKeyboard if mock else UInputKeyboard)):
         if entry.get(slot) is None:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -15000,6 +15000,12 @@ def gamepad_events(msg):
         v = msg.get("v")
         if v not in (0, 1):
             raise ValueError("button v must be 0 or 1")
+        # An unhashable name (a JSON object/array) makes the `in` tests below
+        # raise TypeError, which escapes the caller's `except ValueError` and
+        # kills the session thread. Check the type before the lookup. See the
+        # same guard in keyboard_events and mouse_events.
+        if not isinstance(k, str):
+            raise ValueError("button must be a string")
         if k in BTN_CODES:
             return [(EV_KEY, BTN_CODES[k], v)]
         if k in DPAD_MAP:
@@ -15051,6 +15057,12 @@ def mouse_events(msg):
     if t == "mb":
         k = msg.get("k")
         v = msg.get("v")
+        # An unhashable name (a JSON object/array) makes the `in` test itself
+        # raise TypeError, which escapes the caller's `except ValueError` and
+        # kills the session thread. Check the type before the lookup. See the
+        # same guard in keyboard_events and gamepad_events.
+        if not isinstance(k, str):
+            raise ValueError("mouse button must be a string")
         if k not in MOUSE_BTN_CODES:
             raise ValueError("unknown mouse button %r" % (k,))
         if v not in (0, 1):

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -2856,16 +2856,101 @@ def _pl_conf_read():
     return service, path, query
 
 
+# UI scale for the player's Chrome. A 4K TV at couch distance renders desktop
+# scale unusably small (owner report, 2026-08-17), so the browser gets
+# --force-device-scale-factor. The effective value is either the user's saved
+# choice or an automatic pick from the agent's own display probe. Every value
+# that can reach the conf comes from THIS frozen tuple — a client request can
+# only select a member, and the tile additionally refuses anything outside its
+# own literal whitelist before it becomes argv.
+_PL_UI_SCALES = ("1", "1.25", "1.5", "1.75", "2")
+PLAYER_SCALE_FILE = os.path.expanduser("~/.config/couchside/player-scale")
+
+
+def _pl_scale_override():
+    """The user's saved zoom, or '' when unset/invalid. A garbage file is
+    ignored, never interpreted (§3.6)."""
+    try:
+        with open(PLAYER_SCALE_FILE) as f:
+            v = f.read().strip()
+    except OSError:
+        return ""
+    return v if v in _PL_UI_SCALES else ""
+
+
+def _pl_ui_scale():
+    o = _pl_scale_override()
+    if o:
+        return o
+    # Auto by display height: 4K-class -> 2, 1440p-class -> 1.5, anything
+    # smaller still gets a couch bump (1.0 never reads well from ten feet).
+    try:
+        info = display_info()
+        mode = (info.get("mode") or info.get("preferred_mode") or {}) if info else {}
+        h = int(mode.get("height") or 0)
+    except Exception:
+        h = 0
+    if h >= 2000:
+        return "2"
+    if h >= 1300:
+        return "1.5"
+    if h > 0:
+        return "1.25"
+    return ""   # unknown display: write nothing, tile keeps Chrome's default
+
+
+def player_scale(value):
+    """Set the player zoom. ValueError => 404, nothing written or run.
+
+    The client's value is a SELECTOR into _PL_UI_SCALES — exact membership,
+    no parsing, no clamping (§3.6: reject rather than sanitise). Persisted so
+    every later open uses it; a running page is relaunched to apply it now.
+    """
+    if not isinstance(value, str) or value not in _PL_UI_SCALES:
+        raise ValueError("scale not allowed")
+    if PL_MOCK:
+        _PL_MOCK["scale"] = value
+        return {"ok": True, "scale": value, "relaunched": _PL_MOCK["running"]}
+    os.makedirs(os.path.dirname(PLAYER_SCALE_FILE), exist_ok=True)
+    with open(PLAYER_SCALE_FILE, "w") as f:
+        f.write(value + "\n")
+    relaunched = False
+    if _pl_running():
+        # Rewrite ONLY the scale line; every other conf line is preserved
+        # byte-for-byte (they were validated when written — re-deriving them
+        # here would mean a second writer for the same facts).
+        try:
+            with open(PLAYER_CONF) as f:
+                lines = [l for l in f.read().splitlines()
+                         if l and not l.startswith("scale=")]
+        except OSError:
+            lines = []
+        if lines:
+            with _PL_LOCK:
+                with open(PLAYER_CONF, "w") as f:
+                    f.write("\n".join(lines) + "\nscale=%s\n" % value)
+                player_close()
+                appid = _pl_appid()
+            # Same close -> relaunch shape as player_open: the tile is
+            # single-instance, and _pl_relaunch waits out the old one.
+            _pl_relaunch(appid, True)
+            relaunched = True
+    return {"ok": True, "scale": value, "relaunched": relaunched}
+
+
 def _pl_conf_write(service, path, query="", hub=False, url=""):
     """A deep-link path, a search query, and a free `url` are mutually exclusive
     — the tile treats a query as "open this service's search results" and a url
     as "open exactly this page", and writing more than one would leave which wins
     to reading order. `url` is already validated by _pl_validate_open_url."""
     os.makedirs(os.path.dirname(PLAYER_CONF), exist_ok=True)
+    scale = _pl_ui_scale()
     with open(PLAYER_CONF, "w") as f:
         if hub:
             f.write("hub=1\n")
         f.write("service=%s\n" % service)
+        if scale:
+            f.write("scale=%s\n" % scale)
         if url:
             f.write("url=%s\n" % url)
         elif query:
@@ -3072,6 +3157,8 @@ def player_info():
                 "service_hosts": {k: list(v) for k, v in _PLAYER_SERVICE_HOSTS.items()},
                 "open_url": _pl_custom_url_enabled(),
                 "nav_ops": sorted(PLAYER_JS_NAV),
+                "ui_scale": _PL_MOCK.get("scale") or _pl_ui_scale(),
+                "ui_scales": list(_PL_UI_SCALES),
                 "playback": player_playback(),
                 "seek_secs": list(PLAYER_SEEK_SECS)}
     service, path, query = _pl_conf_read()
@@ -3090,6 +3177,10 @@ def player_info():
             # d-pad's up/down can move focus BETWEEN rows or must fall back to
             # plain arrow keys (which only scroll on the streaming sites).
             "nav_ops": sorted(PLAYER_JS_NAV),
+            # TV zoom (additive): the effective scale and the frozen set of
+            # choices, so the app renders exactly the values the box accepts.
+            "ui_scale": _pl_ui_scale(),
+            "ui_scales": list(_PL_UI_SCALES),
             # Added field, never a shape change: null when nothing is playing
             # or the browser can't be reached, so an old app ignores it and a
             # new one hides the transport rather than showing a dead scrubber.
@@ -3299,8 +3390,14 @@ PLAYER_JS_SEEK = {
 # Enter) activates whatever this landed on.
 _PL_JS_NAV_BODY = """(function(){
   var DIR = %d;
+  var a = document.activeElement;
+  // MODAL SCOPING (measured on tv.apple.com): a signup <dialog> holds a focus
+  // trap — focusing a tile behind it just gets stolen back. When a modal owns
+  // focus, navigate INSIDE it, which is what a native UI does with a modal.
+  var scope = (a && a.closest &&
+               a.closest('dialog,[role="dialog"],[aria-modal="true"]')) || document;
   var sel = 'a[href],button,[tabindex]:not([tabindex="-1"]),input,select,textarea,[role="link"],[role="button"]';
-  var nodes = document.querySelectorAll(sel), all = [];
+  var nodes = scope.querySelectorAll(sel), all = [];
   for (var i = 0; i < nodes.length; i++){
     var e = nodes[i], r = e.getBoundingClientRect();
     if (r.width < 8 || r.height < 8) continue;
@@ -3310,9 +3407,16 @@ _PL_JS_NAV_BODY = """(function(){
     all.push({el: e, cx: r.left + r.width/2, cy: r.top + r.height/2});
   }
   if (!all.length) return false;
-  var a = document.activeElement, ar = a ? a.getBoundingClientRect() : null;
-  var cur = (ar && ar.width) ? {cx: ar.left + ar.width/2, cy: ar.top + ar.height/2}
-                             : {cx: innerWidth/2, cy: 0};
+  var ar = a ? a.getBoundingClientRect() : null;
+  // The current position must be a REAL focused control. With nothing focused,
+  // activeElement is BODY, whose rect spans the whole page — its centre sat at
+  // y=8398 on play.hbomax.com and put every candidate "above" us, so navdown
+  // found nothing (measured; broke max/hulu/paramount landing pages). Anything
+  // taller than ~1.5 viewports is a container, not a control.
+  var real = ar && ar.width && ar.height && ar.height < innerHeight * 1.5 &&
+             a !== document.body && a.tagName !== 'HTML';
+  var cur = real ? {cx: ar.left + ar.width/2, cy: ar.top + ar.height/2}
+                 : {cx: innerWidth/2, cy: 0};
   var best = null, bestScore = Infinity;
   for (var j = 0; j < all.length; j++){
     var c = all[j], dy = (c.cy - cur.cy) * DIR;
@@ -21258,6 +21362,18 @@ class Handler(BaseHTTPRequestHandler):
                     # at import time. A rejected id is a 404 and nothing runs.
                     try:
                         r = player_nav(op)
+                    except ValueError:
+                        self._send(404, {"error": "not allowed"}, started)
+                        return
+                    except RuntimeError as e:
+                        self._send(409, {"error": str(e)}, started)
+                        return
+                    self._send(200, r, started)
+                elif op == "scale":
+                    # TV zoom. The value is a SELECTOR into the frozen
+                    # _PL_UI_SCALES tuple — membership or 404, never parsed.
+                    try:
+                        r = player_scale(req.get("value"))
                     except ValueError:
                         self._send(404, {"error": "not allowed"}, started)
                         return

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3071,6 +3071,7 @@ def player_info():
                 "searchable": list(_PLAYER_SEARCHABLE),
                 "service_hosts": {k: list(v) for k, v in _PLAYER_SERVICE_HOSTS.items()},
                 "open_url": _pl_custom_url_enabled(),
+                "nav_ops": sorted(PLAYER_JS_NAV),
                 "playback": player_playback(),
                 "seek_secs": list(PLAYER_SEEK_SECS)}
     service, path, query = _pl_conf_read()
@@ -3084,6 +3085,11 @@ def player_info():
             # set player.custom_url. Additive; an old app ignores it, a new one
             # shows the "open any web link" field only when the box allows it.
             "open_url": _pl_custom_url_enabled(),
+            # Which spatial focus steps this agent accepts. Additive: an older
+            # app ignores it, and a newer one uses it to decide whether the
+            # d-pad's up/down can move focus BETWEEN rows or must fall back to
+            # plain arrow keys (which only scroll on the streaming sites).
+            "nav_ops": sorted(PLAYER_JS_NAV),
             # Added field, never a shape change: null when nothing is playing
             # or the browser can't be reached, so an old app ignores it and a
             # new one hides the transport rather than showing a dead scrubber.
@@ -3270,6 +3276,62 @@ PLAYER_JS_SEEK = {
            " v.currentTime = Math.max(0, d ? Math.min(d - 0.5, t) : t);"
            " return true;})()" % (_PL_JS_PICK, secs))
     for secs in PLAYER_SEEK_SECS
+}
+
+
+# Spatial (up/down) focus navigation for the on-screen d-pad.
+#
+# WHY THIS IS NOT A KEY. Tab walks a page's focus order LINEARLY, which is right
+# ALONG a row of tiles and useless BETWEEN rows: from the middle of a Netflix
+# row, reaching the row below means tabbing through every remaining tile in the
+# current one. Arrow keys don't help either — measured on the box, netflix.com
+# and youtube.com ignore them entirely (they only scroll the viewport, leaving
+# focus where it was).
+#
+# So vertical movement picks the nearest focusable element in that direction
+# geometrically — the same thing a TV browser's spatial navigation does. No
+# site-specific selectors: it reads the live layout, so it works on any page.
+# Verified on the real Netflix browse grid (552 focusables): down walked
+# Ashley Garcia -> Teen Wolf -> ONE PIECE -> The Hunger Games -> Venom, and up
+# retraced it.
+#
+# Focus set this way is REAL focus, so the d-pad's OK button (a genuine uinput
+# Enter) activates whatever this landed on.
+_PL_JS_NAV_BODY = """(function(){
+  var DIR = %d;
+  var sel = 'a[href],button,[tabindex]:not([tabindex="-1"]),input,select,textarea,[role="link"],[role="button"]';
+  var nodes = document.querySelectorAll(sel), all = [];
+  for (var i = 0; i < nodes.length; i++){
+    var e = nodes[i], r = e.getBoundingClientRect();
+    if (r.width < 8 || r.height < 8) continue;
+    if (r.bottom < -200 || r.top > innerHeight + 600) continue;
+    var s = getComputedStyle(e);
+    if (s.visibility === 'hidden' || s.display === 'none') continue;
+    all.push({el: e, cx: r.left + r.width/2, cy: r.top + r.height/2});
+  }
+  if (!all.length) return false;
+  var a = document.activeElement, ar = a ? a.getBoundingClientRect() : null;
+  var cur = (ar && ar.width) ? {cx: ar.left + ar.width/2, cy: ar.top + ar.height/2}
+                             : {cx: innerWidth/2, cy: 0};
+  var best = null, bestScore = Infinity;
+  for (var j = 0; j < all.length; j++){
+    var c = all[j], dy = (c.cy - cur.cy) * DIR;
+    if (dy < 24) continue;
+    var score = dy + Math.abs(c.cx - cur.cx) * 2;
+    if (score < bestScore){ bestScore = score; best = c; }
+  }
+  if (!best) return false;
+  best.el.focus({preventScroll: true});
+  best.el.scrollIntoView({block: 'center', inline: 'nearest'});
+  return true;
+})()"""
+
+# One script per direction, built at import time. A request only ever indexes
+# this dict by op id; the direction is an agent-chosen literal, never a value
+# formatted out of the request body.
+PLAYER_JS_NAV = {
+    "navdown": _PL_JS_NAV_BODY % 1,
+    "navup": _PL_JS_NAV_BODY % -1,
 }
 
 
@@ -3481,6 +3543,37 @@ def player_transport(op, secs=None):
     ok = _pl_cdp_run(script)
     if ok is None:
         raise RuntimeError("could not reach the player")
+    return {"ok": bool(ok), "op": op}
+
+
+def player_nav(op):
+    """Move the page's focus one step up/down. ValueError => 404, nothing runs.
+
+    Same shape as player_transport: the op id INDEXES a frozen dict of scripts
+    the agent authored; the request never contributes a character of JS.
+    """
+    # Type first: an unhashable op (a JSON object/array) would make the `in`
+    # tests below raise TypeError rather than the ValueError this function's
+    # callers handle — the same hazard fixed in the input decoders (KI-065).
+    if not isinstance(op, str):
+        raise ValueError("nav op must be a string")
+
+    if PL_MOCK:
+        if op in PLAYER_JS_NAV:
+            return {"ok": True, "op": op}
+        raise ValueError("unknown nav op")
+
+    if op not in PLAYER_JS_NAV:
+        raise ValueError("unknown nav op")
+    script = PLAYER_JS_NAV[op]                  # lookup, never interpolation
+
+    if not _pl_running():
+        raise RuntimeError("player is not running")
+    ok = _pl_cdp_run(script)
+    if ok is None:
+        raise RuntimeError("could not reach the player")
+    # False means "nothing focusable that way" (already at the edge) — a true
+    # answer, not a failure, so the app can stay quiet rather than show an error.
     return {"ok": bool(ok), "op": op}
 
 
@@ -21151,6 +21244,20 @@ class Handler(BaseHTTPRequestHandler):
                     # rejected value is a 404 and no script runs.
                     try:
                         r = player_transport(op, secs=req.get("secs"))
+                    except ValueError:
+                        self._send(404, {"error": "not allowed"}, started)
+                        return
+                    except RuntimeError as e:
+                        self._send(409, {"error": str(e)}, started)
+                        return
+                    self._send(200, r, started)
+                elif op in ("navup", "navdown"):
+                    # Spatial focus step for the on-screen d-pad. Same frozen
+                    # lookup as transport: the op id picks one of two scripts
+                    # the agent wrote, and the direction is a literal baked in
+                    # at import time. A rejected id is a 404 and nothing runs.
+                    try:
+                        r = player_nav(op)
                     except ValueError:
                         self._send(404, {"error": "not allowed"}, started)
                         return

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -3650,6 +3650,13 @@ def player_transport(op, secs=None):
     elif op == "seek":
         if secs not in PLAYER_SEEK_SECS:
             raise ValueError("seek offset not allowed")
+        if _pl_seek_wants_keys():
+            # Netflix-class player: direct currentTime writes kill it (M7375,
+            # measured). Press its own arrow key instead. secs is the vetted
+            # frozen-tuple member from the check above.
+            if not _pl_running():
+                raise RuntimeError("player is not running")
+            return _pl_seek_by_key(secs)
         script = PLAYER_JS_SEEK[secs]           # pre-built per allowed offset
     else:
         raise ValueError("unknown transport op")
@@ -3660,6 +3667,51 @@ def player_transport(op, secs=None):
     if ok is None:
         raise RuntimeError("could not reach the player")
     return {"ok": bool(ok), "op": op}
+
+
+# Services whose web player breaks on direct currentTime writes. MEASURED on
+# real playback (Steam Machine, 2026-08-18): v.currentTime += 10 on
+# netflix.com/watch tore the player down with error M7375, while ONE uinput
+# ArrowRight — the binding Netflix's own player ships — seeked +10s cleanly
+# (t 254.4 -> 267.9 over ~4s of wall clock, no error). So for these services
+# the seek op presses the player's own key instead of touching the element.
+_PL_KEY_SEEK_SERVICES = frozenset({"netflix"})
+
+
+def _pl_seek_wants_keys():
+    """True when the OPEN PAGE belongs to a service that must seek by key."""
+    try:
+        with open(PLAYER_CONF) as f:
+            raw = f.read()
+    except OSError:
+        return False
+    if "\nurl=" in "\n" + raw:
+        return False   # free-URL page: a plain <video>, JS seek is correct
+    service, _path, _query = _pl_conf_read()
+    return service in _PL_KEY_SEEK_SERVICES
+
+
+def _pl_seek_by_key(secs):
+    """Seek by pressing the player's own arrow key, one press per 10 seconds.
+
+    A transient uinput keyboard: created, pressed, destroyed. Focus caveat is
+    the same as the d-pad's (the fullscreen player owns focus). `secs` was
+    already validated against PLAYER_SEEK_SECS by the caller — the key and
+    press count derive from that vetted constant, never from the request.
+    """
+    key = KEY_RIGHT if secs > 0 else KEY_LEFT
+    presses = max(1, int(round(abs(secs) / 10.0)))
+    kb = UInputKeyboard()
+    try:
+        for _ in range(presses):
+            kb.emit([(EV_KEY, key, 1), (EV_KEY, key, 0)])
+            time.sleep(0.15)
+    finally:
+        try:
+            kb.destroy()
+        except Exception:
+            pass
+    return {"ok": True, "op": "seek", "secs": secs, "via": "key"}
 
 
 def player_nav(op):

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "186",
+      "buildNumber": "187",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "185",
+      "buildNumber": "186",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "187",
+      "buildNumber": "188",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "184",
+      "buildNumber": "185",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "189",
+      "buildNumber": "190",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "183",
+      "buildNumber": "184",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "188",
+      "buildNumber": "189",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "182",
+      "buildNumber": "183",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "181",
+      "buildNumber": "182",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -12,6 +12,7 @@ import {
 import { useFocusEffect } from 'expo-router';
 
 import { BootSessionCard } from '@/components/BootSessionCard';
+import { UtilitiesSection } from '@/components/UtilitiesSection';
 import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { TourAnchor } from '@/components/TourAnchor';
@@ -260,6 +261,10 @@ function ActionsScreen() {
         {/* Persistent boot preference, directly above the ONE-SHOT session
             switches below it — that adjacency is the point (see the card). */}
         {configured && <BootSessionCard />}
+        {/* OpenPuck flasher, surfaced here for quick reach (also lives under
+            Setup → Utilities). Self-hides on boxes without the utilities
+            endpoint; shows OpenPuck only, with its own flash + auto-flash. */}
+        {configured && <UtilitiesSection context="actions" />}
         {/* TourAnchor REPLACES each group's View and inherits styles.group, so
             the layout is unchanged and the anchor measures the whole block —
             header plus rows. The id uses the UI's word for `low` ("ROUTINE")

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -12,7 +12,7 @@
  */
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Platform, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 
 import { hapticLight, hapticSuccess, hapticWarning } from '@/lib/haptics';
 import { api, ApiError, type BoxCaps, type OpenpuckLatest, type Utility } from '@/lib/api';
@@ -83,8 +83,21 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
     return () => { live.current = false; };
   }, [refresh, canProbe]);
 
-  const flashOpenpuck = useCallback((variant: 'pinned' | 'latest' = 'pinned') => {
-    const doFlash = async () => {
+  // Auto-flash (batch) mode: flash every board plugged in, one after another,
+  // with no per-board prompt. The toggle IS the consent. Implemented purely
+  // app-side over the existing flash endpoint — the agent needs nothing new.
+  const [autoflash, setAutoflash] = useState(false);
+  const [flashedCount, setFlashedCount] = useState(0);
+  // Edge latch: one flash per board-present episode. Cleared when we fire,
+  // re-armed only after the row leaves board_ready (the board rebooted /
+  // unplugged), so a board that lingers ready is never double-flashed and a
+  // failed flash on a stuck board is not hammered.
+  const armed = useRef(true);
+
+  // The core flash, shared by the manual (confirmed) and auto (silent) paths.
+  const doFlash = useCallback(
+    async (variant: 'pinned' | 'latest', opts?: { silent?: boolean }) => {
+      const silent = opts?.silent ?? false;
       hapticLight();
       setBusy('openpuck');
       setNote((n) => { const c = { ...n }; delete c.openpuck; return c; });
@@ -95,18 +108,21 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
           ? (r.stdout || 'Flashed. The board is rebooting as a Steam Controller Puck.')
           : (r.stderr || 'Flash failed.');
         setNote((n) => ({ ...n, openpuck: { tone: r.ok ? 'ok' : 'err', msg } }));
-        if (r.ok) hapticSuccess(); else hapticWarning();
+        if (r.ok) { hapticSuccess(); if (silent) setFlashedCount((c) => c + 1); }
+        else hapticWarning();
       } catch (e) {
         if (live.current) {
           if (e instanceof ApiError && e.kind === 'timeout') {
             // The write may simply be outlasting our patience — the flash often
-            // SUCCEEDS after this (hardware-observed). Say so; the re-poll below
-            // replaces this with the real state.
+            // SUCCEEDS after this (hardware-observed). In auto mode a timeout on
+            // a real write still means a board went through, so count it: the
+            // board reboots, leaves board_ready, and re-arms us for the next.
             setNote((n) => ({ ...n, openpuck: {
               tone: 'info',
               msg: 'Still flashing — the box is writing firmware. The status here '
                 + 'updates when it finishes.',
             } }));
+            if (silent) setFlashedCount((c) => c + 1);
           } else {
             setNote((n) => ({ ...n, openpuck: { tone: 'err', msg: 'Could not reach the box.' } }));
             hapticWarning();
@@ -121,7 +137,31 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
         setTimeout(() => { void refresh(); }, 1500);
         setTimeout(() => { void refresh(); }, 6000);
       }
-    };
+    },
+    [settings, refresh],
+  );
+
+  // While auto-flash is on, poll the row briskly so a freshly-plugged board is
+  // caught within ~1.5s instead of waiting for the mount-time refresh.
+  useEffect(() => {
+    if (!autoflash || !canProbe) return undefined;
+    const id = setInterval(() => { void refresh(); }, 1500);
+    return () => clearInterval(id);
+  }, [autoflash, canProbe, refresh]);
+
+  // The edge trigger: flash on the rising edge of board_ready, re-arm on leave.
+  useEffect(() => {
+    if (!autoflash) { armed.current = true; return; }
+    const st = utils?.find((u) => u.id === 'openpuck')?.state;
+    if (!st) return;
+    if (st !== 'board_ready') { armed.current = true; return; }
+    if (armed.current && busy !== 'openpuck') {
+      armed.current = false;           // sync latch: blocks re-entry before setBusy lands
+      void doFlash('pinned', { silent: true });
+    }
+  }, [utils, autoflash, busy, doFlash]);
+
+  const flashOpenpuck = useCallback((variant: 'pinned' | 'latest' = 'pinned') => {
     // A firmware write is a real action — confirm first, even though the
     // bootloader stays intact and it's re-flashable. The 'latest' path is opt-in
     // and flashes a build newer than the one the app pins, so it says so.
@@ -136,7 +176,7 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
         + 're-flash any time.';
     if (Platform.OS === 'web') {
       // eslint-disable-next-line no-alert
-      if (typeof window !== 'undefined' && window.confirm(q)) void doFlash();
+      if (typeof window !== 'undefined' && window.confirm(q)) void doFlash(variant);
       return;
     }
     Alert.alert(
@@ -144,10 +184,30 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
       q,
       [
         { text: 'Cancel', style: 'cancel' },
-        { text: 'Flash', onPress: () => { void doFlash(); } },
+        { text: 'Flash', onPress: () => { void doFlash(variant); } },
       ],
     );
-  }, [settings, refresh, latest]);
+  }, [latest, doFlash]);
+
+  // Turning auto-flash ON is the batch consent (replaces the per-board prompt),
+  // so it confirms once and resets the counter for a fresh run.
+  const toggleAutoflash = useCallback((on: boolean) => {
+    hapticLight();
+    if (!on) { setAutoflash(false); return; }
+    const start = () => { armed.current = true; setFlashedCount(0); setAutoflash(true); };
+    const q = 'Auto-flash will flash the OpenPuck firmware onto EVERY board you '
+      + 'plug in, with no prompt each time. Plug boards in one after another; '
+      + 'each reboots as a Steam Controller Puck. Turn it off when you’re done.';
+    if (Platform.OS === 'web') {
+      // eslint-disable-next-line no-alert
+      if (typeof window !== 'undefined' && window.confirm(q)) start();
+      return;
+    }
+    Alert.alert('Turn on auto-flash?', q, [
+      { text: 'Cancel', style: 'cancel' },
+      { text: 'Turn on', onPress: start },
+    ]);
+  }, []);
 
   // Opt-in: ask the box to compare its pinned firmware against the fork's newest
   // release. Read-only — this NEVER flashes; it only reveals the "Flash newest"
@@ -186,7 +246,9 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
               <Text style={styles.label}>{u.label}</Text>
               <Text style={styles.sub}>{u.description}</Text>
               <Text style={[styles.status, { color }]}>{p.line}</Text>
-              {canFlash ? (
+              {/* Manual flash — hidden while auto-flash is armed (it fires on
+                  its own). Still shown for the one-off case. */}
+              {canFlash && !autoflash ? (
                 <Pressable
                   onPress={() => flashOpenpuck('pinned')}
                   disabled={running}
@@ -206,6 +268,30 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
                     {running ? 'Flashing…' : 'Flash receiver'}
                   </Text>
                 </Pressable>
+              ) : null}
+
+              {/* Auto-flash (batch) — flash every board plugged in, no prompts. */}
+              {u.id === 'openpuck' ? (
+                <View style={styles.autoRow} testID="openpuck-autoflash">
+                  <View style={styles.autoText}>
+                    <Text style={styles.autoLabel}>Auto-flash</Text>
+                    <Text style={styles.autoSub}>
+                      {autoflash
+                        ? running
+                          ? 'Flashing…'
+                          : u.state === 'board_ready'
+                            ? 'Board detected — flashing…'
+                            : `Armed — plug in the next board.  Flashed: ${flashedCount}`
+                        : 'Flash every board you plug in, one after another.'}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={autoflash}
+                    onValueChange={toggleAutoflash}
+                    trackColor={{ true: t.blue }}
+                    testID="openpuck-autoflash-switch"
+                  />
+                </View>
               ) : null}
               {n ? (
                 <Text style={[styles.note, {
@@ -303,5 +389,17 @@ const makeStyles = (t: Palette) =>
     link: { color: t.blue, fontSize: 12, fontWeight: '700' },
     newerLine: { color: t.textFaint, fontSize: 12, fontWeight: '600', lineHeight: 17 },
     newerHint: { color: t.textFaint, fontSize: 12, marginTop: 6 },
+    autoRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      marginTop: 10,
+      paddingTop: 10,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: t.cardBorder,
+    },
+    autoText: { flex: 1 },
+    autoLabel: { color: t.text, fontSize: 14, fontWeight: '600' },
+    autoSub: { color: t.textFaint, fontSize: 12, marginTop: 2 },
     footNote: { color: t.textFaint, fontSize: 11, lineHeight: 16, marginTop: 4, fontStyle: 'italic' },
   });

--- a/app/components/UtilitiesSection.tsx
+++ b/app/components/UtilitiesSection.tsx
@@ -37,7 +37,16 @@ function present(u: Utility): { line: string; icon: string; tone: 'good' | 'acti
   return { line: u.state, icon: 'construct-outline', tone: 'idle' };
 }
 
-export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
+export function UtilitiesSection({
+  caps,
+  context = 'setup',
+}: {
+  caps?: BoxCaps;
+  /** 'setup' = the full utilities list under Setup (all utilities). 'actions'
+   *  = a slimmed OpenPuck-only card surfaced on the Actions tab for quick
+   *  reach, with its own heading. Same poll + flash + auto-flash logic. */
+  context?: 'setup' | 'actions';
+}) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
@@ -230,10 +239,17 @@ export function UtilitiesSection({ caps }: { caps?: BoxCaps }) {
   // Nothing to show if the box lacks the endpoint (old agent / Windows).
   if (!canProbe || !utils || utils.length === 0) return null;
 
+  // On the Actions tab we surface OpenPuck only — the flash is the reason to
+  // reach it there; CEC is a Setup-time toggle, not a couch action.
+  const shown = context === 'actions'
+    ? utils.filter((u) => u.id === 'openpuck')
+    : utils;
+  if (shown.length === 0) return null;
+
   return (
     <View style={styles.wrap}>
-      <Text style={styles.h}>UTILITIES</Text>
-      {utils.map((u) => {
+      <Text style={styles.h}>{context === 'actions' ? 'OPENPUCK RECEIVER' : 'UTILITIES'}</Text>
+      {shown.map((u) => {
         const p = present(u);
         const color = p.tone === 'good' ? t.green : p.tone === 'action' ? t.blue : t.textFaint;
         const canFlash = u.id === 'openpuck' && u.state === 'board_ready';

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -1,10 +1,27 @@
 /**
- * WatchDpad — an on-screen d-pad for driving the page open in the Couchside
- * Player (Netflix/YouTube tile grids, and any web page's focus ring).
+ * WatchDpad — a swipe pad for driving the page open in the Couchside Player
+ * (Netflix/YouTube tile grids, and any web page's focus ring).
  *
- * WHY THIS EXISTS: streaming UIs are spatial grids you navigate with a remote's
- * arrows, not by scrolling. Before this, the Watch panel could only launch a
- * service and then abandon it — you could not move between tiles from the couch.
+ * WHY THIS EXISTS: streaming UIs are spatial grids you navigate with a remote,
+ * not by scrolling. Before this, the Watch panel could only launch a service
+ * and then abandon it — you could not move between tiles from the couch.
+ *
+ * WHY SWIPES, NOT BUTTONS: owner feedback once the arrow buttons worked —
+ * swiping is the natural phone gesture for "move one tile", and a tap beats
+ * hunting for an OK button mid-scroll. Gestures map onto the same verbs the
+ * buttons used:
+ *
+ *   swipe left/right -> one focus step along the row
+ *   swipe up/down    -> one spatial step between rows
+ *   tap              -> OK (enter)
+ *   two-finger tap   -> Back (esc), same convention as the trackpad's
+ *                       two-finger right-click; a visible Back button stays
+ *                       for discoverability
+ *
+ * The step engine is lib/swipeSteps.planSteps — the unit-tested planner the
+ * Pad's swipe mode uses (first step cheap, repeats expensive, so a flick moves
+ * ONE tile and a deliberate drag walks several; dominant axis wins so a
+ * diagonal never fires both).
  *
  * HOW IT WORKS: the agent exposes a token-authed, hold-gated uinput keyboard on
  * /ws/gamepad, so this reuses GamepadClient.sendKey() exactly like the desktop
@@ -48,15 +65,29 @@
  * offers Take control, mirroring the Pad tab's handoff.
  */
 import React, { useEffect, useRef, useState } from 'react';
-import { AppState, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import {
+  AppState,
+  PanResponder,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useNavigation } from 'expo-router';
 
 import { api } from '@/lib/api';
 import { GamepadClient, GamepadStatus, SpecialKey } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
+import { planSteps, type StepDir, type StepState } from '@/lib/swipeSteps';
 import { useThemedStyles, type Palette } from '@/lib/theme';
 import type { Settings } from '@/lib/settings';
+
+/** Movement under this (px) within TAP_MS is a tap, not a swipe. Matches the
+ *  Pad's swipe surface. */
+const TAP_SLOP = 10;
+const TAP_MS = 350;
 
 /** Names this device to the current holder's Pass/Keep prompt. Matches pad.tsx. */
 const DEVICE_LABEL =
@@ -69,11 +100,19 @@ export function WatchDpad({
   settings,
   ready,
   navOps,
+  onGestureActive,
 }: {
   settings: Settings;
   ready: boolean;
   /** PlayerState.nav_ops — which spatial steps this box accepts. */
   navOps?: string[];
+  /**
+   * Fires true while a touch is on the swipe pad, false when it ends. The
+   * parent ScrollView must set scrollEnabled={false} during it — a native
+   * scroll otherwise steals every vertical drag from the pad's PanResponder,
+   * turning "swipe down a row" into "scroll the panel".
+   */
+  onGestureActive?: (active: boolean) => void;
 }) {
   const styles = useThemedStyles(makeStyles);
   const navigation = useNavigation();
@@ -149,10 +188,17 @@ export function WatchDpad({
 
   const holding = status === 'connected';
 
-  const press = (key: SpecialKey) => {
+  /** Send without haptic — the gesture path fires ONE haptic per move event,
+   *  never one per step; per-step ticks flooded iOS's feedback queue on the Pad
+   *  and were the best-motivated suspect for a JS stall (see pad.tsx). */
+  const pressQuiet = (key: SpecialKey) => {
     if (!holding) return;
-    hapticLight();
     client.sendKey(key);
+  };
+
+  const press = (key: SpecialKey) => {
+    hapticLight();
+    pressQuiet(key);
   };
 
   /**
@@ -164,8 +210,8 @@ export function WatchDpad({
    * different box while the panel is open.
    */
   const focusStep = (forward: boolean) => {
-    if (forward) return press('tab');
-    return press(client.supportsKey('shifttab') ? 'shifttab' : 'left');
+    if (forward) return pressQuiet('tab');
+    return pressQuiet(client.supportsKey('shifttab') ? 'shifttab' : 'left');
   };
 
   /**
@@ -180,10 +226,91 @@ export function WatchDpad({
   const canNav = (op: 'navup' | 'navdown') => navOps?.includes(op) === true;
   const vertical = (down: boolean) => {
     const op = down ? 'navdown' : 'navup';
-    if (!canNav(op)) return press(down ? 'down' : 'up');
-    hapticLight();
+    if (!canNav(op)) return pressQuiet(down ? 'down' : 'up');
     api.playerOp(settings, op).catch(() => {});
   };
+
+  /** One gesture step from the planner onto the right verb. */
+  const stepDir = (d: StepDir) => {
+    if (d === 'dl') focusStep(false);
+    else if (d === 'dr') focusStep(true);
+    else if (d === 'du') vertical(false);
+    else vertical(true);
+  };
+  const stepRef = useRef(stepDir);
+  stepRef.current = stepDir;
+  // press() closes over `holding`; the once-created responder must see the
+  // live version, not the first render's. Same for the gesture-active signal.
+  const pressRef = useRef(press);
+  pressRef.current = press;
+  const gestureRef = useRef<(active: boolean) => void>(() => {});
+  gestureRef.current = onGestureActive ?? (() => {});
+
+  // Swipe surface. planSteps is the Pad's unit-tested planner: first step
+  // cheap, repeats expensive, dominant axis wins. The responder is created
+  // once; live state reaches it through refs.
+  const track = useRef({
+    consumedX: 0,
+    consumedY: 0,
+    stepped: false,
+    moved: false,
+    twoFinger: false,
+    t0: 0,
+  });
+  const sens = usePref('swipeSensitivity');
+  const sensRef = useRef(sens);
+  sensRef.current = sens;
+
+  const responder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onPanResponderGrant: () => {
+        gestureRef.current(true);
+        track.current = {
+          consumedX: 0,
+          consumedY: 0,
+          stepped: false,
+          moved: false,
+          twoFinger: false,
+          t0: Date.now(),
+        };
+      },
+      onPanResponderMove: (_evt, g) => {
+        const t = track.current;
+        // A second finger at ANY point marks the gesture two-finger; checked on
+        // move because Grant often fires before the second finger lands.
+        if (g.numberActiveTouches >= 2) t.twoFinger = true;
+        if (!t.moved && Math.hypot(g.dx, g.dy) > TAP_SLOP) t.moved = true;
+        if (t.twoFinger) return; // two-finger = Back on release, never steps
+        const plan = planSteps(g.dx, g.dy, t as StepState, sensRef.current);
+        t.consumedX = plan.next.consumedX;
+        t.consumedY = plan.next.consumedY;
+        t.stepped = plan.next.stepped;
+        for (const d of plan.dirs) stepRef.current(d);
+        // ONE haptic per move event, never per step — a fast swipe emits a
+        // burst, and per-step selectionAsync() floods iOS's feedback queue
+        // (measured on the Pad; see pad.tsx SwipeSurface).
+        if (plan.dirs.length > 0) hapticLight();
+      },
+      onPanResponderRelease: () => {
+        gestureRef.current(false);
+        const t = track.current;
+        if (t.moved || Date.now() - t.t0 >= TAP_MS) return;
+        // Tap: one finger = OK, two fingers = Back (the trackpad's two-finger
+        // right-click convention, answering "how do we do the back button").
+        if (t.twoFinger) pressRef.current('esc');
+        else pressRef.current('enter');
+      },
+      // A parent stealing the gesture (edge-swipe, navigation) just cancels
+      // it — steps already sent are single presses, nothing latches. Still must
+      // re-enable the parent's scroll.
+      onPanResponderTerminate: () => {
+        gestureRef.current(false);
+      },
+      onPanResponderTerminationRequest: () => false,
+    }),
+  ).current;
 
   const takeControl = () => {
     hapticLight();
@@ -239,47 +366,11 @@ export function WatchDpad({
     <View style={styles.wrap} testID="watch-dpad">
       <Text style={styles.title}>NAVIGATE</Text>
 
-      {/* Cross: up/down SCROLL the page, left/right walk the focus ring. */}
-      <View style={styles.row}>
-        <View style={styles.cell} />
-        <DKey
-          label="▲"
-          testID="watch-dpad-up"
-          onPress={() => vertical(false)}
-          styles={styles}
-        />
-        <View style={styles.cell} />
-      </View>
-      <View style={styles.row}>
-        <DKey
-          label="◀"
-          testID="watch-dpad-left"
-          onPress={() => focusStep(false)}
-          styles={styles}
-        />
-        <DKey
-          label="OK"
-          testID="watch-dpad-ok"
-          onPress={() => press('enter')}
-          styles={styles}
-          main
-        />
-        <DKey
-          label="▶"
-          testID="watch-dpad-right"
-          onPress={() => focusStep(true)}
-          styles={styles}
-        />
-      </View>
-      <View style={styles.row}>
-        <View style={styles.cell} />
-        <DKey
-          label="▼"
-          testID="watch-dpad-down"
-          onPress={() => vertical(true)}
-          styles={styles}
-        />
-        <View style={styles.cell} />
+      {/* Swipe surface: flick left/right = one step along the row, up/down =
+          one row; tap = OK; two-finger tap = Back. */}
+      <View style={styles.swipePad} testID="watch-dpad-swipe" {...responder.panHandlers}>
+        <Text style={styles.swipeGlyph}>✦</Text>
+        <Text style={styles.swipeHint}>swipe to move · tap for OK</Text>
       </View>
 
       <Pressable
@@ -291,35 +382,10 @@ export function WatchDpad({
       </Pressable>
 
       <Text style={styles.hint}>
-        ◀ ▶ along a row · ▲ ▼ between rows · OK selects · Back exits
+        swipe ◀ ▶ along a row · ▲ ▼ between rows · tap selects · two-finger tap
+        or Back exits
       </Text>
     </View>
-  );
-}
-
-/** One d-pad key. Split out so every cell is the same square, keeping the cross
- *  aligned regardless of glyph width. */
-function DKey({
-  label,
-  testID,
-  onPress,
-  styles,
-  main,
-}: {
-  label: string;
-  testID: string;
-  onPress: () => void;
-  styles: ReturnType<typeof makeStyles>;
-  main?: boolean;
-}) {
-  return (
-    <Pressable
-      onPress={onPress}
-      testID={testID}
-      style={({ pressed }) => [styles.key, main && styles.keyMain, pressed && styles.pressed]}
-    >
-      <Text style={[styles.keyText, main && styles.keyMainText]}>{label}</Text>
-    </Pressable>
   );
 }
 
@@ -339,21 +405,19 @@ const makeStyles = (t: Palette) =>
       letterSpacing: 1.2,
       alignSelf: 'stretch',
     },
-    row: { flexDirection: 'row', gap: 8 },
-    cell: { width: 64, height: 52 },
-    key: {
-      width: 64,
-      height: 52,
+    swipePad: {
+      alignSelf: 'stretch',
+      height: 168,
       alignItems: 'center',
       justifyContent: 'center',
-      borderRadius: 10,
+      gap: 6,
+      borderRadius: 12,
       backgroundColor: t.inset,
       borderWidth: StyleSheet.hairlineWidth,
       borderColor: t.cardBorder,
     },
-    keyMain: { backgroundColor: t.accent, borderColor: t.accent },
-    keyText: { color: t.text, fontSize: 18, fontWeight: '700' },
-    keyMainText: { color: '#0b1220', fontSize: 15 },
+    swipeGlyph: { color: t.textFaint, fontSize: 22 },
+    swipeHint: { color: t.textFaint, fontSize: 12 },
     backBtn: {
       marginTop: 2,
       paddingHorizontal: 22,

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -23,12 +23,19 @@
  * Arrow-key grid navigation is a TV-APP behaviour; the WEB versions of these
  * services ignore arrows entirely and move their focus ring on Tab. So:
  *
- *   left / right -> Shift+Tab / Tab   walk the focus ring between tiles
- *   up / down    -> arrow keys        scroll the page (netflix browse scrolled
- *                                     0 -> 51 -> 120 on down)
- *   OK           -> enter             activates the focused tile (observed
- *                                     selecting a Netflix profile)
+ *   left / right -> Shift+Tab / Tab   walk the focus ring ALONG a row
+ *   up / down    -> navup / navdown   a SPATIAL focus step between rows
+ *   OK           -> enter             activates whatever now has focus
  *   Back         -> esc
+ *
+ * Up/down cannot be keys. Tab is linear, so from the middle of a row it would
+ * have to walk every remaining tile to reach the row below, and arrow keys only
+ * scroll the viewport on these sites — the focus ring stays put. The agent's
+ * navup/navdown ops instead pick the nearest focusable element above/below
+ * geometrically (agent >= 2.9.95). Verified on the real Netflix browse grid:
+ * down walked More Info -> Netflix Minigolf -> The Last House -> Walter Boys and
+ * up retraced it; OK then opened that title's detail modal, proving the focus
+ * those ops set is REAL focus a genuine key activates.
  *
  * Shift+Tab needs agent >= 2.9.95 (the `shifttab` chord). An older agent does
  * not merely ignore an unknown key name — it errors and CLOSES the session — so
@@ -44,6 +51,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { AppState, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from 'expo-router';
 
+import { api } from '@/lib/api';
 import { GamepadClient, GamepadStatus, SpecialKey } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
@@ -57,7 +65,16 @@ const DEVICE_LABEL =
 /** How long to wait on a silent holder before offering a forced takeover. */
 const FORCE_AFTER_MS = 20_000;
 
-export function WatchDpad({ settings, ready }: { settings: Settings; ready: boolean }) {
+export function WatchDpad({
+  settings,
+  ready,
+  navOps,
+}: {
+  settings: Settings;
+  ready: boolean;
+  /** PlayerState.nav_ops — which spatial steps this box accepts. */
+  navOps?: string[];
+}) {
   const styles = useThemedStyles(makeStyles);
   const navigation = useNavigation();
 
@@ -151,6 +168,23 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
     return press(client.supportsKey('shifttab') ? 'shifttab' : 'left');
   };
 
+  /**
+   * Vertical step. Rides the agent's spatial nav op when the box offers it,
+   * else falls back to an arrow key — which on these sites only scrolls, but is
+   * the most a pre-2.9.95 box can do and is never harmful.
+   *
+   * Fire-and-forget: a failed step is not worth an error banner (the common
+   * "failure" is simply having reached the last row), and the d-pad must stay
+   * responsive to rapid presses rather than serialising on a round trip.
+   */
+  const canNav = (op: 'navup' | 'navdown') => navOps?.includes(op) === true;
+  const vertical = (down: boolean) => {
+    const op = down ? 'navdown' : 'navup';
+    if (!canNav(op)) return press(down ? 'down' : 'up');
+    hapticLight();
+    api.playerOp(settings, op).catch(() => {});
+  };
+
   const takeControl = () => {
     hapticLight();
     const s = client.getStatus();
@@ -208,7 +242,12 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
       {/* Cross: up/down SCROLL the page, left/right walk the focus ring. */}
       <View style={styles.row}>
         <View style={styles.cell} />
-        <DKey label="▲" testID="watch-dpad-up" onPress={() => press('up')} styles={styles} />
+        <DKey
+          label="▲"
+          testID="watch-dpad-up"
+          onPress={() => vertical(false)}
+          styles={styles}
+        />
         <View style={styles.cell} />
       </View>
       <View style={styles.row}>
@@ -234,7 +273,12 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
       </View>
       <View style={styles.row}>
         <View style={styles.cell} />
-        <DKey label="▼" testID="watch-dpad-down" onPress={() => press('down')} styles={styles} />
+        <DKey
+          label="▼"
+          testID="watch-dpad-down"
+          onPress={() => vertical(true)}
+          styles={styles}
+        />
         <View style={styles.cell} />
       </View>
 
@@ -247,7 +291,7 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
       </Pressable>
 
       <Text style={styles.hint}>
-        ◀ ▶ move between tiles · ▲ ▼ scroll · OK selects · Back exits
+        ◀ ▶ along a row · ▲ ▼ between rows · OK selects · Back exits
       </Text>
     </View>
   );

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -1,0 +1,295 @@
+/**
+ * WatchDpad — an on-screen d-pad for driving the page open in the Couchside
+ * Player (Netflix/YouTube tile grids, and any web page's focus ring).
+ *
+ * WHY THIS EXISTS: streaming UIs are spatial grids you navigate with a remote's
+ * arrows, not by scrolling. Before this, the Watch panel could only launch a
+ * service and then abandon it — you could not move between tiles from the couch.
+ *
+ * HOW IT WORKS (and why it needs no new agent code): the agent already exposes a
+ * token-authed, hold-gated uinput keyboard on /ws/gamepad, and the key names
+ * up/down/left/right/enter/esc are already frozen into its SPECIAL_KEYS table.
+ * So this reuses GamepadClient.sendKey() exactly like the desktop keyboard does.
+ * uinput delivers a REAL, trusted key event to whatever the compositor has
+ * focused — which for the Player tile is its fullscreen Chrome — so Netflix's
+ * own key handler responds. (A synthetic CDP KeyboardEvent would be
+ * isTrusted:false and Netflix ignores it; that is why this path, not CDP.)
+ *
+ * We connect with noPad:true so the agent never materialises a virtual Xbox pad
+ * for this session (which would make Steam announce a controller). Keys only
+ * flow while this session HOLDS control; if another device holds, the panel
+ * offers Take control, mirroring the Pad tab's handoff.
+ */
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useNavigation } from 'expo-router';
+
+import { GamepadClient, GamepadStatus, SpecialKey } from '@/lib/gamepad';
+import { hapticLight } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
+import { useThemedStyles, type Palette } from '@/lib/theme';
+import type { Settings } from '@/lib/settings';
+
+/** Names this device to the current holder's Pass/Keep prompt. Matches pad.tsx. */
+const DEVICE_LABEL =
+  Platform.OS === 'ios' ? 'iPhone' : Platform.OS === 'android' ? 'Android phone' : 'A device';
+
+/** How long to wait on a silent holder before offering a forced takeover. */
+const FORCE_AFTER_MS = 20_000;
+
+export function WatchDpad({ settings, ready }: { settings: Settings; ready: boolean }) {
+  const styles = useThemedStyles(makeStyles);
+  const navigation = useNavigation();
+
+  // Same handoff preference the Pad uses: ask-to-pass vs grab. Read through a
+  // ref so flipping it never re-runs the connection effect (which keys on the
+  // connection identity only).
+  const askToSwitch = usePref('askToSwitchControl');
+  const askRef = useRef(askToSwitch);
+  askRef.current = askToSwitch;
+
+  const [status, setStatus] = useState<GamepadStatus>('closed');
+  const [holder, setHolder] = useState<string | null>(null);
+  const [canForce, setCanForce] = useState(false);
+
+  const clientRef = useRef<GamepadClient | null>(null);
+  if (clientRef.current == null) clientRef.current = new GamepadClient();
+  const client = clientRef.current;
+
+  const settingsRef = useRef(settings);
+  settingsRef.current = settings;
+
+  // Connection lifecycle, mirrored from pad.tsx: connect on mount and on tab
+  // focus, disconnect on blur/unmount and when backgrounded, so a key can never
+  // leak to the box while the user is on another tab. connect() is idempotent;
+  // an idle socket sends nothing, so holding it open while a page is up is free.
+  useEffect(() => {
+    if (!ready) return undefined;
+
+    client.onStatus((s, d) => {
+      setStatus(s);
+      setHolder(d);
+      if (s !== 'waiting') setCanForce(false);
+    });
+
+    const connect = () =>
+      client.connect(settingsRef.current, {
+        handoffAsk: askRef.current,
+        deviceName: DEVICE_LABEL,
+        noPad: true, // never create a virtual gamepad — we only send key frames
+      });
+    const disconnect = () => client.close();
+
+    const offFocus = navigation.addListener('focus', connect);
+    const offBlur = navigation.addListener('blur', disconnect);
+    const appSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') {
+        connect();
+        client.ensureLive();
+      } else disconnect();
+    });
+
+    connect();
+
+    return () => {
+      offFocus();
+      offBlur();
+      appSub.remove();
+      disconnect();
+      client.onStatus(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- connection identity
+    // only; settingsRef/askRef carry the rest without re-running.
+  }, [client, ready, settings.host, settings.port, settings.token, navigation]);
+
+  // A holder who never answers (walked away / app backgrounded) shouldn't block
+  // forever: after a grace period, offer to force the takeover.
+  useEffect(() => {
+    if (status !== 'waiting') return undefined;
+    const t = setTimeout(() => setCanForce(true), FORCE_AFTER_MS);
+    return () => clearTimeout(t);
+  }, [status]);
+
+  const holding = status === 'connected';
+
+  const press = (key: SpecialKey) => {
+    if (!holding) return;
+    hapticLight();
+    client.sendKey(key);
+  };
+
+  const takeControl = () => {
+    hapticLight();
+    const s = client.getStatus();
+    if (s === 'waiting') {
+      if (canForce) client.forceControl();
+      else client.requestControl();
+    } else if (s === 'released') {
+      client.requestControl();
+    } else {
+      // replaced / closed / error / connecting: re-dial and grab (this tap is an
+      // explicit "I want to drive now", so don't ask).
+      client.connect(settingsRef.current, {
+        handoffAsk: false,
+        deviceName: DEVICE_LABEL,
+        noPad: true,
+      });
+    }
+  };
+
+  // Not holding control: show who does and a way to take it, instead of a live
+  // d-pad whose presses the box would silently drop.
+  if (!holding) {
+    const waiting = status === 'connecting' || status === 'closed';
+    return (
+      <View style={styles.wrap} testID="watch-dpad">
+        <Text style={styles.title}>NAVIGATE</Text>
+        <View style={styles.handoff}>
+          <Text style={styles.handoffText} numberOfLines={2}>
+            {waiting
+              ? 'Connecting to the box…'
+              : holder
+                ? `${holder} has the controller.`
+                : 'Another device has the controller.'}
+          </Text>
+          {!waiting && (
+            <Pressable
+              onPress={takeControl}
+              testID="watch-dpad-take"
+              style={({ pressed }) => [styles.takeBtn, pressed && styles.pressed]}
+            >
+              <Text style={styles.takeText}>
+                {status === 'waiting' && canForce ? 'Take control now' : 'Take control'}
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrap} testID="watch-dpad">
+      <Text style={styles.title}>NAVIGATE</Text>
+
+      {/* Cross: up on top, left/OK/right in the middle, down on the bottom. */}
+      <View style={styles.row}>
+        <View style={styles.cell} />
+        <DKey label="▲" testID="watch-dpad-up" onPress={() => press('up')} styles={styles} />
+        <View style={styles.cell} />
+      </View>
+      <View style={styles.row}>
+        <DKey label="◀" testID="watch-dpad-left" onPress={() => press('left')} styles={styles} />
+        <DKey
+          label="OK"
+          testID="watch-dpad-ok"
+          onPress={() => press('enter')}
+          styles={styles}
+          main
+        />
+        <DKey label="▶" testID="watch-dpad-right" onPress={() => press('right')} styles={styles} />
+      </View>
+      <View style={styles.row}>
+        <View style={styles.cell} />
+        <DKey label="▼" testID="watch-dpad-down" onPress={() => press('down')} styles={styles} />
+        <View style={styles.cell} />
+      </View>
+
+      <Pressable
+        onPress={() => press('esc')}
+        testID="watch-dpad-back"
+        style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
+      >
+        <Text style={styles.backText}>Back</Text>
+      </Pressable>
+
+      <Text style={styles.hint}>Arrows move between tiles · OK selects · Back exits</Text>
+    </View>
+  );
+}
+
+/** One d-pad key. Split out so every cell is the same square, keeping the cross
+ *  aligned regardless of glyph width. */
+function DKey({
+  label,
+  testID,
+  onPress,
+  styles,
+  main,
+}: {
+  label: string;
+  testID: string;
+  onPress: () => void;
+  styles: ReturnType<typeof makeStyles>;
+  main?: boolean;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      testID={testID}
+      style={({ pressed }) => [styles.key, main && styles.keyMain, pressed && styles.pressed]}
+    >
+      <Text style={[styles.keyText, main && styles.keyMainText]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    wrap: {
+      gap: 8,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: t.cardBorder,
+      paddingTop: 12,
+      alignItems: 'center',
+    },
+    title: {
+      color: t.textFaint,
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 1.2,
+      alignSelf: 'stretch',
+    },
+    row: { flexDirection: 'row', gap: 8 },
+    cell: { width: 64, height: 52 },
+    key: {
+      width: 64,
+      height: 52,
+      alignItems: 'center',
+      justifyContent: 'center',
+      borderRadius: 10,
+      backgroundColor: t.inset,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+    },
+    keyMain: { backgroundColor: t.accent, borderColor: t.accent },
+    keyText: { color: t.text, fontSize: 18, fontWeight: '700' },
+    keyMainText: { color: '#0b1220', fontSize: 15 },
+    backBtn: {
+      marginTop: 2,
+      paddingHorizontal: 22,
+      paddingVertical: 10,
+      borderRadius: 10,
+      backgroundColor: t.inset,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+    },
+    backText: { color: t.text, fontSize: 13, fontWeight: '600' },
+    hint: { color: t.textFaint, fontSize: 11, textAlign: 'center' },
+    pressed: { opacity: 0.6 },
+    handoff: {
+      alignSelf: 'stretch',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 12,
+      paddingVertical: 4,
+    },
+    handoffText: { color: t.textDim, fontSize: 13, flex: 1 },
+    takeBtn: {
+      paddingHorizontal: 16,
+      paddingVertical: 10,
+      borderRadius: 10,
+      backgroundColor: t.accent,
+    },
+    takeText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+  });

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -213,14 +213,18 @@ export function WatchDpad({
   };
 
   /**
-   * Walk the page's focus ring. Forward is Tab everywhere; backward needs the
-   * Shift+Tab chord (agent >= 2.9.95). Against an older agent that name would
-   * close the session, so fall back to a plain Left arrow — which does nothing
-   * on Netflix/YouTube but is harmless, and still scrolls pages that respond to
-   * arrows. Checked at press time, not mount: the socket may reconnect to a
-   * different box while the panel is open.
+   * One focus step along the row. Prefer the agent's SPATIAL navleft/navright
+   * (CDP, no keys): the key answer — Tab / Shift+Tab — is Steam's OVERLAY
+   * hotkey, and in Game Mode a Shift+Tab from this pad opened the Steam side
+   * menu on the TV instead of walking focus (owner report, Steam Machine).
+   * Key fallback only for boxes whose agent predates the horizontal ops.
    */
   const focusStep = (forward: boolean) => {
+    const op = forward ? 'navright' : 'navleft';
+    if (navOps?.includes(op) === true) {
+      api.playerOp(settings, op).catch(() => {});
+      return;
+    }
     if (forward) return pressQuiet('tab');
     return pressQuiet(client.supportsKey('shifttab') ? 'shifttab' : 'left');
   };

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -113,6 +113,10 @@ export function WatchDpad({
   client: clientProp,
   onKeyboard,
   keyboardOpen,
+  playing,
+  onSeek,
+  onPlayPause,
+  onVolume,
 }: {
   settings: Settings;
   ready: boolean;
@@ -136,6 +140,21 @@ export function WatchDpad({
    *  for typing into whatever the TV has focused — search fields). */
   onKeyboard?: () => void;
   keyboardOpen?: boolean;
+  /**
+   * True while the box reports a video actually playing. MEASURED on the
+   * reference box: during Netflix playback the page has ZERO focusable
+   * controls until its control bar is revealed, so spatial nav has nothing to
+   * land on and every swipe silently does nothing. So the pad becomes a
+   * TRANSPORT while playing — which is what a TV remote does anyway — and
+   * reverts to tile navigation the moment playback stops.
+   */
+  playing?: boolean;
+  /** Seek by an offset the BOX advertised (PlayerState.seek_secs). */
+  onSeek?: (secs: number) => void;
+  /** Toggle play/pause on the box. */
+  onPlayPause?: () => void;
+  /** Nudge the box's volume. */
+  onVolume?: (dir: 1 | -1) => void;
 }) {
   const styles = useThemedStyles(makeStyles);
   const navigation = useNavigation();
@@ -261,8 +280,20 @@ export function WatchDpad({
     api.playerOp(settings, op).catch(() => {});
   };
 
-  /** One gesture step from the planner onto the right verb. */
+  /**
+   * One gesture step onto the right verb.
+   *
+   * While a video is PLAYING the pad is a transport (seek / volume): the page
+   * has no focusable controls then, so tile navigation would be a no-op with
+   * no feedback. Otherwise it navigates tiles.
+   */
   const stepDir = (d: StepDir) => {
+    if (playing) {
+      if (d === 'dl') onSeek?.(-1);
+      else if (d === 'dr') onSeek?.(1);
+      else onVolume?.(d === 'du' ? 1 : -1);
+      return;
+    }
     if (d === 'dl') focusStep(false);
     else if (d === 'dr') focusStep(true);
     else if (d === 'du') vertical(false);
@@ -276,6 +307,17 @@ export function WatchDpad({
   pressRef.current = press;
   const gestureRef = useRef<(active: boolean) => void>(() => {});
   gestureRef.current = onGestureActive ?? (() => {});
+  /** Centre tap: play/pause while playing, OK otherwise. */
+  const tap = () => {
+    if (playing) {
+      hapticLight();
+      onPlayPause?.();
+      return;
+    }
+    press('enter');
+  };
+  const tapRef = useRef(tap);
+  tapRef.current = tap;
   /** Pointer-mode tap-click: press then release, gated on holding control. */
   const click = (btn: MouseButton) => {
     if (!holding) return;
@@ -371,7 +413,9 @@ export function WatchDpad({
           hapticLight();
           clickRef.current('l');
         } else {
-          pressRef.current('enter');
+          // Playing: tap is play/pause (a TV remote's centre button), because
+          // there is no focus ring to "select" during playback.
+          tapRef.current();
         }
       },
       // A parent stealing the gesture (edge-swipe, navigation) just cancels
@@ -468,9 +512,13 @@ export function WatchDpad({
       {/* Tiles: flick = one focus step, tap = OK. Pointer: drag the real mouse,
           tap = left click. Two-finger tap = Back in both. */}
       <View style={styles.swipePad} testID="watch-dpad-swipe" {...responder.panHandlers}>
-        <Text style={styles.swipeGlyph}>{pointer ? '⌖' : '✦'}</Text>
+        <Text style={styles.swipeGlyph}>{pointer ? '⌖' : playing ? '⏯' : '✦'}</Text>
         <Text style={styles.swipeHint}>
-          {pointer ? 'drag the pointer · tap to click' : 'swipe to move · tap for OK'}
+          {pointer
+            ? 'drag the pointer · tap to click'
+            : playing
+              ? 'swipe ◀ ▶ to seek · tap to play/pause'
+              : 'swipe to move · tap for OK'}
         </Text>
       </View>
 
@@ -502,7 +550,9 @@ export function WatchDpad({
       <Text style={styles.hint}>
         {pointer
           ? 'drag moves the TV pointer · tap clicks · two-finger tap = Back'
-          : 'swipe to move · tap selects · two-finger tap = Back'}
+          : playing
+            ? '◀ ▶ seek · ▲ ▼ volume · tap play/pause · two-finger tap = Back'
+            : 'swipe to move · tap selects · two-finger tap = Back'}
       </Text>
     </View>
   );

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -110,6 +110,9 @@ export function WatchDpad({
   ready,
   navOps,
   onGestureActive,
+  client: clientProp,
+  onKeyboard,
+  keyboardOpen,
 }: {
   settings: Settings;
   ready: boolean;
@@ -122,6 +125,17 @@ export function WatchDpad({
    * turning "swipe down a row" into "scroll the panel".
    */
   onGestureActive?: (active: boolean) => void;
+  /**
+   * The gamepad client to drive. Owned by WatchPanel so the panel can ALSO
+   * hang the phone-keyboard hook off the same session (its compose bar must
+   * render at panel root, outside the ScrollView). This component still owns
+   * the connect/hold lifecycle.
+   */
+  client?: GamepadClient;
+  /** Present = render a Keyboard button next to Back (opens the phone keyboard
+   *  for typing into whatever the TV has focused — search fields). */
+  onKeyboard?: () => void;
+  keyboardOpen?: boolean;
 }) {
   const styles = useThemedStyles(makeStyles);
   const navigation = useNavigation();
@@ -137,7 +151,9 @@ export function WatchDpad({
   const [holder, setHolder] = useState<string | null>(null);
   const [canForce, setCanForce] = useState(false);
 
-  const clientRef = useRef<GamepadClient | null>(null);
+  // Use the panel-owned client when given (so the panel's keyboard hook shares
+  // this session); create our own otherwise.
+  const clientRef = useRef<GamepadClient | null>(clientProp ?? null);
   if (clientRef.current == null) clientRef.current = new GamepadClient();
   const client = clientRef.current;
 
@@ -458,13 +474,30 @@ export function WatchDpad({
         </Text>
       </View>
 
-      <Pressable
-        onPress={() => press('esc')}
-        testID="watch-dpad-back"
-        style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
-      >
-        <Text style={styles.backText}>Back</Text>
-      </Pressable>
+      <View style={styles.btnRow2}>
+        <Pressable
+          onPress={() => press('esc')}
+          testID="watch-dpad-back"
+          style={({ pressed }) => [styles.backBtn, pressed && styles.pressed]}
+        >
+          <Text style={styles.backText}>Back</Text>
+        </Pressable>
+        {onKeyboard && (
+          <Pressable
+            onPress={onKeyboard}
+            testID="watch-dpad-keyboard"
+            style={({ pressed }) => [
+              styles.backBtn,
+              keyboardOpen && styles.kbOn,
+              pressed && styles.pressed,
+            ]}
+          >
+            <Text style={[styles.backText, keyboardOpen && styles.kbOnText]}>
+              Keyboard
+            </Text>
+          </Pressable>
+        )}
+      </View>
 
       <Text style={styles.hint}>
         {pointer
@@ -523,8 +556,8 @@ const makeStyles = (t: Palette) =>
     },
     swipeGlyph: { color: t.textFaint, fontSize: 22 },
     swipeHint: { color: t.textFaint, fontSize: 12 },
+    btnRow2: { flexDirection: 'row', gap: 8, marginTop: 2 },
     backBtn: {
-      marginTop: 2,
       paddingHorizontal: 22,
       paddingVertical: 10,
       borderRadius: 10,
@@ -533,6 +566,8 @@ const makeStyles = (t: Palette) =>
       borderColor: t.cardBorder,
     },
     backText: { color: t.text, fontSize: 13, fontWeight: '600' },
+    kbOn: { backgroundColor: t.accent, borderColor: t.accent },
+    kbOnText: { color: '#0b1220', fontWeight: '700' },
     hint: { color: t.textFaint, fontSize: 11, textAlign: 'center' },
     pressed: { opacity: 0.6 },
     handoff: {

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -77,7 +77,7 @@ import {
 import { useNavigation } from 'expo-router';
 
 import { api } from '@/lib/api';
-import { GamepadClient, GamepadStatus, SpecialKey } from '@/lib/gamepad';
+import { GamepadClient, GamepadStatus, MouseButton, SpecialKey } from '@/lib/gamepad';
 import { hapticLight } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { planSteps, type StepDir, type StepState } from '@/lib/swipeSteps';
@@ -88,6 +88,15 @@ import type { Settings } from '@/lib/settings';
  *  Pad's swipe surface. */
 const TAP_SLOP = 10;
 const TAP_MS = 350;
+
+/**
+ * Pointer-mode gain: on-pad px -> on-TV pointer px. A flat multiplier rather
+ * than the Pad trackpad's speed-adaptive curve — this pad is for picking a
+ * tile, not desktop precision work; 1.6 crosses a 4K row in about one swipe.
+ */
+const POINTER_GAIN = 1.6;
+
+type PadMode = 'tiles' | 'pointer';
 
 /** Names this device to the current holder's Pass/Keep prompt. Matches pad.tsx. */
 const DEVICE_LABEL =
@@ -187,6 +196,8 @@ export function WatchDpad({
   }, [status]);
 
   const holding = status === 'connected';
+  const holdingRef = useRef(holding);
+  holdingRef.current = holding;
 
   /** Send without haptic — the gesture path fires ONE haptic per move event,
    *  never one per step; per-step ticks flooded iOS's feedback queue on the Pad
@@ -245,6 +256,24 @@ export function WatchDpad({
   pressRef.current = press;
   const gestureRef = useRef<(active: boolean) => void>(() => {});
   gestureRef.current = onGestureActive ?? (() => {});
+  /** Pointer-mode tap-click: press then release, gated on holding control. */
+  const click = (btn: MouseButton) => {
+    if (!holding) return;
+    client.sendMouseButton(btn, 1);
+    client.sendMouseButton(btn, 0);
+  };
+  const clickRef = useRef(click);
+  clickRef.current = click;
+
+  // Tiles vs Pointer. Tiles steps the focus ring (the couch default); Pointer
+  // drives the real mouse like the Pad's trackpad — same {t:'m'}/{t:'mb'}
+  // frames, so the agent needs nothing new. Per-mount state on purpose: the
+  // right default after reopening a page is tiles.
+  const [mode, setMode] = useState<PadMode>('tiles');
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const clientRefStable = useRef(client);
+  clientRefStable.current = client;
 
   // Swipe surface. planSteps is the Pad's unit-tested planner: first step
   // cheap, repeats expensive, dominant axis wins. The responder is created
@@ -255,6 +284,8 @@ export function WatchDpad({
     stepped: false,
     moved: false,
     twoFinger: false,
+    lastX: 0,
+    lastY: 0,
     t0: 0,
   });
   const sens = usePref('swipeSensitivity');
@@ -273,6 +304,8 @@ export function WatchDpad({
           stepped: false,
           moved: false,
           twoFinger: false,
+          lastX: 0,
+          lastY: 0,
           t0: Date.now(),
         };
       },
@@ -282,7 +315,20 @@ export function WatchDpad({
         // move because Grant often fires before the second finger lands.
         if (g.numberActiveTouches >= 2) t.twoFinger = true;
         if (!t.moved && Math.hypot(g.dx, g.dy) > TAP_SLOP) t.moved = true;
-        if (t.twoFinger) return; // two-finger = Back on release, never steps
+        if (t.twoFinger) return; // two-finger = Back on release, never moves
+        if (modeRef.current === 'pointer') {
+          if (!holdingRef.current) return;
+          // Relative mouse, like the Pad trackpad. g.dx/dy are CUMULATIVE, so
+          // send the delta since the last move event; sendMouseMove coalesces
+          // and rate-limits internally.
+          clientRefStable.current.sendMouseMove(
+            (g.dx - t.lastX) * POINTER_GAIN,
+            (g.dy - t.lastY) * POINTER_GAIN,
+          );
+          t.lastX = g.dx;
+          t.lastY = g.dy;
+          return;
+        }
         const plan = planSteps(g.dx, g.dy, t as StepState, sensRef.current);
         t.consumedX = plan.next.consumedX;
         t.consumedY = plan.next.consumedY;
@@ -297,10 +343,16 @@ export function WatchDpad({
         gestureRef.current(false);
         const t = track.current;
         if (t.moved || Date.now() - t.t0 >= TAP_MS) return;
-        // Tap: one finger = OK, two fingers = Back (the trackpad's two-finger
-        // right-click convention, answering "how do we do the back button").
-        if (t.twoFinger) pressRef.current('esc');
-        else pressRef.current('enter');
+        // Tap: two fingers = Back in both modes; one finger = OK in tiles,
+        // LEFT CLICK in pointer (what a trackpad tap means).
+        if (t.twoFinger) {
+          pressRef.current('esc');
+        } else if (modeRef.current === 'pointer') {
+          hapticLight();
+          clickRef.current('l');
+        } else {
+          pressRef.current('enter');
+        }
       },
       // A parent stealing the gesture (edge-swipe, navigation) just cancels
       // it — steps already sent are single presses, nothing latches. Still must
@@ -337,7 +389,9 @@ export function WatchDpad({
     const waiting = status === 'connecting' || status === 'closed';
     return (
       <View style={styles.wrap} testID="watch-dpad">
-        <Text style={styles.title}>NAVIGATE</Text>
+        <View style={styles.titleRow}>
+          <Text style={styles.title}>NAVIGATE</Text>
+        </View>
         <View style={styles.handoff}>
           <Text style={styles.handoffText} numberOfLines={2}>
             {waiting
@@ -362,15 +416,42 @@ export function WatchDpad({
     );
   }
 
+  const pointer = mode === 'pointer';
   return (
     <View style={styles.wrap} testID="watch-dpad">
-      <Text style={styles.title}>NAVIGATE</Text>
+      <View style={styles.titleRow}>
+        <Text style={styles.title}>NAVIGATE</Text>
+        <View style={styles.modeRow}>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setMode('tiles');
+            }}
+            testID="watch-dpad-mode-tiles"
+            style={[styles.modeChip, !pointer && styles.modeChipOn]}
+          >
+            <Text style={[styles.modeText, !pointer && styles.modeTextOn]}>Tiles</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              hapticLight();
+              setMode('pointer');
+            }}
+            testID="watch-dpad-mode-pointer"
+            style={[styles.modeChip, pointer && styles.modeChipOn]}
+          >
+            <Text style={[styles.modeText, pointer && styles.modeTextOn]}>Pointer</Text>
+          </Pressable>
+        </View>
+      </View>
 
-      {/* Swipe surface: flick left/right = one step along the row, up/down =
-          one row; tap = OK; two-finger tap = Back. */}
+      {/* Tiles: flick = one focus step, tap = OK. Pointer: drag the real mouse,
+          tap = left click. Two-finger tap = Back in both. */}
       <View style={styles.swipePad} testID="watch-dpad-swipe" {...responder.panHandlers}>
-        <Text style={styles.swipeGlyph}>✦</Text>
-        <Text style={styles.swipeHint}>swipe to move · tap for OK</Text>
+        <Text style={styles.swipeGlyph}>{pointer ? '⌖' : '✦'}</Text>
+        <Text style={styles.swipeHint}>
+          {pointer ? 'drag the pointer · tap to click' : 'swipe to move · tap for OK'}
+        </Text>
       </View>
 
       <Pressable
@@ -382,8 +463,9 @@ export function WatchDpad({
       </Pressable>
 
       <Text style={styles.hint}>
-        swipe ◀ ▶ along a row · ▲ ▼ between rows · tap selects · two-finger tap
-        or Back exits
+        {pointer
+          ? 'drag moves the TV pointer · tap clicks · two-finger tap = Back'
+          : 'swipe to move · tap selects · two-finger tap = Back'}
       </Text>
     </View>
   );
@@ -398,16 +480,35 @@ const makeStyles = (t: Palette) =>
       paddingTop: 12,
       alignItems: 'center',
     },
+    titleRow: {
+      alignSelf: 'stretch',
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+    },
     title: {
       color: t.textFaint,
       fontSize: 11,
       fontWeight: '700',
       letterSpacing: 1.2,
-      alignSelf: 'stretch',
     },
+    modeRow: { flexDirection: 'row', gap: 6 },
+    modeChip: {
+      paddingHorizontal: 12,
+      paddingVertical: 6,
+      borderRadius: 8,
+      backgroundColor: t.inset,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+    },
+    modeChipOn: { backgroundColor: t.accent, borderColor: t.accent },
+    modeText: { color: t.textDim, fontSize: 12, fontWeight: '600' },
+    modeTextOn: { color: '#0b1220', fontWeight: '700' },
     swipePad: {
       alignSelf: 'stretch',
-      height: 168,
+      // Owner feedback on the first build: 168 felt cramped. A swipe surface
+      // is the primary control here — give it real estate.
+      height: 300,
       alignItems: 'center',
       justifyContent: 'center',
       gap: 6,

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -6,14 +6,34 @@
  * arrows, not by scrolling. Before this, the Watch panel could only launch a
  * service and then abandon it — you could not move between tiles from the couch.
  *
- * HOW IT WORKS (and why it needs no new agent code): the agent already exposes a
- * token-authed, hold-gated uinput keyboard on /ws/gamepad, and the key names
- * up/down/left/right/enter/esc are already frozen into its SPECIAL_KEYS table.
- * So this reuses GamepadClient.sendKey() exactly like the desktop keyboard does.
- * uinput delivers a REAL, trusted key event to whatever the compositor has
- * focused — which for the Player tile is its fullscreen Chrome — so Netflix's
+ * HOW IT WORKS: the agent exposes a token-authed, hold-gated uinput keyboard on
+ * /ws/gamepad, so this reuses GamepadClient.sendKey() exactly like the desktop
+ * keyboard does. uinput delivers a REAL, trusted key event to whatever the
+ * compositor has focused — the Player tile's fullscreen Chrome — so the page's
  * own key handler responds. (A synthetic CDP KeyboardEvent would be
  * isTrusted:false and Netflix ignores it; that is why this path, not CDP.)
+ *
+ * WHICH KEYS — MEASURED, NOT ASSUMED (2026-08-17, reference box, real sites,
+ * each run carrying a control key whose answer was already known):
+ *
+ *   netflix.com   right/down -> focus UNCHANGED     tab -> Mima to pokemonRhyott
+ *   youtube.com   right/down -> focus UNCHANGED     tab -> "Skip navigation" to
+ *                                                          "Search with voice"
+ *
+ * Arrow-key grid navigation is a TV-APP behaviour; the WEB versions of these
+ * services ignore arrows entirely and move their focus ring on Tab. So:
+ *
+ *   left / right -> Shift+Tab / Tab   walk the focus ring between tiles
+ *   up / down    -> arrow keys        scroll the page (netflix browse scrolled
+ *                                     0 -> 51 -> 120 on down)
+ *   OK           -> enter             activates the focused tile (observed
+ *                                     selecting a Netflix profile)
+ *   Back         -> esc
+ *
+ * Shift+Tab needs agent >= 2.9.95 (the `shifttab` chord). An older agent does
+ * not merely ignore an unknown key name — it errors and CLOSES the session — so
+ * the back-direction button feature-detects via client.supportsKey() and falls
+ * back to a plain arrow rather than risking the socket.
  *
  * We connect with noPad:true so the agent never materialises a virtual Xbox pad
  * for this session (which would make Steam announce a controller). Keys only
@@ -118,6 +138,19 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
     client.sendKey(key);
   };
 
+  /**
+   * Walk the page's focus ring. Forward is Tab everywhere; backward needs the
+   * Shift+Tab chord (agent >= 2.9.95). Against an older agent that name would
+   * close the session, so fall back to a plain Left arrow — which does nothing
+   * on Netflix/YouTube but is harmless, and still scrolls pages that respond to
+   * arrows. Checked at press time, not mount: the socket may reconnect to a
+   * different box while the panel is open.
+   */
+  const focusStep = (forward: boolean) => {
+    if (forward) return press('tab');
+    return press(client.supportsKey('shifttab') ? 'shifttab' : 'left');
+  };
+
   const takeControl = () => {
     hapticLight();
     const s = client.getStatus();
@@ -172,14 +205,19 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
     <View style={styles.wrap} testID="watch-dpad">
       <Text style={styles.title}>NAVIGATE</Text>
 
-      {/* Cross: up on top, left/OK/right in the middle, down on the bottom. */}
+      {/* Cross: up/down SCROLL the page, left/right walk the focus ring. */}
       <View style={styles.row}>
         <View style={styles.cell} />
         <DKey label="▲" testID="watch-dpad-up" onPress={() => press('up')} styles={styles} />
         <View style={styles.cell} />
       </View>
       <View style={styles.row}>
-        <DKey label="◀" testID="watch-dpad-left" onPress={() => press('left')} styles={styles} />
+        <DKey
+          label="◀"
+          testID="watch-dpad-left"
+          onPress={() => focusStep(false)}
+          styles={styles}
+        />
         <DKey
           label="OK"
           testID="watch-dpad-ok"
@@ -187,7 +225,12 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
           styles={styles}
           main
         />
-        <DKey label="▶" testID="watch-dpad-right" onPress={() => press('right')} styles={styles} />
+        <DKey
+          label="▶"
+          testID="watch-dpad-right"
+          onPress={() => focusStep(true)}
+          styles={styles}
+        />
       </View>
       <View style={styles.row}>
         <View style={styles.cell} />
@@ -203,7 +246,9 @@ export function WatchDpad({ settings, ready }: { settings: Settings; ready: bool
         <Text style={styles.backText}>Back</Text>
       </Pressable>
 
-      <Text style={styles.hint}>Arrows move between tiles · OK selects · Back exits</Text>
+      <Text style={styles.hint}>
+        ◀ ▶ move between tiles · ▲ ▼ scroll · OK selects · Back exits
+      </Text>
     </View>
   );
 }

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -160,6 +160,10 @@ export function WatchPanel() {
   const [error, setError] = useState<string | null>(null);
   const [link, setLink] = useState('');
   const [query, setQuery] = useState('');
+  // True while a finger is on the d-pad's swipe surface. The ScrollView must
+  // not scroll during it, or a vertical swipe scrolls the panel instead of
+  // stepping the TV's focus a row.
+  const [dpadGesture, setDpadGesture] = useState(false);
 
   const configured = settings.host.trim().length > 0;
 
@@ -336,6 +340,7 @@ export function WatchPanel() {
       style={styles.root}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
+      scrollEnabled={!dpadGesture}
     >
       {state.running ? (
         <View style={styles.nowCard} testID="watch-now-playing">
@@ -368,7 +373,12 @@ export function WatchPanel() {
           {/* D-pad drives the page's focus ring (Netflix/YouTube tile grids,
               and any web page). Rides the existing uinput key path, so it shows
               for ANY open page — not gated on <video> like the scrubber below. */}
-          <WatchDpad settings={settings} ready={ready} navOps={state.nav_ops} />
+          <WatchDpad
+            settings={settings}
+            ready={ready}
+            navOps={state.nav_ops}
+            onGestureActive={setDpadGesture}
+          />
 
           {/* Transport appears only when the box reports a real <video>. A
               service that is open but sitting on its home screen has nothing to

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -14,6 +14,7 @@ import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
 import { clearRecents, noteRecent, useWatchRecents } from '@/lib/watchRecents';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import { WatchDpad } from '@/components/WatchDpad';
 
 /**
  * DISPLAY ONLY. This is not an allowlist and must never become one — the box's
@@ -364,6 +365,11 @@ export function WatchPanel() {
             </Pressable>
           </View>
 
+          {/* D-pad drives the page's focus ring (Netflix/YouTube tile grids,
+              and any web page). Rides the existing uinput key path, so it shows
+              for ANY open page — not gated on <video> like the scrubber below. */}
+          <WatchDpad settings={settings} ready={ready} />
+
           {/* Transport appears only when the box reports a real <video>. A
               service that is open but sitting on its home screen has nothing to
               scrub, and a dead scrubber is worse than no scrubber. */}
@@ -441,8 +447,8 @@ export function WatchPanel() {
       {error ? <Text style={styles.error}>{error}</Text> : null}
 
       <Text style={styles.beta} testID="watch-beta">
-        EXPERIMENTAL — expect rough edges. Streaming sites need the trackpad,
-        not the d-pad.
+        EXPERIMENTAL — expect rough edges. Use the d-pad above to move between
+        tiles once a page is open.
       </Text>
 
       {/* The box's own screen. Useful when the phone is not the thing in your

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -431,6 +431,24 @@ export function WatchPanel() {
             client={gpRef.current}
             onKeyboard={kb.toggle}
             keyboardOpen={kb.open}
+            // Transport mode while a video actually plays — the page has no
+            // focusable controls then, so tile nav would be a silent no-op.
+            playing={playback?.playing === true}
+            onSeek={(dir) => {
+              const secs = dir > 0 ? fwd : back;
+              if (secs != null) transport('seek', { secs });
+            }}
+            onPlayPause={() => transport('playpause')}
+            onVolume={(dir) => {
+              hapticLight();
+              void api
+                .tvSend(
+                  settings,
+                  dir > 0 ? 'volume_up' : 'volume_down',
+                  settings.volumeTarget ?? 'box',
+                )
+                .catch(() => {});
+            }}
           />
 
           {/* TV zoom. Values come from the BOX (ui_scales — a frozen set), so

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -212,6 +212,33 @@ export function WatchPanel() {
     [settings, player],
   );
 
+  // Free-URL tier (agent §5 tier 3): only when the BOX opted in (open_url) does
+  // the app offer opening an arbitrary web page. The box does the real
+  // validation; looksLikeUrl is a client hint only, so a bad paste is refused
+  // helpfully rather than sent.
+  const canOpenAnyLink = state?.open_url === true;
+  const openUrl = useCallback(
+    async (url: string) => {
+      hapticLight();
+      setBusy('__url__');
+      setError(null);
+      try {
+        await api.playerOp(settings, 'open', { url });
+        hapticSuccess();
+        setLink('');
+        player.refresh();
+      } catch (e) {
+        hapticError();
+        setError(
+          `The box wouldn’t open that page. ${e instanceof Error ? e.message : ''}`.trim(),
+        );
+      } finally {
+        setBusy(null);
+      }
+    },
+    [settings, player],
+  );
+
   const stop = useCallback(async () => {
     hapticLight();
     setBusy('__stop__');
@@ -235,6 +262,13 @@ export function WatchPanel() {
         : null,
     [link, state?.service_urls, state?.service_hosts],
   );
+  // A pasted string the box's free-URL tier could accept: an http(s) URL that
+  // isn't already a known service (those take the deep-link path above). Client
+  // hint only — the box validates scheme/host/port and refuses the rest.
+  const webLink = useMemo(() => {
+    const s = link.trim();
+    return canOpenAnyLink && !parsedLink && /^https?:\/\/\S+$/i.test(s) ? s : null;
+  }, [link, canOpenAnyLink, parsedLink]);
 
   const playback = state?.playback ?? null;
   // Offsets come from the BOX (seek_secs), so the app can never offer a value
@@ -262,9 +296,9 @@ export function WatchPanel() {
   );
 
   const sendLink = useCallback(() => {
-    if (!parsedLink) return;
-    open(parsedLink.service, parsedLink.path);
-  }, [parsedLink, open]);
+    if (parsedLink) { open(parsedLink.service, parsedLink.path); return; }
+    if (webLink) openUrl(webLink);              // free-URL tier (box opted in)
+  }, [parsedLink, webLink, open, openUrl]);
 
   if (!configured) {
     return (
@@ -506,7 +540,7 @@ export function WatchPanel() {
         <TextInput
           value={link}
           onChangeText={setLink}
-          placeholder="Paste a link from a service"
+          placeholder={canOpenAnyLink ? 'Paste a service link or any web page' : 'Paste a link from a service'}
           placeholderTextColor={t.textFaint}
           autoCapitalize="none"
           autoCorrect={false}
@@ -516,22 +550,29 @@ export function WatchPanel() {
         />
         <Pressable
           onPress={sendLink}
-          disabled={!parsedLink || busy !== null}
+          disabled={!(parsedLink || webLink) || busy !== null}
           testID="watch-link-send"
           style={({ pressed }) => [
             styles.sendBtn,
-            !parsedLink && styles.sendBtnOff,
+            !(parsedLink || webLink) && styles.sendBtnOff,
             pressed && styles.pressed,
           ]}
         >
-          <Text style={[styles.sendText, !parsedLink && styles.sendTextOff]}>
-            Send
+          <Text style={[styles.sendText, !(parsedLink || webLink) && styles.sendTextOff]}>
+            {webLink ? 'Open' : 'Send'}
           </Text>
         </Pressable>
       </View>
-      {link.trim() && !parsedLink ? (
+      {link.trim() && !parsedLink && !webLink ? (
         <Text style={styles.hint} testID="watch-link-hint">
-          That isn’t a link from a service this box knows.
+          {canOpenAnyLink
+            ? 'Paste a service link, or a full http(s) web address to open on the box.'
+            : 'That isn’t a link from a service this box knows.'}
+        </Text>
+      ) : null}
+      {webLink ? (
+        <Text style={styles.hintOk} testID="watch-weblink-ok">
+          Opens as a web page on the box.
         </Text>
       ) : null}
       {parsedLink ? (

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -368,7 +368,7 @@ export function WatchPanel() {
           {/* D-pad drives the page's focus ring (Netflix/YouTube tile grids,
               and any web page). Rides the existing uinput key path, so it shows
               for ANY open page — not gated on <video> like the scrubber below. */}
-          <WatchDpad settings={settings} ready={ready} />
+          <WatchDpad settings={settings} ready={ready} navOps={state.nav_ops} />
 
           {/* Transport appears only when the box reports a real <video>. A
               service that is open but sitting on its home screen has nothing to

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -15,6 +15,8 @@ import { useSettings } from '@/lib/SettingsContext';
 import { clearRecents, noteRecent, useWatchRecents } from '@/lib/watchRecents';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 import { WatchDpad } from '@/components/WatchDpad';
+import { useDesktopKeyboard } from '@/components/DesktopKeyboard';
+import { GamepadClient } from '@/lib/gamepad';
 
 /**
  * DISPLAY ONLY. This is not an allowlist and must never become one — the box's
@@ -173,6 +175,12 @@ export function WatchPanel() {
   // Jump the panel to the top when an open starts, so the Starting/Now card is
   // on screen instead of below the fold the user tapped from.
   const scrollRef = useRef<ScrollView | null>(null);
+  // The gamepad session is OWNED here (WatchDpad runs its lifecycle) so the
+  // phone-keyboard hook can share it: typing rides the same {t:'kt'} path,
+  // and the compose bar must render at panel root, outside the ScrollView.
+  const gpRef = useRef<GamepadClient | null>(null);
+  if (gpRef.current == null) gpRef.current = new GamepadClient();
+  const kb = useDesktopKeyboard(gpRef.current);
 
   const configured = settings.host.trim().length > 0;
 
@@ -360,6 +368,7 @@ export function WatchPanel() {
   }
 
   return (
+    <View style={styles.root}>
     <ScrollView
       ref={scrollRef}
       style={styles.root}
@@ -419,6 +428,9 @@ export function WatchPanel() {
             ready={ready}
             navOps={state.nav_ops}
             onGestureActive={setDpadGesture}
+            client={gpRef.current}
+            onKeyboard={kb.toggle}
+            keyboardOpen={kb.open}
           />
 
           {/* TV zoom. Values come from the BOX (ui_scales — a frozen set), so
@@ -728,6 +740,10 @@ export function WatchPanel() {
         })}
       </View>
     </ScrollView>
+    {/* Phone-keyboard compose bar: absolute at panel root so its keyboard-lift
+        math sees the screen, not a card inside the scroll. */}
+    {kb.bar}
+    </View>
   );
 }
 

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import {
   Pressable,
   ScrollView,
@@ -164,6 +164,15 @@ export function WatchPanel() {
   // not scroll during it, or a vertical swipe scrolls the panel instead of
   // stepping the TV's focus a row.
   const [dpadGesture, setDpadGesture] = useState(false);
+  // Optimistic "Starting…" card. The box's truth arrives on a 5s poll, so
+  // without this a tapped service shows NOTHING for up to five seconds — the
+  // single biggest "does not feel native" gap. Set from the POST's own success
+  // (the box really is starting it), cleared when the poll confirms running or
+  // after a timeout that means the tile died.
+  const [pending, setPending] = useState<string | null>(null);
+  // Jump the panel to the top when an open starts, so the Starting/Now card is
+  // on screen instead of below the fold the user tapped from.
+  const scrollRef = useRef<ScrollView | null>(null);
 
   const configured = settings.host.trim().length > 0;
 
@@ -180,6 +189,17 @@ export function WatchPanel() {
 
   const state = player.data;
   const services = state?.services ?? [];
+
+  // Poll confirmed the player is up (or it never came up): drop the optimism.
+  React.useEffect(() => {
+    if (!pending) return undefined;
+    if (state?.running) {
+      setPending(null);
+      return undefined;
+    }
+    const timer = setTimeout(() => setPending(null), 25_000);
+    return () => clearTimeout(timer);
+  }, [pending, state?.running]);
   // Which services can be searched is the BOX's answer, not a guess here:
   // a verified search URL exists for some services and not others.
   const searchable = state?.searchable ?? [];
@@ -199,6 +219,8 @@ export function WatchPanel() {
           query ? { service, query } : path ? { service, path } : { service },
         );
         hapticSuccess();
+        setPending(service);
+        scrollRef.current?.scrollTo({ y: 0, animated: true });
         noteRecent({ service, query, path: query ? '' : path });
         setLink('');
         setQuery('');
@@ -230,6 +252,8 @@ export function WatchPanel() {
       try {
         await api.playerOp(settings, 'open', { url });
         hapticSuccess();
+        setPending('__web__');
+        scrollRef.current?.scrollTo({ y: 0, animated: true });
         setLink('');
         player.refresh();
       } catch (e) {
@@ -283,7 +307,7 @@ export function WatchPanel() {
   const fwd = offsets.filter((n) => n > 0).sort((a, b) => a - b)[0] ?? null;
 
   const transport = useCallback(
-    async (op: PlayerOp, opts: { secs?: number } = {}) => {
+    async (op: PlayerOp, opts: { secs?: number; value?: string } = {}) => {
       hapticLight();
       setBusy(op);
       setError(null);
@@ -337,16 +361,33 @@ export function WatchPanel() {
 
   return (
     <ScrollView
+      ref={scrollRef}
       style={styles.root}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
       scrollEnabled={!dpadGesture}
     >
       {state.running ? (
-        <View style={styles.nowCard} testID="watch-now-playing">
+        <View
+          style={[
+            styles.nowCard,
+            // Service-branded card: the accent the tile carries follows the
+            // service onto the now-playing card, so Netflix feels like
+            // Netflix's card and not a generic player shell.
+            { borderLeftColor: ACCENTS[state.service ?? ''] ?? t.accent, borderLeftWidth: 3 },
+          ]}
+          testID="watch-now-playing"
+        >
           <View style={styles.nowTop}>
             <View style={{ flex: 1 }}>
-              <Text style={styles.nowLabel}>ON THE TV</Text>
+              <Text
+                style={[
+                  styles.nowLabel,
+                  { color: ACCENTS[state.service ?? ''] ?? t.green },
+                ]}
+              >
+                ON THE TV
+              </Text>
               <Text style={styles.nowService}>{label(state.service)}</Text>
               {playback?.title ? (
                 <Text style={styles.nowPath} numberOfLines={1}>
@@ -379,6 +420,33 @@ export function WatchPanel() {
             navOps={state.nav_ops}
             onGestureActive={setDpadGesture}
           />
+
+          {/* TV zoom. Values come from the BOX (ui_scales — a frozen set), so
+              the app can never offer a scale the box would refuse. Older
+              agents don't send it and the row hides. */}
+          {(state.ui_scales?.length ?? 0) > 0 && (
+            <View style={styles.zoomRow} testID="watch-zoom">
+              <Text style={styles.zoomLabel}>TV ZOOM</Text>
+              <View style={styles.zoomChips}>
+                {state.ui_scales!.map((v) => {
+                  const on = v === (state.ui_scale ?? '');
+                  return (
+                    <Pressable
+                      key={v}
+                      onPress={() => transport('scale', { value: v })}
+                      disabled={busy !== null}
+                      testID={`watch-zoom-${v}`}
+                      style={[styles.zoomChip, on && styles.zoomChipOn]}
+                    >
+                      <Text style={[styles.zoomText, on && styles.zoomTextOn]}>
+                        {v}×
+                      </Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            </View>
+          )}
 
           {/* Transport appears only when the box reports a real <video>. A
               service that is open but sitting on its home screen has nothing to
@@ -449,6 +517,38 @@ export function WatchPanel() {
 
             </View>
           ) : null}
+        </View>
+      ) : pending ? (
+        <View
+          style={[
+            styles.nowCard,
+            {
+              borderLeftColor:
+                pending === '__web__' ? t.accent : (ACCENTS[pending] ?? t.accent),
+              borderLeftWidth: 3,
+            },
+          ]}
+          testID="watch-starting"
+        >
+          <View style={styles.nowTop}>
+            <View style={{ flex: 1 }}>
+              <Text
+                style={[
+                  styles.nowLabel,
+                  {
+                    color:
+                      pending === '__web__' ? t.accent : (ACCENTS[pending] ?? t.green),
+                  },
+                ]}
+              >
+                STARTING
+              </Text>
+              <Text style={styles.nowService}>
+                {pending === '__web__' ? 'Web page' : label(pending)}
+              </Text>
+              <Text style={styles.nowPath}>Opening on the TV…</Text>
+            </View>
+          </View>
         </View>
       ) : (
         <Text style={styles.idle}>Nothing playing. Pick a service.</Text>
@@ -686,6 +786,27 @@ const makeStyles = (t: Palette) =>
     tBtnText: { color: t.text, fontSize: 13, fontWeight: '600' },
     tBtnMainText: { color: '#0b1220', fontWeight: '700' },
     nowLabel: { color: t.green, fontSize: 10, fontWeight: '700', letterSpacing: 1.2 },
+    zoomRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: t.cardBorder,
+      paddingTop: 12,
+    },
+    zoomLabel: { color: t.textFaint, fontSize: 11, fontWeight: '700', letterSpacing: 1.2 },
+    zoomChips: { flexDirection: 'row', gap: 6, flex: 1, justifyContent: 'flex-end' },
+    zoomChip: {
+      paddingHorizontal: 10,
+      paddingVertical: 6,
+      borderRadius: 8,
+      backgroundColor: t.inset,
+      borderWidth: StyleSheet.hairlineWidth,
+      borderColor: t.cardBorder,
+    },
+    zoomChipOn: { backgroundColor: t.accent, borderColor: t.accent },
+    zoomText: { color: t.textDim, fontSize: 12, fontWeight: '600' },
+    zoomTextOn: { color: '#0b1220', fontWeight: '700' },
     nowService: { color: t.text, fontSize: 20, fontWeight: '700', marginTop: 2 },
     nowPath: { color: t.textFaint, fontSize: 12, marginTop: 2 },
     stopBtn: {

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -457,7 +457,7 @@ export function WatchPanel() {
       {error ? <Text style={styles.error}>{error}</Text> : null}
 
       <Text style={styles.beta} testID="watch-beta">
-        EXPERIMENTAL — expect rough edges. Use the d-pad above to move between
+        EXPERIMENTAL — expect rough edges. Swipe the pad above to move between
         tiles once a page is open.
       </Text>
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -324,6 +324,13 @@ export type PlayerState = {
    */
   open_url?: boolean;
   /**
+   * Spatial focus steps this agent accepts (e.g. ['navdown','navup'], agent
+   * >= 2.9.95). Absent on older boxes, where the d-pad's up/down falls back to
+   * plain arrow keys — which only scroll on the streaming sites, so the fallback
+   * cannot move between rows. Feature-detect; never assume.
+   */
+  nav_ops?: string[];
+  /**
    * {service -> extra hosts it is reachable on}, for LINK MATCHING only.
    * Measured: play.max.com redirects to play.hbomax.com and shared Max links
    * use the latter, so matching only the canonical host rejected the one
@@ -346,7 +353,12 @@ export type PlayerPlayback = {
 /** Transport ops the box accepts. Anything else is refused with a 404. */
 export type PlayerOp =
   | 'open' | 'close' | 'hub'
-  | 'play' | 'pause' | 'playpause' | 'mute' | 'seek';
+  | 'play' | 'pause' | 'playpause' | 'mute' | 'seek'
+  /** Spatial focus steps for the d-pad (agent >= 2.9.95). Move the page's focus
+   *  to the nearest element above/below — Tab only walks ALONG a row of tiles,
+   *  and arrow keys just scroll on the streaming sites. Gated on
+   *  PlayerState.nav_ops; an older agent answers 400. */
+  | 'navup' | 'navdown';
 
 /** One connected display, from GET /api/displays. */
 export type Display = {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -330,6 +330,10 @@ export type PlayerState = {
    * cannot move between rows. Feature-detect; never assume.
    */
   nav_ops?: string[];
+  /** Effective TV zoom ('2') and the frozen set the box accepts (agent >=
+   *  2.9.95). Absent on older boxes — hide the zoom control there. */
+  ui_scale?: string;
+  ui_scales?: string[];
   /**
    * {service -> extra hosts it is reachable on}, for LINK MATCHING only.
    * Measured: play.max.com redirects to play.hbomax.com and shared Max links
@@ -358,7 +362,9 @@ export type PlayerOp =
    *  to the nearest element above/below — Tab only walks ALONG a row of tiles,
    *  and arrow keys just scroll on the streaming sites. Gated on
    *  PlayerState.nav_ops; an older agent answers 400. */
-  | 'navup' | 'navdown';
+  | 'navup' | 'navdown'
+  /** TV zoom: value must be a member of PlayerState.ui_scales (agent >= 2.9.95). */
+  | 'scale';
 
 /** One connected display, from GET /api/displays. */
 export type Display = {
@@ -2646,6 +2652,8 @@ export const api = {
        *  box set player.custom_url (PlayerState.open_url); the box validates
        *  scheme/host/port and refuses the rest with 403/404. */
       url?: string;
+      /** For op 'scale': must be a member of PlayerState.ui_scales. */
+      value?: string;
     } = {},
   ): Promise<{ ok: boolean; running?: boolean; starting?: boolean; service?: string; url?: string }> {
     return request(settings, '/api/player', {

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -362,7 +362,7 @@ export type PlayerOp =
    *  to the nearest element above/below — Tab only walks ALONG a row of tiles,
    *  and arrow keys just scroll on the streaming sites. Gated on
    *  PlayerState.nav_ops; an older agent answers 400. */
-  | 'navup' | 'navdown'
+  | 'navup' | 'navdown' | 'navleft' | 'navright'
   /** TV zoom: value must be a member of PlayerState.ui_scales (agent >= 2.9.95). */
   | 'scale';
 

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -318,6 +318,12 @@ export type PlayerState = {
   /** Query the tile is currently showing results for, '' otherwise. */
   query?: string;
   /**
+   * True only when the box owner opted into the free-URL tier
+   * (config.json player.custom_url). Absent/false on every box that has not —
+   * so the app offers "open any web page" only where the box allows it.
+   */
+  open_url?: boolean;
+  /**
    * {service -> extra hosts it is reachable on}, for LINK MATCHING only.
    * Measured: play.max.com redirects to play.hbomax.com and shared Max links
    * use the latter, so matching only the canonical host rejected the one
@@ -2624,8 +2630,12 @@ export const api = {
       /** Free text. The box rejects it on structure and percent-encodes the
        *  rest; only services in PlayerState.searchable accept it. */
       query?: string;
+      /** An arbitrary http(s) URL — the free-URL tier. Accepted ONLY when the
+       *  box set player.custom_url (PlayerState.open_url); the box validates
+       *  scheme/host/port and refuses the rest with 403/404. */
+      url?: string;
     } = {},
-  ): Promise<{ ok: boolean; running?: boolean; starting?: boolean; service?: string }> {
+  ): Promise<{ ok: boolean; running?: boolean; starting?: boolean; service?: string; url?: string }> {
     return request(settings, '/api/player', {
       method: 'POST',
       body: { op, ...opts },

--- a/app/lib/gamepad.ts
+++ b/app/lib/gamepad.ts
@@ -85,6 +85,16 @@ export type StickKey = 'l' | 'r';
 export type MouseButton = 'l' | 'r' | 'm';
 
 /** Special keys the server maps to KEY_* codes (see protocol v2). */
+/**
+ * Key names every agent has accepted since the protocol's original set. Used to
+ * answer supportsKey() for an agent too old to advertise hello.keys — anything
+ * outside this set is assumed unsupported there.
+ */
+const LEGACY_KEYS: ReadonlySet<string> = new Set([
+  'backspace', 'enter', 'tab', 'esc', 'space',
+  'up', 'down', 'left', 'right', 'home', 'end',
+]);
+
 export type SpecialKey =
   | 'backspace'
   | 'enter'
@@ -96,7 +106,11 @@ export type SpecialKey =
   | 'left'
   | 'right'
   | 'home'
-  | 'end';
+  | 'end'
+  /** Shift+Tab — walks a web page's focus ring BACKWARDS (agent >= 2.9.95).
+   *  Only send it when the agent advertises it in hello.keys: an agent that
+   *  does not know a name replies {t:'err'} and CLOSES the session. */
+  | 'shifttab';
 
 export const BUTTON_KEYS: ButtonKey[] = [
   'a',
@@ -318,6 +332,15 @@ export class GamepadClient {
   private dev: string | null = null;
   /** Text capability from the hello frame ('unicode'|'ascii'); null until known. */
   private textCaps: 'unicode' | 'ascii' | null = null;
+  /**
+   * Named keys/chords this agent accepts, from hello.keys (agent >= 2.9.95).
+   * null while unknown (older agent, or before hello).
+   *
+   * This exists because an unknown key name is not ignored by the agent — it
+   * raises and CLOSES the session. So a newer app must feature-detect rather
+   * than blind-fire a name an older box has never heard of.
+   */
+  private keyNames: Set<string> | null = null;
   private listener: GamepadStatusListener | null = null;
 
   // Input-injection paused state, signalled by the server (Windows agent):
@@ -900,6 +923,20 @@ export class GamepadClient {
   }
 
   /**
+   * Does the connected agent accept this key name?
+   *
+   * Only meaningful for names added after the original protocol set: an agent
+   * that never advertised `keys` is assumed to know exactly the long-standing
+   * names and nothing more. Answering false for an unknown-but-supported key
+   * costs a disabled button; answering true for an unsupported one costs the
+   * whole session (the agent errors and closes), so this errs to false.
+   */
+  supportsKey(key: SpecialKey): boolean {
+    if (this.keyNames) return this.keyNames.has(key);
+    return LEGACY_KEYS.has(key);
+  }
+
+  /**
    * Walk Steam's focus to its global search field, then resolve.
    *
    * MEASURED on a Legion Go S in Game Mode, 2026-07-22, driven from a real
@@ -1047,6 +1084,8 @@ export class GamepadClient {
         t?: string; dev?: string; msg?: string; text?: string;
         code?: string; name?: string; holder?: string; by?: string;
         open?: boolean; value?: string;
+        /** hello: named keys/chords this agent accepts (agent >= 2.9.95). */
+        keys?: unknown;
       };
       try {
         msg = JSON.parse(String(ev.data));
@@ -1066,6 +1105,13 @@ export class GamepadClient {
             : this.dev === 'ViGEm X360 pad'
               ? 'unicode'
               : 'ascii';
+        // Advertised key names (agent >= 2.9.95). Absent on older agents, which
+        // leaves this null and makes supportsKey() answer false for anything
+        // beyond the long-standing set — the safe direction, since a wrong
+        // guess closes the socket.
+        this.keyNames = Array.isArray(msg.keys)
+          ? new Set(msg.keys.filter((k: unknown): k is string => typeof k === 'string'))
+          : null;
         this.setStatus('connected', this.dev);
         this.startPing();
       } else if (msg.t === 'waiting') {
@@ -1331,6 +1377,10 @@ export class GamepadClient {
     if (status !== 'connected') {
       this.setInputBlocked(false, null);
       this.textCaps = null;
+      // Likewise the advertised key list: reconnecting may land on a DIFFERENT
+      // box (the mDNS fallback, a switched box), and firing a key the new one
+      // never advertised would close that session.
+      this.keyNames = null;
     }
     if (this.listener) this.listener(status, dev);
   }

--- a/docs/memory/project_media-player.md
+++ b/docs/memory/project_media-player.md
@@ -332,6 +332,12 @@ plus CDP. Both are handled explicitly rather than assumed benign.
    share a link from the phone, it opens on the TV — with zero widening of the allowlist.
 3. **Free URL bar.** A genuinely new primitive, so it is gated behind a **box-side config flag
    that ships OFF**. A default install never gains arbitrary navigation.
+   **✅ BUILT 2026-08-11 — PR #491 (branch claude/player-open-url, off main).** Config
+   `"player": {"custom_url": false}`; `_pl_validate_open_url()` (agent, urllib) + a tile
+   `validate_open_url()` scheme backstop; route gated 403-when-off + rate-limited (429); app
+   WatchPanel offers "open as a web page" when the box reports `open_url`. 37-check test
+   (`tests/test_player_open_url.py`) in CI. NOT yet: on-box Chrome open (needs a Player box);
+   WatchPanel field device/harness tap (tsc-clean, testIDs in place).
 
 Tier-3 validation rules (reject, never sanitise — §3 rule 6):
 

--- a/tests/test_key_chords.py
+++ b/tests/test_key_chords.py
@@ -150,6 +150,47 @@ def _bad_type():
 
 check("unknown message type still raises", _bad_type(), True)
 
+# --- 6. the same unhashable-name hazard in the OTHER decoders ----------------
+# Found by sweeping for the shape after fixing it in keyboard_events: a client
+# controls the TYPE of these fields, not just their content, and `x in dict`
+# raises TypeError on an unhashable x — escaping the caller's `except
+# ValueError` and killing the session thread. Every decoder that indexes a
+# frozen table with a client value must type-check first.
+print("6. mouse/gamepad decoders refuse unhashable names too")
+
+_UNHASHABLE = ({"nested": "object"}, ["array"])
+
+
+def refused_by(fn, msg):
+    try:
+        fn(msg)
+    except ValueError:
+        return True
+    except TypeError:
+        return False   # the bug: escapes the caller's handler
+    return False
+
+
+for bad in _UNHASHABLE:
+    check("mouse mb refuses %r" % (bad,),
+          refused_by(cs.mouse_events, {"t": "mb", "k": bad, "v": 1}), True)
+    check("mouse mbp refuses %r" % (bad,),
+          refused_by(cs.mouse_events, {"t": "mbp", "k": bad, "v": 1}), True)
+    check("gamepad b refuses %r" % (bad,),
+          refused_by(cs.gamepad_events, {"t": "b", "k": bad, "v": 1}), True)
+    check("gamepad t refuses %r" % (bad,),
+          refused_by(cs.gamepad_events, {"t": "t", "k": bad, "v": 1}), True)
+    check("gamepad s refuses %r" % (bad,),
+          refused_by(cs.gamepad_events, {"t": "s", "k": bad, "x": 0, "y": 0}), True)
+
+# Controls: the fix must not have made valid input unreachable.
+check("control — gamepad button 'a' still decodes",
+      cs.gamepad_events({"t": "b", "k": "a", "v": 1}),
+      [(EV_KEY, cs.BTN_CODES["a"], 1)])
+check("control — mouse button 'l' still decodes",
+      cs.mouse_events({"t": "mb", "k": "l", "v": 1}),
+      [(EV_KEY, cs.MOUSE_BTN_CODES["l"], 1)])
+
 print()
 if FAILURES:
     print("FAILED: %s" % ", ".join(FAILURES))

--- a/tests/test_key_chords.py
+++ b/tests/test_key_chords.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Named key chords on the {t:'k'} channel — the Shift+Tab web-focus key.
+
+Run: python3 tests/test_key_chords.py
+
+WHY THIS EXISTS: a couch d-pad driving a web page cannot use arrow keys.
+Measured on the reference box 2026-08-17 against the real sites, each run
+carrying a control key whose answer was already known (§11.3): netflix.com and
+youtube.com IGNORE arrows (right/down changed neither focus nor scroll) and walk
+their focus ring on TAB. Going BACKWARDS needs Shift+Tab, which the frozen
+SPECIAL_KEYS table cannot express — hence KEY_CHORDS.
+
+Pins the §6 requirements for that surface, pure-stdlib, no box, no uinput:
+
+  1. HAPPY PATH: {"t":"k","key":"shifttab"} expands to Shift down, Tab down,
+     Tab up, Shift up — modifier wraps the base key, released in reverse.
+  2. UNKNOWN INPUT IS REFUSED: a key name that is not in any frozen table
+     raises ValueError and produces NO events (the caller closes the session).
+     Includes near-miss spellings, so this proves lookup and not prefix/pattern
+     matching (§3.1/§3.3).
+  3. THE DEVICE CAN ACTUALLY EMIT IT: every chord code is declared in
+     KEYBOARD_CODES, else UI_SET_KEYBIT never advertises it and the emit
+     silently does nothing on real hardware.
+  4. DISCOVERY IS HONEST: the hello frame's `keys` list contains exactly the
+     names the decoder accepts — no name is advertised that would be refused,
+     and none is accepted that isn't advertised. That list is what stops a
+     newer app from firing an unknown name at an older agent and killing its
+     own socket.
+  5. NOTHING EXISTING MOVED: the pre-existing named keys still decode as
+     single press+release, and the desktop chord still works (a control
+     proving this file's changes did not redefine the old path).
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+EV_KEY = cs.EV_KEY
+SHIFT = cs.KEY_LEFTSHIFT
+TAB = cs.KEY_TAB
+
+# --- 1. happy path -----------------------------------------------------------
+print("1. shifttab expands to a wrapped chord")
+check(
+    "shifttab -> shift down, tab down, tab up, shift up",
+    cs.keyboard_events({"t": "k", "key": "shifttab"}),
+    [(EV_KEY, SHIFT, 1), (EV_KEY, TAB, 1), (EV_KEY, TAB, 0), (EV_KEY, SHIFT, 0)],
+)
+# The whole point is that it differs from a bare Tab; if these ever matched,
+# the chord would be walking the focus ring the wrong way.
+check(
+    "shifttab differs from bare tab",
+    cs.keyboard_events({"t": "k", "key": "shifttab"})
+    != cs.keyboard_events({"t": "k", "key": "tab"}),
+    True,
+)
+
+# --- 2. unknown names are refused, and nothing runs ---------------------------
+print("2. unknown key names raise (lookup, not pattern match)")
+
+
+def refused(key):
+    try:
+        cs.keyboard_events({"t": "k", "key": key})
+    except ValueError:
+        return True
+    return False
+
+
+for bad in (
+    "shift+tab",     # the spelling a human would guess
+    "shifttab ",     # trailing space
+    "SHIFTTAB",      # case
+    "shift",         # a bare modifier is NOT separately pressable
+    "shifttabx",     # prefix of a valid name + extra
+    "ctrltab",       # a chord that exists in no table
+    "",
+    None,
+    123,
+    {"nested": "object"},
+):
+    check("refused %r" % (bad,), refused(bad), True)
+
+# --- 3. the virtual keyboard actually declares the codes ---------------------
+print("3. chord codes are declared at device create")
+for name, codes in cs.KEY_CHORDS.items():
+    for code in codes:
+        check("KEYBOARD_CODES declares %s code %d" % (name, code),
+              code in cs.KEYBOARD_CODES, True)
+
+# --- 4. hello's advertised key list matches what the decoder accepts ---------
+print("4. advertised `keys` == accepted names")
+advertised = sorted(set(cs.SPECIAL_KEYS) | set(cs.DESKTOP_CHORDS) | set(cs.KEY_CHORDS))
+# Everything advertised must decode without raising...
+accepted = []
+for name in advertised:
+    try:
+        cs.keyboard_events({"t": "k", "key": name})
+        accepted.append(name)
+    except ValueError:
+        pass
+check("every advertised key is accepted", accepted, advertised)
+check("shifttab is advertised", "shifttab" in advertised, True)
+# ...and the names the d-pad relies on are all present.
+for need in ("up", "down", "left", "right", "enter", "esc", "tab", "shifttab"):
+    check("d-pad key %r advertised" % need, need in advertised, True)
+
+# --- 5. controls: the pre-existing paths still behave -------------------------
+print("5. controls — existing keys unchanged")
+check(
+    "plain tab is still a single press+release",
+    cs.keyboard_events({"t": "k", "key": "tab"}),
+    [(EV_KEY, TAB, 1), (EV_KEY, TAB, 0)],
+)
+check(
+    "enter is still a single press+release",
+    cs.keyboard_events({"t": "k", "key": "enter"}),
+    [(EV_KEY, cs.KEY_ENTER, 1), (EV_KEY, cs.KEY_ENTER, 0)],
+)
+check(
+    "desktop chord still wraps in reverse",
+    cs.keyboard_events({"t": "k", "key": "overview"}),
+    [(EV_KEY, cs.KEY_LEFTMETA, 1), (EV_KEY, cs.KEY_W, 1),
+     (EV_KEY, cs.KEY_W, 0), (EV_KEY, cs.KEY_LEFTMETA, 0)],
+)
+def _bad_type():
+    try:
+        cs.keyboard_events({"t": "zzz"})
+    except ValueError:
+        return True
+    return False
+
+
+check("unknown message type still raises", _bad_type(), True)
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all key-chord tests passed")

--- a/tests/test_player_nav.py
+++ b/tests/test_player_nav.py
@@ -191,6 +191,78 @@ finally:
     os.unlink(cs.PLAYER_SCALE_FILE)
     cs.PLAYER_SCALE_FILE = _saved_file
 
+# --- 6. per-service seek strategy (the Netflix M7375 fix) --------------------
+# Measured on real playback: currentTime writes kill Netflix's player (M7375);
+# its own ArrowRight seeks cleanly. So seek presses keys for services in
+# _PL_KEY_SEEK_SERVICES and keeps the JS path for everything else.
+print("6. seek-by-key selection + press derivation")
+import tempfile as _tf
+
+_saved_conf = cs.PLAYER_CONF
+try:
+    fd = _tf.NamedTemporaryFile("w", suffix=".conf", delete=False)
+    cs.PLAYER_CONF = fd.name
+
+    fd.write("service=netflix\npath=\n")
+    fd.flush()
+    check("netflix page -> key seek", cs._pl_seek_wants_keys(), True)
+
+    with open(cs.PLAYER_CONF, "w") as f:
+        f.write("service=youtube\n")
+    check("youtube page -> JS seek", cs._pl_seek_wants_keys(), False)
+
+    # A free-URL open forces service=netflix into the conf, but carries url= —
+    # that page is a plain <video>, so it must NOT key-seek.
+    with open(cs.PLAYER_CONF, "w") as f:
+        f.write("service=netflix\nurl=https://example.com/x\n")
+    check("free-URL page -> JS seek even with service=netflix",
+          cs._pl_seek_wants_keys(), False)
+finally:
+    os.unlink(cs.PLAYER_CONF)
+    cs.PLAYER_CONF = _saved_conf
+
+check("absent conf -> JS seek (degrade to generic)", cs._pl_seek_wants_keys()
+      if not os.path.exists(cs.PLAYER_CONF) else False, False)
+
+
+class _RecKB:
+    """Records emitted key events instead of opening /dev/uinput."""
+    made = []
+
+    def __init__(self):
+        self.events = []
+        _RecKB.made.append(self)
+
+    def emit(self, events):
+        self.events.extend(events)
+
+    def destroy(self):
+        self.destroyed = True
+
+
+_saved_kb = cs.UInputKeyboard
+_saved_sleep = cs.time.sleep
+try:
+    cs.UInputKeyboard = _RecKB
+    cs.time.sleep = lambda s: None
+    _RecKB.made = []
+    r = cs._pl_seek_by_key(10)
+    kb = _RecKB.made[-1]
+    check("+10s = one Right press+release",
+          kb.events, [(cs.EV_KEY, cs.KEY_RIGHT, 1), (cs.EV_KEY, cs.KEY_RIGHT, 0)])
+    check("+10s reports via=key", (r["ok"], r["via"]), (True, "key"))
+    check("keyboard destroyed", getattr(kb, "destroyed", False), True)
+
+    _RecKB.made = []
+    cs._pl_seek_by_key(-30)
+    kb = _RecKB.made[-1]
+    lefts = [e for e in kb.events if e[1] == cs.KEY_LEFT and e[2] == 1]
+    check("-30s = three Left presses", len(lefts), 3)
+    check("-30s uses no Right", any(e[1] == cs.KEY_RIGHT for e in kb.events), False)
+finally:
+    cs.UInputKeyboard = _saved_kb
+    cs.time.sleep = _saved_sleep
+
 print()
 if FAILURES:
     print("FAILED: %s" % ", ".join(FAILURES))

--- a/tests/test_player_nav.py
+++ b/tests/test_player_nav.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Spatial focus navigation for the Watch d-pad: the navup/navdown player ops.
+
+Run: python3 tests/test_player_nav.py
+
+WHY THIS SURFACE EXISTS: Tab walks a page's focus order LINEARLY — right along a
+row of tiles, useless between rows — and the streaming sites ignore arrow keys
+(measured: netflix.com/youtube.com left focus untouched, arrows only scrolled).
+So vertical d-pad movement runs an agent-authored script that picks the nearest
+focusable element above/below. That is JS reaching a live page, i.e. exactly the
+kind of primitive CLAUDE.md §3 exists to fence in.
+
+Pins the §6 requirements, pure-stdlib, no box, no browser:
+
+  1. ALLOWLIST: the op id INDEXES a frozen dict of agent-authored scripts.
+     An unknown id raises ValueError (-> 404) and NO script is produced.
+     Includes near-misses, proving lookup rather than prefix/pattern matching.
+  2. NO CLIENT BYTES IN THE JS: the two scripts differ only by an agent-chosen
+     direction literal, and neither contains a placeholder a request could fill.
+  3. DEGRADE CLOSED: with the player not running, nothing is dispatched to CDP
+     (RuntimeError -> 409), and an unreachable browser is an error, not a
+     pretend success.
+  4. DISCOVERY IS HONEST: the GET payload advertises exactly the ops the
+     dispatcher accepts — the field the app feature-detects on.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+# --- 1. allowlist ------------------------------------------------------------
+print("1. op id is looked up, never interpolated")
+check("exactly two nav ops", sorted(cs.PLAYER_JS_NAV), ["navdown", "navup"])
+
+_saved_running = cs._pl_running
+_saved_run = cs._pl_cdp_run
+_saved_mock = cs.PL_MOCK
+try:
+    cs.PL_MOCK = False
+    ran = []
+    cs._pl_running = lambda: True
+    cs._pl_cdp_run = lambda script: ran.append(script) or True
+
+    for bad in ("navsideways", "nav", "navdow", "navdownx", "NAVDOWN", "navdown ",
+                "", None, 123, {"a": 1}, ["navdown"]):
+        ran.clear()
+        try:
+            cs.player_nav(bad)
+            check("refused %r" % (bad,), "ACCEPTED", "ValueError")
+        except ValueError:
+            check("refused %r (nothing ran)" % (bad,), ran, [])
+        except TypeError as e:
+            check("refused %r without TypeError" % (bad,), "TypeError: %s" % e, "ValueError")
+
+    # happy path: the op runs EXACTLY the script the frozen dict holds
+    for op in ("navdown", "navup"):
+        ran.clear()
+        r = cs.player_nav(op)
+        check("%s dispatches its own script" % op, ran, [cs.PLAYER_JS_NAV[op]])
+        check("%s reports ok" % op, (r["ok"], r["op"]), (True, op))
+
+    # --- 3. degrade closed ---------------------------------------------------
+    print("3. degrade closed")
+    cs._pl_running = lambda: False
+    ran.clear()
+    try:
+        cs.player_nav("navdown")
+        check("not running -> refused", "RAN", "RuntimeError")
+    except RuntimeError:
+        check("not running -> RuntimeError, nothing dispatched", ran, [])
+
+    cs._pl_running = lambda: True
+    cs._pl_cdp_run = lambda script: None      # browser unreachable
+    try:
+        cs.player_nav("navdown")
+        check("unreachable browser -> refused", "OK", "RuntimeError")
+    except RuntimeError:
+        check("unreachable browser -> RuntimeError (not a fake success)", True, True)
+finally:
+    cs._pl_running = _saved_running
+    cs._pl_cdp_run = _saved_run
+    cs.PL_MOCK = _saved_mock
+
+# --- 2. the scripts carry no client-fillable holes ---------------------------
+print("2. scripts are constants with an agent-chosen direction")
+down, up = cs.PLAYER_JS_NAV["navdown"], cs.PLAYER_JS_NAV["navup"]
+check("the two scripts differ", down != up, True)
+check("down uses DIR = 1", "var DIR = 1;" in down, True)
+check("up uses DIR = -1", "var DIR = -1;" in up, True)
+for name, js in (("navdown", down), ("navup", up)):
+    # A leftover %s/%d would mean a later edit could format a request value in.
+    check("%s has no format placeholder" % name,
+          ("%s" not in js) and ("%d" not in js), True)
+    check("%s sets real focus (so a real Enter activates it)" % name,
+          ".focus(" in js, True)
+
+# --- 4. discovery matches the dispatcher -------------------------------------
+print("4. advertised nav_ops == accepted ops")
+_saved_avail = cs.player_available
+try:
+    cs.PL_MOCK = False
+    cs.player_available = lambda: True
+    info = cs.player_info()
+    check("nav_ops advertised", sorted(info.get("nav_ops") or []), ["navdown", "navup"])
+    check("advertised == frozen table", sorted(info.get("nav_ops") or []),
+          sorted(cs.PLAYER_JS_NAV))
+    # additive, not a shape change: the long-standing fields are still there
+    for field in ("available", "running", "service", "path", "services", "seek_secs"):
+        check("existing field %r still present" % field, field in info, True)
+finally:
+    cs.player_available = _saved_avail
+    cs.PL_MOCK = _saved_mock
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all player nav tests passed")

--- a/tests/test_player_nav.py
+++ b/tests/test_player_nav.py
@@ -47,7 +47,8 @@ def check(name, got, want):
 
 # --- 1. allowlist ------------------------------------------------------------
 print("1. op id is looked up, never interpolated")
-check("exactly two nav ops", sorted(cs.PLAYER_JS_NAV), ["navdown", "navup"])
+check("exactly four nav ops", sorted(cs.PLAYER_JS_NAV),
+      ["navdown", "navleft", "navright", "navup"])
 
 _saved_running = cs._pl_running
 _saved_run = cs._pl_cdp_run
@@ -101,10 +102,14 @@ finally:
 # --- 2. the scripts carry no client-fillable holes ---------------------------
 print("2. scripts are constants with an agent-chosen direction")
 down, up = cs.PLAYER_JS_NAV["navdown"], cs.PLAYER_JS_NAV["navup"]
-check("the two scripts differ", down != up, True)
-check("down uses DIR = 1", "var DIR = 1;" in down, True)
-check("up uses DIR = -1", "var DIR = -1;" in up, True)
-for name, js in (("navdown", down), ("navup", up)):
+left, right = cs.PLAYER_JS_NAV["navleft"], cs.PLAYER_JS_NAV["navright"]
+check("all four scripts differ",
+      len({down, up, left, right}), 4)
+check("down is +Y", "var DX = 0, DY = 1;" in down, True)
+check("up is -Y", "var DX = 0, DY = -1;" in up, True)
+check("left is -X", "var DX = -1, DY = 0;" in left, True)
+check("right is +X", "var DX = 1, DY = 0;" in right, True)
+for name, js in (("navdown", down), ("navup", up), ("navleft", left), ("navright", right)):
     # A leftover %s/%d would mean a later edit could format a request value in.
     check("%s has no format placeholder" % name,
           ("%s" not in js) and ("%d" not in js), True)
@@ -118,7 +123,8 @@ try:
     cs.PL_MOCK = False
     cs.player_available = lambda: True
     info = cs.player_info()
-    check("nav_ops advertised", sorted(info.get("nav_ops") or []), ["navdown", "navup"])
+    check("nav_ops advertised", sorted(info.get("nav_ops") or []),
+          ["navdown", "navleft", "navright", "navup"])
     check("advertised == frozen table", sorted(info.get("nav_ops") or []),
           sorted(cs.PLAYER_JS_NAV))
     # additive, not a shape change: the long-standing fields are still there
@@ -127,6 +133,18 @@ try:
 finally:
     cs.player_available = _saved_avail
     cs.PL_MOCK = _saved_mock
+
+# --- 4b. the ROUTE gate covers every nav op ----------------------------------
+# Found the hard way: PLAYER_JS_NAV grew navleft/navright and nav_ops
+# advertised them, but the do_POST membership tuple still said only
+# navup/navdown — so the box advertised ops it then refused with 400. The
+# handler-level test above can't see that; check the dispatch source itself.
+print("4b. route dispatch tuple covers every nav op")
+import re
+_src = open(os.path.join(ROOT, "agent", "couchsided.py")).read()
+_m = re.search(r'elif op in \(([^)]*"navup"[^)]*)\):', _src)
+_route_ops = set(re.findall(r'"(nav[a-z]+)"', _m.group(1))) if _m else set()
+check("route tuple == PLAYER_JS_NAV keys", _route_ops, set(cs.PLAYER_JS_NAV))
 
 # --- 5. TV zoom (op "scale") — a client value can only SELECT a member -------
 print("5. scale op: frozen-membership selector")

--- a/tests/test_player_nav.py
+++ b/tests/test_player_nav.py
@@ -128,6 +128,51 @@ finally:
     cs.player_available = _saved_avail
     cs.PL_MOCK = _saved_mock
 
+# --- 5. TV zoom (op "scale") — a client value can only SELECT a member -------
+print("5. scale op: frozen-membership selector")
+_saved_mock2 = cs.PL_MOCK
+try:
+    cs.PL_MOCK = True
+    for bad in ("3", "0.5", "1.6", "2.0", " 1.5", "1.5 ", "", None, 1.5, 2,
+                {"v": "2"}, ["2"]):
+        try:
+            cs.player_scale(bad)
+            check("scale refused %r" % (bad,), "ACCEPTED", "ValueError")
+        except ValueError:
+            check("scale refused %r" % (bad,), True, True)
+        except TypeError as e:
+            check("scale refused %r without TypeError" % (bad,),
+                  "TypeError: %s" % e, "ValueError")
+    for good in cs._PL_UI_SCALES:
+        r = cs.player_scale(good)
+        check("scale accepts %r" % good, (r["ok"], r["scale"]), (True, good))
+    # discovery matches the acceptor
+    _saved_avail2 = cs.player_available
+    cs.player_available = lambda: True
+    info = cs.player_info()
+    cs.player_available = _saved_avail2
+    check("ui_scales advertised == frozen tuple",
+          info.get("ui_scales"), list(cs._PL_UI_SCALES))
+    check("ui_scale is a member or empty",
+          (info.get("ui_scale") or "2") in cs._PL_UI_SCALES, True)
+finally:
+    cs.PL_MOCK = _saved_mock2
+
+# stale/garbage override file is ignored, never interpreted
+import tempfile
+_saved_file = cs.PLAYER_SCALE_FILE
+try:
+    with tempfile.NamedTemporaryFile("w", suffix=".scale", delete=False) as tf:
+        tf.write("2; rm -rf /\n")
+        cs.PLAYER_SCALE_FILE = tf.name
+    check("garbage override file ignored", cs._pl_scale_override(), "")
+    with open(cs.PLAYER_SCALE_FILE, "w") as f:
+        f.write("1.5\n")
+    check("valid override file honoured", cs._pl_scale_override(), "1.5")
+finally:
+    os.unlink(cs.PLAYER_SCALE_FILE)
+    cs.PLAYER_SCALE_FILE = _saved_file
+
 print()
 if FAILURES:
     print("FAILED: %s" % ", ".join(FAILURES))

--- a/tests/test_player_open_url.py
+++ b/tests/test_player_open_url.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Free-URL tier of the Couchside Player (project_media-player.md §5 tier 3).
+
+Run: python3 tests/test_player_open_url.py
+
+Covers the security boundary of "a client makes the box's browser open an
+arbitrary page": the agent's urllib validator, the opt-in flag (ships OFF), and
+the tile's scheme backstop. No box, no browser — this is the allowlist proof.
+"""
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+
+BASH = shutil.which("bash") or "/bin/bash"
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+TILE = os.path.join(HERE, "..", "agent", "couchside-player.sh")
+
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(name, cond, detail=""):
+    print("%s %s%s" % (PASS if cond else FAIL, name, "" if cond else "  <- %s" % detail))
+    if not cond:
+        _fail.append(name)
+
+
+# --- 1. the agent urllib validator (the primary enforcement) ----------------
+ACCEPT = [
+    "https://en.wikipedia.org/wiki/Steam_Deck",
+    "https://example.com:8443/path?q=1",
+    "http://192.168.1.50:32400/web",          # Plex on the LAN over http
+    "http://10.0.0.5:8096/",                  # Jellyfin
+    "http://plex.local:32400",                # localhost-ish name
+    "http://127.0.0.1:8123/",                 # Home Assistant loopback
+    "https://sub.domain.co.uk/a/b/c",
+]
+REJECT = [
+    "http://example.com/",                    # plaintext to a PUBLIC host
+    "file:///etc/passwd",                     # local file exfiltration
+    "javascript:alert(1)",
+    "data:text/html,<h1>x",
+    "chrome://settings",
+    "ftp://example.com/",
+    "https://user:pw@evil.com/",              # userinfo in the netloc
+    "https://例.jp/",                     # IDN (non-ASCII)
+    "https://example.com/ oops",              # whitespace
+    "https://example.com:9999/",              # port not in the allowed set
+    "https://",                               # no host
+    "https://-bad-.com/",                     # edge-hyphenated label
+    "https://a..b/",                          # empty label
+    "not a url",
+    "",
+    None,
+]
+for u in ACCEPT:
+    check("accept %r" % u, cs._pl_validate_open_url(u) == u)
+for u in REJECT:
+    check("reject %r" % u, cs._pl_validate_open_url(u) is None)
+
+# over-length is rejected
+check("reject over-length", cs._pl_validate_open_url("https://a.com/" + "x" * 4000) is None)
+
+
+# --- 2. the opt-in flag (ships OFF; read fresh from config) ------------------
+def flag_with(cfg):
+    """_pl_custom_url_enabled() against a temp config.json (PL_MOCK off)."""
+    saved_mock, saved_path = cs.PL_MOCK, cs.CONFIG_PATH
+    cs.PL_MOCK = False
+    fd, p = tempfile.mkstemp(suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            if cfg is not None:
+                f.write(cfg)
+        cs.CONFIG_PATH = p
+        return cs._pl_custom_url_enabled()
+    finally:
+        cs.PL_MOCK, cs.CONFIG_PATH = saved_mock, saved_path
+        os.unlink(p)
+
+
+check("flag OFF: empty config", flag_with("{}") is False)
+check("flag OFF: absent key", flag_with('{"port":8787}') is False)
+check("flag OFF: not exactly true", flag_with('{"player":{"custom_url":"yes"}}') is False)
+check("flag OFF: unparseable config", flag_with("{ broken") is False)
+check("flag ON: player.custom_url true", flag_with('{"player":{"custom_url":true}}') is True)
+
+
+# --- 3. the tile scheme backstop (defense-in-depth at the enforcement point) -
+def tile(url):
+    e = dict(os.environ)
+    e.pop("WAYLAND_DISPLAY", None)
+    e.pop("DISPLAY", None)
+    r = subprocess.run([BASH, TILE, "--print-open-url", url],
+                       capture_output=True, text=True, env=e)
+    return r.returncode, r.stdout.strip()
+
+
+rc, out = tile("https://example.com/x")
+check("tile accepts https", rc == 0 and out == "https://example.com/x")
+rc, _ = tile("http://192.168.1.9:32400/web")
+check("tile accepts http-LAN-ish", rc == 0)
+for bad in ("file:///etc/passwd", "javascript:alert(1)", "data:text/html,x", "chrome://x"):
+    rc, _ = tile(bad)
+    check("tile rejects %r" % bad, rc != 0)
+
+
+# --- 4. player_open with a url (mock) validates + echoes it -----------------
+saved = cs.PL_MOCK
+cs.PL_MOCK = True
+try:
+    r = cs.player_open(None, "", "", "https://example.com/watch")
+    check("player_open(url) mock returns validated url", r.get("url") == "https://example.com/watch")
+    try:
+        cs.player_open(None, "", "", "file:///etc/passwd")
+        check("player_open(bad url) raises", False, "did not raise")
+    except ValueError:
+        check("player_open(bad url) raises", True)
+finally:
+    cs.PL_MOCK = saved
+
+print()
+if _fail:
+    print("FAILED: %d" % len(_fail))
+    raise SystemExit(1)
+print("all player-open-url checks passed")


### PR DESCRIPTION
Couchside Player "Watch" build-out — an experimental, opt-in surface for driving streaming apps on the box from the phone. Grew out of the free-URL tier (the original scope of this PR) into a full couch remote for the Player tile. **Still experimental** (opt-in `watchEnabled`, "— experimental" toggle label, in-panel EXPERIMENTAL notice) and intended to **bundle in a future release cycle**, not ship immediately.

Rides **agent 2.9.95** (unreleased). All new agent surfaces follow the §3 allowlist pattern (frozen-dict op-id lookup, no client-interpolated commands/paths/JS); all new app→box features feature-detect so they degrade cleanly against older agents.

### Watch / Player
- **Free-URL tier** (§5 tier 3): open any web page on the box, opt-in behind the box-side `player.custom_url` flag; agent urllib-validates scheme/host/port, argv into Chrome, never re-dispatched.
- **Swipe nav pad** (replaces the button d-pad): swipe = one step, tap = OK, two-finger tap = Back; reuses `lib/swipeSteps.planSteps`. **Spatial focus navigation in all four directions** — `PLAYER_JS_NAV` (navup/down/left/right), geometric nearest-focusable, because Tab is linear and Netflix/YouTube ignore arrow keys (measured), and because Shift+Tab is Steam's overlay hotkey in Game Mode.
- **Playback transport mode**: while a video plays (no focusable controls exist then), the pad becomes a transport — swipe seek/volume, tap play/pause.
- **Pointer mode toggle**: drag the real mouse / tap-click, without leaving the Watch screen.
- **Couch zoom**: `--force-device-scale-factor` (whitelisted literal), auto by display height (4K→2×) and adjustable from the app via a frozen-membership `scale` op; persisted + auto-relaunch.
- **Netflix seek-by-key**: direct `currentTime` writes crash Netflix's player (error M7375, reproduced); seek now presses the player's own arrow key for `_PL_KEY_SEEK_SERVICES` (JS seek kept for everything else). Verified on live playback (no M7375, both directions).
- **Keyboard button**: opens the phone keyboard to type into whatever the TV has focused (search/login), reusing the desktop-keyboard `{t:'kt'}` path.
- **Polish**: optimistic STARTING card (kills the 5s poll blank), service-accent branded now card, TV-zoom chips, auto-scroll-to-card.
- **14/14 services navigable** after a hardware scorecard sweep fixed two spatial-nav root causes (BODY-rect "current position" bug on unfocused pages; Apple TV modal focus-trap → scope candidates inside an open modal).

### Rode along on this branch (unrelated, for the same Metro build)
- **OpenPuck auto-flash (batch) mode** + surfaced on the **Actions tab** — pure app-side over the existing hardware-proven flash endpoint. Owner-confirmed working.

### Fixes found along the way
- **KI-065**: a client-supplied unhashable value (`{"t":"k","key":{}}`) raised `TypeError` past the `except ValueError` in three input decoders (`keyboard_events`/`mouse_events`/`gamepad_events`), killing the WS session thread. Type-checked before the frozen-table lookup. Auth + hold gated.
- `hello.keys` now advertises accepted key names (an unknown name closes the session, so the app must feature-detect).

### Tests
- New: `tests/test_key_chords.py`, `tests/test_player_open_url.py`, `tests/test_player_nav.py` (nav ops, scale op, seek strategy, decoder hardening) + CI steps. Full agent suite **82/82**; `tsc --noEmit` clean.

### Verified on hardware (bazzite + Steam Machine, over CDP / real endpoints)
Free-URL open; 4-direction spatial nav on Netflix; Shift+Tab retrace; couch zoom both directions (devicePixelRatio 1.25↔2); Netflix seek-by-key with no M7375; every d-pad/swipe frame; OpenPuck batch flash.

### NOT verified
On-device *feel* of the swipe/pointer gains by hand (wire layer proven, thresholds are the Pad's); logged-in interiors of services other than Netflix; the **lenovodesktop black-screen** in Game Mode (a display-attach issue, tracked separately — that box went down mid-diagnosis). Agent 2.9.95 deployed to test boxes only, **not released**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
