### PR TITLE
chore(release): sync app.json to shipped build 198 / vc 104

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "197",
+      "buildNumber": "198",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {
@@ -32,7 +32,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "predictiveBackGestureEnabled": false,
-      "versionCode": 103
+      "versionCode": 104
     },
     "web": {
       "bundler": "metro",


### PR DESCRIPTION
The 2.9.55 App Store (build 198) and Play (vc 104) builds auto-incremented past what's committed on main (197/103). Sync so the next production build increments cleanly.