### PR TITLE
release(2.9.59): iOS build 210 — Lottie launch animation + busy-UI (TestFlight)

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "name": "Couchside",
     "slug": "rescue-remote",
     "owner": "ets3d-llc",
-    "version": "2.9.58",
+    "version": "2.9.59",
     "orientation": "default",
     "icon": "./assets/images/icon.png",
     "scheme": "couchside",
@@ -11,7 +11,7 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.ets3d.rescueremote",
-      "buildNumber": "207",
+      "buildNumber": "210",
       "infoPlist": {
         "ITSAppUsesNonExemptEncryption": false,
         "NSAppTransportSecurity": {


### PR DESCRIPTION
Version bump for the next device-test cut. 2.9.58 is live; **2.9.59 / build 210** carries the Lottie opening animation (lottie-react-native native module) plus the busy-UI passes merged since (vitals strip, tour 16→6, Prefs DIAGNOSTICS group, Launch hold-to-edit).

- `version` 2.9.58 → 2.9.59, `ios.buildNumber` 207 → 210 (clears ASC max 209). Local tf-local build; native lottie framework confirmed in the IPA. altool → TestFlight.
- iOS TestFlight only (device-verify the native LottieView render). Android untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)