### PR TITLE
feat: busy-UI passes — tour trim, vitals glance strip, Prefs DIAGNOSTICS group

### DIFF
--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -206,39 +206,42 @@ function ConsoleScreen() {
     gaming: <GamingCard />,
     vitals: s ? (
       <>
-        <View style={styles.row}>
-          {/* TourAnchor REPLACES the half View rather than wrapping it, so
-              the flex row is untouched — see components/TourAnchor.tsx. */}
-          <TourAnchor id="console.cpu" style={styles.half}>
-            <Card title="CPU TEMP" index={0}>
-              <BigMetric
-                value={s.cpu_temp_c != null ? `${s.cpu_temp_c.toFixed(1)}°C` : '—'}
-                numeric={s.cpu_temp_c}
-                color={tempColor(s.cpu_temp_c, t)}
-              />
-              <Spark values={s.history?.temp} color={tempColor(s.cpu_temp_c, t)} />
-            </Card>
-          </TourAnchor>
-          <View style={styles.half}>
-            <Card title="UPTIME" index={1}>
-              <BigMetric value={humanizeUptime(s.uptime_s)} numeric={null} color={t.text} />
-              {s.ip ? <Text style={styles.ipLine}>{s.ip}</Text> : null}
-            </Card>
-          </View>
-        </View>
+        {/* Glance strip — the four numbers you actually scan, in one row. The
+            detail cards (memory breakdown, disks, battery) sit below; the six
+            stacked headline cards this replaced were the busiest part of the
+            Console. console.cpu anchor rides the strip now (tour + measurement).
+            VitalsContext breathing is screen-level and untouched. */}
+        <TourAnchor id="console.cpu">
+          <Card title="VITALS" index={0}>
+            <View style={styles.vstrip}>
+              <View style={styles.vcell}>
+                <Text style={styles.vlabel}>TEMP</Text>
+                <Text style={[styles.vval, { color: tempColor(s.cpu_temp_c, t) }]}>
+                  {s.cpu_temp_c != null ? `${Math.round(s.cpu_temp_c)}\u00b0` : '\u2014'}
+                </Text>
+              </View>
+              <View style={styles.vcell}>
+                <Text style={styles.vlabel}>LOAD</Text>
+                <Text style={[styles.vval, { color: t.text }]}>{s.load[0].toFixed(2)}</Text>
+              </View>
+              <View style={styles.vcell}>
+                <Text style={styles.vlabel}>MEM</Text>
+                <Text style={[styles.vval, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
+              </View>
+              {s.battery && (
+                <View style={styles.vcell}>
+                  <Text style={styles.vlabel}>BATT</Text>
+                  <Text style={[styles.vval, { color: batteryColor(s.battery.pct, t) }]}>{s.battery.pct}%</Text>
+                </View>
+              )}
+            </View>
+            <Text style={styles.vsub} numberOfLines={1}>
+              up {humanizeUptime(s.uptime_s)}{s.ip ? `  \u00b7  ${s.ip}` : ''}
+            </Text>
+          </Card>
+        </TourAnchor>
 
-        <Card title="LOAD 1m / 5m / 15m" index={2}>
-          <View style={styles.loadRow}>
-            {s.load.map((l, i) => (
-              <Text key={i} style={styles.loadVal}>
-                {l.toFixed(2)}
-              </Text>
-            ))}
-          </View>
-          <Spark values={s.history?.load} color={t.blue} />
-        </Card>
-
-        <Card title="MEMORY" index={3}>
+        <Card title="MEMORY" index={1}>
           <View style={styles.barLabelRow}>
             <Text style={styles.barLabel}>
               {(s.mem.used_mb / 1024).toFixed(1)} / {(s.mem.total_mb / 1024).toFixed(1)} GB
@@ -256,12 +259,12 @@ function ConsoleScreen() {
                   : null,
               ]
                 .filter(Boolean)
-                .join('  ·  ')}
+                .join('  \u00b7  ')}
             </Text>
           )}
         </Card>
 
-        <Card title="DISKS" index={4}>
+        <Card title="DISKS" index={2}>
           {s.disks.map((d) => (
             <View key={d.mount} style={styles.diskRow}>
               <View style={styles.barLabelRow}>
@@ -282,7 +285,7 @@ function ConsoleScreen() {
             whole gate -- no cap check, no placeholder, no "0%" on a machine
             that has no pack. */}
         {s.battery && (
-          <Card title="BATTERY" index={5}>
+          <Card title="BATTERY" index={3}>
             <View style={styles.barLabelRow}>
               <Text style={styles.barLabel}>
                 {s.battery.status === 'Charging'
@@ -312,7 +315,7 @@ function ConsoleScreen() {
                   s.battery.profile,
                 ]
                   .filter(Boolean)
-                  .join('  ·  ')}
+                  .join('  \u00b7  ')}
               </Text>
             )}
           </Card>
@@ -565,6 +568,13 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   },
   foldText: { color: t.textDim, fontSize: 12, fontWeight: '700', letterSpacing: 1.2 },
   foldSub: { color: t.textFaint, fontSize: 12, flex: 1 },
+  // Vitals glance strip (pass #4): one row of the four scanned numbers, then a
+  // quiet uptime/ip line. Detail cards (memory/disks/battery) render below.
+  vstrip: { flexDirection: 'row', gap: 14 },
+  vcell: { flex: 1 },
+  vlabel: { color: t.textFaint, fontFamily: mono, fontSize: 10, letterSpacing: 1 },
+  vval: { ...numeric, fontSize: 22, fontWeight: '700', marginTop: 2 },
+  vsub: { color: t.textFaint, fontFamily: mono, fontSize: 11, marginTop: 8 },
   doneBtn: {
     backgroundColor: t.blue, borderRadius: 999,
     paddingVertical: 8, paddingHorizontal: 22,

--- a/app/app/(tabs)/launch.tsx
+++ b/app/app/(tabs)/launch.tsx
@@ -26,6 +26,9 @@ import { Gated } from '@/components/Gated';
 import { GameSheet } from '@/components/GameSheet';
 import { InstallableSection } from '@/components/InstallableSection';
 import { PlaylogCard } from '@/components/PlaylogCard';
+import { EditableSection } from '@/components/EditableSection';
+import { effectiveOrder, moveSection } from '@/lib/cardLayout';
+import { useLaunchLayout, setLaunchLayout } from '@/lib/launchLayout';
 import { useCompat } from '@/hooks/useCompat';
 import { type Compat, deckLabel, protonLabel } from '@/lib/compat';
 import { LibraryFilterSheet } from '@/components/LibraryFilterSheet';
@@ -286,11 +289,10 @@ function QueuedRow({ d }: { d: SteamDownload }) {
 function DownloadsSection({ downloads }: { downloads: SteamDownload[] }) {
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
-  const hidden = usePref('hideDownloads');
   const [showQueue, setShowQueue] = useState(false);
   // Gate inside the component, not at the call site: the hooks above must run
   // unconditionally, and any future second call site inherits the pref for free.
-  if (hidden || downloads.length === 0) return null;
+  if (downloads.length === 0) return null;
   const active = downloads.filter(isActiveDownload);
   const queued = downloads.filter((d) => !isActiveDownload(d));
   return (
@@ -393,7 +395,6 @@ function SteamLinkSection({
   const t = useTheme();
   const styles = useThemedStyles(makeStyles);
   const hideOffline = usePref('hideOfflineStreamHosts');
-  const hideSection = usePref('hideStreamFromPc');
   const collapsed = usePref('streamCollapsed');
   // Expand the freshest host by default, preferring one that's actually up.
   // `online` is absent on agents older than 2.9.32, and undefined !== false, so
@@ -402,10 +403,6 @@ function SteamLinkSection({
     const first = data.hosts.find((h) => h.online !== false) ?? data.hosts[0];
     return first ? { [first.host]: true } : {};
   });
-  // Turned off outright in Preferences. Checked AFTER the hooks above so the
-  // hook order never changes between renders, and before the empty-host check
-  // so the reason for an absent card is the pref, not the data.
-  if (hideSection) return null;
   if (data.hosts.length === 0) return null;
   const hosts = hideOffline ? data.hosts.filter((h) => h.online !== false) : data.hosts;
   return (
@@ -840,6 +837,56 @@ function LaunchScreen() {
     [],
   );
 
+  // --- Launch aux-card layout: hold-to-edit reorder + hide (persisted) ------
+  // The cards above the grid (installable, playlog, downloads, stream-from-PC)
+  // are movable/hideable, same store/pattern as the Console. Now Playing stays
+  // pinned above (urgent-by-design) and the grid is the primary content. This
+  // hide gesture replaced the old "Hide the downloads card" / "Hide this
+  // section" Prefs toggles.
+  const launchLayout = useLaunchLayout();
+  const [editingCards, setEditingCards] = useState(false);
+  const [cardPresent, setCardPresent] = useState<Record<string, boolean>>({});
+  const LAUNCH_CARD_ORDER = ['installable', 'playlog', 'downloads', 'streamfrompc'];
+  const launchOrder = effectiveOrder(launchLayout.order, LAUNCH_CARD_ORDER);
+  const launchHidden = new Set(launchLayout.hidden);
+  const setCardPres = (id: string, pres: boolean) =>
+    setCardPresent((prev) => (prev[id] === pres ? prev : { ...prev, [id]: pres }));
+  const visibleLaunch = launchOrder.filter((id) => cardPresent[id] && !launchHidden.has(id));
+  const moveLaunchCard = (id: string, dir: -1 | 1) =>
+    setLaunchLayout({ order: moveSection(launchOrder, visibleLaunch, id, dir), hidden: launchLayout.hidden });
+  const toggleHideLaunch = (id: string) => {
+    const h = new Set(launchLayout.hidden);
+    if (h.has(id)) h.delete(id); else h.add(id);
+    setLaunchLayout({ order: launchOrder, hidden: [...h] });
+  };
+  const launchCardNodes: Record<string, React.ReactNode> = {
+    installable: <InstallableSection />,
+    playlog: <PlaylogCard />,
+    downloads: <DownloadsSection downloads={downloads} />,
+    streamfrompc: steamlink?.available ? <SteamLinkSection data={steamlink} onStream={streamLaunch} /> : null,
+  };
+  const renderLaunchCards = () =>
+    launchOrder.map((id) => {
+      const node = launchCardNodes[id];
+      if (node == null) return null;
+      return (
+        <EditableSection
+          key={id}
+          editing={editingCards}
+          hidden={launchHidden.has(id)}
+          isFirst={visibleLaunch[0] === id}
+          isLast={visibleLaunch[visibleLaunch.length - 1] === id}
+          onEnterEdit={() => setEditingCards(true)}
+          onPresent={(pres) => setCardPres(id, pres)}
+          onUp={() => moveLaunchCard(id, -1)}
+          onDown={() => moveLaunchCard(id, 1)}
+          onToggleHide={() => toggleHideLaunch(id)}
+          inertWhileEditing>
+          {node}
+        </EditableSection>
+      );
+    });
+
   return (
     <View style={styles.screen}>
       <View style={styles.header}>
@@ -854,6 +901,18 @@ function LaunchScreen() {
             style={({ pressed }) => [styles.addBtn, pressed && styles.pressed]}>
             <Ionicons name="add" size={18} color={t.blue} />
             <Text style={styles.addBtnText}>Add</Text>
+          </Pressable>
+        )}
+        {/* CUSTOMIZE: same hold-to-edit entry as the Console (games section only,
+            and the only way back in once every aux card is hidden). */}
+        {configured && activeSection === 'games' && !editingCards && (
+          <Pressable
+            onPress={() => { hapticSelection(); setEditingCards(true); }}
+            accessibilityRole="button"
+            accessibilityLabel="Reorder or hide cards"
+            hitSlop={8}
+            style={({ pressed }) => [styles.customizeBtn, pressed && styles.pressed]}>
+            <Ionicons name="options-outline" size={18} color={t.textDim} />
           </Pressable>
         )}
       </View>
@@ -908,23 +967,13 @@ function LaunchScreen() {
             seeing what is running belongs in both places. */}
         <NowPlayingCard />
 
-        {/* Install games you own but haven't downloaded — a PROMINENT card near the
-            top (above downloads) so it's discoverable while browsing, not a thin row
-            buried in the list. Probe-and-appear on the LIVE endpoint (no cached
-            cap that could go stale); taps through to the full library page. */}
-        <InstallableSection />
-
-        {/* Playlog: the ordered "play next" queue (your bookmarks). Hidden until
-            you've queued at least one game. Taps through to app/playlog.tsx. */}
-        <PlaylogCard />
-
-        {/* Active Steam downloads (hidden when none / agent < 2.8) */}
-        <DownloadsSection downloads={downloads} />
-
-        {/* Stream from PC (hidden when no host / agent < 2.9.23) */}
-        {steamlink?.available && (
-          <SteamLinkSection data={steamlink} onStream={streamLaunch} />
-        )}
+        {/* Aux cards (installable, playlog, downloads, stream-from-PC) — movable
+            and hideable via hold-to-edit (Customize in the header, Done bar
+            below), same pattern as the Console. Each is inert while editing so a
+            tap lands on the reorder/hide strip. Now Playing above stays pinned.
+            Each self-gates internally (probe-and-appear), so an absent card
+            renders null and shows no reorder/hide controls. */}
+        {renderLaunchCards()}
 
         {/* Fresh install: nothing paired yet, so nothing is "unreachable". */}
         {!configured && (
@@ -1124,12 +1173,36 @@ function LaunchScreen() {
       )}
 
       <AddLauncherForm visible={addOpen} onClose={() => setAddOpen(false)} onSubmit={add} />
+      {/* Edit-layout bar: hold any aux card (or tap Customize) to enter, then
+          reorder / hide, Done. Matches the Console tab. */}
+      {editingCards && (
+        <View style={styles.editBar}>
+          <Text style={styles.editHint}>Reorder or hide cards</Text>
+          <Pressable
+            onPress={() => setEditingCards(false)}
+            accessibilityRole="button"
+            accessibilityLabel="Done editing layout"
+            style={({ pressed }) => [styles.doneBtn, pressed && styles.pressed]}>
+            <Text style={styles.doneText}>Done</Text>
+          </Pressable>
+        </View>
+      )}
     </View>
   );
 }
 
 const makeStyles = (t: Palette) => StyleSheet.create({
   screen: { flex: 1, backgroundColor: t.bg },
+  customizeBtn: { marginLeft: 10, padding: 6, borderRadius: 8 },
+  editBar: {
+    position: 'absolute', left: 0, right: 0, bottom: 0,
+    flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
+    paddingHorizontal: 16, paddingTop: 12, paddingBottom: 28,
+    backgroundColor: t.card, borderTopColor: t.cardBorder, borderTopWidth: 1,
+  },
+  editHint: { color: t.textDim, fontSize: 13 },
+  doneBtn: { backgroundColor: t.blue, borderRadius: 999, paddingVertical: 8, paddingHorizontal: 22 },
+  doneText: { color: t.onAccent, fontWeight: '700', fontSize: 14 },
   header: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -1585,6 +1585,12 @@ function SetupBody() {
                   hapticSelection();
                 }}
               />
+            </View>
+
+            {/* DIAGNOSTICS: the polling/logs controls, pulled out of the
+                overloaded GENERAL group (busy-UI pass). */}
+            <View style={prefCardGroupStyle}>
+              <CardHeader icon="pulse-outline" label="DIAGNOSTICS" />
               <SegPref
                 label="Vitals refresh"
                 sub="How often the console polls the box."

--- a/app/app/(tabs)/setup.tsx
+++ b/app/app/(tabs)/setup.tsx
@@ -932,10 +932,8 @@ function SetupBody() {
   const searchButtonSide = usePref('searchButtonSide');
   const volumeButtons = usePref('volumeButtons');
   const hideOfflineStreamHosts = usePref('hideOfflineStreamHosts');
-  const hideDownloads = usePref('hideDownloads');
   const hideNoteMode = usePref('hideNoteMode');
   const appUpdateReminder = usePref('appUpdateReminder');
-  const hideStreamFromPc = usePref('hideStreamFromPc');
   const hideTvVolume = usePref('hideTvVolume');
   const showTaps = usePref('showTaps');
   const traceDrags = usePref('traceDrags');
@@ -1469,15 +1467,6 @@ function SetupBody() {
                 />
               </View>
               </PrefFilterable>
-              <TogglePref
-                label="Hide the downloads card"
-                sub="Removes the Steam downloads panel from the top of the Launch tab. Downloads keep running — this only hides the card."
-                value={hideDownloads}
-                onValueChange={(v) => {
-                  void setPref('hideDownloads', v);
-                  hapticSelection();
-                }}
-              />
               <TogglePref
                 label="Hide note mode"
                 sub="Removes the NOTE segment from the Pad's mode bar. Note mode is a phone-side scratchpad for jotting a clue while a game runs. Your note is kept either way — this only hides the segment."
@@ -2181,15 +2170,6 @@ function SetupBody() {
                 value={hideOfflineStreamHosts}
                 onValueChange={(v) => {
                   void setPref('hideOfflineStreamHosts', v);
-                  hapticSelection();
-                }}
-              />
-              <TogglePref
-                label="Hide this section"
-                sub="Removes Stream from PC from the Launch tab. For setups where you'd never stream a game off another machine."
-                value={hideStreamFromPc}
-                onValueChange={(v) => {
-                  void setPref('hideStreamFromPc', v);
                   hapticSelection();
                 }}
               />

--- a/app/lib/launchLayout.ts
+++ b/app/lib/launchLayout.ts
@@ -1,0 +1,17 @@
+/**
+ * Launch tab card layout — order + hidden set for the tab's AUX cards, persisted.
+ *
+ * Same shared store as the Console (lib/cardLayout). The ids here are the aux
+ * cards that sit above the game grid: 'installable', 'playlog', 'downloads',
+ * 'streamfrompc'. The Now Playing card stays pinned (urgent-by-design) and the
+ * game grid is the primary content, so neither is movable. Hold-to-edit hide
+ * replaces the old per-card "Hide the downloads card" / "Hide this section"
+ * Prefs toggles — one gesture instead of two buried switches.
+ */
+import { makeCardLayoutStore } from './cardLayout';
+
+const store = makeCardLayoutStore('couchside.launchLayout.v1');
+
+export const useLaunchLayout = store.useLayout;
+export const setLaunchLayout = store.setLayout;
+export const loadLaunchLayout = store.load;

--- a/app/lib/prefs.ts
+++ b/app/lib/prefs.ts
@@ -166,13 +166,6 @@ export type Prefs = {
    * control would then re-offer the popup instead of replaying the flow.
    */
   whatsNewOffered: boolean;
-  /** Remove the Steam downloads card from the Launch tab. Off by default: a
-   *  transfer in flight is the most useful thing that tab can tell you. On for
-   *  people who never queue from the couch and want the games grid to start at
-   *  the top. Hiding the card does not touch the downloads -- Steam keeps
-   *  going. Named `hide` to match hideStreamFromPc / hideTvVolume; a mixed
-   *  polarity is how a toggle ends up wired backwards. */
-  hideDownloads: boolean;
   /** Hide the NOTE segment from the Pad's mode bar. Off by default (visible):
    *  note mode is a phone-side scratchpad for jotting a clue mid-game. On for
    *  people who don't want the extra segment. `hide` polarity to match the
@@ -235,16 +228,6 @@ export type Prefs = {
       check is conservative and does call a live host offline, so the row stays
       visible and tappable unless you ask for it gone. Agent >= 2.9.32. */
   hideOfflineStreamHosts: boolean;
-  /** Drop the Launch tab's "Stream from PC" section entirely.
-   *
-   *  Distinct from hideOfflineStreamHosts, which only filters rows: this hides
-   *  the whole card. Asked for by a user running SteamOS on their main PC with
-   *  Remote Play disabled -- every host listed was one they would never stream
-   *  from, and there was no way to make the section go away. The agent cannot
-   *  currently tell "Remote Play is off" from "no host is online", so this stays
-   *  a manual switch rather than an auto-hide; guessing wrong here removes a
-   *  working feature. */
-  hideStreamFromPc: boolean;
   /** Drop the TV side of the Box/TV volume switch.
    *
    *  On a setup where the box's own volume already reaches the speakers -- CEC
@@ -328,7 +311,6 @@ export const DEFAULTS: Prefs = {
   consoleMoreCollapsed: true,
   onboardingDone: false,
   whatsNewOffered: false,
-  hideDownloads: false,
   hideNoteMode: false,
   appUpdateReminder: true,
   defaultPadMode: 'swipe',
@@ -352,7 +334,6 @@ export const DEFAULTS: Prefs = {
   // until the user opts in.
   volumeButtons: Platform.OS === 'android',
   hideOfflineStreamHosts: false,
-  hideStreamFromPc: false,
   hideTvVolume: false,
   showTaps: false,
   traceDrags: false,
@@ -426,7 +407,6 @@ function normalize(raw: unknown): Prefs {
   const consoleMoreCollapsed = bool(o.consoleMoreCollapsed, DEFAULTS.consoleMoreCollapsed);
   const onboardingDone = bool(o.onboardingDone, DEFAULTS.onboardingDone);
   const whatsNewOffered = bool(o.whatsNewOffered, DEFAULTS.whatsNewOffered);
-  const hideDownloads = bool(o.hideDownloads, DEFAULTS.hideDownloads);
   const hideNoteMode = bool(o.hideNoteMode, DEFAULTS.hideNoteMode);
   const appUpdateReminder = bool(o.appUpdateReminder, DEFAULTS.appUpdateReminder);
   const searchSide: 'left' | 'right' | 'off' =
@@ -442,7 +422,6 @@ function normalize(raw: unknown): Prefs {
     consoleMoreCollapsed,
     onboardingDone,
     whatsNewOffered,
-    hideDownloads,
     hideNoteMode,
     appUpdateReminder,
     confirmSuspend:
@@ -477,7 +456,6 @@ function normalize(raw: unknown): Prefs {
     askToSwitchControl: bool(o.askToSwitchControl, DEFAULTS.askToSwitchControl),
     volumeButtons: bool(o.volumeButtons, DEFAULTS.volumeButtons),
     hideOfflineStreamHosts: bool(o.hideOfflineStreamHosts, DEFAULTS.hideOfflineStreamHosts),
-    hideStreamFromPc: bool(o.hideStreamFromPc, DEFAULTS.hideStreamFromPc),
     hideTvVolume: bool(o.hideTvVolume, DEFAULTS.hideTvVolume),
     showTaps: bool(o.showTaps, DEFAULTS.showTaps),
     traceDrags: bool(o.traceDrags, DEFAULTS.traceDrags),

--- a/app/lib/tour.ts
+++ b/app/lib/tour.ts
@@ -43,6 +43,11 @@ export type TourStep = {
 };
 
 export const TOUR_STEPS: TourStep[] = [
+  // Six steps, one per place a new user would otherwise miss the point. The tour
+  // was 16 and read as a manual; trimmed to the handful that teach something the
+  // UI does not make obvious on its own. Steps whose anchor is absent still
+  // self-skip (see useTourAnchor), so a box missing one surface just shows fewer.
+
   // CONSOLE — why the app exists.
   {
     tab: 'index',
@@ -50,67 +55,13 @@ export const TOUR_STEPS: TourStep[] = [
     title: 'Is the box even awake?',
     body: 'Temperature, load, memory and disks, live. The first thing to check when the TV is black and the controller does nothing.',
   },
-  {
-    tab: 'index',
-    anchor: 'console.display',
-    title: 'What the TV is actually being sent',
-    body: 'Resolution, refresh, HDR and which output is connected. When the picture is wrong, this says whether the box even thinks a screen is there.',
-  },
-  {
-    tab: 'index',
-    anchor: 'console.screen',
-    title: 'See the screen from here',
-    body: 'Pull a still frame of what the TV is actually showing — the difference between "it crashed" and "it is sitting on a login prompt".',
-  },
 
   // LAUNCH — the thing people open it for daily.
   {
     tab: 'launch',
     anchor: 'launch.grid',
-    title: 'Your library, with cover art',
-    // Do NOT say "tap one and it starts": tapping opens the confirm sheet, and
-    // the very next step explains that. Saying both is a tour arguing with
-    // itself in front of a new user.
-    body: 'Every game the box has, laid out with its art. No Big Picture menus, no hunting across a grid with a D-pad.',
-  },
-  {
-    tab: 'launch',
-    anchor: 'launch.grid',
     title: 'Tap asks before it launches',
-    body: 'A tap opens the game rather than starting it, with playtime and when you last opened it. Launching takes over the TV, so it is never one stray tap.',
-  },
-  // The next two are anchored to controls that only exist once a library is
-  // big enough to need them (8+ games). On a small library there is no filter
-  // and no shuffle, and these steps skip themselves rather than describing
-  // buttons the user will go hunting for and never find.
-  {
-    tab: 'launch',
-    anchor: 'launch.filter',
-    title: 'Narrow it down',
-    body: 'Filter by never-played, under two hours, or not touched in a year. The button counts as you go, so you can see the shortlist shrink.',
-  },
-  {
-    tab: 'launch',
-    anchor: 'launch.shuffle',
-    title: 'Or let it choose',
-    body: 'The shuffle picks from whatever is currently showing — so "something short I have never played" is one tap away.',
-  },
-  // Anchored INSIDE the cards (components/InstallableSection, PlaylogCard), so
-  // each step only shows when its card actually rendered: the install card needs
-  // owned-but-uninstalled games, the Playlog needs at least one queued game.
-  // No card, no anchor, step skips — the same "never describe an absent control"
-  // rule as the filter/shuffle steps above.
-  {
-    tab: 'launch',
-    anchor: 'launch.installable',
-    title: 'Your whole library — even what you haven’t installed',
-    body: 'Games you own but never downloaded show up here. Kick off the install on the box from the couch; no Big Picture, no keyboard.',
-  },
-  {
-    tab: 'launch',
-    anchor: 'launch.playlog',
-    title: 'Line up what to play next',
-    body: 'Bookmark a game and it lands in your Playlog — a play-next queue you can reorder. Not installed yet? Tap it there to install.',
+    body: 'Your library with cover art — no Big Picture, no D-pad hunting. A tap opens the game rather than starting it, with playtime and when you last opened it; launching takes over the TV, so it is never one stray tap.',
   },
 
   // PAD — the hardware replacement.
@@ -121,15 +72,9 @@ export const TOUR_STEPS: TourStep[] = [
     tab: 'pad',
     anchor: 'pad.modes',
     title: 'The phone is a controller',
-    body: 'Switch to PAD for a real gamepad the box cannot tell from plastic: sticks, D-pad, triggers, haptics. For when the real one is dead or across the room.',
+    body: 'Switch to PAD for a real gamepad the box cannot tell from plastic: sticks, D-pad, triggers, haptics. SWIPE works like an Apple TV remote and MOUSE is a trackpad you can type through — for the login boxes a controller cannot handle.',
   },
-  {
-    tab: 'pad',
-    anchor: 'pad.modes',
-    title: 'Trackpad, swipe, and a keyboard',
-    body: 'SWIPE works like an Apple TV remote and MOUSE is a trackpad you can type through — for the login boxes and launcher updates a controller cannot handle.',
-  },
-  // The shortcut for the switch two steps up. Worth its own step because the
+  // The shortcut for the mode switch above. Worth its own step because the
   // selector sits at the very top of the screen and this does the same job
   // under your thumb — and nobody finds it by accident.
   {
@@ -144,35 +89,13 @@ export const TOUR_STEPS: TourStep[] = [
     tab: 'actions',
     anchor: 'actions.high',
     title: 'Unstick a frozen display',
-    // NAME THE CONTROL AS IT IS LABELLED. This used to say "restart the
-    // display", which is not a button that exists — the user scanned the list
-    // for it and found nothing. It also sold the action as the harmless hero
-    // move while the UI tags it red and "ends session". A tour that undersells
-    // the cost of a destructive action is worse than one that never mentions it.
+    // NAME THE CONTROL AS IT IS LABELLED. Saying "restart the display" sent users
+    // hunting for a button that does not exist; and the action is tagged red and
+    // "ends session", so the tour must not undersell its cost.
     body: 'Restart Session rebuilds the desktop when the TV is black but the machine is plainly still running. It closes what is open, which is why it sits under "Ends your session".',
-  },
-  // Anchored to the ROUTINE group, which is the one that is often ABSENT: a
-  // plain Linux box reports no harmless actions at all (the only one is
-  // "Restart Decky", which needs Decky installed), while a Windows box does.
-  // This step used to claim three groups unconditionally, in front of a screen
-  // showing two.
-  {
-    tab: 'actions',
-    anchor: 'actions.routine',
-    title: 'Grouped by what it costs you',
-    body: 'The harmless ones sit up here, apart from the ones that change what is on the TV and the ones that end your session. Nothing destructive sits next to something safe.',
   },
 
   // SETUP — where the rest lives.
-  // The logs step lives HERE, not on Console. It used to be a Console step
-  // describing "the services you care about and their journal" — a screen that
-  // has no logs on it at all. LogsPanel is a Setup section, and always was.
-  {
-    tab: 'setup',
-    anchor: 'setup.logs',
-    title: 'Read the logs without a keyboard',
-    body: 'The services you care about and their journal, on the phone. No SSH, no crawling behind the TV.',
-  },
   {
     tab: 'setup',
     anchor: 'setup.tabs',


### PR DESCRIPTION
Busy-UI passes. Four built, one skipped on evidence.

**#6 Feature tour 16 → 6 steps** (`lib/tour.ts`) — one high-value step per place a new user would miss the point; cut 10 pointing at self-evident/conditional UI. Counts derive from `TOUR_STEPS.length`; orphaned anchors inert + invisible to the one-directional parity test. `tour.test.ts` green.

**#4 Console vitals glance strip** (`index.tsx`) — six stacked cards → one strip (TEMP · LOAD · MEM% · BATT% + uptime/ip) with MEMORY/DISKS/BATTERY detail below. console.cpu anchor rides the strip; VitalsContext breathing untouched.

**#5a Prefs DIAGNOSTICS group** (`setup.tsx`) — pulled the two polling controls out of the 13-item GENERAL into their own group.

**#5b Launch hold-to-edit + drop 2 redundant toggles** (`launch.tsx`, `lib/launchLayout.ts`, `prefs.ts`, `setup.tsx`) — extended the Console/Fleet/Actions reorder/hide to the Launch aux cards (installable, playlog, downloads, stream-from-PC; Now Playing pinned, grid primary). Deleted the `hideDownloads` / `hideStreamFromPc` prefs + their Setup toggles — hold-to-edit hide replaces them. Kept the offline-hosts row filter and the stream fold.

**Verified by pressing (web harness):** tour "1 of 6" spotlights the strip + advances to /launch; vitals strip renders with detail below; Prefs shows GENERAL < DIAGNOSTICS < APPEARANCE; Launch Customize shows ↑/↓/eye strips, eye-off hides downloads (persists to `couchside.launchLayout.v1`), Done removes it, the two Setup toggles are gone. tsc clean (3 pre-existing `/decky` route-type errors, untouched files).

**Skipped, with evidence:**
- **#2 collapsed-card summaries** — the MORE tool cards are LIVE probe-and-appear by design (poll the box, render null on unavailable; deliberately not caps-cached). So no accurate presence exists while collapsed+unmounted: caps-based over-advertises absent hardware, mount-always defeats the fold (perf), last-known only works after you've already opened MORE. No honest+useful version without a perf regression — left as-is.
- **#7 contextual Pad rows** — pad already aggressively state-gated; the one candidate would hide working buttons on older Steam boxes. Net-negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)