### PR TITLE
Release 2.9.56 — auto-drop pad, focused Console, Did-you-know tips, theme packs

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.55",
+    "version": "2.9.56",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "198",
+      "buildNumber": "200",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {

--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -9,6 +9,7 @@ import { useImmersive } from '@/lib/immersive';
 import { usePref } from '@/lib/prefs';
 import { FeatureTour } from '@/components/FeatureTour';
 import { TourThanks } from '@/components/TourThanks';
+import { TipToast } from '@/components/TipToast';
 import VolumeOsd from '@/components/VolumeOsd';
 import { WhatsNewOffer } from '@/components/WhatsNewOffer';
 import { useFeatureTour } from '@/hooks/useFeatureTour';
@@ -85,6 +86,19 @@ export default function TabLayout() {
   // existed — the exact mirror of the fleet guard, which refuses to force it on
   // them. Local state so answering hides it on the same frame.
   const [offerDismissed, setOfferDismissed] = useState(false);
+  // Computed ONCE so the offer card and the tip toast agree on it: a tip must
+  // never stack on this card — one interruption at a time.
+  const offerVisible =
+    !offerDismissed &&
+    !tour.visible &&
+    !thanksVisible &&
+    shouldOfferWhatsNew({
+      offered: whatsNewOffered,
+      done: onboardingDone,
+      boxCount: boxes.length,
+      tvCount: tvs.length,
+      ready,
+    });
   // EXACTLY ONE watcher for the whole app. This lived in the Launch tab, which
   // mounts lazily on first focus — so a download finishing while the user sat on
   // Console went unnoticed, which is precisely the case the feature exists for.
@@ -314,18 +328,20 @@ export default function TabLayout() {
         Rendered after the tour so it sits above it during the frame the tour is
         tearing down. */}
     {thanksVisible ? <TourThanks /> : null}
+    {/* "Did you know" — one contextual tip on the tab in view, once each, ever.
+        Never over the tour or its thank-you (busy), never before a box is
+        paired, and off with the same pref as the tour. See lib/tips.ts. */}
+    <TipToast
+      tab={(() => {
+        const last = segments[segments.length - 1];
+        return !last || last === '(tabs)' ? 'index' : String(last);
+      })()}
+      paired={boxes.length > 0}
+      busy={tour.visible || thanksVisible || offerVisible}
+    />
     {/* Never stacked on the tour or the thank-you card — one interruption at a
         time, and the tour is the one already in progress. */}
-    {!offerDismissed &&
-    !tour.visible &&
-    !thanksVisible &&
-    shouldOfferWhatsNew({
-      offered: whatsNewOffered,
-      done: onboardingDone,
-      boxCount: boxes.length,
-      tvCount: tvs.length,
-      ready,
-    }) ? (
+    {offerVisible ? (
       <WhatsNewOffer onDone={() => setOfferDismissed(true)} />
     ) : null}
     {/* App-wide volume OSD: flashes when Couchside changes the volume, so the

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -28,7 +28,7 @@ import {
 } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
 import { useSettings } from '@/lib/SettingsContext';
-import { mono, numeric, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import { mono, numeric, textOn, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 const DANGER_ORDER: Danger[] = ['low', 'medium', 'high'];
 
@@ -301,7 +301,9 @@ function ActionsScreen() {
                       session is worth repeating; the other two are not. */}
                   {a.danger === 'high' && (
                     <View style={[styles.badge, { backgroundColor: DANGER_COLOR[a.danger] }]}>
-                      <Text style={styles.badgeText}>{BADGE_TEXT[a.danger]}</Text>
+                      {/* The badge's fill is per-danger (red/amber/green), so its text is
+                          chosen for contrast against THAT fill, not a fixed on-red. */}
+                      <Text style={[styles.badgeText, { color: textOn(DANGER_COLOR[a.danger], t) }]}>{BADGE_TEXT[a.danger]}</Text>
                     </View>
                   )}
                 </View>
@@ -403,7 +405,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 3,
   },
-  badgeText: { color: '#0b1220', fontSize: 11, fontWeight: '800' },
+  badgeText: { color: t.onRed, fontSize: 11, fontWeight: '800' },
   pressed: { opacity: 0.7 },
   emptyCard: {
     backgroundColor: t.card,
@@ -431,7 +433,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 28,
     borderRadius: 8,
   },
-  retryText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  retryText: { color: t.onRed, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   dim: { color: t.textDim, fontSize: 13 },
   dimMono: { color: t.textFaint, fontSize: 12, fontFamily: mono },
   resultPanel: {
@@ -470,5 +472,5 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 22,
     borderRadius: 8,
   },
-  countdownCancelText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  countdownCancelText: { color: t.onRed, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
 });

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -409,17 +409,19 @@ function ConsoleScreen() {
               Long-press still works; this just makes the same mode discoverable.
               Gone while editing — the Done bar owns the exit. */}
           {configured && !editingCards && (
-            <Pressable
-              onPress={() => {
-                hapticSelection();
-                setEditingCards(true);
-              }}
-              accessibilityRole="button"
-              accessibilityLabel="Customize which cards show"
-              hitSlop={8}
-              style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
-              <Ionicons name="options-outline" size={18} color={t.textDim} />
-            </Pressable>
+            <TourAnchor id="console.customize">
+              <Pressable
+                onPress={() => {
+                  hapticSelection();
+                  setEditingCards(true);
+                }}
+                accessibilityRole="button"
+                accessibilityLabel="Customize which cards show"
+                hitSlop={8}
+                style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
+                <Ionicons name="options-outline" size={18} color={t.textDim} />
+              </Pressable>
+            </TourAnchor>
           )}
         </View>
 
@@ -474,25 +476,27 @@ function ConsoleScreen() {
             the choice persists. Disabled while editing, when it is forced open
             so hidden tool cards stay reachable. */}
         {configured && moreOrder.length > 0 && (
-          <Pressable
-            onPress={() => {
-              hapticSelection();
-              void setPref('consoleMoreCollapsed', !moreCollapsedPref);
-            }}
-            disabled={editingCards}
-            accessibilityRole="button"
-            accessibilityState={{ expanded: moreOpen }}
-            accessibilityLabel={moreOpen ? 'Collapse more controls' : 'Show more controls'}
-            style={({ pressed }) => [styles.foldRow, pressed && !editingCards && styles.pressed]}>
-            <Ionicons name="options-outline" size={14} color={t.blue} />
-            <Text style={styles.foldText}>MORE</Text>
-            <Text style={styles.foldSub} numberOfLines={1}>controls &amp; tools</Text>
-            <Ionicons
-              name={moreOpen ? 'chevron-up' : 'chevron-down'}
-              size={15}
-              color={t.textDim}
-            />
-          </Pressable>
+          <TourAnchor id="console.more">
+            <Pressable
+              onPress={() => {
+                hapticSelection();
+                void setPref('consoleMoreCollapsed', !moreCollapsedPref);
+              }}
+              disabled={editingCards}
+              accessibilityRole="button"
+              accessibilityState={{ expanded: moreOpen }}
+              accessibilityLabel={moreOpen ? 'Collapse more controls' : 'Show more controls'}
+              style={({ pressed }) => [styles.foldRow, pressed && !editingCards && styles.pressed]}>
+              <Ionicons name="options-outline" size={14} color={t.blue} />
+              <Text style={styles.foldText}>MORE</Text>
+              <Text style={styles.foldSub} numberOfLines={1}>controls &amp; tools</Text>
+              <Ionicons
+                name={moreOpen ? 'chevron-up' : 'chevron-down'}
+                size={15}
+                color={t.textDim}
+              />
+            </Pressable>
+          </TourAnchor>
         )}
         {moreOpen && renderCards(moreOrder)}
         </Screen>

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { EditableSection } from '@/components/EditableSection';
 import { Gated } from '@/components/Gated';
@@ -23,7 +24,8 @@ import { useStreak } from '@/hooks/useStreak';
 import { api, hostKey, humanizeUptime, Status, Unit } from '@/lib/api';
 import { fmtLastSeen, noteBoxSeen } from '@/lib/lastSeen';
 import { useConsoleLayout, effectiveOrder, moveSection, setConsoleLayout } from '@/lib/consoleLayout';
-import { usePref } from '@/lib/prefs';
+import { hapticSelection } from '@/lib/haptics';
+import { setPref, usePref } from '@/lib/prefs';
 import { useSkinKit, VitalsContext, vitality } from '@/lib/skin';
 import { noteBoxReachable } from '@/lib/review';
 import { useSettings } from '@/lib/SettingsContext';
@@ -150,9 +152,25 @@ function ConsoleScreen() {
   const cardHidden = new Set(cardLayout.hidden);
   const setPresent = (id: string, p: boolean) =>
     setCardPresent((prev) => (prev[id] === p ? prev : { ...prev, [id]: p }));
-  const visibleCards = cardOrder.filter((id) => cardPresent[id]);
-  const moveCard = (id: string, dir: -1 | 1) =>
-    setConsoleLayout({ order: moveSection(cardOrder, visibleCards, id, dir), hidden: cardLayout.hidden });
+  // FOCUSED DEFAULT (App Store review, 2026-08-30: "the UI is a little busy").
+  // Cards split into what is happening NOW (media, a stream, a game, the box's
+  // vitals) and the box's CONTROLS & TOOLS (lights, display/audio, screen,
+  // units, file drop). Status stays in the main flow; the tools fold behind one
+  // "More" row, collapsed by default. Folding is NOT hiding: a folded card still
+  // exists and opens in one tap, where a hidden one leaves you wondering where
+  // it went. The split is by card id, so a user's saved order is respected
+  // inside each group and reorder moves stay within a group. The fold is forced
+  // open while editing so every card — hidden ones included — is reachable.
+  const MORE_IDS = new Set(['screen', 'display', 'audio', 'leds', 'stripleds', 'openrgb', 'units', 'filedrop']);
+  const primaryOrder = cardOrder.filter((id) => !MORE_IDS.has(id));
+  const moreOrder = cardOrder.filter((id) => MORE_IDS.has(id));
+  const moreCollapsedPref = usePref('consoleMoreCollapsed');
+  const moreOpen = editingCards || !moreCollapsedPref;
+  const visibleIn = (ids: string[]) => ids.filter((id) => cardPresent[id]);
+  const moveCard = (id: string, dir: -1 | 1) => {
+    const group = MORE_IDS.has(id) ? moreOrder : primaryOrder;
+    setConsoleLayout({ order: moveSection(cardOrder, visibleIn(group), id, dir), hidden: cardLayout.hidden });
+  };
   const toggleHideCard = (id: string) => {
     const h = new Set(cardLayout.hidden);
     if (h.has(id)) h.delete(id); else h.add(id);
@@ -318,6 +336,34 @@ function ConsoleScreen() {
     filedrop: <FileDropCard />,
   };
 
+  // One group of movable cards (status or tools), each in EditableSection
+  // (long-press → edit; ↑ ↓ hide). first/last are computed WITHIN the group so
+  // the arrows never try to cross the fold. Self-gating cards still render null
+  // internally when the box lacks the feature; EditableSection then shows no
+  // controls for them.
+  const renderCards = (group: string[]) => {
+    const vis = visibleIn(group);
+    return group.map((id) => {
+      const node = cardNodes[id];
+      if (node == null) return null;
+      return (
+        <EditableSection
+          key={id}
+          editing={editingCards}
+          hidden={cardHidden.has(id)}
+          isFirst={vis[0] === id}
+          isLast={vis[vis.length - 1] === id}
+          onEnterEdit={() => setEditingCards(true)}
+          onPresent={(p) => setPresent(id, p)}
+          onUp={() => moveCard(id, -1)}
+          onDown={() => moveCard(id, 1)}
+          onToggleHide={() => toggleHideCard(id)}>
+          {node}
+        </EditableSection>
+      );
+    });
+  };
+
   return (
     <VitalsContext.Provider value={vitals}>
     <View style={styles.screen}>
@@ -357,6 +403,24 @@ function ConsoleScreen() {
               </Text>
             )}
           </View>
+          {/* CUSTOMIZE: a visible way into the layout editor. Hold-to-edit
+              shipped long ago but is an invisible gesture nobody found (the
+              review that called the UI busy never knew cards could be hidden).
+              Long-press still works; this just makes the same mode discoverable.
+              Gone while editing — the Done bar owns the exit. */}
+          {configured && !editingCards && (
+            <Pressable
+              onPress={() => {
+                hapticSelection();
+                setEditingCards(true);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel="Customize which cards show"
+              hitSlop={8}
+              style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
+              <Ionicons name="options-outline" size={18} color={t.textDim} />
+            </Pressable>
+          )}
         </View>
 
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
@@ -403,25 +467,34 @@ function ConsoleScreen() {
             Each wrapped in EditableSection (long-press → edit; ↑ ↓ hide). The
             self-gating cards still render null internally when their box lacks
             the feature; EditableSection shows no controls for a null card. */}
-        {cardOrder.map((id) => {
-          const node = cardNodes[id];
-          if (node == null) return null;
-          return (
-            <EditableSection
-              key={id}
-              editing={editingCards}
-              hidden={cardHidden.has(id)}
-              isFirst={visibleCards[0] === id}
-              isLast={visibleCards[visibleCards.length - 1] === id}
-              onEnterEdit={() => setEditingCards(true)}
-              onPresent={(p) => setPresent(id, p)}
-              onUp={() => moveCard(id, -1)}
-              onDown={() => moveCard(id, 1)}
-              onToggleHide={() => toggleHideCard(id)}>
-              {node}
-            </EditableSection>
-          );
-        })}
+        {renderCards(primaryOrder)}
+
+        {/* MORE: the box's controls & tools, folded by default (see the layout
+            note above). The row is the whole affordance — one tap opens it and
+            the choice persists. Disabled while editing, when it is forced open
+            so hidden tool cards stay reachable. */}
+        {configured && moreOrder.length > 0 && (
+          <Pressable
+            onPress={() => {
+              hapticSelection();
+              void setPref('consoleMoreCollapsed', !moreCollapsedPref);
+            }}
+            disabled={editingCards}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: moreOpen }}
+            accessibilityLabel={moreOpen ? 'Collapse more controls' : 'Show more controls'}
+            style={({ pressed }) => [styles.foldRow, pressed && !editingCards && styles.pressed]}>
+            <Ionicons name="options-outline" size={14} color={t.blue} />
+            <Text style={styles.foldText}>MORE</Text>
+            <Text style={styles.foldSub} numberOfLines={1}>controls &amp; tools</Text>
+            <Ionicons
+              name={moreOpen ? 'chevron-up' : 'chevron-down'}
+              size={15}
+              color={t.textDim}
+            />
+          </Pressable>
+        )}
+        {moreOpen && renderCards(moreOrder)}
         </Screen>
       </ScrollView>
       {/* Edit-layout bar: hold any card to enter, then reorder/hide + Done. */}
@@ -452,6 +525,18 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
   },
   editHint: { color: t.textDim, fontSize: 13 },
+  // Header "customize" affordance: quiet on purpose — the point of this pass is
+  // LESS chrome, so it is an icon at the header's edge, not a labelled button.
+  customizeBtn: { marginLeft: 10, padding: 6, borderRadius: 8 },
+  // The "More" fold row: reads as a section label, not a card, so it doesn't
+  // add to the very stack it is there to shorten.
+  foldRow: {
+    flexDirection: 'row', alignItems: 'center', gap: 8,
+    paddingVertical: 10, paddingHorizontal: 12, marginTop: 2, marginBottom: 10,
+    borderRadius: 10, backgroundColor: t.inset,
+  },
+  foldText: { color: t.textDim, fontSize: 12, fontWeight: '700', letterSpacing: 1.2 },
+  foldSub: { color: t.textFaint, fontSize: 12, flex: 1 },
   doneBtn: {
     backgroundColor: t.blue, borderRadius: 999,
     paddingVertical: 8, paddingHorizontal: 22,

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -595,7 +595,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 36,
     borderRadius: 8,
   },
-  retryText: { color: '#450a0a', fontWeight: '800', fontSize: 15, letterSpacing: 1 },
+  retryText: { color: t.onRed, fontWeight: '800', fontSize: 15, letterSpacing: 1 },
   pressed: { opacity: 0.7 },
   row: { flexDirection: 'row', gap: 10 },
   half: { flex: 1 },

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -140,7 +140,7 @@ function LauncherTile({
       style={({ pressed }) => [styles.tile, { width, height }, pressed && styles.tilePressed]}>
       {bookmarked ? (
         <View style={styles.bookmarkMark} pointerEvents="none">
-          <Ionicons name="bookmark" size={13} color="#04140c" />
+          <Ionicons name="bookmark" size={13} color={t.onGreen} />
         </View>
       ) : null}
       {/* Only drawn when a rating actually exists — an unrated game shows
@@ -1364,7 +1364,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 28,
     borderRadius: 8,
   },
-  retryText: { color: '#450a0a', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  retryText: { color: t.onRed, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
 
   emptyCard: {
     backgroundColor: t.card,

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -2502,7 +2502,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     paddingHorizontal: 22,
   },
   waitBtnText: {
-    color: '#08101f',
+    color: t.onAccent,
     fontSize: 13,
     fontWeight: '800',
     letterSpacing: 1,
@@ -2675,7 +2675,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     backgroundColor: t.card,
   },
   kbDoneText: {
-    color: '#0b1220',
+    color: t.onAccent,
     fontFamily: mono,
     fontSize: 13,
     fontWeight: '800',
@@ -2782,7 +2782,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     fontWeight: '800',
     letterSpacing: 1,
   },
-  handoffBtnPassText: { color: '#0b1220' },
+  handoffBtnPassText: { color: t.onAccent },
   inputBlockedText: {
     color: t.amber,
     fontFamily: mono,

--- a/app/app/(tabs)/pad.tsx
+++ b/app/app/(tabs)/pad.tsx
@@ -898,7 +898,22 @@ function PadScreen() {
   // arrow keys, and the pad has a cost the keyboard does not -- see the pref's
   // doc comment in lib/prefs.ts. Read here rather than inside the surfaces so
   // ONE value drives both the send path and which segments exist.
-  const keyboardMode = usePref('keyboardMode');
+  const keyboardModePref = usePref('keyboardMode');
+  // AUTO-DROP THE PAD (opt-in, see prefs.ts). A running game is folded into the
+  // SAME "act as keys, not a pad" state the manual toggle drives, so the box
+  // tears its virtual pad down while a game is up and recreates it on exit —
+  // stopping the phone from stealing player one from a real controller. The
+  // running-game probe (also the MOVE segment's source) is polled faster when
+  // auto-drop is armed so the pad is yielded within a few seconds of launch,
+  // not up to the idle 15 s the MOVE segment alone is happy with.
+  const autoDropPad = usePref('autoDropPad');
+  const gamingPoll = usePoll<Gaming | null>(
+    () => api.gaming(settings), autoDropPad ? 5000 : 15000, true, hostKey(settings));
+  const runningGame = gamingPoll.data?.game != null;
+  // The EFFECTIVE keyboard-mode every surface below reads: the manual pref OR an
+  // armed auto-drop with a game actually running. One value, one code path — so
+  // segment list, connect noPad, and the send path all follow automatically.
+  const keyboardMode = keyboardModePref || (autoDropPad && runningGame);
   const [localMode, setLocalMode] = useState<PadMode>(getPref('defaultPadMode'));
   // EMPTY_SETTINGS hardcodes padMode:'swipe', so key off "is a box paired"
   // rather than ?? — otherwise the local fallback never engages.
@@ -1374,14 +1389,6 @@ function PadScreen() {
   // frames into a browser that ignores them.
   const playerRunningRef = useRef(playerRunning);
   playerRunningRef.current = playerRunning;
-
-  // Running-game probe for the MOVE segment. Slow: a game starting or quitting
-  // is a once-in-minutes event. api.gaming is caps-gated, so a box that cannot
-  // report it resolves null and the segment simply never appears — probe-and-
-  // appear, the house pattern.
-  const gamingPoll = usePoll<Gaming | null>(
-    () => api.gaming(settings), 15000, true, hostKey(settings));
-  const runningGame = gamingPoll.data?.game != null;
 
   // Publish the running game's appid so the controller surfaces can dress for
   // it (lib/gameTheme.ts). A store rather than a prop because the immersive

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -916,6 +916,7 @@ function SetupBody() {
   const controllerTheme = usePref('controllerTheme');
   const askToSwitchControl = usePref('askToSwitchControl');
   const keyboardMode = usePref('keyboardMode');
+  const autoDropPad = usePref('autoDropPad');
   const searchButtonSide = usePref('searchButtonSide');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
@@ -1947,6 +1948,15 @@ function SetupBody() {
                 value={keyboardMode}
                 onValueChange={(v) => {
                   void setPref('keyboardMode', v);
+                  hapticSelection();
+                }}
+              />
+              <TogglePref
+                label="Drop the pad while a game is running"
+                sub="For playing with a real controller: while a Steam game is up, the phone stops presenting a controller so it can't take player one from your gamepad — then goes back to a full pad the moment the game exits. Leave off if you play with the phone itself. Needs the Couchside service 2.9.39 or newer."
+                value={autoDropPad}
+                onValueChange={(v) => {
+                  void setPref('autoDropPad', v);
                   hapticSelection();
                 }}
               />

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -83,11 +83,16 @@ import {
   ACCENTS,
   ACCENT_KEYS,
   mono,
+  packPalette,
   setAccent,
   setThemeMode,
+  setThemePack,
+  THEME_PACKS,
+  THEME_PACK_KEYS,
   useAccent,
   useResolvedScheme,
   useTheme,
+  useThemePack,
   useThemedStyles,
   useThemeMode,
   type Palette,
@@ -879,6 +884,7 @@ function SetupBody() {
   const watchEnabled = usePref('watchEnabled');
   const themeMode = useThemeMode();
   const accent = useAccent();
+  const themePack = useThemePack();
   const scheme = useResolvedScheme();
   const confirmSuspend = usePref('confirmSuspend');
   const streakCelebrations = usePref('streakCelebrations');
@@ -1621,6 +1627,59 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+              {/* LOOK = a whole palette, not just an accent (owner ask 2026-09-02).
+                  One horizontal row of preview cards, each drawn in ITS OWN colours
+                  for the scheme in effect, so a light-mode phone previews the light
+                  variants where a pack has one. Dark-only packs say so in their
+                  blurb. Midnight is today's look, so nothing changes until chosen. */}
+              <PrefFilterable
+                label="Look"
+                sub={'Midnight OLED Black Steam Nord Dracula Solarized High Contrast theme pack palette'}>
+              <View style={styles.prefCol}>
+                <View style={styles.prefBody}>
+                  <Text style={styles.prefLabel}>Look</Text>
+                  <Text style={styles.prefSub}>
+                    A whole palette. The accent below layers on top of any of them.
+                  </Text>
+                </View>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={styles.packRow}>
+                  {THEME_PACK_KEYS.map((k) => {
+                    const pk = THEME_PACKS[k];
+                    const pv = packPalette(k, scheme);
+                    const on = themePack === k;
+                    return (
+                      <Pressable
+                        key={k}
+                        onPress={() => {
+                          void setThemePack(k);
+                          hapticSelection();
+                        }}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: on }}
+                        accessibilityLabel={`${pk.label} look`}
+                        style={({ pressed }) => [
+                          styles.packCard,
+                          { backgroundColor: pv.bg, borderColor: on ? t.accent : pv.cardBorder },
+                          on && styles.packCardActive,
+                          pressed && { opacity: 0.8 },
+                        ]}>
+                        {/* mini preview: a card on the bg, a text line, an accent dot */}
+                        <View style={[styles.packInner, { backgroundColor: pv.card, borderColor: pv.cardBorder }]}>
+                          <View style={[styles.packLine, { backgroundColor: pv.text }]} />
+                          <View style={[styles.packLine, styles.packLineShort, { backgroundColor: pv.textDim }]} />
+                          <View style={[styles.packDot, { backgroundColor: pv.accent }]} />
+                        </View>
+                        <Text style={[styles.packName, { color: pv.text }]} numberOfLines={1}>{pk.label}</Text>
+                        <Text style={[styles.packBlurb, { color: pv.textFaint }]} numberOfLines={2}>{pk.blurb}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </ScrollView>
+              </View>
+              </PrefFilterable>
               <PrefFilterable
                 label="Accent"
                 sub="The app&apos;s highlight color.">
@@ -2448,7 +2507,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   btnTest: { backgroundColor: t.inset, borderColor: t.blue, borderWidth: 1 },
   btnTestText: { color: t.blue, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   btnSave: { backgroundColor: t.blue },
-  btnSaveText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  btnSaveText: { color: t.onAccent, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   rateRow: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -2498,7 +2557,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     alignItems: 'center',
     marginBottom: 10,
   },
-  btnBuyText: { color: '#0b1220', fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+  btnBuyText: { color: t.onAccent, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
   btnRestore: {
     backgroundColor: t.inset,
     borderColor: t.cardBorder,
@@ -2555,6 +2614,17 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   segText: { color: t.textDim, fontSize: 13, fontWeight: '700', fontFamily: mono },
   segTextActive: { color: t.text },
   accentRow: { flexDirection: 'row', gap: 12, flexWrap: 'wrap' },
+  // Theme-pack "Look" cards: each is painted in the pack's OWN palette (inline),
+  // so these carry only geometry. Border colour is set inline (accent when on).
+  packRow: { flexDirection: 'row', gap: 10, paddingVertical: 4, paddingRight: 8 },
+  packCard: { width: 128, borderRadius: 12, borderWidth: 1, padding: 10 },
+  packCardActive: { borderWidth: 2 },
+  packInner: { borderRadius: 8, borderWidth: 1, padding: 8, gap: 5, marginBottom: 8 },
+  packLine: { height: 6, borderRadius: 3, width: '80%' },
+  packLineShort: { width: '55%' },
+  packDot: { width: 12, height: 12, borderRadius: 6, marginTop: 2 },
+  packName: { fontSize: 12, fontWeight: '800', fontFamily: mono },
+  packBlurb: { fontSize: 10, marginTop: 2, lineHeight: 13 },
   accentSwatch: {
     width: 30,
     height: 30,

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -65,6 +65,7 @@ import {
 } from '@/lib/mediaSeek';
 import { clearCompatCache } from '@/lib/compatFetch';
 import { resetFeatureTour } from '@/hooks/useFeatureTour';
+import { resetTips } from '@/lib/tips';
 import { setPref, usePref } from '@/lib/prefs';
 import { THEME_PICKER } from '@/lib/gameTheme';
 import {
@@ -1540,6 +1541,9 @@ function SetupBody() {
                   // watch nothing happen — the same dead control, one layer down.
                   await setPref('featureTour', true);
                   await resetFeatureTour();
+                  // The tips are the same idea to the person flipping this
+                  // switch ("show me the onboarding again"), so they reset too.
+                  await resetTips();
                 }}
               />
               {/* A BUTTON, not a toggle. There is nothing to switch off — the

--- a/app/app/installable.tsx
+++ b/app/app/installable.tsx
@@ -93,6 +93,7 @@ function Cell({
   appid: number; d?: AppDetails; requested: boolean;
   colW: number; onOpen: (appid: number) => void;
 }) {
+  const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const { settings } = useSettings();
   const source = api.steamCoverSource(settings, appid);
@@ -112,7 +113,7 @@ function Cell({
           <Image source={source} style={StyleSheet.absoluteFill} resizeMode="cover" onError={() => setFailed(true)} />
         ) : (
           <View style={[StyleSheet.absoluteFill, styles.coverFallback]}>
-            <Ionicons name="cloud-download-outline" size={22} color="#8aa" />
+            <Ionicons name="cloud-download-outline" size={22} color={t.textDim} />
           </View>
         )}
         {mc !== undefined ? (
@@ -267,8 +268,8 @@ function GameSheet({
             disabled={busy || requested}
             style={({ pressed }) => [styles.gsPrimary, { opacity: busy || requested ? 0.6 : pressed ? 0.85 : 1 }]}
             accessibilityRole="button">
-            {busy ? <ActivityIndicator size="small" color="#fff" />
-              : <Ionicons name="cloud-download-outline" size={18} color="#fff" />}
+            {busy ? <ActivityIndicator size="small" color={t.onAccent} />
+              : <Ionicons name="cloud-download-outline" size={18} color={t.onAccent} />}
             <Text style={styles.gsPrimaryText}>{requested ? 'Waiting for approval…' : 'Install on box'}</Text>
           </Pressable>
           <Pressable
@@ -720,7 +721,7 @@ const makeStyles = (t: Palette) =>
       flex: 1, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
       backgroundColor: t.blue, paddingVertical: 13, borderRadius: 12,
     },
-    gsPrimaryText: { color: '#fff', fontWeight: '700', fontSize: 14 },
+    gsPrimaryText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
     gsGhost: {
       flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8,
       paddingVertical: 13, paddingHorizontal: 16, borderRadius: 12, borderWidth: 1, backgroundColor: t.card,
@@ -747,5 +748,5 @@ const makeStyles = (t: Palette) =>
     sheetActions: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginTop: 20 },
     clear: { color: t.textFaint, fontSize: 14 },
     doneBtn: { backgroundColor: t.blue, paddingVertical: 10, paddingHorizontal: 20, borderRadius: 10 },
-    doneText: { color: '#fff', fontWeight: '700', fontSize: 14 },
+    doneText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
   });

--- a/app/app/onboarding.tsx
+++ b/app/app/onboarding.tsx
@@ -340,7 +340,7 @@ const makeStyles = (t: Palette) =>
       paddingVertical: 15,
       backgroundColor: t.green,
     },
-    primaryText: { color: '#04140c', fontSize: 13.5, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    primaryText: { color: t.onGreen, fontSize: 13.5, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     skip: { alignItems: 'center', paddingVertical: 11 },
     skipText: { color: t.textFaint, fontSize: 13 },
     pressed: { opacity: 0.75 },

--- a/app/app/theme-picker.tsx
+++ b/app/app/theme-picker.tsx
@@ -27,7 +27,6 @@ import { backdropAssets } from '@/lib/gameThemeAssets';
 import { setPref, usePref } from '@/lib/prefs';
 import { useResolvedScheme, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
-const BASE = '#0b1220'; // the same dark base the real backdrop sits on
 const COLUMNS = 2;
 
 const isSpecial = (v: ControllerThemePref): v is 'off' | 'auto' => v === 'off' || v === 'auto';
@@ -131,7 +130,7 @@ function Card({
         ) : null}
         {selected ? (
           <View style={[styles.check, { backgroundColor: accent }]}>
-            <Ionicons name="checkmark" size={14} color={BASE} />
+            <Ionicons name="checkmark" size={14} color={t.onAccent} />
           </View>
         ) : null}
       </View>
@@ -209,7 +208,8 @@ const makeStyles = (t: Palette) =>
     card: { borderRadius: 14, borderWidth: 1, borderColor: t.cardBorder, backgroundColor: t.card, padding: 6 },
     art: {
       width: '100%', aspectRatio: 0.82, borderRadius: 10, overflow: 'hidden',
-      backgroundColor: BASE, position: 'relative',
+      // The same base the real backdrop (GameBackdrop) sits on: the live bg.
+      backgroundColor: t.bg, position: 'relative',
     },
     specialArt: { alignItems: 'center', justifyContent: 'center', backgroundColor: t.inset },
     artScrim: {

--- a/app/components/AgentUpdateBanner.tsx
+++ b/app/components/AgentUpdateBanner.tsx
@@ -277,7 +277,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     marginTop: 2,
   },
   btnPressed: { opacity: 0.85 },
-  btnText: { color: '#0b1220', fontSize: 14, fontWeight: '700' },
+  btnText: { color: t.onAccent, fontSize: 14, fontWeight: '700' },
   msg: { color: t.text, fontSize: 13, lineHeight: 19 },
   // Quieter and monospaced: this is machine output, and it should read as
   // detail under the headline rather than competing with it.

--- a/app/components/BoxScanQr.tsx
+++ b/app/components/BoxScanQr.tsx
@@ -532,9 +532,9 @@ const makeStyles = (t: Palette) =>
 
     // Permission gate — no feed behind it, so theme-ish darks are fine.
     permWrap: { alignItems: 'center', justifyContent: 'center', padding: 32, gap: 12 },
-    permTitle: { color: '#e5ecf8', fontSize: 17, fontWeight: '700', textAlign: 'center' },
+    permTitle: { color: t.text, fontSize: 17, fontWeight: '700', textAlign: 'center' },
     permSub: {
-      color: '#8b97ad',
+      color: t.textDim,
       fontSize: 13,
       lineHeight: 19,
       textAlign: 'center',

--- a/app/components/EncryptionBadge.tsx
+++ b/app/components/EncryptionBadge.tsx
@@ -13,8 +13,6 @@ import { Alert, Pressable, Text, View } from 'react-native';
 
 import { useTheme } from '@/lib/theme';
 
-const AMBER = '#e0a12e';
-
 /** Compact lock glyph — for the box switcher pill + fleet rows. */
 export function LockBadge({ secure, size = 13 }: { secure?: boolean; size?: number }) {
   const t = useTheme();
@@ -22,7 +20,7 @@ export function LockBadge({ secure, size = 13 }: { secure?: boolean; size?: numb
     <Ionicons
       name={secure ? 'lock-closed' : 'lock-open-outline'}
       size={size}
-      color={secure ? t.green : AMBER}
+      color={secure ? t.green : t.amber}
       accessibilityLabel={secure ? 'Encrypted connection' : 'Unencrypted connection'}
     />
   );
@@ -46,7 +44,7 @@ export function EncryptionBadge({ secure }: { secure?: boolean }) {
     <Pressable onPress={explain} hitSlop={8}>
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
         <LockBadge secure={secure} size={15} />
-        <Text style={{ color: secure ? t.green : AMBER, fontSize: 13, fontWeight: '600' }}>
+        <Text style={{ color: secure ? t.green : t.amber, fontSize: 13, fontWeight: '600' }}>
           {secure ? 'Encrypted' : 'Unencrypted'}
         </Text>
         <Ionicons name="information-circle-outline" size={13} color={t.textDim} />

--- a/app/components/FeatureTour.tsx
+++ b/app/components/FeatureTour.tsx
@@ -319,7 +319,7 @@ export function FeatureTour({
             accessibilityRole="button"
             style={({ pressed }) => [styles.next, pressed && styles.pressed]}>
             <Text style={styles.nextText}>{isLast(state) ? 'DONE' : 'GOT IT'}</Text>
-            {isLast(state) ? null : <Ionicons name="arrow-forward" size={14} color="#04140c" />}
+            {isLast(state) ? null : <Ionicons name="arrow-forward" size={14} color={t.onGreen} />}
           </Pressable>
         </View>
       </View>
@@ -391,6 +391,6 @@ const makeStyles = (t: Palette) =>
       borderRadius: 11,
       paddingVertical: 12,
     },
-    nextText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    nextText: { color: t.onGreen, fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     pressed: { opacity: 0.7 },
   });

--- a/app/components/FileDropCard.tsx
+++ b/app/components/FileDropCard.tsx
@@ -205,7 +205,7 @@ const makeStyles = (t: Palette) =>
     },
     btnPressed: { opacity: 0.85 },
     btnDisabled: { opacity: 0.6 },
-    btnText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+    btnText: { color: t.onAccent, fontSize: 13, fontWeight: '700' },
     // Secondary action: outlined, so it reads as "optional extra" next to the
     // filled primary button rather than competing with it.
     btnGhost: {

--- a/app/components/GameBackdrop.tsx
+++ b/app/components/GameBackdrop.tsx
@@ -22,10 +22,13 @@ import { Image, StyleSheet, View, type ImageSourcePropType } from 'react-native'
 
 import { backdropAssets } from '@/lib/gameThemeAssets';
 import type { Backdrop } from '@/lib/gameTheme';
+import { useTheme } from '@/lib/theme';
 
-/** The dark base every backdrop sits on — the app's own bg, so a missing or
- *  transparent asset can never flash a bright frame. */
-const BASE = '#0b1220';
+// The base every backdrop sits on is the live palette's `bg` (read via
+// useTheme() inside the component) — the app's own bg, so a missing or
+// transparent asset can never flash a frame that clashes with the pad, and a
+// theme pack (OLED black, Steam, Nord, ...) gets its own base rather than the
+// default navy.
 
 /**
  * The legibility scrim. Four bands from top (light) to bottom (heavy): the
@@ -50,6 +53,9 @@ export function GameBackdrop({
   backdrop: Backdrop | null;
   landscape: boolean;
 }) {
+  // Hook first (unconditionally), then the guard: the base colour is the live
+  // palette's bg so the backdrop follows theme packs.
+  const t = useTheme();
   // No theme, or a theme with no backdrop: draw nothing. The pad keeps its
   // normal bg. (This component is only mounted when backdrop != null, but the
   // guard keeps it honest and cheap.)
@@ -63,7 +69,7 @@ export function GameBackdrop({
   // sizes its inner image from an onLayout MEASUREMENT of its container, then
   // stamps that as a numeric width/height. On native (iOS), the immersive/rotation
   // transition measured the container once at a non-final size and never
-  // re-measured, so the art filled only a top band with BASE showing below —
+  // re-measured, so the art filled only a top band with the base bg showing below —
   // invisible in the web harness, where ImageBackground is a CSS `cover` div that
   // always fills. A bare Image at absoluteFill covers the parent directly at
   // layout time with no measurement step. The Scrim is a following sibling, so it
@@ -71,7 +77,7 @@ export function GameBackdrop({
   if (assets) {
     const source = landscape ? assets.landscape : assets.portrait;
     return (
-      <View style={[StyleSheet.absoluteFill, { backgroundColor: BASE }]} pointerEvents="none">
+      <View style={[StyleSheet.absoluteFill, { backgroundColor: t.bg }]} pointerEvents="none">
         <Image
           source={source as ImageSourcePropType}
           style={StyleSheet.absoluteFill}
@@ -87,7 +93,7 @@ export function GameBackdrop({
   // controls sit — plus the same scrim, so it reads as "styled" without ever
   // competing with the buttons.
   return (
-    <View style={[StyleSheet.absoluteFill, { backgroundColor: BASE }]} pointerEvents="none">
+    <View style={[StyleSheet.absoluteFill, { backgroundColor: t.bg }]} pointerEvents="none">
       <View
         pointerEvents="none"
         style={{

--- a/app/components/GameSheet.tsx
+++ b/app/components/GameSheet.tsx
@@ -189,7 +189,7 @@ export function GameSheet({
               accessibilityRole="button"
               accessibilityLabel={`Play ${launcher.label}`}
               style={({ pressed }) => [styles.btn, styles.btnPlay, pressed && styles.pressed]}>
-              <Ionicons name="play" size={15} color="#04140c" />
+              <Ionicons name="play" size={15} color={t.onGreen} />
               <Text style={styles.btnPlayText}>{busy ? 'LAUNCHING…' : 'PLAY'}</Text>
             </Pressable>
           </View>
@@ -270,6 +270,6 @@ const makeStyles = (t: Palette) =>
     btnGhost: { backgroundColor: t.inset, borderWidth: 1, borderColor: t.cardBorder },
     btnGhostText: { color: t.textDim, fontSize: 13, fontWeight: '800', letterSpacing: 1, fontFamily: mono },
     btnPlay: { backgroundColor: t.green },
-    btnPlayText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    btnPlayText: { color: t.onGreen, fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     pressed: { opacity: 0.65 },
   });

--- a/app/components/LibraryFilterSheet.tsx
+++ b/app/components/LibraryFilterSheet.tsx
@@ -470,7 +470,7 @@ const makeStyles = (t: Palette) =>
       backgroundColor: t.green,
     },
     confirmEmpty: { backgroundColor: t.inset, borderWidth: 1, borderColor: t.cardBorder },
-    confirmText: { color: '#04140c', fontSize: 14, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    confirmText: { color: t.onGreen, fontSize: 14, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     confirmTextEmpty: { color: t.textDim },
     pressed: { opacity: 0.6 },
   });

--- a/app/components/PadDiagnostics.tsx
+++ b/app/components/PadDiagnostics.tsx
@@ -217,5 +217,5 @@ const makeStyles = (t: Palette) =>
       alignItems: 'center',
       marginTop: 6,
     },
-    btnText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+    btnText: { color: t.onAccent, fontSize: 13, fontWeight: '700' },
   });

--- a/app/components/Paywall.tsx
+++ b/app/components/Paywall.tsx
@@ -179,7 +179,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     alignItems: 'center',
     marginBottom: 12,
   },
-  buyBtnText: { color: '#0b1220', fontSize: 14, fontWeight: '800', letterSpacing: 1 },
+  buyBtnText: { color: t.onAccent, fontSize: 14, fontWeight: '800', letterSpacing: 1 },
   restoreBtn: {
     alignSelf: 'stretch',
     backgroundColor: t.inset,

--- a/app/components/RemoteView.tsx
+++ b/app/components/RemoteView.tsx
@@ -642,6 +642,7 @@ export function Dpad({
   /** Joystick armed/released — the parent locks page scrolling while armed. */
   onJoyActive: (active: boolean) => void;
 }) {
+  const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const sens = usePref('trackpadSensitivity');
   const [joy, setJoy] = useState(false);
@@ -753,7 +754,7 @@ export function Dpad({
       </Pressable>
       <View {...okResponder.panHandlers} style={[styles.ok, geo.ok, joy && styles.okJoy]}>
         {joy ? (
-          <Ionicons name="move" size={Math.round(size * 0.15)} color="#f8fafc" />
+          <Ionicons name="move" size={Math.round(size * 0.15)} color={t.onAccent} />
         ) : (
           <Text style={[styles.okText, { fontSize: Math.round(size * 0.1) }]}>OK</Text>
         )}
@@ -914,7 +915,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderRadius: 10,
     backgroundColor: t.card,
     borderWidth: 1,
-    borderColor: 'rgba(248,113,113,0.5)',
+    borderColor: t.red + '80',
     alignItems: 'center',
     justifyContent: 'center',
   },
@@ -1063,7 +1064,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderWidth: 1,
     borderColor: t.cardBorder,
   },
-  sourcePillBox: { borderColor: 'rgba(52,211,153,0.5)' },
+  sourcePillBox: { borderColor: t.green + '80' },
   sourceText: {
     color: t.textDim,
     fontSize: 11,
@@ -1108,5 +1109,5 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   textBtnSendBg: { backgroundColor: t.blue },
   textBtnCancel: { color: t.textDim, fontWeight: '700', fontSize: 13 },
-  textBtnSend: { color: t.bg, fontWeight: '800', fontSize: 13 },
+  textBtnSend: { color: t.onAccent, fontWeight: '800', fontSize: 13 },
 });

--- a/app/components/ReviewToast.tsx
+++ b/app/components/ReviewToast.tsx
@@ -110,6 +110,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   btnText: { color: t.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
   btnPrimary: { backgroundColor: t.blue, borderColor: t.blue },
-  btnPrimaryText: { color: '#0b1220', fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  btnPrimaryText: { color: t.onAccent, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
   pressed: { opacity: 0.7 },
 });

--- a/app/components/ScreensaverSheet.tsx
+++ b/app/components/ScreensaverSheet.tsx
@@ -218,7 +218,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     borderRadius: 12,
     backgroundColor: t.blue,
   },
-  startText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+  startText: { color: t.onAccent, fontSize: 15, fontWeight: '700' },
 
   armedRow: {
     flexDirection: 'row',

--- a/app/components/SystemUpdatesCard.tsx
+++ b/app/components/SystemUpdatesCard.tsx
@@ -308,7 +308,7 @@ const makeStyles = (t: Palette) => StyleSheet.create({
     marginTop: 1,
   },
   btnPressed: { opacity: 0.85 },
-  btnText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+  btnText: { color: t.onAccent, fontSize: 13, fontWeight: '700' },
   hint: { color: t.textFaint, fontSize: 11, lineHeight: 16 },
   code: { fontFamily: mono, color: t.textDim },
 });

--- a/app/components/TipToast.tsx
+++ b/app/components/TipToast.tsx
@@ -182,6 +182,6 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   btnText: { color: t.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
   btnPrimary: { backgroundColor: t.blue, borderColor: t.blue },
-  btnPrimaryText: { color: '#0b1220', fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  btnPrimaryText: { color: t.onAccent, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
   pressed: { opacity: 0.7 },
 });

--- a/app/components/TipToast.tsx
+++ b/app/components/TipToast.tsx
@@ -1,0 +1,187 @@
+/**
+ * "Did you know" — one contextual tip, on the tab it belongs to, once each.
+ *
+ * Modelled on ReviewToast (same slot above the tab bar, same dismiss shape)
+ * rather than the pointer-events-none AppToast, because a tip has a button:
+ * SHOW ME scrolls the tab to the control it describes. Every rule that keeps
+ * this from becoming clutter lives in lib/tips.ts; this file is the timer and
+ * the pixels.
+ *
+ * Mounted once in the tabs layout, which knows the active tab and whether the
+ * tour or its thank-you is on screen. A tip never appears over either.
+ */
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { measureAnchor, scrollTabBy } from '@/hooks/useTourAnchor';
+import { subscribeReviewInvite } from '@/lib/review';
+import { hapticLight } from '@/lib/haptics';
+import { usePref } from '@/lib/prefs';
+import { canShowTip, markTipShown, pickCandidates, useTipsState, type Tip } from '@/lib/tips';
+import { mono, useThemedStyles, type Palette } from '@/lib/theme';
+
+/** Let the tab settle and its cards finish probing before offering anything —
+ *  a tip that lands on a still-loading screen reads as noise. */
+const SETTLE_MS = 6000;
+/** Long enough to read twice. It asks nothing, so it need not linger. */
+const TOAST_MS = 14000;
+
+type Props = {
+  /** Route name of the tab on screen ('index', 'pad', …), or null if unknown. */
+  tab: string | null;
+  /** At least one box paired. Tips describe box features; none before that. */
+  paired: boolean;
+  /** Something else owns the screen (feature tour, its thank-you). */
+  busy: boolean;
+};
+
+export function TipToast({ tab, paired, busy }: Props) {
+  const enabled = usePref('featureTour');
+  const tips = useTipsState(); // subscribed so a reset re-arms the timer below
+  const [tip, setTip] = useState<Tip | null>(null);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const insets = useSafeAreaInsets();
+  const styles = useThemedStyles(makeStyles);
+
+  // The review invite owns this same slot and matters more (Apple rating), so
+  // it wins: a pending invite pulls any tip and blocks a new one for a window.
+  // ReviewToast is mounted at the root, out of this tree's reach, so we listen
+  // to the same source it does rather than to the toast. One interruption at a
+  // time — the whole reason tips exist.
+  const reviewActive = useRef(false);
+  useEffect(() => {
+    let clear: ReturnType<typeof setTimeout> | null = null;
+    const unsub = subscribeReviewInvite(() => {
+      reviewActive.current = true;
+      setTip(null);
+      if (clear) clearTimeout(clear);
+      clear = setTimeout(() => { reviewActive.current = false; }, 20000);
+    });
+    return () => {
+      unsub();
+      if (clear) clearTimeout(clear);
+    };
+  }, []);
+
+  // Arm when the tab settles. The gate is re-evaluated at fire time too: the
+  // user may have opened the tour, or another tab may have shown today's tip.
+  useEffect(() => {
+    if (!enabled || !paired || busy || !tips.ready || !tab) return;
+    if (!canShowTip()) return;
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      void (async () => {
+        if (cancelled || reviewActive.current || !canShowTip()) return;
+        for (const cand of pickCandidates(tab)) {
+          // Never describe a control the user cannot see (the tour's rule).
+          if (cand.anchor && !(await measureAnchor(cand.anchor))) continue;
+          if (cancelled) return;
+          markTipShown(cand.id);
+          setTip(cand);
+          if (hideTimer.current) clearTimeout(hideTimer.current);
+          hideTimer.current = setTimeout(() => setTip(null), TOAST_MS);
+          return;
+        }
+      })();
+    }, SETTLE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [enabled, paired, busy, tab, tips.ready, tips.lastDay]);
+
+  // Yield to anything modal, and don't follow the user to another tab — a tip
+  // about the Console shown on the Pad points at nothing.
+  useEffect(() => {
+    if (busy) setTip(null);
+  }, [busy]);
+  useEffect(() => {
+    setTip((cur) => (cur && cur.tab !== 'any' && cur.tab !== tab ? null : cur));
+  }, [tab]);
+  useEffect(() => () => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+  }, []);
+
+  const onDismiss = useCallback(() => {
+    hapticLight();
+    setTip(null);
+  }, []);
+
+  const onShow = useCallback(() => {
+    hapticLight();
+    const t = tip;
+    setTip(null);
+    if (!t?.anchor || t.tab === 'any') return;
+    void measureAnchor(t.anchor).then((r) => {
+      // Bring it just below the header. scrollTabBy takes a DELTA; a tab that
+      // never registered a scroller no-ops, which is fine — it is on screen.
+      if (r) scrollTabBy(t.tab, r.y - 140);
+    });
+  }, [tip]);
+
+  if (!tip) return null;
+
+  return (
+    <View style={[styles.wrap, { bottom: insets.bottom + 76 }]}>
+      <View style={styles.toast} accessibilityRole="alert">
+        <Text style={styles.eyebrow}>{tip.eyebrow ?? 'DID YOU KNOW'}</Text>
+        <Text style={styles.text}>{tip.text}</Text>
+        <View style={styles.actions}>
+          {tip.anchor ? (
+            <Pressable
+              onPress={onShow}
+              accessibilityRole="button"
+              accessibilityLabel="Show me"
+              style={({ pressed }) => [styles.btn, pressed && styles.pressed]}>
+              <Text style={styles.btnText}>SHOW ME</Text>
+            </Pressable>
+          ) : null}
+          <Pressable
+            onPress={onDismiss}
+            accessibilityRole="button"
+            accessibilityLabel="Got it"
+            style={({ pressed }) => [styles.btn, styles.btnPrimary, pressed && styles.pressed]}>
+            <Text style={styles.btnPrimaryText}>GOT IT</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) => StyleSheet.create({
+  wrap: { position: 'absolute', left: 0, right: 0, alignItems: 'center' },
+  toast: {
+    maxWidth: '92%',
+    backgroundColor: t.card,
+    borderColor: t.blue,
+    borderWidth: 1,
+    borderRadius: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+  },
+  eyebrow: {
+    color: t.blue,
+    fontFamily: mono,
+    fontSize: 11,
+    fontWeight: '800',
+    letterSpacing: 1.4,
+    textAlign: 'center',
+  },
+  text: { color: t.text, fontSize: 13, marginTop: 6, textAlign: 'center', lineHeight: 18 },
+  actions: { flexDirection: 'row', gap: 10, marginTop: 12 },
+  btn: {
+    flex: 1,
+    paddingVertical: 9,
+    borderRadius: 8,
+    alignItems: 'center',
+    backgroundColor: t.inset,
+    borderWidth: 1,
+    borderColor: t.cardBorder,
+  },
+  btnText: { color: t.textDim, fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  btnPrimary: { backgroundColor: t.blue, borderColor: t.blue },
+  btnPrimaryText: { color: '#0b1220', fontSize: 12, fontWeight: '800', letterSpacing: 1 },
+  pressed: { opacity: 0.7 },
+});

--- a/app/components/TourThanks.tsx
+++ b/app/components/TourThanks.tsx
@@ -154,7 +154,7 @@ const makeStyles = (t: Palette) =>
       paddingVertical: 13,
       backgroundColor: t.green,
     },
-    secondaryText: { color: '#04140c', fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    secondaryText: { color: t.onGreen, fontSize: 13, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     primary: {
       flex: 1,
       alignItems: 'center',

--- a/app/components/WatchDpad.tsx
+++ b/app/components/WatchDpad.tsx
@@ -615,7 +615,7 @@ const makeStyles = (t: Palette) =>
     },
     modeChipOn: { backgroundColor: t.accent, borderColor: t.accent },
     modeText: { color: t.textDim, fontSize: 12, fontWeight: '600' },
-    modeTextOn: { color: '#0b1220', fontWeight: '700' },
+    modeTextOn: { color: t.onAccent, fontWeight: '700' },
     swipePad: {
       alignSelf: 'stretch',
       // Owner feedback on the first build: 168 felt cramped. A swipe surface
@@ -642,7 +642,7 @@ const makeStyles = (t: Palette) =>
     },
     backText: { color: t.text, fontSize: 13, fontWeight: '600' },
     kbOn: { backgroundColor: t.accent, borderColor: t.accent },
-    kbOnText: { color: '#0b1220', fontWeight: '700' },
+    kbOnText: { color: t.onAccent, fontWeight: '700' },
     hint: { color: t.textFaint, fontSize: 11, textAlign: 'center' },
     pressed: { opacity: 0.6 },
     handoff: {
@@ -659,5 +659,5 @@ const makeStyles = (t: Palette) =>
       borderRadius: 10,
       backgroundColor: t.accent,
     },
-    takeText: { color: '#0b1220', fontSize: 13, fontWeight: '700' },
+    takeText: { color: t.onAccent, fontSize: 13, fontWeight: '700' },
   });

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -819,7 +819,7 @@ const makeStyles = (t: Palette) =>
     },
     tBtnMain: { backgroundColor: t.accent, borderColor: t.accent },
     tBtnText: { color: t.text, fontSize: 13, fontWeight: '600' },
-    tBtnMainText: { color: '#0b1220', fontWeight: '700' },
+    tBtnMainText: { color: t.onAccent, fontWeight: '700' },
     nowLabel: { color: t.green, fontSize: 10, fontWeight: '700', letterSpacing: 1.2 },
     zoomRow: {
       flexDirection: 'row',
@@ -841,7 +841,7 @@ const makeStyles = (t: Palette) =>
     },
     zoomChipOn: { backgroundColor: t.accent, borderColor: t.accent },
     zoomText: { color: t.textDim, fontSize: 12, fontWeight: '600' },
-    zoomTextOn: { color: '#0b1220', fontWeight: '700' },
+    zoomTextOn: { color: t.onAccent, fontWeight: '700' },
     nowService: { color: t.text, fontSize: 20, fontWeight: '700', marginTop: 2 },
     nowPath: { color: t.textFaint, fontSize: 12, marginTop: 2 },
     stopBtn: {
@@ -871,7 +871,7 @@ const makeStyles = (t: Palette) =>
       backgroundColor: t.accent,
     },
     sendBtnOff: { backgroundColor: t.inset },
-    sendText: { color: '#0b1220', fontWeight: '700', fontSize: 14 },
+    sendText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
     sendTextOff: { color: t.textFaint },
     searchBtn: {
       flexGrow: 1,

--- a/app/components/WhatsNewOffer.tsx
+++ b/app/components/WhatsNewOffer.tsx
@@ -121,6 +121,6 @@ const makeStyles = (t: Palette) =>
       paddingVertical: 13,
       backgroundColor: t.green,
     },
-    primaryText: { color: '#04140c', fontSize: 12.5, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
+    primaryText: { color: t.onGreen, fontSize: 12.5, fontWeight: '900', letterSpacing: 1, fontFamily: mono },
     pressed: { opacity: 0.75 },
   });

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -119,6 +119,15 @@ export type Prefs = {
    *  and reopens in one tap, which a hidden one cannot. Persisted, because a
    *  section you fold away should stay folded. */
   streamCollapsed: boolean;
+  /** Fold the Console's CONTROLS & TOOLS cards (lights, display/audio, screen,
+   *  units, file drop) behind one "More" row. Defaults to FOLDED — the focused
+   *  default that answers "the UI is a little busy" (App Store review,
+   *  2026-08-30): the console opens showing what is happening NOW (media, a
+   *  stream, a game, vitals) and the tools are one tap away. Folding is not
+   *  hiding: every card still exists and hold-to-edit still reorders/hides.
+   *  Persisted, because a fold you opened should stay open. Driven by the fold
+   *  itself, not a Setup toggle — no new switch to find. */
+  consoleMoreCollapsed: boolean;
   /**
    * The first-run flow (welcome -> which device -> how to set it up) has been
    * seen and exited. Set on ANY exit: either card, the skip link, or the Android
@@ -297,6 +306,7 @@ export const DEFAULTS: Prefs = {
   keyboardMode: false,
   searchButtonSide: 'left',
   streamCollapsed: false,
+  consoleMoreCollapsed: true,
   onboardingDone: false,
   whatsNewOffered: false,
   hideDownloads: false,
@@ -394,6 +404,7 @@ function normalize(raw: unknown): Prefs {
       ? o.defaultPadMode
       : 'swipe';
   const streamCollapsed = bool(o.streamCollapsed, DEFAULTS.streamCollapsed);
+  const consoleMoreCollapsed = bool(o.consoleMoreCollapsed, DEFAULTS.consoleMoreCollapsed);
   const onboardingDone = bool(o.onboardingDone, DEFAULTS.onboardingDone);
   const whatsNewOffered = bool(o.whatsNewOffered, DEFAULTS.whatsNewOffered);
   const hideDownloads = bool(o.hideDownloads, DEFAULTS.hideDownloads);
@@ -409,6 +420,7 @@ function normalize(raw: unknown): Prefs {
   return {
     searchButtonSide: searchSide,
     streamCollapsed,
+    consoleMoreCollapsed,
     onboardingDone,
     whatsNewOffered,
     hideDownloads,

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -104,6 +104,24 @@ export type Prefs = {
    *  benefit. The dedicated PAD screen always sends gamepad frames regardless:
    *  a gamepad screen with no gamepad would be a lie. */
   keyboardMode: boolean;
+  /** AUTO-DROP THE PAD while a real game is running.
+   *
+   *  Same problem `keyboardMode` fixes, but automatic and temporary. The app's
+   *  virtual pad persists across tabs once created, so a phone kept in hand for
+   *  nav/media registers as a SECOND controller and a running game can hand it
+   *  player one instead of the real controller you're playing with. When this
+   *  is on, the Pad screen treats "a game is running" exactly like keyboard
+   *  mode — the box tears its virtual pad down for the duration of the game and
+   *  recreates it the moment the game exits. Nothing persists: your keyboardMode
+   *  pref is untouched, this only overrides while a game is actually up.
+   *
+   *  OFF by default and opt-in: someone who plays with the phone AS the
+   *  controller must not have it yanked mid-game. Only useful to people who
+   *  play with a real pad and hold the phone for the second screen. Detection is
+   *  the same `/api/gaming` running-game probe the MOVE segment uses (agent
+   *  >= 2.9.25); older agents never report a game, so the override never fires
+   *  and the app behaves exactly as before. */
+  autoDropPad: boolean;
   /** Input mode a newly paired box starts on. */
   /** Where the Steam search button sits on the keyboard bar, or 'off' to hide
    *  it entirely.
@@ -304,6 +322,7 @@ export const DEFAULTS: Prefs = {
   landingTab: 'index',
   autoKeyboard: true,
   keyboardMode: false,
+  autoDropPad: false,
   searchButtonSide: 'left',
   streamCollapsed: false,
   consoleMoreCollapsed: true,
@@ -436,6 +455,7 @@ function normalize(raw: unknown): Prefs {
     landingTab,
     autoKeyboard: bool(o.autoKeyboard, DEFAULTS.autoKeyboard),
     keyboardMode: bool(o.keyboardMode, DEFAULTS.keyboardMode),
+    autoDropPad: bool(o.autoDropPad, DEFAULTS.autoDropPad),
     defaultPadMode: padMode,
     statusIntervalMs: num(o.statusIntervalMs, STATUS_INTERVAL_OPTIONS, DEFAULTS.statusIntervalMs),
     journalLines: num(o.journalLines, JOURNAL_LINE_OPTIONS, DEFAULTS.journalLines),

--- a/app/lib/theme.ts
+++ b/app/lib/theme.ts
@@ -43,6 +43,19 @@ export type Palette = {
   tabBarBorder: string;
   /** The resolved accent hue (drives the active/link color; mirrors `blue`). */
   accent: string;
+  /**
+   * Text/icon drawn ON an accent-coloured surface (primary buttons, the Done
+   * pill). Sites used to hardcode the navy `'#0b1220'`, which is unreadable on
+   * a light pack's blue button and simply wrong on any pack whose bg isn't
+   * navy. Always this token on an accent surface; never a literal.
+   */
+  onAccent: string;
+  /** Text/icon drawn ON a `green` button (Play, Next, Confirm). Sites hardcoded
+   *  `'#04140c'`; on a light pack's darker green that is unreadable. */
+  onGreen: string;
+  /** Text/icon drawn ON a `red` button (Retry, Cancel countdown). Sites hardcoded
+   *  `'#450a0a'`; same story as onGreen. */
+  onRed: string;
 };
 
 /** Dark ops-console palette. Legible at 2am. The historical default. */
@@ -69,6 +82,9 @@ const dark: Palette = {
   tabBar: '#0e1526',
   tabBarBorder: '#1e2942',
   accent: '#60a5fa',
+  onAccent: '#0b1220',
+  onGreen: '#04140c',
+  onRed: '#450a0a',
 };
 
 /** Light palette. Same navy/green identity, tuned for contrast on a light bg. */
@@ -96,6 +112,9 @@ const light: Palette = {
   tabBar: '#ffffff',
   tabBarBorder: '#dbe3f0',
   accent: '#2563eb',
+  onAccent: '#ffffff',
+  onGreen: '#ffffff',
+  onRed: '#ffffff',
 };
 
 export const palettes: Record<'dark' | 'light', Palette> = { dark, light };
@@ -114,7 +133,10 @@ export type AccentKey = 'blue' | 'green' | 'violet' | 'amber' | 'rose' | 'teal';
 
 /** The selectable accent hues, one value per scheme (tuned for contrast). */
 export const ACCENTS: Record<AccentKey, { label: string; dark: string; light: string }> = {
-  blue: { label: 'Blue', dark: '#60a5fa', light: '#2563eb' },
+  // 'blue' is the DEFAULT slot: it resolves to the active pack's own accent
+  // (Steam's #66c0f4, Dracula's purple…) rather than a fixed hue, so every pack
+  // looks like itself out of the box and the other five still override.
+  blue: { label: 'Default', dark: '#60a5fa', light: '#2563eb' },
   green: { label: 'Green', dark: '#34d399', light: '#059669' },
   violet: { label: 'Violet', dark: '#a78bfa', light: '#7c3aed' },
   amber: { label: 'Amber', dark: '#fbbf24', light: '#d97706' },
@@ -123,6 +145,134 @@ export const ACCENTS: Record<AccentKey, { label: string; dark: string; light: st
 };
 
 export const ACCENT_KEYS = Object.keys(ACCENTS) as AccentKey[];
+
+// ---------------------------------------------------------------------------
+// Theme packs — whole looks, not just an accent (owner ask, 2026-09-02).
+//
+// A pack is a dark palette plus, where the look has a canonical one, a light
+// palette. Light/Dark/System keeps working: for a pack with both variants the
+// switch chooses between them; a dark-only pack (OLED, Steam, Nord, Dracula)
+// stays dark whatever the switch says — you chose black, you get black. The
+// accent picker layers on top of any pack; its "Default" slot is the pack's own
+// accent. Midnight is today's look exactly, so existing installs change nothing.
+//
+// Every value below is a full Palette (spread from Midnight so a pack can never
+// forget a token — tsc enforces the shape). Contrast was kept at or above the
+// Midnight baseline for text tiers; the faint tier is the one to watch.
+// ---------------------------------------------------------------------------
+
+export type ThemePackKey =
+  | 'midnight' | 'oled' | 'steam' | 'nord' | 'dracula' | 'solarized' | 'contrast';
+
+export type ThemePack = {
+  label: string;
+  /** One line for the picker card. */
+  blurb: string;
+  dark: Palette;
+  light?: Palette;
+};
+
+const oledDark: Palette = {
+  ...dark,
+  bg: '#000000', card: '#0c0c0e', cardBorder: '#1f1f24', inset: '#080809',
+  text: '#f2f4f8', textDim: '#a0a6b3', textFaint: '#7d8494',
+  tabBar: '#000000', tabBarBorder: '#1f1f24',
+  onAccent: '#000000',
+};
+
+/** Valve's own palette: the Steam client's navy/slate with its light-blue links. */
+const steamDark: Palette = {
+  ...dark,
+  bg: '#171a21', card: '#1b2838', cardBorder: '#2a475e', inset: '#16202d',
+  text: '#c6d4df', textDim: '#9aa6b1', textFaint: '#8290a0',
+  green: '#a4d007', amber: '#e5b800', red: '#e0563c',
+  redDeep: '#5c1a12', onRedDeep: '#f4c7bf',
+  blue: '#66c0f4', slate: '#4b6479',
+  tabBar: '#171a21', tabBarBorder: '#2a475e',
+  accent: '#66c0f4', onAccent: '#0f1a26',
+};
+
+const nordDark: Palette = {
+  ...dark,
+  bg: '#2e3440', card: '#3b4252', cardBorder: '#4c566a', inset: '#353b49',
+  text: '#eceff4', textDim: '#d8dee9', textFaint: '#a3b1c6',
+  green: '#a3be8c', amber: '#ebcb8b', red: '#bf616a',
+  redDeep: '#4b2a30', onRedDeep: '#f1c6ca',
+  blue: '#88c0d0', slate: '#4c566a',
+  tabBar: '#2e3440', tabBarBorder: '#4c566a',
+  accent: '#88c0d0', onAccent: '#2e3440',
+};
+
+const draculaDark: Palette = {
+  ...dark,
+  bg: '#282a36', card: '#343746', cardBorder: '#44475a', inset: '#2c2f3d',
+  text: '#f8f8f2', textDim: '#bfc3d9', textFaint: '#8b93b8',
+  green: '#50fa7b', amber: '#f1fa8c', red: '#ff5555',
+  redDeep: '#4a1f2a', onRedDeep: '#ffb3b3',
+  blue: '#8be9fd', slate: '#6272a4',
+  tabBar: '#282a36', tabBarBorder: '#44475a',
+  accent: '#bd93f9', onAccent: '#282a36',
+};
+
+const solarizedDark: Palette = {
+  ...dark,
+  bg: '#002b36', card: '#073642', cardBorder: '#1c4a58', inset: '#00232c',
+  text: '#eee8d5', textDim: '#a7b5b8', textFaint: '#8a9a9c',
+  green: '#859900', amber: '#b58900', red: '#dc322f',
+  redDeep: '#4a1512', onRedDeep: '#f5c2c0',
+  blue: '#268bd2', slate: '#586e75',
+  tabBar: '#002b36', tabBarBorder: '#1c4a58',
+  accent: '#268bd2', onAccent: '#fdf6e3',
+};
+const solarizedLight: Palette = {
+  ...light,
+  bg: '#fdf6e3', card: '#eee8d5', cardBorder: '#d6cfb8', inset: '#f5efdc',
+  text: '#073642', textDim: '#586e75', textFaint: '#657b83',
+  green: '#6f8000', amber: '#b58900', red: '#dc322f',
+  redDeep: '#f8d0ce', onRedDeep: '#7a1a17',
+  blue: '#268bd2', slate: '#93a1a1',
+  tabBar: '#eee8d5', tabBarBorder: '#d6cfb8',
+  accent: '#268bd2', onAccent: '#fdf6e3',
+};
+
+const contrastDark: Palette = {
+  ...dark,
+  bg: '#000000', card: '#000000', cardBorder: '#ffffff', inset: '#111111',
+  text: '#ffffff', textDim: '#ffffff', textFaint: '#d0d0d0',
+  green: '#00ff88', amber: '#ffd60a', red: '#ff4d4d',
+  redDeep: '#330000', onRedDeep: '#ffffff',
+  blue: '#4dc3ff', slate: '#bbbbbb',
+  tabBar: '#000000', tabBarBorder: '#ffffff',
+  accent: '#4dc3ff', onAccent: '#000000',
+};
+const contrastLight: Palette = {
+  ...light,
+  bg: '#ffffff', card: '#ffffff', cardBorder: '#000000', inset: '#f0f0f0',
+  text: '#000000', textDim: '#000000', textFaint: '#333333',
+  green: '#006b3c', amber: '#8a5a00', red: '#b00020',
+  redDeep: '#ffd6d6', onRedDeep: '#5a0010',
+  blue: '#0044cc', slate: '#444444',
+  tabBar: '#ffffff', tabBarBorder: '#000000',
+  accent: '#0044cc', onAccent: '#ffffff',
+};
+
+export const THEME_PACKS: Record<ThemePackKey, ThemePack> = {
+  midnight: { label: 'Midnight', blurb: 'The original. Navy, legible at 2am.', dark, light },
+  oled: { label: 'OLED Black', blurb: 'True black for OLED screens. Dark only.', dark: oledDark },
+  steam: { label: 'Steam', blurb: "Valve's navy and light blue. Dark only.", dark: steamDark },
+  nord: { label: 'Nord', blurb: 'Arctic, bluish greys. Dark only.', dark: nordDark },
+  dracula: { label: 'Dracula', blurb: 'Purple accent on deep grey. Dark only.', dark: draculaDark },
+  solarized: { label: 'Solarized', blurb: 'Precision colours; has a light side too.', dark: solarizedDark, light: solarizedLight },
+  contrast: { label: 'High Contrast', blurb: 'Maximum legibility, both schemes.', dark: contrastDark, light: contrastLight },
+};
+
+export const THEME_PACK_KEYS = Object.keys(THEME_PACKS) as ThemePackKey[];
+
+/** The pack's palette for a scheme; a dark-only pack stays dark in light mode. */
+export function packPalette(pack: ThemePackKey, scheme: 'light' | 'dark'): Palette {
+  const p = THEME_PACKS[pack] ?? THEME_PACKS.midnight;
+  return scheme === 'light' && p.light ? p.light : p.dark;
+}
 
 // ---------------------------------------------------------------------------
 // Type + numeric fragments (unchanged)
@@ -171,12 +321,12 @@ export function batteryColor(pct: number, t: Palette = dark): string {
 
 export type ThemeMode = 'system' | 'light' | 'dark';
 
-type ThemePrefs = { mode: ThemeMode; accent: AccentKey };
+type ThemePrefs = { mode: ThemeMode; accent: AccentKey; pack: ThemePackKey };
 
 // Default preserves today's look exactly: forced dark, blue accent. Change
 // `mode` to 'system' here once the light palette is verified across every
 // screen and you want new installs to follow the OS by default.
-const THEME_DEFAULTS: ThemePrefs = { mode: 'dark', accent: 'blue' };
+const THEME_DEFAULTS: ThemePrefs = { mode: 'dark', accent: 'blue', pack: 'midnight' };
 
 const THEME_KEY = 'couchside.theme.v1';
 
@@ -224,7 +374,11 @@ function normalize(raw: unknown): ThemePrefs {
     typeof o.accent === 'string' && (ACCENT_KEYS as string[]).includes(o.accent)
       ? (o.accent as AccentKey)
       : THEME_DEFAULTS.accent;
-  return { mode, accent };
+  const pack: ThemePackKey =
+    typeof o.pack === 'string' && (THEME_PACK_KEYS as string[]).includes(o.pack)
+      ? (o.pack as ThemePackKey)
+      : THEME_DEFAULTS.pack;
+  return { mode, accent, pack };
 }
 
 let loadStarted = false;
@@ -291,6 +445,58 @@ export function useAccent(): AccentKey {
   );
 }
 
+export function getThemePack(): ThemePackKey {
+  return prefs.pack;
+}
+
+export async function setThemePack(pack: ThemePackKey): Promise<void> {
+  if (prefs.pack === pack) return;
+  prefs = { ...prefs, pack };
+  emitChange();
+  await storageSet(THEME_KEY, JSON.stringify(prefs));
+}
+
+export function useThemePack(): ThemePackKey {
+  return useSyncExternalStore(
+    subscribe,
+    () => prefs.pack,
+    () => prefs.pack,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Contrast helpers
+// ---------------------------------------------------------------------------
+
+/** WCAG relative luminance of a '#rrggbb' colour (0 = black, 1 = white).
+ *  Anything unparsable reads as mid-grey, which makes textOn pick dark text —
+ *  the conservative choice on a light surface and harmless on a dark one. */
+export function relLum(hex: string): number {
+  const m = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})/i.exec(hex.trim());
+  if (!m) return 0.5;
+  const ch = (h: string) => {
+    const c = parseInt(h, 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * ch(m[1]) + 0.7152 * ch(m[2]) + 0.0722 * ch(m[3]);
+}
+
+/**
+ * The text colour to paint ON a filled surface of colour `surface`, chosen for
+ * contrast: dark text on light-ish fills, light text on dark fills. Black and
+ * white reach equal contrast at luminance ≈ 0.18, so that is the split.
+ *
+ * `t.onAccent` / `t.onGreen` / `t.onRed` are already resolved this way by
+ * useTheme(); reach for textOn() directly when the surface is chosen at render
+ * time (a per-danger badge, a service brand colour, a user-picked swatch).
+ */
+export function textOn(surface: string, t: Palette): string {
+  const dark = relLum(t.bg) < 0.5;           // is this a dark palette?
+  const darkText = dark ? t.onAccent : t.text; // the palette's dark candidate
+  const lightText = dark ? t.text : t.onAccent; // ...and its light candidate
+  return relLum(surface) >= 0.18 ? darkText : lightText;
+}
+
 // ---------------------------------------------------------------------------
 // The hooks components use
 // ---------------------------------------------------------------------------
@@ -307,12 +513,25 @@ export function useResolvedScheme(): 'light' | 'dark' {
 export function useTheme(): Palette {
   const scheme = useResolvedScheme();
   const accent = useAccent();
+  const pack = useThemePack();
   return useMemo(() => {
-    const base = palettes[scheme];
-    const acc = ACCENTS[accent][scheme];
-    // The accent drives the primary active/link color (historically `blue`).
-    return { ...base, accent: acc, blue: acc };
-  }, [scheme, accent]);
+    const base = packPalette(pack, scheme);
+    // 'blue' is the "Default" slot = the pack's own accent; any other key
+    // overrides it. The accent drives the primary active/link color (`blue`).
+    const acc = accent === 'blue' ? base.accent : ACCENTS[accent][scheme];
+    const resolved: Palette = { ...base, accent: acc, blue: acc };
+    // On-surface text is DERIVED from the surface it sits on, not fixed per
+    // palette: a light accent (amber, Steam's sky blue) wants dark text, a deep
+    // one (Solarized blue) wants light — and the accent picker can swap the
+    // surface under the text at runtime. The static tokens above are the two
+    // candidates textOn() chooses between.
+    return {
+      ...resolved,
+      onAccent: textOn(acc, resolved),
+      onGreen: textOn(resolved.green, resolved),
+      onRed: textOn(resolved.red, resolved),
+    };
+  }, [scheme, accent, pack]);
 }
 
 /**

--- a/app/lib/tips.ts
+++ b/app/lib/tips.ts
@@ -1,0 +1,237 @@
+/**
+ * "Did you know" tips — the light-touch answer to "I never knew it could do
+ * that" (App Store review, 2026-08-30).
+ *
+ * The full feature tour is sixteen modals on day one, and most people skip it —
+ * so the features it describes stay undiscovered. A tip is the opposite shape:
+ * ONE short line, delivered on the tab it belongs to, only while the thing it
+ * describes is actually on screen, at most once a day, and each one once, ever.
+ * It is the mechanism that lets the tour shrink: the long tail of tour steps
+ * becomes hints that arrive when they are relevant.
+ *
+ * RULES (all enforced here or in components/TipToast.tsx — they are what keep
+ * this from becoming the busyness it exists to reduce):
+ *   - once per app session, and at most one per calendar day (persisted);
+ *   - each tip shown ONCE EVER, then forgotten (persisted seen-set);
+ *   - only on its own tab, and only when its anchor MEASURES on screen — never
+ *     describe a control the user cannot see (the tour's rule, kept);
+ *   - never over the tour, the tour's thank-you, or when the pref is off;
+ *   - gated by the EXISTING `featureTour` pref ("onboarding hints") — no new
+ *     switch to find.
+ *
+ * Same module-level external-store shape as hooks/useTourThanks.ts: written by
+ * the toast, readable by anything, and a reset is observed live.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import type { TourTab } from './tour';
+
+export type Tip = {
+  id: string;
+  /** Tab the tip belongs to; shown only while that tab is on screen. 'any' =
+   *  wherever the user happens to be. */
+  tab: TourTab | 'any';
+  /** Element the tip is about ("Show me" scrolls to it). When set, the tip is
+   *  skipped until the anchor measures — see hooks/useTourAnchor.ts. */
+  anchor?: string;
+  /** Small caps line above the text. Defaults to "DID YOU KNOW". */
+  eyebrow?: string;
+  text: string;
+};
+
+/**
+ * The catalog. ORDER IS PRIORITY within a tab — the first unseen, visible tip
+ * wins. Keep each line a single fact that reads naturally after "Did you know".
+ * The thank-you sits last and belongs to no tab, so it arrives after the useful
+ * ones, wherever the person is.
+ */
+export const TIPS: Tip[] = [
+  {
+    id: 'console.more',
+    tab: 'index',
+    anchor: 'console.more',
+    text: 'Lights, display, audio and tools live under MORE — one tap opens them, and it stays how you leave it.',
+  },
+  {
+    id: 'console.customize',
+    tab: 'index',
+    anchor: 'console.customize',
+    text: 'Tap the sliders in the header — or hold any card — to reorder or hide cards. Make the Console yours.',
+  },
+  {
+    id: 'pad.combos',
+    tab: 'pad',
+    anchor: 'pad.keybar',
+    text: 'Hold the keyboard button for Combos — one-tap copy, paste, and Kodi / media shortcuts.',
+  },
+  {
+    id: 'pad.sendkeys',
+    tab: 'pad',
+    anchor: 'pad.modes',
+    text: 'A game grabbing player one from your phone? Setup › Prefs › "Send keys instead of a controller" keeps the real pad in charge.',
+  },
+  {
+    id: 'launch.playlog',
+    tab: 'launch',
+    anchor: 'launch.playlog',
+    text: 'Bookmark a game to add it to your Playlog — a play-next queue you can reorder from the couch.',
+  },
+  {
+    id: 'launch.shuffle',
+    tab: 'launch',
+    anchor: 'launch.shuffle',
+    text: 'Can’t decide? Filter to "never played" and hit shuffle — something new is one tap away.',
+  },
+  {
+    id: 'actions.restart',
+    tab: 'actions',
+    anchor: 'actions.high',
+    text: 'TV black but the box is plainly on? Restart Session rebuilds the desktop without a reboot.',
+  },
+  {
+    id: 'setup.search',
+    tab: 'setup',
+    anchor: 'setup.tabs',
+    text: 'Prefs has a search box — type what you’re after instead of scrolling the switches.',
+  },
+  {
+    id: 'setup.updates',
+    tab: 'setup',
+    anchor: 'setup.tabs',
+    text: 'Check for updates now and then — Setup › Account for the app, and the Console shows when your box has one. Couchside keeps evolving, and each update brings the latest improvements and features.',
+  },
+  {
+    id: 'thanks',
+    tab: 'any',
+    eyebrow: 'A NOTE FROM THE MAKER',
+    text: 'Thank you for using Couchside. Your feedback shapes it — if you’d like, let me know anything good or bad you experience, or what you’d like to see in the app. — Taylor',
+  },
+];
+
+// ---------- persistence (mirrors hooks/useTourThanks.ts) ----------
+
+const KEY = 'couchside.tips.v1';
+const DAY_MS = 86_400_000;
+
+async function get(k: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage ? window.localStorage.getItem(k) : null;
+    } catch {
+      return null;
+    }
+  }
+  return SecureStore.getItemAsync(k);
+}
+
+async function set(k: string, v: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(k, v);
+    } catch {
+      // storage unavailable: a tip may repeat next launch, never worse
+    }
+    return;
+  }
+  await SecureStore.setItemAsync(k, v);
+}
+
+type Snapshot = {
+  /** Ids shown, ever. */
+  seen: ReadonlySet<string>;
+  /** Day index (floor(now / 1 day)) of the last tip shown; 0 = never. */
+  lastDay: number;
+  /** False until storage has been read — never show before we know. */
+  ready: boolean;
+};
+
+/** Starts "everything seen" so a slow keychain read can never flash a tip we
+ *  have in fact already shown. */
+let snap: Snapshot = { seen: new Set(TIPS.map((t) => t.id)), lastDay: 0, ready: false };
+const listeners = new Set<() => void>();
+
+function commit(next: Snapshot): void {
+  snap = next;
+  for (const l of listeners) l();
+}
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+const getSnapshot = () => snap;
+
+function persist(): void {
+  void set(KEY, JSON.stringify({ seen: [...snap.seen], lastDay: snap.lastDay }));
+}
+
+let loadStarted = false;
+export async function loadTips(): Promise<void> {
+  if (loadStarted) return;
+  loadStarted = true;
+  let seen = new Set<string>();
+  let lastDay = 0;
+  try {
+    const raw = await get(KEY);
+    if (raw) {
+      const p = JSON.parse(raw) as { seen?: unknown; lastDay?: unknown };
+      if (Array.isArray(p.seen)) seen = new Set(p.seen.filter((x): x is string => typeof x === 'string'));
+      if (typeof p.lastDay === 'number' && Number.isFinite(p.lastDay)) lastDay = p.lastDay;
+    }
+  } catch {
+    // corrupt/unreadable: treat as nothing seen (a repeat beats a lost tip)
+  }
+  commit({ seen, lastDay, ready: true });
+}
+void loadTips();
+
+/** One tip per process lifetime, regardless of tab changes. */
+let shownThisSession = false;
+
+export function todayIndex(now = Date.now()): number {
+  return Math.floor(now / DAY_MS);
+}
+
+/**
+ * May a tip be considered right now? Pure gate, no side effects. The caller
+ * still has to find a tip whose anchor measures (async) — see pickCandidates.
+ */
+export function canShowTip(now = Date.now()): boolean {
+  return snap.ready && !shownThisSession && snap.lastDay !== todayIndex(now);
+}
+
+/**
+ * Unseen tips eligible on `tab`, in priority order: the tab's own tips first,
+ * then the 'any' ones. The caller measures anchors and takes the first that is
+ * actually visible.
+ */
+export function pickCandidates(tab: string | null | undefined): Tip[] {
+  const own = TIPS.filter((t) => t.tab !== 'any' && t.tab === tab && !snap.seen.has(t.id));
+  const any = TIPS.filter((t) => t.tab === 'any' && !snap.seen.has(t.id));
+  return [...own, ...any];
+}
+
+/** Record that a tip was put on screen: seen forever, and today is spent. */
+export function markTipShown(id: string, now = Date.now()): void {
+  shownThisSession = true;
+  const seen = new Set(snap.seen);
+  seen.add(id);
+  commit({ seen, lastDay: todayIndex(now), ready: true });
+  persist();
+}
+
+export function useTipsState(): Snapshot {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/** Forget everything, so tips can play again. Called alongside resetFeatureTour
+ *  when the onboarding pref is turned back on — the two are one idea to the
+ *  person flipping the switch. */
+export async function resetTips(): Promise<void> {
+  shownThisSession = false;
+  commit({ seen: new Set(), lastDay: 0, ready: true });
+  await set(KEY, JSON.stringify({ seen: [], lastDay: 0 }));
+}


### PR DESCRIPTION
The 2.9.56 app train, one PR (owner asked for a single train). App-only; agent unchanged (agent 2.9.103 already released separately).

## What's in it
1. **feat(pad): auto-drop the virtual pad while a game runs** (`autoDropPad`, opt-in) — stops the phone's pad stealing player 1 from a real controller. `?nopad=1` agent contract hardware-verified on the bazzite box.
2. **feat(console): focused default** — status cards stay; lights/display/audio/tools fold behind one **MORE** row (collapsed by default, pref `consoleMoreCollapsed`); a visible **Customize** icon opens the existing hold-to-edit. Answers the "UI is a little busy" review. No new toggle.
3. **feat(onboarding): "Did you know" tips** — one contextual toast on the tab a feature lives on, once/day, once ever, anchor-gated, yields to the review invite. Gated by the existing feature-tour pref. Includes an update-check tip and a thank-you/feedback note from Taylor.
4. **feat(theme): theme packs** — Midnight (unchanged default), **OLED Black**, **Steam**, Nord, Dracula, Solarized (+light), High Contrast, chosen in Setup → APPEARANCE. Whole palettes, not just an accent. Plus a hex sweep (69→35 literals; the rest are content colours) and `textOn()` deriving on-button text from surface luminance (fixes a latent light-mode contrast bug).

## Verification
All four verified in the web harness by pressing, both states observed (see each commit body). tsc clean.

**Not verified (device-only):** auto-drop's in-game player-1 hand-off, tip SHOW-ME scroll + non-Console-tab tips, native layout of the fold/header/Look rows, packs on Pad/Launch/Actions, theming on a real screen. These get a TestFlight (201) device pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)