### PR TITLE
fix(scan): neutral camera permission button (App Review 5.1.1)

### DIFF
--- a/app/components/BoxScanQr.tsx
+++ b/app/components/BoxScanQr.tsx
@@ -436,7 +436,7 @@ function PermissionGate({
         }}
         accessibilityRole="button"
         style={({ pressed }) => [styles.permBtn, pressed && styles.pressed]}>
-        <Text style={styles.permBtnText}>{deniedForever ? 'OPEN SETTINGS' : 'ALLOW CAMERA'}</Text>
+        <Text style={styles.permBtnText}>{deniedForever ? 'OPEN SETTINGS' : 'CONTINUE'}</Text>
       </Pressable>
     </View>
   );


### PR DESCRIPTION
Apple rejected 2.9.54 (build 194) under **5.1.1 Privacy — Data Collection and Storage**: the camera pre-permission button read "ALLOW CAMERA", which Apple treats as steering the consent decision. Renamed to "CONTINUE". Explainer text + the denied-forever OPEN SETTINGS branch unchanged. Unblocks the 2.9.55 submission.