### PR TITLE
fix: self-heal the TLS listener so a box update can't strand a paired app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,6 +339,16 @@ jobs:
       - name: Unit tests (TLS tickets)
         run: python3 tests/test_tls_ticket.py
 
+      # TLS listener self-heal. TLS is on by default and a paired app is LOCKED to
+      # the TLS port (fails closed, no plaintext fallback), so a listener that
+      # misses its bind after an in-place update — or whose serve thread dies —
+      # would strand every secure client in a connect/disconnect loop until a
+      # manual box reboot (observed on a Steam Machine after a 2.9.10x update).
+      # Proves _tls_start retries the bind through the restart race and the
+      # watchdog re-binds a down listener + re-advertises it, so the box self-heals.
+      - name: Unit tests (TLS self-heal)
+        run: python3 tests/test_tls_selfheal.py
+
       # Pairing PIN full-screen launch resolver. A desktop-session box is a system
       # service with a partial env, so a bare xdg-open failed and the PIN never
       # showed (a hard stop for pairing). Pins the browser->--kiosk argv mapping

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -23453,6 +23453,12 @@ def _tls_ensure(cfg, persist=True):
 _TLS_SERVER = None
 _TLS_THREAD = None
 _TLS_LOCK = threading.Lock()
+# Cooperative stop for the watchdog: set() makes _tls_supervisor exit its loop
+# promptly (it waits ON this event, not a bare sleep). Never set in production —
+# the daemon runs for the life of the process — but it makes the watchdog
+# responsive to shutdown and lets tests stop a supervisor deterministically
+# instead of leaking daemon threads across cases.
+_TLS_WATCH_STOP = threading.Event()
 # Initial-bind retries cover the restart race: systemd can start the new process
 # before the old one's listening socket is released (EADDRINUSE for a fraction of
 # a second). ~4s of retries outlasts a normal handoff.
@@ -23554,9 +23560,12 @@ def _tls_supervisor(host, handler_cls, force_enable=False):
     client. This daemon re-attempts the start until it succeeds, then idles
     cheaply once the listener is confirmed alive. Never raises."""
     global _TLS_SERVER, _TLS_THREAD
-    while True:
+    while not _TLS_WATCH_STOP.is_set():
         try:
-            time.sleep(_TLS_WATCH_INTERVAL_S)
+            # Wait ON the stop event so a shutdown (or a test) exits promptly
+            # instead of sleeping out the interval; returns True when stopped.
+            if _TLS_WATCH_STOP.wait(_TLS_WATCH_INTERVAL_S):
+                return
             if not (force_enable or (CONFIG_TLS and CONFIG_TLS.get("enabled"))):
                 continue  # TLS turned off at runtime: nothing to supervise.
             with _TLS_LOCK:

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -23440,6 +23440,30 @@ def _tls_ensure(cfg, persist=True):
             "fp": fp, "spki": spki, "cert_pem": cert_pem}
 
 
+# The live HTTPS server + its serve thread, tracked so the TLS watchdog
+# (_tls_supervisor) can tell whether the listener is actually up and re-bind it
+# WITHOUT a full agent reboot. This matters because TLS is on by default and a
+# paired app is LOCKED to the TLS port -- api.ts fails closed with no plaintext
+# fallback (deliberately, so a killed TLS port can't downgrade the token onto the
+# wire). So a listener that never bound after an in-place update, or whose serve
+# thread later dies, strands EVERY secure client in a connect/disconnect loop
+# until the box is rebooted. Restart=always/RestartSec=3 does not help: if the
+# port is briefly held during the restart race the first bind used to give up for
+# the whole life of the process. The retry-then-watchdog below closes that gap.
+_TLS_SERVER = None
+_TLS_THREAD = None
+_TLS_LOCK = threading.Lock()
+# Initial-bind retries cover the restart race: systemd can start the new process
+# before the old one's listening socket is released (EADDRINUSE for a fraction of
+# a second). ~4s of retries outlasts a normal handoff.
+_TLS_BIND_ATTEMPTS = 8
+_TLS_BIND_BACKOFF_S = 0.5
+# Steady-state watchdog cadence: re-check the listener is alive this often and, if
+# not, re-attempt the whole start. 20s recovers a box within an app reconnect
+# cycle or two without busy-looping.
+_TLS_WATCH_INTERVAL_S = 20
+
+
 def _tls_start(host, handler_cls, force_enable=False):
     """If TLS is enabled, mint/ensure the cert and start an HTTPS
     BoundedThreadingHTTPServer on its own daemon thread, sharing the same Handler
@@ -23447,8 +23471,14 @@ def _tls_start(host, handler_cls, force_enable=False):
     Handler.tls_info + the banner) or None. NEVER raises: any failure leaves the
     plaintext listener serving alone.
 
+    Retries the initial BIND through a restart race (EADDRINUSE while the old
+    process releases the port) instead of giving up for the life of the process;
+    on success records the live server in _TLS_SERVER/_TLS_THREAD so
+    _tls_supervisor can watch it and re-bind if it ever goes down.
+
     force_enable (the --tls dev/CI flag) enables TLS regardless of config and does
     NOT persist (an ephemeral cert per boot; SPKI stability is irrelevant there)."""
+    global _TLS_SERVER, _TLS_THREAD
     cfg = CONFIG_TLS
     if force_enable:
         cfg = dict(cfg or {})
@@ -23462,18 +23492,97 @@ def _tls_start(host, handler_cls, force_enable=False):
         return None
     if not info:
         return None
-    try:
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        ctx.load_cert_chain(certfile=info["cert_path"], keyfile=info["key_path"])
-        tls_srv = BoundedThreadingHTTPServer((host, info["port"]), handler_cls)
-        tls_srv.daemon_threads = True
-        tls_srv.socket = ctx.wrap_socket(tls_srv.socket, server_side=True)
-    except Exception as e:
-        print("warning: HTTPS listener on %d failed to start (%s); plaintext only"
-              % (info["port"], e), file=sys.stderr, flush=True)
-        return None
-    threading.Thread(target=tls_srv.serve_forever, daemon=True, name="tls").start()
-    return info
+    port = info["port"]
+    for attempt in range(_TLS_BIND_ATTEMPTS):
+        try:
+            ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            ctx.load_cert_chain(certfile=info["cert_path"], keyfile=info["key_path"])
+            tls_srv = BoundedThreadingHTTPServer((host, port), handler_cls)
+            tls_srv.daemon_threads = True
+            tls_srv.socket = ctx.wrap_socket(tls_srv.socket, server_side=True)
+        except OSError as e:
+            # EADDRINUSE (or similar) during the restart race: the old process
+            # has not released the listening socket yet. Back off and retry --
+            # never give up here, or a TLS-locked app loops until a box reboot.
+            if attempt + 1 < _TLS_BIND_ATTEMPTS:
+                time.sleep(_TLS_BIND_BACKOFF_S)
+                continue
+            print("warning: HTTPS listener on %d could not bind after %d tries "
+                  "(%s); plaintext only for now -- the TLS watchdog will keep "
+                  "retrying" % (port, _TLS_BIND_ATTEMPTS, e),
+                  file=sys.stderr, flush=True)
+            return None
+        except Exception as e:
+            # A non-bind failure (bad cert/ssl): immediate retry with the same
+            # inputs won't help, so hand off to the watchdog's slow retry rather
+            # than spinning here.
+            print("warning: HTTPS listener on %d failed to start (%s); plaintext "
+                  "only for now -- the TLS watchdog will keep retrying"
+                  % (port, e), file=sys.stderr, flush=True)
+            return None
+        th = threading.Thread(target=tls_srv.serve_forever, daemon=True, name="tls")
+        th.start()
+        with _TLS_LOCK:
+            _TLS_SERVER = tls_srv
+            _TLS_THREAD = th
+        return info
+    return None
+
+
+def _tls_apply_serve(handler_cls, serve):
+    """Publish a serve dict (from _tls_start) to the surfaces that read TLS state:
+    Handler.tls_info (the cert PEM the pinning handshake needs) and the TLS_ADVERT
+    module global (no PEM; the UDP discovery reply + build_pair_url read it).
+    Called at startup AND by the watchdog when the listener comes up LATE, so a
+    box that recovered HTTPS advertises it without a reboot. None clears both
+    (TLS dark) so the payloads/URLs stay byte-for-byte unchanged."""
+    global TLS_ADVERT
+    if serve:
+        handler_cls.tls_info = {"cert_pem": serve["cert_pem"], "fp": serve["fp"],
+                                "spki": serve["spki"], "port": serve["port"]}
+        TLS_ADVERT = {"port": serve["port"], "fp": serve["fp"], "spki": serve["spki"]}
+    else:
+        handler_cls.tls_info = None
+        TLS_ADVERT = None
+
+
+def _tls_supervisor(host, handler_cls, force_enable=False):
+    """Watchdog that keeps the HTTPS listener up so the box self-heals instead of
+    needing a manual reboot. TLS is on by default and a paired app is LOCKED to it
+    (fails closed, no plaintext fallback), so a listener that never bound after an
+    in-place update -- or whose serve thread dies -- would strand every secure
+    client. This daemon re-attempts the start until it succeeds, then idles
+    cheaply once the listener is confirmed alive. Never raises."""
+    global _TLS_SERVER, _TLS_THREAD
+    while True:
+        try:
+            time.sleep(_TLS_WATCH_INTERVAL_S)
+            if not (force_enable or (CONFIG_TLS and CONFIG_TLS.get("enabled"))):
+                continue  # TLS turned off at runtime: nothing to supervise.
+            with _TLS_LOCK:
+                srv, th = _TLS_SERVER, _TLS_THREAD
+            if srv is not None and th is not None and th.is_alive():
+                continue  # listener healthy
+            # Down (never bound, or the serve thread died). Release a half-dead
+            # server's socket before re-binding, or we'd EADDRINUSE against
+            # ourselves.
+            if srv is not None:
+                for close in (srv.shutdown, srv.server_close):
+                    try:
+                        close()
+                    except Exception:
+                        pass
+                with _TLS_LOCK:
+                    _TLS_SERVER = None
+                    _TLS_THREAD = None
+            serve = _tls_start(host, handler_cls, force_enable=force_enable)
+            if serve:
+                _tls_apply_serve(handler_cls, serve)
+                print("tls: HTTPS listener recovered on %s:%d" % (host, serve["port"]),
+                      flush=True)
+        except Exception as e:
+            print("warning: TLS watchdog iteration failed (%s)" % e,
+                  file=sys.stderr, flush=True)
 
 
 class BoundedThreadingHTTPServer(ThreadingHTTPServer):
@@ -23619,15 +23728,19 @@ def main():
     # Optional HTTPS/WSS listener (dark unless config.tls.enabled or --tls). Shares
     # this Handler; failures degrade closed and never touch the plaintext server.
     tls_serve = _tls_start(args.host, Handler, force_enable=args.tls)
-    Handler.tls_info = ({"cert_pem": tls_serve["cert_pem"], "fp": tls_serve["fp"],
-                         "spki": tls_serve["spki"], "port": tls_serve["port"]}
-                        if tls_serve else None)
-    # Public advert bits (no cert PEM) for the surfaces that have no Handler in hand:
-    # the UDP discovery reply and build_pair_url read this module global. Stays None
-    # while TLS is dark, so those payloads/URLs are byte-for-byte unchanged.
-    global TLS_ADVERT
-    TLS_ADVERT = ({"port": tls_serve["port"], "fp": tls_serve["fp"],
-                   "spki": tls_serve["spki"]} if tls_serve else None)
+    # Publish TLS state (Handler.tls_info for the pinning handshake + the TLS_ADVERT
+    # module global for the UDP discovery reply / build_pair_url). Stays None while
+    # TLS is dark, so those payloads/URLs are byte-for-byte unchanged.
+    _tls_apply_serve(Handler, tls_serve)
+    # Keep the HTTPS listener up without a reboot (see _tls_supervisor): TLS is on
+    # by default and a paired app is LOCKED to the TLS port (fails closed, no
+    # plaintext fallback), so a listener that missed its bind after an in-place
+    # update would otherwise strand every secure client in a connect/disconnect
+    # loop until a manual box restart. Real mode only; honours --tls.
+    if (args.tls or (CONFIG_TLS and CONFIG_TLS.get("enabled"))) and not args.mock:
+        threading.Thread(target=_tls_supervisor,
+                         args=(args.host, Handler, args.tls),
+                         daemon=True, name="tls-watch").start()
     mode = "mock" if args.mock else "real"
     print("%s %s listening on %s:%d (%s mode)" % (
         APP_NAME, VERSION, args.host, port, mode), flush=True)

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -1636,6 +1636,15 @@ async function attempt(
     if (e instanceof Error && e.name === 'AbortError') {
       throw new ApiError('timeout', `Timed out after ${timeoutMs / 1000}s`);
     }
+    if (settings.secure && settings.pinModulus && settings.tlsPort) {
+      // A secure box whose PINNED TLS port did not answer — distinct from the pin
+      // MISMATCH handled above. The common cause is the box mid-update: the agent
+      // restarts and its HTTPS listener re-binds a moment later (the agent
+      // self-heals its listener), so this recovers on its own without a re-pair.
+      // Still fail CLOSED — never downgrade the token to plaintext — but say
+      // something the user can act on instead of a bare "unreachable" loop.
+      throw new ApiError('unreachable', 'Secure link down — the box may be restarting');
+    }
     throw new ApiError('unreachable', 'Box unreachable: network error');
   } finally {
     clearTimeout(abortTimer);

--- a/tests/test_tls_selfheal.py
+++ b/tests/test_tls_selfheal.py
@@ -22,6 +22,11 @@ DECISIVE control (CLAUDE.md §11, observe-both-states): while the port is held t
 listener is DOWN (no HTTPS connect); the ONLY change after freeing it is the SAME
 port comes UP -- i.e. genuine recovery, not a new identity or a silent no-op.
 
+Test isolation: the watchdog is a daemon thread, so each case that starts one STOPS
+and JOINs it (via cs._TLS_WATCH_STOP) before the next case runs -- otherwise a
+leftover supervisor sharing the module globals grabs the next test's port (the exact
+Linux-only flake that first shipped here).
+
 Pure stdlib, no pytest.
 """
 import http.client
@@ -87,7 +92,26 @@ def https_ping_ok(port, timeout=2.0):
         return False
 
 
+def start_watch():
+    """Start a fresh watchdog for one test; returns the thread to stop later."""
+    cs._TLS_WATCH_STOP.clear()
+    th = threading.Thread(target=cs._tls_supervisor, args=(HOST, DummyHandler, True),
+                          daemon=True)
+    th.start()
+    return th
+
+
+def stop_watch(th):
+    """Stop and JOIN a watchdog so it can't leak into the next case."""
+    cs._TLS_WATCH_STOP.set()
+    if th is not None:
+        th.join(timeout=3)
+    cs._TLS_WATCH_STOP.clear()
+
+
 def reset_tls_globals():
+    cs._TLS_WATCH_STOP.set()  # make any stray supervisor exit before we tear down
+    time.sleep(0.02)
     srv = cs._TLS_SERVER
     if srv is not None:
         for close in (srv.shutdown, srv.server_close):
@@ -97,6 +121,7 @@ def reset_tls_globals():
                 pass
     cs._TLS_SERVER = None
     cs._TLS_THREAD = None
+    cs._TLS_WATCH_STOP.clear()
 
 
 def _require_cert_or_skip():
@@ -111,10 +136,10 @@ def _require_cert_or_skip():
 
 
 def test_bind_retry_then_success():
+    reset_tls_globals()
     port = free_port()
     cs.CONFIG_TLS = {"enabled": True, "port": port}
     DummyHandler.tls_info = None
-    reset_tls_globals()
     cs._TLS_BIND_ATTEMPTS = 6
     cs._TLS_BIND_BACKOFF_S = 0.15
 
@@ -136,10 +161,10 @@ def test_bind_retry_then_success():
 
 
 def test_watchdog_recovers_late():
+    reset_tls_globals()
     port = free_port()
     cs.CONFIG_TLS = {"enabled": True, "port": port}
     DummyHandler.tls_info = None
-    reset_tls_globals()
     cs._TLS_BIND_ATTEMPTS = 2
     cs._TLS_BIND_BACKOFF_S = 0.05
     cs._TLS_WATCH_INTERVAL_S = 0.2
@@ -150,28 +175,30 @@ def test_watchdog_recovers_late():
     cs._tls_apply_serve(DummyHandler, serve)  # None -> tls_info cleared (TLS dark)
     assert DummyHandler.tls_info is None
 
-    threading.Thread(target=cs._tls_supervisor, args=(HOST, DummyHandler, True),
-                     daemon=True).start()
-    time.sleep(cs._TLS_WATCH_INTERVAL_S * 3)
-    assert not https_ping_ok(port), "listener must stay DOWN while the port is held"
-    assert cs._TLS_SERVER is None, "must not claim a live server while down"
+    th = start_watch()
+    try:
+        time.sleep(cs._TLS_WATCH_INTERVAL_S * 3)
+        assert not https_ping_ok(port), "listener must stay DOWN while the port is held"
+        assert cs._TLS_SERVER is None, "must not claim a live server while down"
 
-    occ.close()
-    deadline = time.time() + 5
-    while time.time() < deadline and not https_ping_ok(port):
-        time.sleep(0.1)
-    assert https_ping_ok(port), "watchdog did not recover the listener after the port freed"
-    assert cs._TLS_SERVER is not None, "recovered server not tracked"
-    assert DummyHandler.tls_info is not None and DummyHandler.tls_info["port"] == port, \
-        "a late listener must be re-advertised (tls_info republished)"
+        occ.close()
+        deadline = time.time() + 5
+        while time.time() < deadline and not https_ping_ok(port):
+            time.sleep(0.1)
+        assert https_ping_ok(port), "watchdog did not recover the listener after the port freed"
+        assert cs._TLS_SERVER is not None, "recovered server not tracked"
+        assert DummyHandler.tls_info is not None and DummyHandler.tls_info["port"] == port, \
+            "a late listener must be re-advertised (tls_info republished)"
+    finally:
+        stop_watch(th)
     reset_tls_globals()
     print("ok watchdog-recovers-late")
 
 
 def test_watchdog_restarts_dead_thread():
+    reset_tls_globals()
     port = free_port()
     cs.CONFIG_TLS = {"enabled": True, "port": port}
-    reset_tls_globals()
     cs._TLS_BIND_ATTEMPTS = 4
     cs._TLS_BIND_BACKOFF_S = 0.1
     cs._TLS_WATCH_INTERVAL_S = 0.2
@@ -180,20 +207,22 @@ def test_watchdog_restarts_dead_thread():
     assert serve is not None and https_ping_ok(port), "initial listener should be up"
     old = cs._TLS_SERVER
 
-    threading.Thread(target=cs._tls_supervisor, args=(HOST, DummyHandler, True),
-                     daemon=True).start()
-    # Simulate the serve thread dying: serve_forever returns, the daemon thread
-    # ends, but the socket stays bound until the watchdog's server_close.
-    old.shutdown()
+    th = start_watch()
+    try:
+        # Simulate the serve thread dying: serve_forever returns, the daemon thread
+        # ends, but the socket stays bound until the watchdog's server_close.
+        old.shutdown()
 
-    deadline = time.time() + 6
-    ok = False
-    while time.time() < deadline:
-        if cs._TLS_SERVER is not None and cs._TLS_SERVER is not old and https_ping_ok(port):
-            ok = True
-            break
-        time.sleep(0.1)
-    assert ok, "watchdog did not restart a dead listener on the same port"
+        deadline = time.time() + 6
+        ok = False
+        while time.time() < deadline:
+            if cs._TLS_SERVER is not None and cs._TLS_SERVER is not old and https_ping_ok(port):
+                ok = True
+                break
+            time.sleep(0.1)
+        assert ok, "watchdog did not restart a dead listener on the same port"
+    finally:
+        stop_watch(th)
     reset_tls_globals()
     print("ok watchdog-restarts-dead-thread")
 

--- a/tests/test_tls_selfheal.py
+++ b/tests/test_tls_selfheal.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""TLS listener self-heal: bind-retry through a restart race + watchdog recovery.
+
+Run: python3 tests/test_tls_selfheal.py
+
+CLAUDE.md §4 protects reachability. TLS is on by default and a paired app is LOCKED
+to the TLS port -- api.ts fails closed with NO plaintext fallback (so a killed TLS
+port can't downgrade the token onto the wire). The cost of that guarantee: a
+listener that misses its bind after an in-place update, or whose serve thread later
+dies, strands every secure client in a connect/disconnect loop until a manual box
+reboot (observed on a Steam Machine after a 2.9.10x agent update). This proves the
+fix that lets the box self-heal instead:
+
+  * _tls_start RETRIES the bind through a busy port (the systemd Restart=always
+    race, where the new process can start before the old releases the socket)
+    instead of giving up for the life of the process, and binds once the port frees.
+  * _tls_supervisor RE-BINDS on its own after the listener is down -- never bound,
+    or the serve thread died -- so the box recovers without a reboot, and it
+    republishes tls_info so a LATE listener is still advertised for pinning.
+
+DECISIVE control (CLAUDE.md §11, observe-both-states): while the port is held the
+listener is DOWN (no HTTPS connect); the ONLY change after freeing it is the SAME
+port comes UP -- i.e. genuine recovery, not a new identity or a silent no-op.
+
+Pure stdlib, no pytest.
+"""
+import http.client
+import importlib.util
+import os
+import socket
+import ssl
+import threading
+import time
+from http.server import BaseHTTPRequestHandler
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+HOST = "127.0.0.1"
+
+
+class DummyHandler(BaseHTTPRequestHandler):
+    """Minimal handler: _tls_start only needs a handler_cls to build the server;
+    the auth-gated Handler behaviour is proven in test_tls_smoke.py."""
+    tls_info = None
+
+    def do_GET(self):
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *a):
+        pass
+
+
+def free_port():
+    s = socket.socket()
+    s.bind((HOST, 0))
+    p = s.getsockname()[1]
+    s.close()
+    return p
+
+
+def occupy(port):
+    """Hold `port` with a real LISTENING socket so a second bind gets EADDRINUSE
+    (SO_REUSEADDR rebinds a TIME_WAIT socket, not an active listener)."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    s.bind((HOST, port))
+    s.listen(1)
+    return s
+
+
+def https_ping_ok(port, timeout=2.0):
+    ctx = ssl._create_unverified_context()
+    try:
+        c = http.client.HTTPSConnection(HOST, port, context=ctx, timeout=timeout)
+        c.request("GET", "/x")
+        r = c.getresponse()
+        r.read()
+        c.close()
+        return r.status == 200
+    except Exception:
+        return False
+
+
+def reset_tls_globals():
+    srv = cs._TLS_SERVER
+    if srv is not None:
+        for close in (srv.shutdown, srv.server_close):
+            try:
+                close()
+            except Exception:
+                pass
+    cs._TLS_SERVER = None
+    cs._TLS_THREAD = None
+
+
+def _require_cert_or_skip():
+    """These tests need a mintable cert (openssl). If cert generation is
+    unavailable on this host, _tls_start returns None even with a free port --
+    skip rather than false-fail (CI mints one on Linux; test_tls_smoke covers it)."""
+    port = free_port()
+    cs.CONFIG_TLS = {"enabled": True, "port": port}
+    serve = cs._tls_start(HOST, DummyHandler, force_enable=True)
+    reset_tls_globals()
+    return serve is not None
+
+
+def test_bind_retry_then_success():
+    port = free_port()
+    cs.CONFIG_TLS = {"enabled": True, "port": port}
+    DummyHandler.tls_info = None
+    reset_tls_globals()
+    cs._TLS_BIND_ATTEMPTS = 6
+    cs._TLS_BIND_BACKOFF_S = 0.15
+
+    occ = occupy(port)
+    t0 = time.time()
+    serve = cs._tls_start(HOST, DummyHandler, force_enable=True)
+    elapsed = time.time() - t0
+    assert serve is None, "expected None while the port is busy"
+    assert elapsed >= 0.3, "did not actually retry (returned in %.3fs)" % elapsed
+    assert not https_ping_ok(port), "listener should be down while the port is busy"
+
+    occ.close()
+    serve = cs._tls_start(HOST, DummyHandler, force_enable=True)
+    assert serve is not None and serve["port"] == port, "bind failed after port freed"
+    assert cs._TLS_SERVER is not None and cs._TLS_THREAD.is_alive(), "server not tracked/alive"
+    assert https_ping_ok(port), "listener should be up on the same port after it freed"
+    reset_tls_globals()
+    print("ok bind-retry-then-success")
+
+
+def test_watchdog_recovers_late():
+    port = free_port()
+    cs.CONFIG_TLS = {"enabled": True, "port": port}
+    DummyHandler.tls_info = None
+    reset_tls_globals()
+    cs._TLS_BIND_ATTEMPTS = 2
+    cs._TLS_BIND_BACKOFF_S = 0.05
+    cs._TLS_WATCH_INTERVAL_S = 0.2
+
+    occ = occupy(port)
+    serve = cs._tls_start(HOST, DummyHandler, force_enable=True)
+    assert serve is None
+    cs._tls_apply_serve(DummyHandler, serve)  # None -> tls_info cleared (TLS dark)
+    assert DummyHandler.tls_info is None
+
+    threading.Thread(target=cs._tls_supervisor, args=(HOST, DummyHandler, True),
+                     daemon=True).start()
+    time.sleep(cs._TLS_WATCH_INTERVAL_S * 3)
+    assert not https_ping_ok(port), "listener must stay DOWN while the port is held"
+    assert cs._TLS_SERVER is None, "must not claim a live server while down"
+
+    occ.close()
+    deadline = time.time() + 5
+    while time.time() < deadline and not https_ping_ok(port):
+        time.sleep(0.1)
+    assert https_ping_ok(port), "watchdog did not recover the listener after the port freed"
+    assert cs._TLS_SERVER is not None, "recovered server not tracked"
+    assert DummyHandler.tls_info is not None and DummyHandler.tls_info["port"] == port, \
+        "a late listener must be re-advertised (tls_info republished)"
+    reset_tls_globals()
+    print("ok watchdog-recovers-late")
+
+
+def test_watchdog_restarts_dead_thread():
+    port = free_port()
+    cs.CONFIG_TLS = {"enabled": True, "port": port}
+    reset_tls_globals()
+    cs._TLS_BIND_ATTEMPTS = 4
+    cs._TLS_BIND_BACKOFF_S = 0.1
+    cs._TLS_WATCH_INTERVAL_S = 0.2
+
+    serve = cs._tls_start(HOST, DummyHandler, force_enable=True)
+    assert serve is not None and https_ping_ok(port), "initial listener should be up"
+    old = cs._TLS_SERVER
+
+    threading.Thread(target=cs._tls_supervisor, args=(HOST, DummyHandler, True),
+                     daemon=True).start()
+    # Simulate the serve thread dying: serve_forever returns, the daemon thread
+    # ends, but the socket stays bound until the watchdog's server_close.
+    old.shutdown()
+
+    deadline = time.time() + 6
+    ok = False
+    while time.time() < deadline:
+        if cs._TLS_SERVER is not None and cs._TLS_SERVER is not old and https_ping_ok(port):
+            ok = True
+            break
+        time.sleep(0.1)
+    assert ok, "watchdog did not restart a dead listener on the same port"
+    reset_tls_globals()
+    print("ok watchdog-restarts-dead-thread")
+
+
+if __name__ == "__main__":
+    if not _require_cert_or_skip():
+        print("SKIP: TLS cert generation unavailable on this host (need openssl); "
+              "run in CI where test_tls_smoke also mints one")
+        raise SystemExit(0)
+    test_bind_retry_then_success()
+    test_watchdog_recovers_late()
+    test_watchdog_restarts_dead_thread()
+    print("ALL TLS SELF-HEAL TESTS PASSED")


### PR DESCRIPTION
## Problem

TLS-paired apps loop **connecting → disconnected** forever after an in-place agent update; only a full box reboot fixes it. Device-reported on a Steam Machine after a 2.9.10x update.

## Root cause

TLS is on by default and a paired app is **locked to the TLS port** — `api.ts` fails closed with no plaintext fallback (deliberate: a killed TLS port must not downgrade the bearer token onto the wire). But `_tls_start` ran **once at boot and swallowed any bind failure** (`"plaintext only"`), giving up for the whole life of the process. With systemd `Restart=always/RestartSec=3`, if 8788 is briefly held during the installer's restart race — or cert/bind hits any transient — the box serves plaintext-only and every secure client is stranded until a reboot re-binds it.

## Fix

**Agent — self-heals, no reboot needed:**
- `_tls_start` **retries the bind** through the restart race (EADDRINUSE) with backoff instead of giving up, and records the live server/thread.
- `_tls_supervisor` watchdog re-attempts the start whenever the listener is down (never bound, or the serve thread died), tears down a half-dead server first, and **republishes `tls_info`** via `_tls_apply_serve` so a late listener is still advertised for pinning. Recovery lands within ~one app reconnect cycle.

**App — actionable, still fails closed:**
- A secure box whose pinned TLS port didn't answer (distinct from a pin **mismatch**) now surfaces `Secure link down — the box may be restarting` instead of a bare `unreachable` loop. The token is never downgraded to plaintext.

## Safety / compat

Additive only, degrade-closed preserved (a persistently un-mintable cert still just serves plaintext), no response shapes changed, agent stays pure stdlib.

## Verification

- New `tests/test_tls_selfheal.py` (wired into CI): retry-then-bind, watchdog recovery of a never-bound listener (+ re-advertise), restart of a dead serve thread. **PASS.**
- Full TLS suite (cert / smoke / advertise / ticket / selfheal) — **all PASS** locally (macOS mints the cert).

**NOT yet verified on the real box** (currently offline). On-box check next update:

```bash
ssh deck@<box> 'journalctl -u couchside.service | grep -i "HTTPS listener"'
```

A `recovered` line (or `address already in use` then a successful bind) confirms the watchdog worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
