### PR TITLE
feat(app): reorder + hide cards on the Fleet and Actions tabs

### DIFF
--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -10,8 +10,10 @@ import {
 } from 'react-native';
 
 import { useFocusEffect } from 'expo-router';
+import Ionicons from '@expo/vector-icons/Ionicons';
 
 import { BootSessionCard } from '@/components/BootSessionCard';
+import { EditableSection } from '@/components/EditableSection';
 import { UtilitiesSection } from '@/components/UtilitiesSection';
 import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
@@ -20,10 +22,13 @@ import { registerScroller } from '@/hooks/useTourAnchor';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
+import { effectiveOrder, moveSection } from '@/lib/cardLayout';
+import { useActionsLayout, setActionsLayout } from '@/lib/actionsLayout';
 import {
   hapticError,
   hapticHeavy,
   hapticLight,
+  hapticSelection,
   hapticSuccess,
 } from '@/lib/haptics';
 import { usePref } from '@/lib/prefs';
@@ -57,6 +62,12 @@ const BADGE_TEXT: Record<Danger, string> = {
   medium: 'interrupts',
   high: 'ends session',
 };
+
+/** The Actions tab's movable SECTIONS for hold-to-edit reorder/hide (same store
+ *  as the Console). 'boot' is the Boot Session card; the other three are the
+ *  impact groups keyed by the UI's word (low → 'routine'). The Utilities surface
+ *  is deliberately absent — it stays pinned, never reordered or hidden. */
+const SECTION_ORDER = ['boot', 'routine', 'medium', 'high'] as const;
 
 /** Seconds a session-ending action waits, cancellable, before it actually fires.
  *  This REPLACES the old blind second "Are you sure?" dialog: one confirm, then a
@@ -230,9 +241,103 @@ function ActionsScreen() {
     [],
   );
 
+  // --- Actions section layout: hold-to-edit reorder + hide (persisted) ------
+  // The movable "cards" are the Boot Session card and the three impact groups.
+  // Utilities is NOT movable (pinned above). Same store/pattern as the Console:
+  // long-press a section (or tap Customize) to enter, ↑ ↓ / hide, then Done.
+  const layout = useActionsLayout();
+  const [editing, setEditing] = useState(false);
+  const [present, setPresent] = useState<Record<string, boolean>>({});
+  const order = effectiveOrder(layout.order, [...SECTION_ORDER]);
+  const hidden = new Set(layout.hidden);
+  const setPres = (id: string, p: boolean) =>
+    setPresent((prev) => (prev[id] === p ? prev : { ...prev, [id]: p }));
+  const visible = order.filter((id) => present[id]);
+  const moveCard = (id: string, dir: -1 | 1) =>
+    setActionsLayout({ order: moveSection(order, visible, id, dir), hidden: layout.hidden });
+  const toggleHide = (id: string) => {
+    const h = new Set(layout.hidden);
+    if (h.has(id)) h.delete(id); else h.add(id);
+    setActionsLayout({ order, hidden: [...h] });
+  };
+
+  // The impact groups by section id (undefined when the box reports none of that
+  // level — the section then renders null and shows no edit controls).
+  const groupById: Record<string, { danger: Danger; items: ActionInfo[] } | undefined> = {
+    routine: groups.find((g) => g.danger === 'low'),
+    medium: groups.find((g) => g.danger === 'medium'),
+    high: groups.find((g) => g.danger === 'high'),
+  };
+  const renderGroup = (g: { danger: Danger; items: ActionInfo[] }) => (
+    // TourAnchor REPLACES the group's View and inherits styles.group, so the
+    // layout and the tour anchor are unchanged by the wrapping EditableSection.
+    <TourAnchor id={TOUR_ANCHOR[g.danger]} style={styles.group}>
+      <Text style={[styles.groupTitle, { color: DANGER_COLOR[g.danger] }]}>
+        {GROUP_TITLE[g.danger]}
+      </Text>
+      {g.items.map((a) => (
+        <Pressable
+          key={a.id}
+          onPress={() => onTap(a)}
+          style={({ pressed }) => [styles.card, pressed && styles.pressed]}>
+          <View style={styles.cardHead}>
+            <Text style={styles.cardLabel}>{a.label}</Text>
+            {a.danger === 'high' && (
+              <View style={[styles.badge, { backgroundColor: DANGER_COLOR[a.danger] }]}>
+                {/* The badge's fill is per-danger (red/amber/green), so its text is
+                    chosen for contrast against THAT fill, not a fixed on-red. */}
+                <Text style={[styles.badgeText, { color: textOn(DANGER_COLOR[a.danger], t) }]}>{BADGE_TEXT[a.danger]}</Text>
+              </View>
+            )}
+          </View>
+        </Pressable>
+      ))}
+    </TourAnchor>
+  );
+  const sectionNodes: Record<string, React.ReactNode> = {
+    boot: configured ? <BootSessionCard /> : null,
+    routine: groupById.routine ? renderGroup(groupById.routine) : null,
+    medium: groupById.medium ? renderGroup(groupById.medium) : null,
+    high: groupById.high ? renderGroup(groupById.high) : null,
+  };
+  const renderSection = (id: string) => {
+    const node = sectionNodes[id];
+    if (node == null) return null;
+    return (
+      <EditableSection
+        key={id}
+        editing={editing}
+        hidden={hidden.has(id)}
+        isFirst={visible[0] === id}
+        isLast={visible[visible.length - 1] === id}
+        onEnterEdit={() => setEditing(true)}
+        onPresent={(p) => setPres(id, p)}
+        onUp={() => moveCard(id, -1)}
+        onDown={() => moveCard(id, 1)}
+        onToggleHide={() => toggleHide(id)}
+        inertWhileEditing>
+        {node}
+      </EditableSection>
+    );
+  };
+
   return (
     <View style={[styles.screen, { paddingTop: 12 }]}>
-      <Text style={styles.title}>Actions</Text>
+      <View style={styles.titleRow}>
+        <Text style={styles.title}>Actions</Text>
+        {/* CUSTOMIZE: a visible way into hold-to-edit, and the way back in when a
+            section is hidden. Gone while editing — the Done bar owns the exit. */}
+        {configured && !editing && (
+          <Pressable
+            onPress={() => { hapticSelection(); setEditing(true); }}
+            accessibilityRole="button"
+            accessibilityLabel="Reorder or hide sections"
+            hitSlop={8}
+            style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
+            <Ionicons name="options-outline" size={18} color={t.textDim} />
+          </Pressable>
+        )}
+      </View>
       <ScrollView
         ref={scrollRef}
         onScroll={(e) => {
@@ -264,58 +369,38 @@ function ActionsScreen() {
         {configured && !actions.data && actions.error == null && (
           <Text style={styles.dim}>loading…</Text>
         )}
-        {/* Persistent boot preference, directly above the ONE-SHOT session
-            switches below it — that adjacency is the point (see the card). */}
-        {configured && <BootSessionCard />}
         {/* OpenPuck flasher, surfaced here for quick reach (also lives under
             Setup → Utilities). OPT-IN: gated on the same `utilitiesEnabled`
             pref as the Setup surface, OFF by default, so it no longer shows
-            unasked. Self-hides on boxes without the utilities endpoint too. */}
+            unasked. Self-hides on boxes without the utilities endpoint too.
+            PINNED above the movable sections — an advanced flashing tool is not
+            something to reorder or hide by accident. */}
         {configured && utilitiesEnabled && <UtilitiesSection context="actions" />}
-        {/* TourAnchor REPLACES each group's View and inherits styles.group, so
-            the layout is unchanged and the anchor measures the whole block —
-            header plus rows. The id uses the UI's word for `low` ("ROUTINE")
-            rather than the agent's danger level, matching lib/tour.ts. A group
-            with no items is already filtered out above, so a box that reports no
-            harmless actions registers no `actions.routine` and that step skips
-            itself instead of pointing at a header that is not there. */}
-        {groups.map((g) => (
-          <TourAnchor
-            key={g.danger}
-            id={TOUR_ANCHOR[g.danger]}
-            style={styles.group}>
-            <Text style={[styles.groupTitle, { color: DANGER_COLOR[g.danger] }]}>
-              {GROUP_TITLE[g.danger]}
-            </Text>
-            {g.items.map((a) => (
-              <Pressable
-                key={a.id}
-                onPress={() => onTap(a)}
-                style={({ pressed }) => [styles.card, pressed && styles.pressed]}>
-                <View style={styles.cardHead}>
-                  <Text style={styles.cardLabel}>{a.label}</Text>
-                  {/* Only the destructive one keeps a badge. "routine" under a
-                      ROUTINE header and "interrupts" under CHANGES WHAT'S ON
-                      SCREEN said the same thing twice on every single row —
-                      that repetition was the reported noise. Ending your
-                      session is worth repeating; the other two are not. */}
-                  {a.danger === 'high' && (
-                    <View style={[styles.badge, { backgroundColor: DANGER_COLOR[a.danger] }]}>
-                      {/* The badge's fill is per-danger (red/amber/green), so its text is
-                          chosen for contrast against THAT fill, not a fixed on-red. */}
-                      <Text style={[styles.badgeText, { color: textOn(DANGER_COLOR[a.danger], t) }]}>{BADGE_TEXT[a.danger]}</Text>
-                    </View>
-                  )}
-                </View>
-                {/* The description is NOT lost — confirm() already shows it in
-                    full before anything runs, which is where the detail belongs.
-                    On the row it mostly restated the label ("Switch to Desktop"
-                    / "Leave Game Mode for the SteamOS desktop"). */}
-              </Pressable>
-            ))}
-            </TourAnchor>
-          ))}
+        {/* Movable sections — the Boot Session card and the three impact groups —
+            with hold-to-edit reorder + hide (Customize in the header, Done bar
+            below). Each is inert while editing so a tap lands on the reorder/hide
+            strip, not on a card or an action. renderSection returns null for a
+            section the box has nothing for, so its edit controls never orphan.
+            The group blocks keep their tour anchors (actions.routine/medium/high),
+            matching lib/tour.ts; a group with no items renders null and that tour
+            step skips itself rather than pointing at a header that is not there. */}
+        {configured && order.map((id) => renderSection(id))}
       </ScrollView>
+
+      {/* Edit-layout bar: hold any section (or tap Customize) to enter; reorder /
+          hide, then Done. Matches the Console tab. */}
+      {editing && (
+        <View style={styles.editBar}>
+          <Text style={styles.editHint}>Reorder or hide sections</Text>
+          <Pressable
+            onPress={() => setEditing(false)}
+            accessibilityRole="button"
+            accessibilityLabel="Done editing actions"
+            style={({ pressed }) => [styles.doneBtn, pressed && styles.pressed]}>
+            <Text style={styles.doneText}>Done</Text>
+          </Pressable>
+        </View>
+      )}
 
       {/* Countdown before a session-ending action fires */}
       {pending && (
@@ -386,7 +471,21 @@ function ActionsScreen() {
 
 const makeStyles = (t: Palette) => StyleSheet.create({
   screen: { flex: 1, backgroundColor: t.bg, paddingHorizontal: 14 },
+  titleRow: { flexDirection: 'row', alignItems: 'center' },
   title: { color: t.text, fontSize: 26, fontWeight: '700', marginBottom: 12, fontFamily: mono },
+  customizeBtn: { marginLeft: 'auto', marginBottom: 12, padding: 6, borderRadius: 8 },
+  editBar: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 16, paddingTop: 12, paddingBottom: 28,
+    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  },
+  editHint: { color: t.textDim, fontSize: 13 },
+  doneBtn: {
+    backgroundColor: t.blue, borderRadius: 999,
+    paddingVertical: 8, paddingHorizontal: 22,
+  },
+  doneText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
   list: { flex: 1 },
   group: { marginBottom: 16 },
   groupTitle: { fontSize: 11, fontWeight: '800', letterSpacing: 1.5, marginBottom: 8 },

--- a/app/app/(tabs)/fleet.tsx
+++ b/app/app/(tabs)/fleet.tsx
@@ -1,12 +1,17 @@
 import { router } from 'expo-router';
-import React from 'react';
+import Ionicons from '@expo/vector-icons/Ionicons';
+import React, { useState } from 'react';
 import { AppState, AppStateStatus, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 
+import { EditableSection } from '@/components/EditableSection';
 import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { useFocusEffect } from 'expo-router';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { api, Status } from '@/lib/api';
+import { effectiveOrder, moveSection } from '@/lib/cardLayout';
+import { useFleetLayout, setFleetLayout } from '@/lib/fleetLayout';
+import { hapticSelection } from '@/lib/haptics';
 import { fmtLastSeen, noteBoxSeen } from '@/lib/lastSeen';
 import { usePref } from '@/lib/prefs';
 import { Box } from '@/lib/settings';
@@ -229,40 +234,133 @@ export default function FleetTab() {
 }
 
 function FleetScreen() {
+  const t = useTheme();
   const { boxes, activeBoxId, switchBox } = useBoxes();
   const statusInterval = usePref('statusIntervalMs');
   const fleet = useFleetStatus(boxes, statusInterval);
   const styles = useThemedStyles(makeStyles);
   const { Screen, SectionTitle } = useSkinKit();
 
+  // Hold-to-edit reorder + hide, same store/pattern as the Console tab, but the
+  // ids are BOX ids: order is which box sits where, hidden is boxes tucked out of
+  // the fleet list (still paired, still switchable from Setup). effectiveOrder
+  // reconciles against the live boxes each render, so pairing appends and
+  // unpairing drops cleanly.
+  const layout = useFleetLayout();
+  const [editing, setEditing] = useState(false);
+  const [present, setPresent] = useState<Record<string, boolean>>({});
+  const canonical = boxes.map((b) => b.id);
+  const order = effectiveOrder(layout.order, canonical);
+  const hidden = new Set(layout.hidden);
+  const boxById = new Map(boxes.map((b) => [b.id, b]));
+  const setPres = (id: string, p: boolean) =>
+    setPresent((prev) => (prev[id] === p ? prev : { ...prev, [id]: p }));
+  // Every tile renders content, so "visible" is the ordered ids that aren't
+  // hidden — that is what the up/down arrows step through.
+  const visible = order.filter((id) => boxById.has(id) && !hidden.has(id));
+  const moveTile = (id: string, dir: -1 | 1) =>
+    setFleetLayout({ order: moveSection(order, visible, id, dir), hidden: layout.hidden });
+  const toggleHide = (id: string) => {
+    const h = new Set(layout.hidden);
+    if (h.has(id)) h.delete(id); else h.add(id);
+    setFleetLayout({ order, hidden: [...h] });
+  };
+
   return (
-    <ScrollView
-      style={styles.scroll}
-      contentContainerStyle={{ paddingTop: 12, paddingBottom: 32, paddingHorizontal: 14 }}>
-      <Screen>
-        <SectionTitle>YOUR FLEET</SectionTitle>
-        {boxes.map((box, i) => (
-          <Tile
-            key={box.id}
-            box={box}
-            entry={fleet[box.id]}
-            active={box.id === activeBoxId}
-            index={i}
-            onPress={() => {
-              switchBox(box.id);
-              // Land on the box's Console; a box whose gaming tabs are hidden
-              // still always has Console.
-              router.replace('/(tabs)');
-            }}
-          />
-        ))}
-      </Screen>
-    </ScrollView>
+    <View style={styles.screen}>
+      <ScrollView
+        style={styles.scroll}
+        contentContainerStyle={{ paddingTop: 12, paddingBottom: 32, paddingHorizontal: 14 }}>
+        <Screen>
+          <View style={styles.headerRow}>
+            <SectionTitle>YOUR FLEET</SectionTitle>
+            {/* CUSTOMIZE: a visible way into the same hold-to-edit mode, and the
+                only way back in when every box is hidden. Gone while editing —
+                the Done bar owns the exit. */}
+            {!editing && boxes.length > 0 && (
+              <Pressable
+                onPress={() => { hapticSelection(); setEditing(true); }}
+                accessibilityRole="button"
+                accessibilityLabel="Reorder or hide boxes"
+                hitSlop={8}
+                style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
+                <Ionicons name="options-outline" size={18} color={t.textDim} />
+              </Pressable>
+            )}
+          </View>
+          {order.map((id, i) => {
+            const box = boxById.get(id);
+            if (box == null) return null;
+            return (
+              <EditableSection
+                key={id}
+                editing={editing}
+                hidden={hidden.has(id)}
+                isFirst={visible[0] === id}
+                isLast={visible[visible.length - 1] === id}
+                onEnterEdit={() => setEditing(true)}
+                onPresent={(p) => setPres(id, p)}
+                onUp={() => moveTile(id, -1)}
+                onDown={() => moveTile(id, 1)}
+                onToggleHide={() => toggleHide(id)}
+                inertWhileEditing>
+                <Tile
+                  box={box}
+                  entry={fleet[box.id]}
+                  active={box.id === activeBoxId}
+                  index={i}
+                  onPress={() => {
+                    // A tap while editing belongs to the reorder/hide strip
+                    // (inertWhileEditing already blocks it); guard anyway.
+                    if (editing) return;
+                    switchBox(box.id);
+                    // Land on the box's Console; a box whose gaming tabs are
+                    // hidden still always has Console.
+                    router.replace('/(tabs)');
+                  }}
+                />
+              </EditableSection>
+            );
+          })}
+        </Screen>
+      </ScrollView>
+      {/* Edit-layout bar: hold any tile (or tap Customize) to enter; reorder/hide
+          then Done. Matches the Console tab. */}
+      {editing && (
+        <View style={styles.editBar}>
+          <Text style={styles.editHint}>Reorder or hide boxes</Text>
+          <Pressable
+            onPress={() => setEditing(false)}
+            accessibilityRole="button"
+            accessibilityLabel="Done editing fleet"
+            style={({ pressed }) => [styles.doneBtn, pressed && styles.pressed]}>
+            <Text style={styles.doneText}>Done</Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
   );
 }
 
 const makeStyles = (t: Palette) => StyleSheet.create({
+  screen: { flex: 1, backgroundColor: t.bg },
   scroll: { flex: 1 },
+  // The title row now also holds the Customize entry point, so the bare
+  // SectionTitle's own margin is dropped in favour of the row's.
+  headerRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
+  customizeBtn: { marginLeft: 'auto', padding: 6, borderRadius: 8 },
+  editBar: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 16, paddingTop: 12, paddingBottom: 28,
+    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  },
+  editHint: { color: t.textDim, fontSize: 13 },
+  doneBtn: {
+    backgroundColor: t.blue, borderRadius: 999,
+    paddingVertical: 8, paddingHorizontal: 22,
+  },
+  doneText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
   sectionTitle: {
     color: t.textFaint,
     fontFamily: mono,

--- a/app/components/EditableSection.tsx
+++ b/app/components/EditableSection.tsx
@@ -18,7 +18,7 @@ import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 export function EditableSection({
   editing, hidden, isFirst, isLast,
-  onEnterEdit, onUp, onDown, onToggleHide, onPresent, children,
+  onEnterEdit, onUp, onDown, onToggleHide, onPresent, inertWhileEditing, children,
 }: {
   editing: boolean;
   hidden: boolean;
@@ -31,6 +31,12 @@ export function EditableSection({
   /** Reports whether the card actually rendered content (measured height > 0),
    *  so the parent's arrow bounds skip probe-and-appear cards that are null. */
   onPresent?: (present: boolean) => void;
+  /** Make the card's OWN controls inert while editing, so a tap lands on the
+   *  reorder/hide strip and not on the card. Console leaves this off — its cards
+   *  are display-only and harmless to tap. Fleet (a tap switches box + navigates)
+   *  and Actions (a tap arms an action) turn it ON so editing never fires the
+   *  card. Layout measurement is unaffected (pointerEvents does not change it). */
+  inertWhileEditing?: boolean;
   children: React.ReactNode;
 }) {
   const t = useTheme();
@@ -50,6 +56,10 @@ export function EditableSection({
   const content = (
     <View
       onLayout={(e) => measure(e.nativeEvent.layout.height)}
+      // While editing, a card whose own taps have side effects (Fleet switches
+      // box, Actions arms an action) is made non-interactive so the tap belongs
+      // to the reorder/hide strip, not the card.
+      pointerEvents={editing && inertWhileEditing ? 'none' : 'auto'}
       style={hidden && editing ? styles.dim : undefined}>
       {children}
     </View>

--- a/app/lib/__tests__/cardLayout.test.ts
+++ b/app/lib/__tests__/cardLayout.test.ts
@@ -1,0 +1,74 @@
+/**
+ * cardLayout — the reorder/hide reconciliation shared by the Console, Fleet and
+ * Actions tabs. These pin the two pure helpers (effectiveOrder, moveSection)
+ * that decide what renders and how a move lands. The store itself is thin glue
+ * over useSyncExternalStore + storage and is exercised in the harness.
+ *
+ * Run: node --experimental-strip-types --test lib/__tests__/cardLayout.test.ts
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { effectiveOrder, moveSection } from '../cardOrder.ts';
+
+test('effectiveOrder: empty stored order falls back to canonical', () => {
+  assert.deepEqual(effectiveOrder([], ['a', 'b', 'c']), ['a', 'b', 'c']);
+});
+
+test('effectiveOrder: honours a saved order', () => {
+  assert.deepEqual(effectiveOrder(['c', 'a', 'b'], ['a', 'b', 'c']), ['c', 'a', 'b']);
+});
+
+test('effectiveOrder: drops ids that no longer exist (unpaired box / removed section)', () => {
+  // 'x' was saved but is gone now; it must not appear.
+  assert.deepEqual(effectiveOrder(['x', 'b', 'a'], ['a', 'b']), ['b', 'a']);
+});
+
+test('effectiveOrder: appends a NEW canonical id at its canonical position', () => {
+  // 'b' was never ordered by the user; it slots in at index 1, not lost, not last.
+  assert.deepEqual(effectiveOrder(['a', 'c'], ['a', 'b', 'c']), ['a', 'b', 'c']);
+});
+
+test('effectiveOrder: a brand-new id after a fully custom order still appears', () => {
+  // User ordered every old id; a freshly-paired box ('d') must show up.
+  const out = effectiveOrder(['c', 'a', 'b'], ['a', 'b', 'c', 'd']);
+  assert.ok(out.includes('d'), 'the new id is present');
+  assert.equal(out.length, 4);
+  assert.deepEqual(new Set(out), new Set(['a', 'b', 'c', 'd']));
+});
+
+test('moveSection: down swaps a section with its next VISIBLE neighbour', () => {
+  assert.deepEqual(moveSection(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', 1), ['b', 'a', 'c']);
+});
+
+test('moveSection: up swaps with the previous visible neighbour', () => {
+  assert.deepEqual(moveSection(['a', 'b', 'c'], ['a', 'b', 'c'], 'c', -1), ['a', 'c', 'b']);
+});
+
+test('moveSection: at the top edge, up is a no-op (same array contents)', () => {
+  assert.deepEqual(moveSection(['a', 'b', 'c'], ['a', 'b', 'c'], 'a', -1), ['a', 'b', 'c']);
+});
+
+test('moveSection: at the bottom edge, down is a no-op', () => {
+  assert.deepEqual(moveSection(['a', 'b', 'c'], ['a', 'b', 'c'], 'c', 1), ['a', 'b', 'c']);
+});
+
+test('moveSection: a HIDDEN/absent id between two visible ones is jumped over', () => {
+  // 'b' is not visible (hidden or a null card), so moving 'a' down swaps it past
+  // 'b' with 'c' — the arrows step through visible neighbours only, and the FULL
+  // order (including 'b') is preserved otherwise.
+  const out = moveSection(['a', 'b', 'c'], ['a', 'c'], 'a', 1);
+  assert.deepEqual(out, ['c', 'b', 'a']);
+});
+
+test('moveSection: moving a hidden id (not in visible) is a no-op', () => {
+  assert.deepEqual(moveSection(['a', 'b', 'c'], ['a', 'c'], 'b', 1), ['a', 'b', 'c']);
+});
+
+test('effectiveOrder + moveSection compose: reorder survives a reconcile', () => {
+  const canonical = ['boot', 'routine', 'medium', 'high'];
+  const moved = moveSection(effectiveOrder([], canonical), canonical, 'high', -1);
+  assert.deepEqual(moved, ['boot', 'routine', 'high', 'medium']);
+  // and it is stable through another reconcile against the same canonical set
+  assert.deepEqual(effectiveOrder(moved, canonical), ['boot', 'routine', 'high', 'medium']);
+});

--- a/app/lib/actionsLayout.ts
+++ b/app/lib/actionsLayout.ts
@@ -1,0 +1,17 @@
+/**
+ * Actions tab card layout — order + hidden set for the tab's SECTIONS, persisted.
+ *
+ * Same shared store as the Console (lib/cardLayout). The ids here are the fixed
+ * section ids: 'boot' (the Boot Session card) and the three impact groups
+ * 'routine' / 'medium' / 'high'. Reorder puts the group you use first up top;
+ * hide tucks away a group you never touch (e.g. someone who only switches to
+ * desktop can hide "Ends your session"). The Utilities surface is intentionally
+ * NOT movable — it is an advanced, opt-in flashing tool that stays pinned.
+ */
+import { makeCardLayoutStore } from './cardLayout';
+
+const store = makeCardLayoutStore('couchside.actionsLayout.v1');
+
+export const useActionsLayout = store.useLayout;
+export const setActionsLayout = store.setLayout;
+export const loadActionsLayout = store.load;

--- a/app/lib/cardLayout.ts
+++ b/app/lib/cardLayout.ts
@@ -1,0 +1,96 @@
+/**
+ * Reusable card-layout store — a persisted user ORDER (id list) + HIDDEN set,
+ * driving the hold-to-edit reorder/hide mode shared by the Console, Fleet and
+ * Actions tabs.
+ *
+ * Console shipped this first as lib/consoleLayout.ts; this is that exact store,
+ * turned into a factory so each tab gets its OWN persisted layout under its own
+ * storage key without copying the boilerplate. An external store (same shape as
+ * lib/haptics) so an arrow/eye tap re-renders live and the pref survives restart.
+ *
+ * The stored order is reconciled against the canonical id list at render time
+ * (effectiveOrder): ids no longer known are dropped, new ids appended in their
+ * canonical position — so a future card is never lost and a removed one never
+ * errors. On Fleet the ids are BOX ids (they come and go as you pair/unpair), so
+ * that reconciliation is load-bearing there, not just forward-compatibility.
+ */
+import * as SecureStore from 'expo-secure-store';
+import { useSyncExternalStore } from 'react';
+import { Platform } from 'react-native';
+
+import type { CardLayout } from './cardOrder';
+
+// Re-export the pure reconciliation helpers so callers keep importing them from
+// '@/lib/cardLayout' (they live in the import-free cardOrder module so a
+// `node --test` can load them without expo-secure-store — see cardOrder.ts).
+export { effectiveOrder, moveSection } from './cardOrder';
+export type { CardLayout } from './cardOrder';
+
+async function storageGet(key: string): Promise<string | null> {
+  if (Platform.OS === 'web') {
+    try {
+      return typeof window !== 'undefined' && window.localStorage
+        ? window.localStorage.getItem(key) : null;
+    } catch { return null; }
+  }
+  return SecureStore.getItemAsync(key);
+}
+async function storageSet(key: string, value: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    try { if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(key, value); }
+    catch { /* private mode: in-memory this session */ }
+    return;
+  }
+  await SecureStore.setItemAsync(key, value);
+}
+
+export type CardLayoutStore = {
+  /** Live layout pref (a hook — new object on each change, so it re-renders). */
+  useLayout: () => CardLayout;
+  /** Replace the layout and persist it. */
+  setLayout: (next: CardLayout) => void;
+  /** Load the persisted layout once (idempotent). Called at module init; kept
+   *  public so a startup path can await it if it ever needs to. */
+  load: () => Promise<void>;
+};
+
+/** One independent, self-loading layout store bound to `key`. */
+export function makeCardLayoutStore(key: string): CardLayoutStore {
+  let layout: CardLayout = { order: [], hidden: [] };
+  const listeners = new Set<() => void>();
+  let loadStarted = false;
+
+  const emit = (): void => { for (const l of listeners) l(); };
+  const subscribe = (cb: () => void): (() => void) => {
+    listeners.add(cb);
+    return () => { listeners.delete(cb); };
+  };
+  const getSnapshot = (): CardLayout => layout;
+
+  async function load(): Promise<void> {
+    if (loadStarted) return;
+    loadStarted = true;
+    const raw = await storageGet(key);
+    if (!raw) return;
+    try {
+      const p = JSON.parse(raw) as Partial<CardLayout>;
+      if (Array.isArray(p.order) && Array.isArray(p.hidden)
+          && p.order.every((x) => typeof x === 'string')
+          && p.hidden.every((x) => typeof x === 'string')) {
+        layout = { order: p.order, hidden: p.hidden };
+        emit();
+      }
+    } catch { /* corrupt pref: keep defaults */ }
+  }
+  void load();
+
+  return {
+    useLayout: () => useSyncExternalStore(subscribe, getSnapshot, getSnapshot),
+    setLayout: (next: CardLayout) => {
+      layout = { order: [...next.order], hidden: [...next.hidden] };
+      emit();
+      void storageSet(key, JSON.stringify(layout));
+    },
+    load,
+  };
+}

--- a/app/lib/cardOrder.ts
+++ b/app/lib/cardOrder.ts
@@ -1,0 +1,44 @@
+/**
+ * Pure reorder/hide reconciliation for the hold-to-edit card layouts (Console,
+ * Fleet, Actions). IMPORT-FREE ON PURPOSE: the storage/React glue lives in
+ * lib/cardLayout, so this logic — the part worth testing — loads under
+ * `node --test` without pulling in expo-secure-store / react-native. See
+ * lib/__tests__/cardLayout.test.ts and the same split in lib/streak.ts.
+ */
+
+export type CardLayout = { order: string[]; hidden: string[] };
+
+/**
+ * The order to actually render: the stored order filtered to ids that still
+ * exist, then any canonical id the user has never ordered appended in its
+ * canonical position (so a new card shows near where it was added, not lost).
+ */
+export function effectiveOrder(stored: string[], canonical: string[]): string[] {
+  const known = new Set(canonical);
+  const out = stored.filter((id) => known.has(id));
+  const seen = new Set(out);
+  for (let i = 0; i < canonical.length; i += 1) {
+    const id = canonical[i];
+    if (seen.has(id)) continue;
+    // insert at the canonical index, clamped to the current length
+    out.splice(Math.min(i, out.length), 0, id);
+    seen.add(id);
+  }
+  return out;
+}
+
+/** Move `id` one step up/down among the CURRENTLY-VISIBLE ids (skips absent). */
+export function moveSection(
+  order: string[], visible: string[], id: string, dir: -1 | 1,
+): string[] {
+  const vis = order.filter((x) => visible.includes(x));
+  const vi = vis.indexOf(id);
+  const target = vis[vi + dir];
+  if (vi < 0 || target == null) return order; // at an end
+  // swap id and target in the FULL order array
+  const out = [...order];
+  const a = out.indexOf(id);
+  const b = out.indexOf(target);
+  [out[a], out[b]] = [out[b], out[a]];
+  return out;
+}

--- a/app/lib/consoleLayout.ts
+++ b/app/lib/consoleLayout.ts
@@ -1,114 +1,20 @@
 /**
  * Console tab card layout — user order + hidden set, persisted.
  *
- * The Console tab renders a fixed set of movable "sections" (NOW PLAYING,
- * GAMING, the vitals block, SCREEN, DISPLAY/AUDIO, UNITS, file drop). This store
- * remembers the user's ORDER (an id list) and which ids they HID, set from the
- * tab's hold-to-edit mode. An external store (same shape as lib/haptics) so a
- * `<Switch>`/arrow tap re-renders live and the pref survives restarts.
- *
- * The stored order is reconciled against the canonical id list at render time
- * (see effectiveOrder): ids no longer known are dropped, new ids appended — so
- * a future card is never lost and a removed one never errors.
+ * This is now a thin binding over the shared store in lib/cardLayout (Console
+ * was the first tab to grow hold-to-edit; Fleet and Actions reuse the same
+ * store). The public names below are unchanged, so callers are untouched. The
+ * storage key is likewise unchanged, so an existing user's saved Console layout
+ * survives the refactor.
  */
-import * as SecureStore from 'expo-secure-store';
-import { useSyncExternalStore } from 'react';
-import { Platform } from 'react-native';
+import { makeCardLayoutStore, type CardLayout } from './cardLayout';
 
-const KEY = 'couchside.consoleLayout.v1';
+export { effectiveOrder, moveSection } from './cardLayout';
 
-export type ConsoleLayout = { order: string[]; hidden: string[] };
+export type ConsoleLayout = CardLayout;
 
-let layout: ConsoleLayout = { order: [], hidden: [] };
-const listeners = new Set<() => void>();
-let loadStarted = false;
+const store = makeCardLayoutStore('couchside.consoleLayout.v1');
 
-async function storageGet(key: string): Promise<string | null> {
-  if (Platform.OS === 'web') {
-    try {
-      return typeof window !== 'undefined' && window.localStorage
-        ? window.localStorage.getItem(key) : null;
-    } catch { return null; }
-  }
-  return SecureStore.getItemAsync(key);
-}
-async function storageSet(key: string, value: string): Promise<void> {
-  if (Platform.OS === 'web') {
-    try { if (typeof window !== 'undefined' && window.localStorage) window.localStorage.setItem(key, value); }
-    catch { /* private mode: in-memory this session */ }
-    return;
-  }
-  await SecureStore.setItemAsync(key, value);
-}
-
-function emit(): void { for (const l of listeners) l(); }
-function persist(): void { void storageSet(KEY, JSON.stringify(layout)); }
-
-export async function loadConsoleLayout(): Promise<void> {
-  if (loadStarted) return;
-  loadStarted = true;
-  const raw = await storageGet(KEY);
-  if (!raw) return;
-  try {
-    const p = JSON.parse(raw) as Partial<ConsoleLayout>;
-    if (Array.isArray(p.order) && Array.isArray(p.hidden)
-        && p.order.every((x) => typeof x === 'string')
-        && p.hidden.every((x) => typeof x === 'string')) {
-      layout = { order: p.order, hidden: p.hidden };
-      emit();
-    }
-  } catch { /* corrupt pref: keep defaults */ }
-}
-void loadConsoleLayout();
-
-function subscribe(cb: () => void): () => void {
-  listeners.add(cb);
-  return () => { listeners.delete(cb); };
-}
-function getSnapshot(): ConsoleLayout { return layout; }
-
-/** Live layout pref. New object on every change, so getSnapshot re-renders. */
-export function useConsoleLayout(): ConsoleLayout {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
-}
-
-export function setConsoleLayout(next: ConsoleLayout): void {
-  layout = { order: [...next.order], hidden: [...next.hidden] };
-  emit();
-  persist();
-}
-
-/**
- * The order to actually render: the stored order filtered to ids that still
- * exist, then any canonical id the user has never ordered appended in its
- * canonical position (so a new card shows near where it was added, not lost).
- */
-export function effectiveOrder(stored: string[], canonical: string[]): string[] {
-  const known = new Set(canonical);
-  const out = stored.filter((id) => known.has(id));
-  const seen = new Set(out);
-  for (let i = 0; i < canonical.length; i += 1) {
-    const id = canonical[i];
-    if (seen.has(id)) continue;
-    // insert at the canonical index, clamped to the current length
-    out.splice(Math.min(i, out.length), 0, id);
-    seen.add(id);
-  }
-  return out;
-}
-
-/** Move `id` one step up/down among the CURRENTLY-VISIBLE ids (skips absent). */
-export function moveSection(
-  order: string[], visible: string[], id: string, dir: -1 | 1,
-): string[] {
-  const vis = order.filter((x) => visible.includes(x));
-  const vi = vis.indexOf(id);
-  const target = vis[vi + dir];
-  if (vi < 0 || target == null) return order; // at an end
-  // swap id and target in the FULL order array
-  const out = [...order];
-  const a = out.indexOf(id);
-  const b = out.indexOf(target);
-  [out[a], out[b]] = [out[b], out[a]];
-  return out;
-}
+export const useConsoleLayout = store.useLayout;
+export const setConsoleLayout = store.setLayout;
+export const loadConsoleLayout = store.load;

--- a/app/lib/fleetLayout.ts
+++ b/app/lib/fleetLayout.ts
@@ -1,0 +1,15 @@
+/**
+ * Fleet tab card layout — the user's box ORDER + a HIDDEN set, persisted.
+ *
+ * Same shared store as the Console (lib/cardLayout), but the ids here are BOX
+ * ids, so the order is "which box sits where" and hidden is "boxes I don't want
+ * cluttering the fleet list". effectiveOrder reconciles against the live box ids
+ * every render, so pairing a box appends it and unpairing one drops it cleanly.
+ */
+import { makeCardLayoutStore } from './cardLayout';
+
+const store = makeCardLayoutStore('couchside.fleetLayout.v1');
+
+export const useFleetLayout = store.useLayout;
+export const setFleetLayout = store.setLayout;
+export const loadFleetLayout = store.load;


### PR DESCRIPTION
Brings the Console tab's hold-to-edit reorder/hide to **Fleet** and **Actions** (owner request). Same gesture, same Customize button + Done bar — no new toggles.

## What's movable
- **Fleet** → the **boxes**. Reorder your fleet; hide a box from the list (still paired, still switchable from Setup). Ids are box ids, so `effectiveOrder` reconciles against the live boxes each render.
- **Actions** → the **sections**: the Boot Session card + the three impact groups (Routine / Changes what's on screen / Ends your session). Utilities stays pinned (advanced opt-in flashing tool).

## Refactor (Console untouched)
- `lib/cardOrder.ts` — pure `effectiveOrder`/`moveSection`, **import-free** so `node --test` loads them (same split as `lib/streak`).
- `lib/cardLayout.ts` — `makeCardLayoutStore(key)`, the persisted `{order,hidden}` store factored out of `consoleLayout`. `consoleLayout.ts` is now a thin re-export with its **storage key unchanged**, so existing Console layouts survive.
- `EditableSection` gains opt-in `inertWhileEditing` (default off): while editing, a card's own controls are inert so a tap lands on the reorder/hide strip, not on switch-box / an action.

## Verified (harness, by pressing — both tabs, both states)
Customize → strips appear; hide → dims + persists; reorder → swaps in storage and on screen, edge arrows disabled; Done → exits; **reload → order + hidden set persist**. Console regression-checked. `tsc` clean; 12-check `cardLayout` test + full app lib suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)