### PR TITLE
release(2.9.57): iOS build 203 — Fleet/Actions card reorder+hide (TestFlight)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.56",
+    "version": "2.9.57",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "202",
+      "buildNumber": "203",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Version bump for the next device-test cut. 2.9.56 (build 202) is in App Store review; **2.9.57 / build 203** adds the Fleet + Actions hold-to-edit reorder/hide (#508) on top of the 2.9.56 train (theme packs, focused Console, tips, auto-drop).

- `version` 2.9.56 → 2.9.57, `ios.buildNumber` 202 → 203 (clears the local + cloud 2.9.56 builds on ASC). `android.versionCode` unchanged (105) — this cut is an iOS TestFlight only.
- Built local (tf-local), uploaded to TestFlight (altool). App-only; no agent/store-notes change yet — store notes get rewritten when 2.9.57 goes to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)