### PR TITLE
feat(agent): switch the TV to this box over HDMI-CEC (source_box, 2.9.104)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,9 @@ jobs:
       - name: Unit tests (tv identify)
         run: python3 tests/test_tv_identify.py
 
+      - name: Unit tests (tv source_box over CEC)
+        run: python3 tests/test_tv_source_box.py
+
       # Config load. _parse_config() returns a POSITIONAL tuple that
       # load_config() unpacks, so a new optional section must be threaded
       # through both ends -- miss either and the agent crash-loops on startup

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,14 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.104
+
+**Switch your TV to the box, over HDMI-CEC.** On a box with real CEC (a Steam
+Machine, most modern motherboards) the app's "switch the TV to this box" button
+now works — one tap wakes the TV and pulls it to the box's HDMI input, no
+universal-remote setup, no IR blaster. It was already there for the serial-panel
+boxes; now CEC boxes get it too. Nothing changes on a box without CEC.
+
 ## 2.9.103
 
 **The Player no longer requires Google Chrome.** Couchside Player (the experimental

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.103"
+VERSION = "2.9.104"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -11369,6 +11369,82 @@ def mock_cec(op):
             "stderr": "", "duration_ms": 100}
 
 
+# One Touch Play over CEC -- switch the TV to THIS box's HDMI input.
+_CEC_PHYS_RE = re.compile(r"Physical Address\s*:\s*([0-9a-fA-F](?:\.[0-9a-fA-F]){3})")
+
+
+def _cec_phys_addr(cec):
+    """This box's OWN CEC physical address (e.g. '4.0.0.0'), read from the
+    adapter itself via `cec-ctl -d <dev>` (config dump, no ops), or None. The
+    value is KERNEL-sourced and regex-validated -- never a client value. Rejects
+    'f.f.f.f' (unconfigured) and '0.0.0.0' (the TV, never a playback box's own).
+    cec-ctl only; never raises."""
+    if cec.get("tool") != "cec-ctl" or not cec.get("device"):
+        return None
+    try:
+        r = subprocess.run([cec["bin"], "-d", cec["device"]],
+                           capture_output=True, timeout=6)
+    except Exception:
+        return None
+    m = _CEC_PHYS_RE.search((r.stdout or b"").decode("utf-8", "replace"))
+    if not m:
+        return None
+    addr = m.group(1).lower()
+    return None if addr in ("f.f.f.f", "0.0.0.0") else addr
+
+
+def _cec_source_box_available():
+    """True when CEC One Touch Play could switch the TV to this box: the kernel
+    cec-ctl backend on a live port. Cheap (cec_current is sysfs reads) so it is
+    safe on the per-request tv_info path; the physical-address read that can fail
+    happens at ACTION time in real_cec_source_box(), which degrades closed.
+    libcec is excluded -- its one-shot mode cannot broadcast Active Source."""
+    cec = cec_current()
+    return bool(cec and cec.get("tool") == "cec-ctl")
+
+
+def real_cec_source_box():
+    """CEC One Touch Play: switch the TV to THIS box's HDMI input. Image View On
+    (wake; harmless if already on), then an Active Source broadcast carrying the
+    box's OWN physical address, re-sent once to beat a TV that returns to its
+    launcher on wake. Confirmed on real hardware (a MediaTek Google TV) 2026-09-04.
+
+    ALLOWLIST (CLAUDE.md 3.1-3.2): the argv is a fixed literal list; the ONLY
+    variable is the box's own physical address, read from the kernel adapter and
+    regex-validated (never a client value). `--playback` claims the playback
+    logical address so the Active Source comes from a valid source -- without it
+    some TVs ignore it. cec-ctl only; degrades closed if the address is
+    unreadable. ActionResult-shaped."""
+    start = time.monotonic()
+
+    def done(ok, err=""):
+        return {"ok": bool(ok), "exit_code": 0 if ok else -1, "stdout": "",
+                "stderr": err,
+                "duration_ms": int((time.monotonic() - start) * 1000)}
+
+    cec = cec_current()
+    if cec is None or cec.get("tool") != "cec-ctl":
+        return done(False, "CEC input-switch needs the kernel cec-ctl backend")
+    addr = _cec_phys_addr(cec)
+    if addr is None:
+        return done(False, "could not read this box's CEC physical address")
+    base = [cec["bin"], "-d", cec["device"], "--playback"]
+    announce = base + ["--active-source", "phys-addr=" + addr]
+    try:
+        r1 = subprocess.run(base + ["--to", "0", "--image-view-on"],
+                            capture_output=True, timeout=10)
+        time.sleep(0.8)                     # let the TV wake/settle
+        r2 = subprocess.run(announce, capture_output=True, timeout=10)
+        time.sleep(2.0)
+        subprocess.run(announce, capture_output=True, timeout=10)  # re-send
+    except subprocess.TimeoutExpired:
+        return done(False, "cec command timed out")
+    except Exception as e:
+        return done(False, "%s: %s" % (e.__class__.__name__, e))
+    ok = r1.returncode == 0 and r2.returncode == 0
+    return done(ok, "" if ok else "cec-ctl returned non-zero")
+
+
 # ---- panel backend (RS-232 serial) ----------------------------------------
 # Supported serial line speeds (int -> termios constant). Membership is also
 # the config validator for panel.baud (see _parse_config).
@@ -13876,7 +13952,10 @@ _POWER_OPS = ("power_on", "power_off")
 
 # Ops only the RS-232 panel can do (no CEC/soft equivalent): jump to the box's
 # OPS input, and blank/unblank the screen without cutting power.
-_PANEL_ONLY_OPS = ("source_box", "screen_toggle")
+# TV ops that ride POST /api/tv/<op> but are NOT volume/power: the input
+# jump-to-this-box and the screen blank. Kept as an allowlist for the route;
+# tv_send() dispatches each (source_box -> panel OR CEC; screen_toggle -> panel).
+_EXTRA_TV_OPS = ("source_box", "screen_toggle")
 
 
 def set_tv(mock):
@@ -14007,10 +14086,11 @@ def tv_info():
         "box_volume": box_vol,
         "tv_volume": hw is not None,
         "tv_power": hw is not None,
-        # Input source switch (jump the panel to the box's OPS input). Only the
-        # RS-232 panel backend can do it, so the app shows the button solely for
-        # panel boxes — CEC/soft boxes never see it (keeps the default UI clean).
-        "source_box": panel_available(),
+        # Input source switch: jump the TV to THIS box's input. The RS-232 panel
+        # does it as a discrete input-select; a CEC box does it via One Touch Play
+        # (hardware-confirmed 2026-09-04). Either lights up the app's existing
+        # "pull the display to this box" button — no app change needed.
+        "source_box": panel_available() or _cec_source_box_available(),
         # Full display-input picker (panel only). Each entry: {id,label}; the app
         # POSTs /api/tv/source/<id> to switch. Empty when no panel backend.
         "sources": ([{"id": sid, "label": label}
@@ -14079,9 +14159,21 @@ def tv_send(op, mock, target=None):
     goes to the box's own OS volume (soft) by default, or to the TV backend when
     target == "tv" (the app's opt-in). Falls back to whichever exists when the
     chosen target is missing. None when nothing can handle it (caller 404s)."""
-    if op in _PANEL_ONLY_OPS:
-        # Input-select and screen-blank are panel-only (RS-232). No CEC/soft
-        # fallback exists for them.
+    if op == "source_box":
+        # Jump the TV to THIS box's input. The RS-232 panel does it as a discrete
+        # input-select; a CEC box does it via One Touch Play (Image View On +
+        # Active Source with the box's own physical address) -- hardware-confirmed
+        # on a MediaTek Google TV 2026-09-04. Panel wins when present (an
+        # unambiguous discrete select), else CEC. Under --mock the panel backend
+        # handles it (set_cec registers no CEC in --mock).
+        if panel_available():
+            return mock_panel(op) if mock else real_panel(op)
+        if _cec_source_box_available():
+            return mock_cec("source_box") if mock else real_cec_source_box()
+        return None
+    if op == "screen_toggle":
+        # Blank/unblank the screen without cutting power -- RS-232 panel only, no
+        # CEC/soft equivalent.
         if not panel_available():
             return None
         return mock_panel(op) if mock else real_panel(op)
@@ -22145,7 +22237,7 @@ class Handler(BaseHTTPRequestHandler):
                 op = path[len(tprefix):]
                 # source_box/screen_toggle ride the same route but are not
                 # volume/power ops, so they are not in TV_OPS; allow explicitly.
-                if op not in TV_OPS and op not in _PANEL_ONLY_OPS:
+                if op not in TV_OPS and op not in _EXTRA_TV_OPS:
                     self._send(404, {"error": "unknown tv op"}, started)
                     return
                 target = parse_qs(parsed.query).get("target", [None])[0]

--- a/tests/test_tv_source_box.py
+++ b/tests/test_tv_source_box.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""CEC One Touch Play (source_box) — switch the TV to THIS box's input.
+
+Confirmed on real hardware 2026-09-04; these lock the CONTRACT so it can't
+regress: the argv is fixed literals, the ONLY variable is the box's OWN physical
+address read from the kernel adapter (never a client value), and it degrades
+closed. Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(HERE, "..", "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+class FakeProc:
+    def __init__(self, rc=0, out=b""):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = b""
+
+
+ADAPTER_DUMP = (b"\tDriver Name : cros-ec-cec\n"
+                b"\tPhysical Address           : 4.0.0.0\n"
+                b"\tLogical Address            : 4\n")
+
+
+def install(runs, *, phys=ADAPTER_DUMP, cec_tool="cec-ctl", panel=False):
+    """Capture every subprocess argv into `runs`; the no-op adapter dump returns
+    `phys`, everything else returns rc 0."""
+    saved = {k: getattr(cs, k) for k in
+             ("subprocess", "cec_current", "panel_available", "time")}
+
+    class FakeSub:
+        TimeoutExpired = cs.subprocess.TimeoutExpired
+        @staticmethod
+        def run(argv, **kw):
+            runs.append(list(argv))
+            # `cec-ctl -d <dev>` with no op flags is the address read.
+            if len(argv) == 3 and argv[1] == "-d":
+                return FakeProc(0, phys)
+            return FakeProc(0, b"")
+    cs.subprocess = FakeSub
+    cs.cec_current = (lambda: {"tool": cec_tool, "bin": "/usr/bin/cec-ctl",
+                               "device": "/dev/cec0", "adapter": "kernel CEC"}
+                      if cec_tool else lambda: None)
+    if cec_tool is None:
+        cs.cec_current = lambda: None
+    cs.panel_available = lambda: panel
+
+    class FakeTime:
+        monotonic = staticmethod(cs.time.monotonic)
+        sleep = staticmethod(lambda s: None)   # don't actually wait 3s
+    cs.time = FakeTime
+
+    def restore():
+        for k, v in saved.items():
+            setattr(cs, k, v)
+    return restore
+
+
+print("source_box over CEC: One Touch Play with the box's own address")
+runs = []
+restore = install(runs)
+try:
+    r = cs.real_cec_source_box()
+    check(r["ok"], "succeeds on a cec-ctl box with a readable address")
+    # image-view-on THEN active-source (>=2x for the re-send), all fixed literals
+    iva = [a for a in runs if "--image-view-on" in a]
+    asrc = [a for a in runs if "--active-source" in a]
+    check(len(iva) == 1, "sends Image View On exactly once")
+    check(len(asrc) >= 2, "broadcasts Active Source at least twice (re-send)")
+    # the ONLY variable is the phys-addr, and it is the one READ from the adapter
+    check(all(a[:4] == ["/usr/bin/cec-ctl", "-d", "/dev/cec0", "--playback"] for a in iva + asrc),
+          "every command is the fixed cec-ctl/-d/device/--playback prefix")
+    check(all("phys-addr=4.0.0.0" in a for a in asrc),
+          "Active Source carries the adapter's OWN address (4.0.0.0), not a literal")
+    # nothing client-shaped ever reaches argv: no op string, no interpolation
+    joined = " ".join(" ".join(a) for a in runs)
+    check("source_box" not in joined and ";" not in joined and "&" not in joined,
+          "no client/op string reaches the argv")
+finally:
+    restore()
+
+print("\ndegrade closed")
+runs = []
+restore = install(runs, cec_tool=None)   # no CEC backend
+try:
+    r = cs.real_cec_source_box()
+    check(not r["ok"] and not runs, "no cec backend -> refused, nothing run")
+finally:
+    restore()
+
+runs = []
+restore = install(runs, phys=b"\tPhysical Address : f.f.f.f\n")  # unconfigured
+try:
+    r = cs.real_cec_source_box()
+    check(not r["ok"], "unconfigured address (f.f.f.f) -> refused")
+    check(not any("--active-source" in a for a in runs),
+          "never broadcasts Active Source without a valid own address")
+finally:
+    restore()
+
+runs = []
+restore = install(runs, phys=b"\tPhysical Address : 0.0.0.0\n")  # that's the TV
+try:
+    check(not cs.real_cec_source_box()["ok"], "0.0.0.0 (the TV's address) -> refused")
+finally:
+    restore()
+
+print("\nrouting + capability")
+# tv_send prefers the panel; falls to CEC; else None
+restore = install([], panel=True)
+try:
+    saved = cs.mock_panel
+    cs.mock_panel = lambda op: {"ok": True, "via": "panel"}
+    check(cs.tv_send("source_box", mock=True).get("via") == "panel",
+          "panel present -> source_box goes to the panel")
+    cs.mock_panel = saved
+finally:
+    restore()
+
+restore = install([], panel=False, cec_tool="cec-ctl")
+try:
+    r = cs.tv_send("source_box", mock=True)   # mock -> mock_cec, no hardware
+    check(r is not None and r.get("ok"), "no panel, CEC present -> source_box goes to CEC (mock)")
+    check(cs._cec_source_box_available() is True, "cec-ctl box advertises source_box")
+finally:
+    restore()
+
+restore = install([], panel=False, cec_tool=None)
+try:
+    check(cs.tv_send("source_box", mock=True) is None, "no panel, no CEC -> None (404)")
+    check(cs._cec_source_box_available() is False, "no CEC -> source_box not advertised")
+finally:
+    restore()
+
+print("\n%d checks failed" % len(_fail))
+raise SystemExit(1 if _fail else 0)


### PR DESCRIPTION
## Why
The app already has a "switch the TV to this box" button, but `source_box` was hard-wired to the RS-232 panel backend — so on a CEC box (Steam Machine, most modern motherboards) it never showed and Couch Mode's tv_input step skipped. The agent's CEC backend only did power + volume.

## What
`real_cec_source_box()` — CEC One Touch Play: Image View On (wake) then an Active Source broadcast carrying the box's **own** physical address, re-sent once to beat a TV that returns to its launcher on wake. `tv_send` routes `source_box` to **panel-OR-cec** (panel wins when present); `tv_info` advertises `source_box: panel_available() or _cec_source_box_available()`, so the **existing app button lights up on CEC boxes with no app change**. `_EXTRA_TV_OPS` replaces the now-misnamed `_PANEL_ONLY_OPS` in the route allowlist; `screen_toggle` stays panel-only.

## Allowlist (CLAUDE.md §3)
The argv is a fixed literal list; the **only** variable is the box's own physical address, read from the **kernel** adapter (`cec-ctl -d <dev>`) and regex-validated — never a client value. `f.f.f.f`/`0.0.0.0` rejected (degrade closed). `--playback` claims the playback logical address so the broadcast comes from a valid source.

## Verification
- **Hardware, real switch:** a power-cycled MediaTek Google TV switched Apple TV → Steam Machine on the spec-correct self-announce (observed).
- **Full agent path** on the Steam Machine (test agent 2.9.104): `/api/tv` → `backend=cec source_box=True`; `POST /api/tv/source_box` → `ok=True`, running the real `cec-ctl` commands.
- **Unit:** `tests/test_tv_source_box.py`, 15 checks (fixed argv, own-address-from-kernel, no client string reaches argv, degrade-closed on no-CEC/f.f.f.f/0.0.0.0, panel-vs-CEC routing, cap gating); wired into `ci.yml`. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)