### PR TITLE
fix(harness): web-dev.sh reachable (same-origin auto-seed) + node bootstrap

### DIFF
--- a/scripts/web-dev.sh
+++ b/scripts/web-dev.sh
@@ -33,6 +33,21 @@ TOKEN="web-dev-$RANDOM"
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DIST="$ROOT/app/dist"
 
+# Ensure a working node/npx is on PATH. This is launched from contexts whose PATH
+# may not include node (preview_start, CI, a bare login shell), where it used to
+# die with "npx: command not found". Resolve one from the usual spots instead.
+if ! command -v npx >/dev/null 2>&1; then
+  for _nb in "$HOME"/actions-runner/externals*/node20/bin \
+             "$HOME"/.nvm/versions/node/*/bin /opt/homebrew/bin /usr/local/bin; do
+    if [ -x "$_nb/npx" ]; then PATH="$_nb:$PATH"; break; fi
+  done
+  export PATH
+fi
+command -v npx >/dev/null 2>&1 || {
+  echo "error: node/npx not found. Install Node 18-20 or add it to PATH." >&2
+  exit 127
+}
+
 cleanup() {
   [ -n "${AGENT_PID:-}" ] && kill "$AGENT_PID" 2>/dev/null || true
   [ -n "${PROXY_PID:-}" ] && kill "$PROXY_PID" 2>/dev/null || true
@@ -41,6 +56,24 @@ trap cleanup EXIT INT TERM
 
 echo "==> exporting the web bundle (this takes a minute)"
 (cd "$ROOT/app" && npx expo export -p web >/dev/null)
+
+# Auto-configure the mock box on first load. The box host is taken from
+# location.hostname so it ALWAYS matches the origin the page is opened at:
+# localhost and 127.0.0.1 are DIFFERENT origins, and since the app fetches an
+# absolute http://<host>:<port> URL (lib/api.ts), a mismatch makes every request
+# cross-origin -> the dev proxy sends no CORS -> the box shows "unreachable".
+# Injected into the exported shell so no manual console paste is needed.
+_seed="<script>try{if(!localStorage.getItem('couchpilot.boxes.v1')){localStorage.setItem('couchpilot.boxes.v1',JSON.stringify({boxes:[{id:'web-dev',name:'mock box',host:location.hostname,port:Number(location.port)||80,token:'$TOKEN',padMode:'trackpad'}],activeBoxId:'web-dev'}));location.reload();}}catch(e){}</script>"
+DIST="$DIST" SEED="$_seed" python3 - <<'PY'
+import glob, os
+dist, seed = os.environ["DIST"], os.environ["SEED"]
+for f in glob.glob(os.path.join(dist, "**", "*.html"), recursive=True):
+    s = open(f, encoding="utf-8").read()
+    if "couchpilot.boxes.v1" in s:
+        continue                                   # already seeded (idempotent)
+    s = s.replace("</body>", seed + "</body>", 1) if "</body>" in s else s + seed
+    open(f, "w", encoding="utf-8").write(s)
+PY
 
 echo "==> starting mock agent on 127.0.0.1:$AGENT_PORT"
 python3 "$ROOT/agent/couchsided.py" --mock --host 127.0.0.1 \
@@ -58,14 +91,14 @@ PROXY_PID=$!
 
 cat <<EOF
 
-  Open:  http://127.0.0.1:$PORT
+  Open:  http://127.0.0.1:$PORT   (or http://localhost:$PORT -- either works now)
 
-  The app starts with no box configured. Paste this in the browser console,
-  then reload -- it points the app at this same origin, so the proxy forwards
-  /api to the mock agent and no CORS is involved:
+  The mock box auto-configures on first load: its host is taken from the page's
+  own origin, so it is always same-origin -- no console paste, no CORS. To
+  re-seed manually, clear site data and reload, or paste:
 
 localStorage.setItem('couchpilot.boxes.v1', JSON.stringify({
-  boxes: [{ id: 'web-dev', name: 'mock box', host: '127.0.0.1',
+  boxes: [{ id: 'web-dev', name: 'mock box', host: location.hostname,
             port: $PORT, token: '$TOKEN', padMode: 'trackpad' }],
   activeBoxId: 'web-dev' }));
 


### PR DESCRIPTION
Restores the web harness for box-dependent UI verification (§6).

**1. 'Box unreachable' (origin mismatch):** `preview_start` opens the app at `localhost:<port>`, but the box config used `127.0.0.1`. The app fetches an *absolute* `http://<host>:<port>` URL, so localhost vs 127.0.0.1 are different origins → cross-origin → the dev proxy (no CORS by design) fails it → 'unreachable'. Fix: the exported shell now auto-seeds the mock box with `host=location.hostname` (always same-origin, no manual paste).

**2. Node bootstrap:** `web-dev.sh` resolves node from the usual spots so it stops dying with 'npx: command not found' from launchers without node in PATH.

Verified live end-to-end: box auto-connects + renders mock data, and the OpenPuck gate flips correctly (hidden by default, shown when Utilities enabled).