### PR TITLE
fix(agent): built-in LED themes rendered as darkness (2.9.102)

### DIFF
--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,18 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.102
+
+**The light-bar themes actually light up now.** Portal, Police, Rainbow River and
+Heartbeat in the LED card played to a dark strip — the box accepted the tap and
+then rendered every frame as "off", so nothing visibly happened. Fixed: all four
+built-in themes now animate the strip the way they were designed to (verified on
+a Steam Machine's light bar). Solid colours, firmware effects and your own saved
+presets were never affected. If you're a version or two behind, this update also
+brings the Combos panel (hold the keyboard button on the Pad for one-tap copy /
+paste / Kodi and media shortcuts) and a fix for the first keypress after
+connecting sometimes being dropped.
+
 ## 2.9.101
 
 **Combos, and a snappier connection.** This powers the app's new Combos panel —

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.101"
+VERSION = "2.9.102"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -6078,6 +6078,13 @@ def apply_led_theme(theme_id, prefix, brightness):
         return None
     n = len(members)
     frames, holds = LED_THEMES[theme_id][1](n)
+    # Generators speak (r, g, b) TUPLES; apply_strip_sequence validates the JSON
+    # wire shape {r,g,b} (_is_rgb_triple) and turns anything else into an OFF
+    # cell. Convert at this boundary or every theme renders as darkness — which
+    # is exactly how the themes shipped broken in 2.9.97 (caught on the Steam
+    # Machine 2026-08-29; test_builtin_themes_paint_colour pins this).
+    frames = [[({"r": c[0], "g": c[1], "b": c[2]} if c is not None else None)
+               for c in fr] for fr in frames]
     b = brightness if _is_pct(brightness) else 100
     return apply_strip_sequence(prefix, frames, holds[0] if holds else 120, b,
                                 loop=True, holds=holds)

--- a/tests/test_led_strip.py
+++ b/tests/test_led_strip.py
@@ -420,6 +420,61 @@ def test_sequence_starts_and_persists():
         restore()
 
 
+def test_builtin_themes_paint_colour():
+    """REGRESSION (found on the Steam Machine, 2026-08-29): every built-in theme
+    rendered as darkness. The theme generators emit TUPLE colours ((255,0,0)) but
+    apply_strip_sequence's normalizer validates with _is_rgb_triple, which accepts
+    only the JSON dict shape {r,g,b} — so every cell normalized to None and the
+    render thread wrote brightness=0 forever, with the API answering ok:true.
+    This drives every catalog theme through apply_led_theme TO THE WRITERS and
+    asserts real colour lands, so a generator/validator shape drift can never
+    ship dark themes again."""
+    print("built-in themes: apply_led_theme paints actual colour (tuple/dict drift)")
+    writes = []
+    restore = _install(writes)
+    saved_wc = cs._led_write_color
+    painted = {}
+    cs._led_write_color = lambda name, raw, c: painted.__setitem__(name, dict(c))
+    saved_thread, saved_save = cs._seq_ensure_thread, cs._led_state_save
+    try:
+        cs._seq_ensure_thread = lambda: None
+        cs._led_state_save = lambda: None
+        for theme_id in cs.LED_THEMES:
+            with cs._SEQ_LOCK:
+                cs._SEQ_ACTIVE.clear()
+            painted.clear()
+            del writes[:]
+            res = cs.apply_led_theme(theme_id, "valve-leds", 100)
+            check(res and res.get("ok"), "%s: accepted" % theme_id)
+            spec = cs._SEQ_ACTIVE.get("valve-leds")
+            lit = spec and any(c is not None for fr in spec["frames"] for c in fr)
+            check(bool(lit), "%s: frames survive normalization (not all-None)" % theme_id)
+            if not spec:
+                continue
+            # Walk the whole timeline: every theme must paint at least one LED a
+            # non-black colour at some point (heartbeat has all-off REST frames,
+            # so sample many instants rather than one).
+            holds = spec.get("holds") or [spec.get("hold_ms", 120)] * len(spec["frames"])
+            total_s = max(0.001, sum(holds) / 1000.0)
+            t0 = spec["t0"]
+            saw_colour = False
+            steps = max(8, 2 * len(spec["frames"]))
+            for k in range(steps):
+                painted.clear()
+                cs._seq_render(spec, t0 + (k / float(steps)) * total_s)
+                if any(v and (v.get("r") or v.get("g") or v.get("b"))
+                       for v in painted.values()):
+                    saw_colour = True
+                    break
+            check(saw_colour, "%s: render writes a non-black colour" % theme_id)
+    finally:
+        cs._led_write_color = saved_wc
+        cs._seq_ensure_thread, cs._led_state_save = saved_thread, saved_save
+        with cs._SEQ_LOCK:
+            cs._SEQ_ACTIVE.clear()
+        restore()
+
+
 def test_sequence_per_frame_holds_timeline():
     print("per-frame holds: render walks a cumulative timeline (loop wraps)")
     writes = []
@@ -527,6 +582,7 @@ if __name__ == "__main__":
     test_reconcile_skips_agent_effects()
     test_sequence_validation()
     test_sequence_starts_and_persists()
+    test_builtin_themes_paint_colour()
     test_sequence_per_frame_holds_timeline()
     test_led_restore_rearms_per_frame_holds()
     print()


### PR DESCRIPTION
## What

Every built-in LED theme (Portal, Police, Rainbow River, Heartbeat — shipped agent 2.9.97) played to a **dark strip on all hardware**: the theme generators emit `(r, g, b)` tuples, but `apply_strip_sequence` normalizes cells with `_is_rgb_triple`, which accepts only the JSON wire shape `{r,g,b}` — so every cell became `None` and the render thread wrote brightness-0 to the whole strip while the API answered `ok: true`.

Found via a user report ("portal and police don't work") on the Steam Machine; diagnosed live against agent 2.9.99: POST accepted, `effect=manual` set, all 17 `valve-leds` nodes writable, spec active — and `multi_intensity` frozen with brightness pinned to 0.

## Fix

Convert tuple→dict at the internal→shared boundary in `apply_led_theme`. The client-facing validator stays strict (reject-don't-sanitise unchanged for wire input). Agent version → 2.9.102 + changelog section.

## Verification

- **Regression test written first**: `test_builtin_themes_paint_colour` drives every catalog theme through `apply_led_theme` **to the writers** and asserts a non-black colour lands. RED on the old code (8 failures, all 4 themes), GREEN after.
- Full agent suite 86/86 locally.
- **Hardware-verified on the Steam Machine** (`valve-leds`, 17 nodes) via a sandboxed test agent on :8790 — led0 red / led16 blue flashing anti-phase at 110 ms in sysfs samples; prod service untouched.
- NOT verified: the physical light by eye (sysfs alternation observed; user present for visual confirm after release), and the fix on a prod agent (ships as 2.9.102).

## Allowlist

No new endpoints or ids; `theme_id` remains a frozen-dict lookup; `_is_rgb_triple` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)