### PR TITLE
fix(leds): stand down when Steam owns the light bar instead of fighting it (agent 2.9.106)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,16 @@ jobs:
       - name: Unit tests (led strip)
         run: python3 tests/test_led_strip.py
 
+      # Steam grabs valve-leds for its own use (download progress) by writing
+      # multi_intensity in the SAME manual mode our sequence engine paints in, so
+      # our repaint fights it and the bar flickers (seen on hardware). The engine
+      # reads back a canary node and STANDS DOWN when its paint stops sticking,
+      # resuming only once the strip is free. Proves both states -- fires under
+      # clobbering, never under a paint that sticks -- and that a stood-down strip
+      # stops writing and only ever touches the fixed-literal attrs.
+      - name: Unit tests (led stand-down)
+        run: python3 tests/test_led_standdown.py
+
       # Which filesystems the dashboard reports. A Deck owner was shown
       # "3.5 / 5.0 GB, 69%" because read_disks() only looked at "/" -- which on
       # SteamOS is a small READ-ONLY rootfs -- and never mentioned /home. Asserts

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,16 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.106
+
+**Your light bar stops fighting Steam.** On a Steam Deck or Steam Machine, Steam
+sometimes takes over the front light bar for itself — for example to show download
+progress. If you had a Couchside effect running (a rainbow or any animation), the
+two used to fight over the bar and it flickered. Now Couchside notices when Steam
+has taken the bar, quietly steps aside so Steam's own lighting shows cleanly, and
+brings your effect back on its own a few seconds after Steam is done. Nothing to
+set — a bar that wasn't flickering is unaffected.
+
 ## 2.9.105
 
 **Install Decky Loader and manage its plugins from your phone.** A new Decky

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.105"
+VERSION = "2.9.106"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -5003,10 +5003,11 @@ def _led_clear_trigger(name):
         pass
 
 
-def _led_write_color(name, raw, color):
-    """Write client {r,g,b} (0-255) to multi_intensity in the DEVICE's channel
-    order (raw['index']), scaled to each channel's max, whole array at once (the
-    kernel needs every element in one write)."""
+def _led_color_vals(raw, color):
+    """The multi_intensity STRING for {r,g,b} on `raw`: the DEVICE's channel order
+    (raw['index']), each value scaled to its channel max. Single source of truth
+    shared by the writer AND the stand-down readback check, so the compare uses the
+    exact string we wrote (no re-derivation drift)."""
     canon = {"red": color["r"], "green": color["g"], "blue": color["b"]}
     maxint = raw["maxint"]
     maxb = raw["max_brightness"]
@@ -5015,7 +5016,14 @@ def _led_write_color(name, raw, color):
         v = canon.get(ch, 0)
         chmax = _led_chmax(maxint, i, maxb)
         vals.append(str(max(0, min(chmax, round(v * chmax / 255)))))
-    _led_write(name, "multi_intensity", " ".join(vals))
+    return " ".join(vals)
+
+
+def _led_write_color(name, raw, color):
+    """Write client {r,g,b} (0-255) to multi_intensity in the DEVICE's channel
+    order (raw['index']), scaled to each channel's max, whole array at once (the
+    kernel needs every element in one write)."""
+    _led_write(name, "multi_intensity", _led_color_vals(raw, color))
 
 
 def set_led(name, brightness, color):
@@ -5630,6 +5638,18 @@ _SEQ_ACTIVE = {}                 # prefix -> spec (members/effect/color/speed/br
 _SEQ_THREAD = [None]
 _SEQ_TAIL = 3                    # comet head + fading-tail length
 
+# Stand-down: Steam grabs valve-leds itself (download progress, etc.), writing
+# multi_intensity in the SAME `manual` mode we paint in -> our repaint fights it
+# and the bar flickers. We read back a canary node each frame; if our paint stops
+# sticking we STOP writing (let Steam own the bar) and probe a single node on a
+# slow cadence, resuming only once it holds again. Readback = ground truth, so
+# this catches ANY external writer, self-resumes, and cuts our write load while
+# Steam is busy. Thresholds give ~fast detect (a few frames) + slow, hysteretic
+# resume (avoid oscillating against a still-busy Steam). See _seq_standdown_decide.
+_SEQ_STANDDOWN_MISS = 3          # consecutive canary misses before standing down (~100ms @30fps)
+_SEQ_STANDDOWN_HITS = 3          # consecutive clean probes before resuming
+_SEQ_PROBE_INTERVAL = 2.0        # seconds between probes while stood down
+
 
 def _seq_period(speed):
     """Speed 1..100 -> seconds for one full lap around the strip (higher = faster).
@@ -5690,8 +5710,10 @@ def _seq_frame_twinkle(n, t, period, color):
     return frame
 
 
-def _seq_render(spec, now):
-    """Write ONE frame of `spec` to its strip via the fixed-literal writers."""
+def _seq_compute_frame(spec, now):
+    """The per-LED frame for this strip animation at time `now`, or None if there's
+    nothing to draw. Pure time+geometry -> colour; performs no writes so it stays
+    unit-testable and is reused by both the paint path and the stand-down probe."""
     members = spec["members"]
     n = len(members)
     t = now - spec["t0"]
@@ -5700,14 +5722,14 @@ def _seq_render(spec, now):
     color = spec["color"]
     rev = bool(spec.get("reverse"))
     if e == "circle":
-        frame = _seq_frame_sweep(n, t, period, color, _SEQ_TAIL, rev)
-    elif e == "comet":
-        frame = _seq_frame_sweep(n, t, period, color, max(4, n // 2), rev)
-    elif e == "wipe":
-        frame = _seq_frame_wipe(n, t, period, color, rev)
-    elif e == "twinkle":
-        frame = _seq_frame_twinkle(n, t, period, color)
-    elif e == "sequence":
+        return _seq_frame_sweep(n, t, period, color, _SEQ_TAIL, rev)
+    if e == "comet":
+        return _seq_frame_sweep(n, t, period, color, max(4, n // 2), rev)
+    if e == "wipe":
+        return _seq_frame_wipe(n, t, period, color, rev)
+    if e == "twinkle":
+        return _seq_frame_twinkle(n, t, period, color)
+    if e == "sequence":
         # A custom TIMED sequence: a list of per-LED frames (already normalized to n
         # members at validation). With per-frame `holds` (one ms per frame) we walk a
         # cumulative timeline; without them every frame shows for the uniform
@@ -5715,7 +5737,7 @@ def _seq_render(spec, now):
         # alternate-colour feature builds (2 frames) and the N-frame editor builds.
         frames = spec.get("frames") or []
         if not frames:
-            return
+            return None
         loop = spec.get("loop", True)
         holds = spec.get("holds")
         if holds and len(holds) == len(frames):
@@ -5743,11 +5765,32 @@ def _seq_render(spec, now):
             hold = max(0.03, spec.get("hold_ms", 500) / 1000.0)
             step = int(t / hold)
             idx = (step % len(frames)) if loop else min(step, len(frames) - 1)
-        frame = frames[idx]
-    else:
-        return
+        return frames[idx]
+    return None
+
+
+def _seq_canary_index(frame):
+    """Index of the first LIT (non-black) member in `frame` -- the node we read
+    back to tell whether our paint stuck, and the ONLY node we touch while probing
+    a stood-down strip. None if the frame lights nothing (can't verify this tick)."""
+    for i, c in enumerate(frame):
+        if c is not None and (c.get("r") or c.get("g") or c.get("b")):
+            return i
+    return None
+
+
+def _seq_paint(spec, frame, only_index=None):
+    """Write `frame` to the strip via the SAME fixed-literal writers as before
+    (multi_intensity + brightness, per member; brightness 0 for a dark cell).
+    only_index -> write JUST that one member (a light one-LED probe used while
+    stood down). Returns (canary_name, expected_multi_intensity) for a lit member
+    we can read back, or (None, None) when the frame lit nothing we wrote."""
+    members = spec["members"]
     bmax = spec["brightness"]
-    for i, name in enumerate(members):
+    canary_name, canary_vals = None, None
+    idxs = (only_index,) if only_index is not None else range(len(members))
+    for i in idxs:
+        name = members[i]
         raw = spec["raws"].get(name)
         if not raw:
             continue
@@ -5757,10 +5800,99 @@ def _seq_render(spec, now):
                 _led_write_color(name, raw, c)
                 _led_write(name, "brightness",
                            str(int(bmax / 100.0 * raw["max_brightness"] + 0.5)))
+                if canary_name is None and (c.get("r") or c.get("g") or c.get("b")):
+                    # Remember the exact string _led_write_color just wrote, so the
+                    # readback compare is an identity check (no re-derivation drift).
+                    canary_name, canary_vals = name, _led_color_vals(raw, c)
             else:
                 _led_write(name, "brightness", "0")
         except OSError:
             pass
+    return canary_name, canary_vals
+
+
+def _seq_canary_matches(name, expected):
+    """True if strip node `name` still reads back the multi_intensity we wrote (our
+    paint stuck), False if another writer clobbered it (e.g. Steam grabbing the bar
+    for download progress -- it writes in the SAME `manual` mode we do), None if
+    unreadable/undeterminable (degrade closed -> the decider ignores None)."""
+    if name is None:
+        return None
+    got = _led_read_attr(name, "multi_intensity")
+    if got is None:
+        return None
+    return got.split() == expected.split()
+
+
+def _seq_standdown_decide(spec, matched, now):
+    """Advance a strip's stand-down state from whether our last paint stuck.
+    `matched`: True (stuck) / False (clobbered) / None (couldn't tell -> ignore).
+    Returns True while we are stood down, so the caller stops full painting and
+    lets Steam own the bar cleanly. See _SEQ_STANDDOWN_* for the mechanism."""
+    if matched is None:
+        return spec.get("_down", False)
+    if not spec.get("_down", False):
+        if matched:
+            spec["_miss"] = 0
+            return False
+        spec["_miss"] = spec.get("_miss", 0) + 1
+        if spec["_miss"] >= _SEQ_STANDDOWN_MISS:
+            spec["_down"] = True
+            spec["_hit"] = 0
+            spec["_probe_at"] = now + _SEQ_PROBE_INTERVAL
+            print("[led] %s: standing down (strip owned by another writer)"
+                  % spec.get("effect", "seq"), flush=True)
+        return spec.get("_down", False)
+    # Stood down: a clean probe advances toward resume; a clobbered one resets the
+    # streak and holds us down (hysteresis -> no flicker fighting a busy Steam).
+    if matched:
+        spec["_hit"] = spec.get("_hit", 0) + 1
+        if spec["_hit"] >= _SEQ_STANDDOWN_HITS:
+            spec["_down"] = False
+            spec["_miss"] = 0
+            spec["_hit"] = 0
+            print("[led] %s: resuming (strip free again)"
+                  % spec.get("effect", "seq"), flush=True)
+    else:
+        spec["_hit"] = 0
+    return spec.get("_down", False)
+
+
+def _seq_render(spec, now):
+    """Write ONE frame of `spec` to its strip via the fixed-literal writers -- but
+    STAND DOWN while another writer owns the strip. On a Steam Deck/Machine, Steam
+    grabs valve-leds for its own use (download progress, etc.) by writing
+    multi_intensity in the SAME `manual` mode we paint in, so our ~30fps repaint
+    fights it (observed: the bar flickers between our frame and all-black).
+
+    Detection is a SURVIVAL check across the inter-frame gap: read the canary we
+    wrote LAST frame BEFORE repainting. Reading right after our own write is
+    useless -- we always win that microsecond; Steam clobbers in the ~33ms between
+    frames, which only a cross-frame readback sees. Once our paint stops surviving
+    we stop writing and let Steam have the bar, probing a SINGLE node every
+    _SEQ_PROBE_INTERVAL and resuming only when our paint holds again. The timeline
+    is `now`-based, so a resume picks up at the correct phase (no restart jump)."""
+    frame = _seq_compute_frame(spec, now)
+    if frame is None:
+        return
+    if spec.get("_down", False):
+        # Leave Steam's bar alone; just probe one node on a slow cadence, checking
+        # whether the PREVIOUS probe write survived the interval.
+        if now < spec.get("_probe_at", 0.0):
+            return
+        matched = _seq_canary_matches(*spec.get("_canary", (None, None)))
+        ci = _seq_canary_index(frame)
+        if ci is not None:
+            spec["_canary"] = _seq_paint(spec, frame, only_index=ci)
+        _seq_standdown_decide(spec, matched, now)
+        if spec.get("_down", False):
+            spec["_probe_at"] = now + _SEQ_PROBE_INTERVAL
+        return
+    # Did last frame's paint survive until now? (the window Steam actually writes
+    # in). Decide on that, THEN lay down this frame and remember its canary.
+    matched = _seq_canary_matches(*spec.get("_canary", (None, None)))
+    spec["_canary"] = _seq_paint(spec, frame)
+    _seq_standdown_decide(spec, matched, now)
 
 
 def _seq_loop():

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1381,6 +1381,24 @@ recommendation was wrong, not merely superseded.
 
 ## ✅ Completed
 
+### LED strip stand-down — stop fighting Steam for the light bar — 2026-09-08
+- **was:** owner-reported "light bar spazzing on the Steam machine" while a game ran and a
+  download was in flight, LED set to rainbow · **affects:** agent (`agent/couchsided.py`)
+- **Root cause (hardware-confirmed on `steam-machine`):** the rainbow was an agent-rendered
+  `sequence` (not the firmware `rainbow` effect). Steam grabs the valve-leds bar for its own
+  use during downloads, writing `multi_intensity` in the SAME `manual` mode we paint in; our
+  ~30fps repaint fought it → the strip flickered rainbow↔black (a fast sysfs sample read
+  all-black on ~half the ticks; `effect` stayed `manual` throughout).
+- **Fix:** `_seq_render` reads back a canary node and STANDS DOWN when its paint stops
+  surviving the inter-frame gap — stops writing, lets Steam own the bar, probes one node
+  every `_SEQ_PROBE_INTERVAL`, resumes on a clean-probe streak. Hysteresis both ways;
+  `None` readback degrades closed. No new client surface (fixed-literal attr on an
+  allowlisted node). New pattern recorded in CONVENTIONS §1.
+- **Verified:** `tests/test_led_standdown.py` (8 checks, both states) + a CI step; all four
+  existing LED suites still green. In-vivo on `steam-machine`: journal shows
+  `standing down` ↔ `resuming (strip free again)` tracking the download, flicker gone
+  (~50% black → 24/24 clean). Ships in agent 2.9.106.
+
 ### Repo-wide audit — bugs fixed + dead code removed — 2026-08-16
 - **was:** owner-directed "analyze the repo for simplification/optimization" ·
   **affects:** agent, installer, release scripts, tests, app

--- a/docs/memory/CONVENTIONS.md
+++ b/docs/memory/CONVENTIONS.md
@@ -104,6 +104,30 @@ and the frozen `_DM_CONF_DIRS` table (`sddm`, `plasmalogin`) — conf dir, drop-
 only itself; the symlink proves which manager runs. No detected manager (or no grant for
 the detected one) = no capability, no action — never a fallback to SDDM.
 
+### Don't fight a shared device — stand down on a readback-survival check
+
+When the agent animates a device the platform ALSO writes, cooperate instead of
+overwriting. The valve-leds strip is the case: on a Steam Deck/Machine, Steam grabs the
+front bar for its own use (download progress — it writes `multi_intensity` in the SAME
+`manual` mode we paint in), so the sequence engine's ~30fps repaint fought it and the bar
+flickered between our frame and all-black. Fix (`_seq_render`, since agent 2.9.106): read
+back a canary node and STAND DOWN — stop writing, let the platform own the device — probing
+a single node every `_SEQ_PROBE_INTERVAL` and resuming only once our paint holds again.
+
+Two rules the hardware taught:
+- **Measure survival across the inter-frame gap, not right after your own write.** A
+  readback in the same frame you wrote always matches — you won that microsecond; the other
+  writer clobbers in the ~33ms *between* frames. Check whether LAST frame's canary is still
+  there BEFORE repainting. (The first version read back in-frame, passed its unit test, and
+  did nothing on the box — the mock modelled "always black" and hid the timing. Test the
+  thing: the log line `[led] … standing down` and a rapid sysfs sample were the proof.)
+- **Hysteresis both ways + degrade closed.** A few consecutive misses to stand down, a
+  streak of clean probes to resume (`_SEQ_STANDDOWN_MISS`/`_HITS`), and an unreadable
+  canary (`None`) never trips it. Verified on `steam-machine` 2026-09-08: the state machine
+  oscillates with the download (`standing down` ↔ `resuming (strip free again)` in the
+  journal), flicker gone (was ~50% black, went 24/24 clean). No new client-reachable
+  surface — the readback is a fixed-literal attr on an already-allowlisted node (§3).
+
 ---
 
 ## 2. Tests (`tests/test_*.py`)

--- a/tests/test_led_standdown.py
+++ b/tests/test_led_standdown.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Tests for the LED strip STAND-DOWN under an external writer (valve-leds).
+
+Run: python3 tests/test_led_standdown.py
+
+On a Steam Deck / Machine, Steam grabs the front strip for its own use (download
+progress, etc.) by writing multi_intensity in the SAME `manual` mode the agent's
+sequence engine paints in. Our ~30fps repaint then FIGHTS Steam's writes and the
+bar flickers between our frame and all-black (observed on hardware: ~half of a
+fast sample read [0 0 0] on every node at once).
+
+The fix: read back a canary node each frame; when our paint stops sticking, STOP
+writing (let Steam own the bar) and probe a single node on a slow cadence,
+resuming only once our paint holds again.
+
+The properties that matter, and are proved here by OBSERVING BOTH STATES:
+  * paint sticks  -> never stands down, keeps painting  (the control)
+  * paint clobbered -> stands down after a few frames, then stops writing
+  * strip freed   -> resumes after a clean-probe streak
+  * an undeterminable readback (None) never trips it (degrade closed)
+  * only the fixed-literal attrs are ever written (no new write surface, §3)
+
+Pure stdlib, no pytest.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+
+
+def check(cond, label):
+    print((PASS if cond else FAIL) + "  " + label)
+    if not cond:
+        _fail.append(label)
+
+
+_N = 3
+
+
+def _raw(name):
+    return {"name": name, "desc": name, "rgb": True, "notable": True,
+            "writable": True, "max_brightness": 255,
+            "index": ["red", "green", "blue"], "maxint": [255, 255, 255],
+            "brightness": 0, "color": {"r": 0, "g": 0, "b": 0}}
+
+
+def _make_spec():
+    """A 3-node strip playing a 2-frame all-red / all-blue sequence (both frames
+    light node 0, so the canary is always verifiable)."""
+    members = ["valve-leds[%d]" % i for i in range(_N)]
+    R = [{"r": 255, "g": 0, "b": 0} for _ in range(_N)]
+    B = [{"r": 0, "g": 0, "b": 255} for _ in range(_N)]
+    return {"members": members, "effect": "sequence", "frames": [R, B],
+            "hold_ms": 100, "holds": None, "loop": True, "brightness": 100,
+            "color": {"r": 255, "g": 255, "b": 255}, "speed": 50,
+            "t0": 0.0, "raws": {n: _raw(n) for n in members}}
+
+
+def _install(steam):
+    """Fake sysfs. `steam` is a mutable {"on": bool}: when on, every
+    multi_intensity readback comes back [0 0 0] (Steam has blanked the strip),
+    modelling the observed contention; when off, our last write reads back (our
+    paint sticks). Returns (writes, restore)."""
+    saved = {k: getattr(cs, k) for k in ("_led_write", "_led_read_attr")}
+    writes = []
+    hw = {}
+
+    def _write(name, attr, value):
+        writes.append((name, attr, value))
+        if attr == "multi_intensity":
+            hw[name] = value
+
+    def _read(name, attr):
+        if attr == "multi_intensity":
+            return "0 0 0" if steam["on"] else hw.get(name)
+        if attr == "trigger":
+            return "[none]"
+        return None
+
+    cs._led_write = _write
+    cs._led_read_attr = _read
+
+    def restore():
+        for k, v in saved.items():
+            setattr(cs, k, v)
+    return writes, restore
+
+
+# --------------------------------------------------------------------------- #
+# Pure decider: fires, ignores None, resumes -- all thresholds observed both ways
+# --------------------------------------------------------------------------- #
+def test_decider_fires_and_controls():
+    print("decider: clobbered N times stands down; clean paint never does")
+    # CONTROL: a paint that always sticks must NEVER stand down, however long.
+    st = {}
+    for _ in range(50):
+        down = cs._seq_standdown_decide(st, True, 0.0)
+        if down:
+            break
+    check(not st.get("_down"), "clean paint never stands down (control)")
+
+    # FIRES: exactly _SEQ_STANDDOWN_MISS consecutive misses trip it, not fewer.
+    st = {}
+    for i in range(cs._SEQ_STANDDOWN_MISS - 1):
+        cs._seq_standdown_decide(st, False, 0.0)
+    check(not st.get("_down"),
+          "not down at %d misses" % (cs._SEQ_STANDDOWN_MISS - 1))
+    cs._seq_standdown_decide(st, False, 0.0)
+    check(st.get("_down") is True,
+          "down at %d misses" % cs._SEQ_STANDDOWN_MISS)
+
+
+def test_decider_none_ignored():
+    print("decider: an undeterminable readback (None) never trips it")
+    st = {}
+    for _ in range(cs._SEQ_STANDDOWN_MISS + 5):
+        cs._seq_standdown_decide(st, None, 0.0)
+    check(not st.get("_down"), "None readbacks never stand down (degrade closed)")
+
+
+def test_decider_miss_streak_resets():
+    print("decider: a single clean paint resets the miss streak")
+    st = {}
+    for _ in range(cs._SEQ_STANDDOWN_MISS - 1):
+        cs._seq_standdown_decide(st, False, 0.0)
+    cs._seq_standdown_decide(st, True, 0.0)      # clean -> reset
+    for _ in range(cs._SEQ_STANDDOWN_MISS - 1):
+        cs._seq_standdown_decide(st, False, 0.0)
+    check(not st.get("_down"), "reset streak means still up after a near miss")
+
+
+def test_decider_resume_needs_streak():
+    print("decider: resume needs a full clean-probe streak (a miss resets it)")
+    st = {"_down": True, "_hit": 0}
+    for _ in range(cs._SEQ_STANDDOWN_HITS - 1):
+        cs._seq_standdown_decide(st, True, 0.0)
+    check(st.get("_down"), "still down before the streak completes")
+    cs._seq_standdown_decide(st, False, 0.0)     # one dirty probe wipes progress
+    for _ in range(cs._SEQ_STANDDOWN_HITS - 1):
+        cs._seq_standdown_decide(st, True, 0.0)
+    check(st.get("_down"), "a dirty probe reset the resume streak")
+    cs._seq_standdown_decide(st, True, 0.0)
+    check(not st.get("_down"), "resumes after a full clean streak")
+
+
+# --------------------------------------------------------------------------- #
+# Integration through _seq_render against a fake contended sysfs
+# --------------------------------------------------------------------------- #
+def test_render_control_keeps_painting():
+    print("render CONTROL: when our paint sticks, it keeps painting, never down")
+    steam = {"on": False}
+    writes, restore = _install(steam)
+    try:
+        sp = _make_spec()
+        for k in range(20):
+            cs._seq_render(sp, k * 0.05)
+        painted = [w for w in writes if w[1] == "multi_intensity"]
+        check(not sp.get("_down"), "never stands down while paint sticks")
+        check(len(painted) >= 20 * _N - _N,
+              "keeps painting every node every frame (%d writes)" % len(painted))
+    finally:
+        restore()
+
+
+def test_render_stands_down_and_stops_writing():
+    print("render FIRES: Steam clobbering -> stand down -> stop writing the strip")
+    steam = {"on": True}
+    writes, restore = _install(steam)
+    try:
+        sp = _make_spec()
+        # Detection is cross-frame (survival), so frame 0 has no prior canary and
+        # counts no miss -> tripping takes MISS + 1 frames.
+        for k in range(cs._SEQ_STANDDOWN_MISS + 1):
+            cs._seq_render(sp, k * 0.01)
+        check(sp.get("_down") is True, "stood down under sustained clobbering")
+        probe_at = sp["_probe_at"]
+
+        # Between probes it must write NOTHING (leave Steam's bar alone).
+        del writes[:]
+        cs._seq_render(sp, probe_at - 0.01)
+        check(len(writes) == 0, "no writes between probes while stood down")
+
+        # A probe touches ONLY the single canary node, not the whole strip.
+        del writes[:]
+        cs._seq_render(sp, probe_at + 0.01)
+        touched = {w[0] for w in writes}
+        check(len(touched) == 1, "a probe touches exactly one node, not all %d" % _N)
+        check(sp.get("_down") is True, "still down (probe was clobbered too)")
+    finally:
+        restore()
+
+
+def test_render_resumes_when_freed():
+    print("render RESUME: strip freed -> clean probes -> full painting returns")
+    steam = {"on": True}
+    writes, restore = _install(steam)
+    try:
+        sp = _make_spec()
+        for k in range(cs._SEQ_STANDDOWN_MISS + 1):
+            cs._seq_render(sp, k * 0.01)
+        check(sp.get("_down"), "stood down first")
+
+        # Steam lets go; each probe (>= probe_at) now sticks. Walk enough probes.
+        steam["on"] = False
+        now = sp["_probe_at"]
+        for _ in range(cs._SEQ_STANDDOWN_HITS + 1):
+            cs._seq_render(sp, now + 0.01)
+            now = sp.get("_probe_at", now) if sp.get("_down") else now
+        check(not sp.get("_down"), "resumed after a clean-probe streak")
+
+        # And a normal frame now paints the whole strip again.
+        del writes[:]
+        cs._seq_render(sp, now + 0.5)
+        touched = {w[0] for w in writes if w[1] == "multi_intensity"}
+        check(len(touched) == _N, "full painting resumed (all %d nodes)" % _N)
+    finally:
+        restore()
+
+
+def test_render_only_touches_fixed_attrs():
+    print("safety: stand-down never writes anything but the fixed-literal attrs")
+    allowed = {"multi_intensity", "brightness"}
+    for on in (False, True):
+        steam = {"on": on}
+        writes, restore = _install(steam)
+        try:
+            sp = _make_spec()
+            now = 0.0
+            for _ in range(cs._SEQ_STANDDOWN_MISS + 3):
+                cs._seq_render(sp, now)
+                now = (sp.get("_probe_at", now) + 0.01) if sp.get("_down") else now + 0.05
+            bad = sorted({w[1] for w in writes} - allowed)
+            check(not bad, "steam=%s: only %s written (saw extra: %s)"
+                  % (on, sorted(allowed), bad))
+        finally:
+            restore()
+
+
+if __name__ == "__main__":
+    for fn in (test_decider_fires_and_controls, test_decider_none_ignored,
+               test_decider_miss_streak_resets, test_decider_resume_needs_streak,
+               test_render_control_keeps_painting,
+               test_render_stands_down_and_stops_writing,
+               test_render_resumes_when_freed,
+               test_render_only_touches_fixed_attrs):
+        fn()
+    if _fail:
+        print("\n\033[31m%d check(s) failed\033[0m" % len(_fail))
+        raise SystemExit(1)
+    print("\nall led stand-down tests passed")


### PR DESCRIPTION
## The bug

Owner report: "light bar spazzing out on my Steam machine" while a game was running and a game was downloading — LED set to rainbow from the app.

Diagnosed on hardware (`steam-machine`), not from the code alone:
- The rainbow was an **agent-rendered `sequence`** (per-frame `multi_intensity` writes), not the firmware `rainbow` effect. So firmware CPU-offload doesn't apply.
- A fast sysfs sample of a strip node read **all-black on ~half the ticks**, interleaved with valid rainbow frames — while `effect` stayed `manual` the whole time. The sequence has no black frame, so the black came from **another writer**: Steam grabs the valve-leds bar for its own use during the download, writing `multi_intensity` in the same `manual` mode we paint in.
- Result: our ~30fps repaint fought Steam's writes → rainbow↔black flicker.

## The fix

`_seq_render` now runs a **readback-survival stand-down**:
- Read back a canary node **before repainting** — i.e. check whether *last* frame's paint survived the ~33ms inter-frame gap (the window Steam actually writes in). An in-frame readback is useless: we always win that microsecond.
- On a short miss streak → **stop writing** and let Steam own the bar. Probe a single node every `_SEQ_PROBE_INTERVAL`; resume on a clean-probe streak.
- Hysteresis both directions (`_SEQ_STANDDOWN_MISS` / `_HITS`); an unreadable canary (`None`) degrades closed.

**Allowlist / security (CLAUDE.md §3):** no new client-reachable surface. The readback is a fixed-literal attr (`multi_intensity`) on an already-allowlisted strip node; nothing client-supplied reaches a path. Verified by a test that only `multi_intensity`/`brightness` are ever written.

## Verified

- **Unit:** new `tests/test_led_standdown.py` — 8 checks, **both states** (fires under clobbering, never under a paint that sticks), resume streak + reset, `None`-ignored, and the safety assertion. Wired as its own CI step. All four existing LED suites unchanged and green.
- **In-vivo on `steam-machine`** (patched agent deployed, service restarted): journal captured the full cycle repeatedly —
  ```
  standing down (strip owned by another writer)
  resuming (strip free again)      ← Steam let go
  standing down                    ← Steam retook
  resuming (strip free again)
  ```
  Flicker eliminated: a fast sample went from ~50% black (before) to **24/24 clean** (after). Resume is automatic ~6–10s after Steam releases the bar — no app action, no restart.

### Not verified
- The other agent-rendered strip effects (`circle`/`comet`/`wipe`/`twinkle`) share this exact code path but were only exercised via the `sequence` effect on hardware; covered by unit tests, not eyeballed on the bar.
- Behavior on a non-Steam box is unchanged by inspection (no external writer → canary always sticks → never stands down), not separately hardware-tested.

Ships in **agent 2.9.106** (VERSION + CHANGELOG bumped; new pattern recorded in CONVENTIONS §1; ROADMAP → Completed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
