### PR TITLE
chore(ios): build 207 (effects trimmed to alarm-only)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "206",
+      "buildNumber": "207",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Build-number bump for the TestFlight build that ships the effects trim (#513). Default look unchanged (reactor, effects off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)