### PR TITLE
chore(release): sync main to agent 2.9.98 + redeem hint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,6 +584,15 @@ jobs:
       - name: Unit tests (LED themes)
         run: python3 tests/test_led_themes.py
 
+      # Graphical-session env discovery for launches. The agent (a --user
+      # service) inherits no DISPLAY, so it used to hard-guess ":0"; a wrong
+      # guess is Steam's "Unable to open a connection to X". The guard is that
+      # _session_env() DISCOVERS the display from a live session process and
+      # only falls back to the guess when nothing is found — pinned in both
+      # directions, since healthy hardware only exercises the ":0-is-right" half.
+      - name: Unit tests (session env discovery)
+        run: python3 tests/test_session_env.py
+
       # Player routes. Drives a real Handler on loopback with STUB steam /
       # steamos-add-to-steam binaries that log every call, so "refused" and
       # "nothing ran" are two separate observations -- a test that only checked

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,15 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.98
+
+**Games launch reliably from the couch.** On some setups, launching a game from
+the app could fail with Steam's "Unable to open a connection to X" instead of
+starting the game — the box couldn't tell which display to launch onto and
+guessed wrong. It now reads the right display from your running session, so a
+tap on the phone starts the game like it should. If yours already worked, nothing
+changes.
+
 ## 2.9.97
 
 **Light themes update from the box.** Built-in RGB strip themes (Portal, Rainbow

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.97"
+VERSION = "2.9.98"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -10364,14 +10364,120 @@ def _launcher_argv(launcher_id):
     return None
 
 
+# Graphical-session env vars a launched process needs to reach the display.
+# The agent (a systemd --user service) inherits NONE of these, so without
+# discovery it can only guess -- and a wrong DISPLAY is exactly Steam's
+# "Unable to open a connection to X" (kb ref 4050-WOJB-0608). Measured on a
+# SteamOS Game Mode box: the Steam UI is on :0, games on :1, and the agent's
+# process environ carried only XDG_RUNTIME_DIR.
+_SESSION_ENV_KEYS = ("DISPLAY", "WAYLAND_DISPLAY", "XAUTHORITY")
+
+# Live processes to harvest that env from, most authoritative first. `steam`
+# is the exact context a Steam handoff launches into; the desktop shells cover
+# a box sitting on the desktop with Steam closed. gamescope is deliberately
+# absent -- on SteamOS its /proc/<pid>/environ is NOT readable by our uid
+# (measured: EACCES), so relying on it would silently degrade to the guess.
+_SESSION_ENV_DONORS = ("steam", "plasmashell", "kwin_wayland", "gnome-shell",
+                       "sway", "Hyprland", "labwc", "weston", "Xwayland")
+
+
+def _parse_environ_blob(raw):
+    """NUL-separated KEY=VALUE bytes (as in /proc/<pid>/environ) -> dict.
+    Skips chunks without '=' and any value that is not valid UTF-8."""
+    out = {}
+    for chunk in raw.split(b"\0"):
+        if b"=" not in chunk:
+            continue
+        k, _, v = chunk.partition(b"=")
+        try:
+            out[k.decode()] = v.decode()
+        except UnicodeDecodeError:
+            pass
+    return out
+
+
+def _read_proc_environ(pid):
+    """Parse /proc/<pid>/environ into a dict. Returns {} on any error (the
+    process may be gone, or owned by another uid). Never raises."""
+    try:
+        with open("/proc/%d/environ" % pid, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return {}
+    return _parse_environ_blob(raw)
+
+
+def _session_donor_pids():
+    """PIDs of same-uid graphical-session donor processes, ordered by
+    _SESSION_ENV_DONORS priority. Reads only /proc; degrades to [] on error."""
+    our_uid = UID
+    by_donor = {d: [] for d in _SESSION_ENV_DONORS}
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return []
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        try:
+            if os.stat("/proc/%d" % pid).st_uid != our_uid:
+                continue
+            with open("/proc/%d/comm" % pid) as f:
+                comm = f.read().strip()
+        except OSError:
+            continue
+        if comm in by_donor:
+            by_donor[comm].append(pid)
+    ordered = []
+    for d in _SESSION_ENV_DONORS:
+        ordered.extend(by_donor[d])
+    return ordered
+
+
+def _harvest_session_env():
+    """Best-effort DISPLAY / WAYLAND_DISPLAY / XAUTHORITY read from a live,
+    same-uid process already inside the graphical session. Returns a dict of
+    only the keys actually found (so the caller can leave the rest to its
+    fallbacks). Never raises; {} means "discovered nothing, use the guess".
+
+    Only reflects reality -- it never invents a value. A per-game
+    pressure-vessel sandbox XAUTHORITY is skipped: it is not valid for a
+    general launch, and the real host one (if any) comes from another donor."""
+    found = {}
+    for pid in _session_donor_pids():
+        env = _read_proc_environ(pid)
+        if not env:
+            continue
+        for k in _SESSION_ENV_KEYS:
+            if k in found or not env.get(k):
+                continue
+            v = env[k]
+            if k == "XAUTHORITY" and "/pressure-vessel/" in v:
+                continue
+            found[k] = v
+        # A DISPLAY or WAYLAND_DISPLAY is the load-bearing bit; once we have one
+        # from the highest-priority donor that had it, stop.
+        if found.get("DISPLAY") or found.get("WAYLAND_DISPLAY"):
+            break
+    return found
+
+
 def _session_env():
     """Env for launching into the user's graphical session.
 
-    Starts from _user_env() (sets XDG_RUNTIME_DIR) and best-effort discovers
-    DISPLAY / WAYLAND_DISPLAY if not already present: DISPLAY defaults to ":0";
-    WAYLAND_DISPLAY is inferred from a wayland-* socket in XDG_RUNTIME_DIR.
+    Starts from _user_env() (sets XDG_RUNTIME_DIR), then DISCOVERS
+    DISPLAY / WAYLAND_DISPLAY / XAUTHORITY from a live session process
+    (_harvest_session_env) rather than guessing -- the guess is what produced
+    Steam's X-connection error on boxes whose display was not :0. Anything
+    discovery cannot find falls back to the old behaviour: DISPLAY defaults to
+    ":0"; WAYLAND_DISPLAY is inferred from a wayland-* socket in
+    XDG_RUNTIME_DIR. A value already present in the environ always wins.
     """
     env = _user_env()
+    if any(not env.get(k) for k in _SESSION_ENV_KEYS):
+        for k, v in _harvest_session_env().items():
+            env.setdefault(k, v)  # never override an inherited real value
     if not env.get("DISPLAY"):
         env["DISPLAY"] = ":0"
     if not env.get("WAYLAND_DISPLAY"):

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -67,7 +67,14 @@ import { clearCompatCache } from '@/lib/compatFetch';
 import { resetFeatureTour } from '@/hooks/useFeatureTour';
 import { setPref, usePref } from '@/lib/prefs';
 import { THEME_PICKER } from '@/lib/gameTheme';
-import { buy, userFacingPurchaseError, getProduct, restoreFromUserAction } from '@/lib/purchase';
+import {
+  buy,
+  userFacingPurchaseError,
+  getProduct,
+  restoreFromUserAction,
+  openRedeemCode,
+  REDEEM_STORE_NAME,
+} from '@/lib/purchase';
 import { Box, DEFAULT_PORT, normalizeMac } from '@/lib/settings';
 import { VolumeTarget } from '@/lib/api';
 import { useBoxes, useBoxOnlineStatus, BoxReachability } from '@/lib/SettingsContext';
@@ -2067,6 +2074,13 @@ function SetupBody() {
                   One-time unlock · no subscription, no account, no tracking.
                 </Text>
               )}
+              {!isGenuinelyPurchased(entitlement) && (
+                <Pressable onPress={() => void openRedeemCode()} hitSlop={8}>
+                  <Text style={styles.redeemHint}>
+                    Have a code? Redeem it in the {REDEEM_STORE_NAME}, then tap Restore Purchases.
+                  </Text>
+                </Pressable>
+              )}
             </View>
 
             {/* User-initiated, always available. This LINKS OUT to the store's
@@ -2472,6 +2486,13 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   btnRestoreText: { color: t.textDim, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   restoreMsg: { fontSize: 12, fontFamily: mono, marginTop: 10 },
   purchaseHint: { color: t.textFaint, fontSize: 11, marginTop: 10 },
+  redeemHint: {
+    color: t.textDim,
+    fontSize: 11,
+    lineHeight: 16,
+    marginTop: 10,
+    textDecorationLine: 'underline',
+  },
   pressed: { opacity: 0.7 },
   stepRow: { flexDirection: 'row', alignItems: 'flex-start', marginBottom: 10, gap: 10 },
   stepMark: { fontSize: 18, fontWeight: '800', width: 22, textAlign: 'center' },

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -4,7 +4,14 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { recordPurchaseDate } from '@/lib/entitlement';
 import { useEntitlement } from '@/lib/EntitlementContext';
-import { buy, userFacingPurchaseError, getProduct, restoreFromUserAction } from '@/lib/purchase';
+import {
+  buy,
+  userFacingPurchaseError,
+  getProduct,
+  restoreFromUserAction,
+  openRedeemCode,
+  REDEEM_STORE_NAME,
+} from '@/lib/purchase';
 import { mono, useThemedStyles } from '@/lib/theme';
 import type { Palette } from '@/lib/theme';
 
@@ -118,6 +125,16 @@ export default function Paywall() {
         </Pressable>
 
         {error != null && <Text style={styles.error}>{error}</Text>}
+
+        <Pressable
+          onPress={() => void openRedeemCode()}
+          disabled={busy != null}
+          hitSlop={8}
+          style={({ pressed }) => [styles.redeemHint, pressed && styles.pressed]}>
+          <Text style={styles.redeemHintText}>
+            Have a code? Redeem it in the {REDEEM_STORE_NAME}, then tap Restore.
+          </Text>
+        </Pressable>
       </View>
     </View>
   );
@@ -179,6 +196,14 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     fontFamily: mono,
     textAlign: 'center',
     marginTop: 14,
+  },
+  redeemHint: { marginTop: 20, paddingHorizontal: 8 },
+  redeemHintText: {
+    color: t.textDim,
+    fontSize: 12,
+    lineHeight: 17,
+    textAlign: 'center',
+    textDecorationLine: 'underline',
   },
   pressed: { opacity: 0.7 },
 });

--- a/app/lib/purchase.ts
+++ b/app/lib/purchase.ts
@@ -10,7 +10,7 @@ export { isUserCancellation, userFacingPurchaseError } from './purchaseErrors';
  * throwing; callers (lib/entitlement.ts) treat that as "nothing to sell here,
  * do not gate".
  */
-import { Platform } from 'react-native';
+import { Linking, Platform } from 'react-native';
 import { shouldReconcileWithStore } from './restoreSync';
 
 /** The single non-consumable unlock product (App Store + Play Store). */
@@ -344,5 +344,38 @@ export async function restore(): Promise<RestoreResult> {
     // NOT to make — and it lands in red on someone who may well own the app.
     if (isUserCancellation(e)) return { state: 'cancelled' };
     return { state: 'error', message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** The store whose promo-code redeem flow a "Have a code?" hint points at. */
+export const REDEEM_STORE_NAME = Platform.OS === 'ios' ? 'App Store' : 'Play Store';
+
+/**
+ * Open the platform store's promo-code redeem screen.
+ *
+ * Non-consumable IAP codes are NOT entered inside the app — Apple redeems them
+ * in the App Store (a hidden in-app unlock field is an App Review 2.3.1 / 2.1(b)
+ * rejection; see docs/memory). This just hands the user off to the right place;
+ * the redeemed unlock then flows back in via Restore Purchases.
+ *
+ * iOS -> the App Store "Redeem Code" sheet. Android -> Play's redeem page.
+ * Best-effort and never throws: falls back to the https form, which always
+ * resolves to something.
+ */
+export async function openRedeemCode(): Promise<void> {
+  const deep = Platform.OS === 'ios' ? 'itms-apps://apps.apple.com/redeem' : 'https://play.google.com/redeem';
+  const web = Platform.OS === 'ios' ? 'https://apps.apple.com/redeem' : 'https://play.google.com/redeem';
+  try {
+    if (await Linking.canOpenURL(deep)) {
+      await Linking.openURL(deep);
+      return;
+    }
+  } catch {
+    // fall through to the https form
+  }
+  try {
+    await Linking.openURL(web);
+  } catch {
+    // Nothing sensible left to do; never crash over a redeem link.
   }
 }

--- a/tests/test_session_env.py
+++ b/tests/test_session_env.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Graphical-session env discovery for launches: _session_env() and friends.
+
+Run: python3 tests/test_session_env.py
+
+WHY THIS SURFACE EXISTS: the agent is a systemd --user service and inherits
+NONE of DISPLAY / WAYLAND_DISPLAY / XAUTHORITY (measured on a SteamOS Game Mode
+box: its process environ carried only XDG_RUNTIME_DIR). Every launch runs with
+env=_session_env(). The old code hard-guessed DISPLAY=":0"; on a box whose
+Steam UI sat on a different display that guess produced Steam's "Unable to open
+a connection to X" (kb ref 4050-WOJB-0608) instead of launching the game.
+
+The fix DISCOVERS the real values from a live same-uid session process
+(the running Steam, or a desktop shell) via /proc/<pid>/environ, and only
+falls back to the old guess when discovery finds nothing.
+
+The healthy hardware box could only prove the ":0"-happens-to-be-right case
+(its display really is :0). This pins the case that box could NOT show — a
+session on :1 — in both directions, plus the fallbacks and the safety skips:
+
+  1. DISCOVERS a non-:0 display: a donor on :1 -> _session_env DISPLAY == ":1",
+     NOT the ":0" guess. (The customer's failing case, now passing.)
+  2. FALLS BACK to ":0" when no donor is found (degrades to old behaviour).
+  3. INHERITED env always wins: a real DISPLAY in the base env is never
+     overridden by discovery.
+  4. NEVER INVENTS: a per-game pressure-vessel sandbox XAUTHORITY is skipped
+     (it is not valid for a general launch); a real host XAUTHORITY is kept.
+  5. PRIORITY: the highest-priority donor that has a DISPLAY wins.
+  6. PARSING: the NUL-separated /proc environ blob parses like the kernel's,
+     and a non-UTF-8 value is dropped, never crashes.
+"""
+import importlib.util
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def with_session(donor_envs, base=None):
+    """Run _session_env() with a fake set of donor processes.
+
+    donor_envs: ordered list of (pid, environ_dict) as _session_donor_pids +
+    _read_proc_environ would return them. base: the pre-discovery env
+    _user_env() yields (defaults to just XDG_RUNTIME_DIR, i.e. the agent's
+    real blind spot). Returns the resolved env dict."""
+    saved = (cs._session_donor_pids, cs._read_proc_environ, cs._user_env, cs.os.listdir)
+    envmap = {pid: env for pid, env in donor_envs}
+    try:
+        cs._session_donor_pids = lambda: [pid for pid, _ in donor_envs]
+        cs._read_proc_environ = lambda pid: dict(envmap.get(pid, {}))
+        cs._user_env = lambda: dict(base if base is not None else {"XDG_RUNTIME_DIR": "/run/user/1000"})
+        # neutralise the wayland-socket fallback (no real runtime dir in CI)
+        cs.os.listdir = lambda p: (_ for _ in ()).throw(OSError("no dir"))
+        return cs._session_env()
+    finally:
+        (cs._session_donor_pids, cs._read_proc_environ, cs._user_env, cs.os.listdir) = saved
+
+
+# 1. DISCOVERS a non-:0 display — the customer's failing case, now passing.
+env = with_session([(101, {"DISPLAY": ":1"})])
+check("discovers DISPLAY :1 from a live donor (not the :0 guess)", env.get("DISPLAY"), ":1")
+
+# 2. FALLS BACK to :0 when nothing is discoverable (old behaviour preserved).
+env = with_session([])
+check("no donor -> falls back to :0", env.get("DISPLAY"), ":0")
+env = with_session([(101, {"HOME": "/home/deck"})])  # donor exists, no DISPLAY
+check("donor without DISPLAY -> falls back to :0", env.get("DISPLAY"), ":0")
+
+# 3. INHERITED env wins — discovery never overrides a real inherited value.
+env = with_session([(101, {"DISPLAY": ":1"})],
+                   base={"XDG_RUNTIME_DIR": "/run/user/1000", "DISPLAY": ":9"})
+check("inherited DISPLAY is not overridden by discovery", env.get("DISPLAY"), ":9")
+
+# 4. NEVER INVENTS: pressure-vessel sandbox XAUTHORITY is skipped; host one kept.
+env = with_session([(101, {"DISPLAY": ":1",
+                           "XAUTHORITY": "/run/pressure-vessel/Xauthority"})])
+check("sandbox pressure-vessel XAUTHORITY is skipped", env.get("XAUTHORITY"), None)
+check("  (DISPLAY still discovered alongside the skip)", env.get("DISPLAY"), ":1")
+env = with_session([(101, {"DISPLAY": ":0", "XAUTHORITY": "/home/deck/.Xauthority"})])
+check("host XAUTHORITY is kept", env.get("XAUTHORITY"), "/home/deck/.Xauthority")
+
+# 5. PRIORITY: first donor (highest priority) that has a DISPLAY wins.
+env = with_session([(101, {"HOME": "/h"}),          # steam, no DISPLAY
+                    (202, {"DISPLAY": ":0"}),        # next donor, has it
+                    (303, {"DISPLAY": ":7"})])       # lower — must not win
+check("first donor with a DISPLAY wins", env.get("DISPLAY"), ":0")
+
+# 6. PARSING: /proc environ blob semantics, including a bad-UTF-8 value.
+blob = b"DISPLAY=:0\x00XAUTHORITY=/home/deck/.Xauthority\x00BAD=\xff\xfe\x00NOEQ\x00"
+parsed = cs._parse_environ_blob(blob)
+check("parse: DISPLAY", parsed.get("DISPLAY"), ":0")
+check("parse: XAUTHORITY", parsed.get("XAUTHORITY"), "/home/deck/.Xauthority")
+check("parse: non-UTF-8 value dropped", "BAD" in parsed, False)
+check("parse: chunk without '=' ignored", "NOEQ" in parsed, False)
+
+# _harvest_session_env returns only what it found (leaves the rest to fallbacks).
+saved = (cs._session_donor_pids, cs._read_proc_environ)
+try:
+    cs._session_donor_pids = lambda: [1]
+    cs._read_proc_environ = lambda pid: {"DISPLAY": ":4", "IRRELEVANT": "x"}
+    h = cs._harvest_session_env()
+    check("harvest returns only session keys it found", h, {"DISPLAY": ":4"})
+finally:
+    (cs._session_donor_pids, cs._read_proc_environ) = saved
+
+print()
+if FAILURES:
+    print("FAILED: %s" % ", ".join(FAILURES))
+    sys.exit(1)
+print("all session-env discovery tests passed")


### PR DESCRIPTION
Single atomic commit (Trees API) = one CI run.

- **agent 2.9.98** — `_session_env()` discovers the graphical-session DISPLAY from a live process instead of guessing `:0`; fixes Steam's "Unable to open a connection to X" (kb 4050-WOJB-0608) on remote game launch. Published onto release v2.9.53. HW-verified on a SteamOS Game Mode box; the wrong-guess `:1` case is pinned both-directions in `tests/test_session_env.py`.
- **app** — "Have a code?" redeem hint on Paywall + Setup>Account (`openRedeemCode()` in `lib/purchase.ts`); no in-app code field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)