### PR TITLE
Console sensors + countdown 'Do it now' + Player seek-hold (agent 2.9.107)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,13 @@ jobs:
       - name: Unit tests (console sensors)
         run: python3 tests/test_console_sensors.py
 
+      # The /api/actions route dispatch. A non-allowlisted id must be 404'd AND
+      # dispatch nothing (asserted on a spy, not inferred from the status code) —
+      # this route hands ids to subprocess, so a hole here runs arbitrary
+      # allowlisted-adjacent commands. Also pins the auth gate on GET and POST.
+      - name: Unit tests (actions endpoint)
+        run: python3 tests/test_actions_endpoint.py
+
       # Steam cover art. The resolver looked only for library_600x900.jpg and
       # left 30 of 80 installed games showing a blank text card while the real
       # capsule sat one directory deeper under a content-hash subdirectory.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,6 +866,14 @@ jobs:
       - name: Unit tests (memory pressure parsing)
         run: python3 tests/test_mem_pressure.py
 
+      # CPU frequency scaling on GET /api/status. read_cpu_freq degrades to {} on
+      # a box with no cpufreq (so `cur_mhz` is never a fabricated 0), reports the
+      # PEAK core clock, and surfaces EPP because amd-pstate-epp handhelds sit on
+      # governor "powersave" permanently. The status splice must OMIT the block
+      # entirely when absent, like `battery` — never a null.
+      - name: Unit tests (console sensors)
+        run: python3 tests/test_console_sensors.py
+
       # Steam cover art. The resolver looked only for library_600x900.jpg and
       # left 30 of 80 installed games showing a blank text card while the real
       # capsule sat one directory deeper under a content-hash subdirectory.

--- a/agent/CHANGELOG.md
+++ b/agent/CHANGELOG.md
@@ -18,6 +18,17 @@ the same thing regardless of what actually changed.
 Write for the person holding the phone, not for the commit log. They are
 deciding whether to press "Update now" on a machine across the room.
 
+## 2.9.107
+
+**More at a glance on the Console.** The vitals strip now shows your CPU's live
+clock speed, and — on a handheld — how healthy the battery is: its full-charge
+capacity compared to when it was new, plus how many charge cycles it has been
+through, so a tired battery is easy to tell from a fresh one. When a game is
+running, each GPU also reports how many watts it is drawing and how fast its
+cores are clocked. Every one of these shows up only on boxes that actually
+measure it, so a machine that can't report a number simply doesn't display it —
+nothing to turn on.
+
 ## 2.9.106
 
 **Your light bar stops fighting Steam.** On a Steam Deck or Steam Machine, Steam

--- a/agent/couchsided.py
+++ b/agent/couchsided.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     fcntl = None
 
 APP_NAME = "couchside-agent"
-VERSION = "2.9.106"
+VERSION = "2.9.107"
 UID = os.getuid()
 XDG_RUNTIME_DIR = "/run/user/%d" % UID
 
@@ -3915,6 +3915,7 @@ def real_status():
     temp = read_cpu_temp_c()
     mem = read_mem()
     battery = read_box_battery()
+    cpu = read_cpu_freq()
     display = display_info()
     audio = audio_info()
     now = int(time.time())
@@ -3936,6 +3937,10 @@ def real_status():
         # new ones can treat "absent" as "this box has no battery" rather than
         # having to distinguish that from 0%.
         **({"battery": battery} if battery else {}),
+        # CPU frequency scaling -- governor, live peak clock, and (on amd-pstate-epp
+        # handhelds) the energy-performance preference. ADDITIVE and OMITTED ENTIRELY
+        # on a box with no cpufreq (a VM), so old apps ignore it (agent >= 2.9.107).
+        **({"cpu": cpu} if cpu else {}),
         # The panel the box is driving, and the default audio OUT/IN devices.
         # Same shape of contract as `battery`: ADDITIVE, and OMITTED ENTIRELY
         # when nothing could be read, so absence means "unavailable" and never
@@ -8857,8 +8862,16 @@ def mock_status():
         # harness -- a mains desktop would render nothing and prove nothing.
         # Mock is DISCHARGING by default; flip status/on_ac and swap
         # minutes for minutes_to_full to exercise the charging layout.
+        # health_pct/cycle_count/capacity_level are set to a slightly-worn pack so
+        # the health detail line renders (100%/0 cycles would read as "no wear").
         "battery": {"pct": 58, "status": "Discharging", "on_ac": False,
-                    "minutes": 251, "watts": 7.7, "profile": "balanced"},
+                    "minutes": 251, "watts": 7.7, "profile": "balanced",
+                    "health_pct": 94, "cycle_count": 112, "capacity_level": "Normal"},
+        # A handheld CPU under load: amd-pstate-epp reports governor "powersave"
+        # permanently, so EPP carries the real intent. Non-quiet values so the
+        # CLOCK tile renders in --mock.
+        "cpu": {"governor": "powersave", "cur_mhz": 2745,
+                "max_mhz": 4900, "epp": "balance_performance"},
         # Mock drives a 4K HDR VRR TV so every display row is renderable, and a
         # sink/source pair that are DIFFERENT devices with a long description --
         # see mock_display_info() / mock_audio_info() for why those specific
@@ -19818,6 +19831,70 @@ def _read_int(path):
         return None
 
 
+def _read_str(path):
+    """Stripped one-line string from a sysfs file, or None (never raises)."""
+    try:
+        with open(path) as f:
+            return f.read().strip() or None
+    except OSError:
+        return None
+
+
+# Root of the per-CPU sysfs tree; a module constant so tests point it at a fixture.
+_CPUFREQ_DIR = "/sys/devices/system/cpu"
+
+
+def read_cpu_freq():
+    """{"governor", "cur_mhz"[, "max_mhz"][, "epp"]} for CPU frequency scaling, or
+    {} when the machine exposes no cpufreq (a VM, or a kernel without the driver).
+
+    Read-only, best-effort, never raises. Every field is independently optional and
+    OMITTED when unreadable -- absence means "unavailable", never a fabricated zero.
+
+    cur_mhz is the HIGHEST scaling_cur_freq across cores -- what the busiest core is
+    doing right now, which a cpu0-only read would miss when the scheduler has parked
+    core 0. On amd-pstate-epp handhelds (Legion Go S, ROG Ally) scaling_governor is
+    permanently "powersave" and the real lever is energy_performance_preference, so
+    EPP is surfaced ALONGSIDE the governor, not instead of it. cpuinfo_cur_freq is
+    deliberately NOT read -- it is 0400 root-only on many kernels, whereas
+    scaling_cur_freq is world-readable.
+    """
+    base = os.path.join(_CPUFREQ_DIR, "cpu0", "cpufreq")
+    governor = _read_str(os.path.join(base, "scaling_governor"))
+    if governor is None:
+        return {}
+    out = {"governor": governor}
+
+    # Peak current clock across all online cores (kHz -> MHz). Reject non-positive
+    # readings rather than reporting a confident 0 MHz.
+    peak_khz = None
+    try:
+        names = os.listdir(_CPUFREQ_DIR)
+    except OSError:
+        names = []
+    for name in names:
+        if not re.fullmatch(r"cpu\d+", name):
+            continue
+        khz = _read_int(os.path.join(_CPUFREQ_DIR, name, "cpufreq",
+                                     "scaling_cur_freq"))
+        if khz and khz > 0 and (peak_khz is None or khz > peak_khz):
+            peak_khz = khz
+    if peak_khz:
+        out["cur_mhz"] = peak_khz // 1000
+
+    max_khz = _read_int(os.path.join(base, "scaling_max_freq"))
+    if max_khz and max_khz > 0:
+        out["max_mhz"] = max_khz // 1000
+
+    # Verbatim like the platform profile -- an EPP string we do not recognise is
+    # still the box's honest self-report.
+    epp = _read_str(os.path.join(base, "energy_performance_preference"))
+    if epp:
+        out["epp"] = epp
+
+    return out
+
+
 def gaming_available():
     """Boot-time caps hint: a box with Steam can have a gaming session worth
     showing. GET /api/gaming is the live authority (per-field probe-and-appear).
@@ -19853,7 +19930,7 @@ def _gpu_sensors_all():
     out = []
     for card in sorted(cards):
         dev = os.path.join(drm, card, "device")
-        hw_name, temp_path = None, None
+        hw_name, temp_path, hw_dir = None, None, None
         # hwmon index is not stable across boxes: match on the name file, never a
         # hardcoded hwmonN (as read_cpu_temp_c does).
         for nf in sorted(glob.glob(os.path.join(dev, "hwmon", "hwmon*", "name"))):
@@ -19864,7 +19941,8 @@ def _gpu_sensors_all():
                 continue
             if nm == "amdgpu":
                 hw_name = nm
-                cand = os.path.join(os.path.dirname(nf), "temp1_input")
+                hw_dir = os.path.dirname(nf)
+                cand = os.path.join(hw_dir, "temp1_input")
                 temp_path = cand if os.path.exists(cand) else None
                 break
         if hw_name is None:
@@ -19907,6 +19985,23 @@ def _gpu_sensors_all():
         busy = _read_int(os.path.join(dev, "gpu_busy_percent"))
         if busy is not None and 0 <= busy <= 100:
             gpu["busy_pct"] = busy
+
+        # Package power draw and core clock, from the amdgpu hwmon. power1_average
+        # is the smoothed draw; newer ASICs expose only power1_input. Microwatts ->
+        # watts; a non-positive reading is a gauge not measuring, so OMIT it (same
+        # rule as battery watts). freq1_input is the core (sclk) clock in Hz -> MHz.
+        # power1_cap (a LIMIT, not a draw) and pp_dpm_sclk (a multi-line,
+        # root-writable table) are deliberately NOT read. MEASURED on a Legion Go S,
+        # 2026-08-27: power1_average 5.07 W, freq1_input 800 MHz, no power1_cap.
+        if hw_dir:
+            uw = _read_int(os.path.join(hw_dir, "power1_average"))
+            if uw is None:
+                uw = _read_int(os.path.join(hw_dir, "power1_input"))
+            if uw is not None and uw > 0:
+                gpu["power_w"] = round(uw / 1e6, 1)
+            hz = _read_int(os.path.join(hw_dir, "freq1_input"))
+            if hz is not None and hz > 0:
+                gpu["clock_mhz"] = hz // 1_000_000
         out.append(gpu)
     return out
 
@@ -20193,6 +20288,49 @@ def read_box_battery():
     if profile:
         out["profile"] = profile
 
+    # Battery HEALTH: full-charge capacity as a percentage of the pack's design
+    # capacity, plus wear indicators. All THREE are additive and OMITTED when the
+    # gauge does not expose them -- an old agent or a desktop simply lacks them,
+    # and a missing wear reading must never read as "0% healthy". Two gauge
+    # families exist and both are handled: ENERGY_FULL[_DESIGN] is microwatt-hours,
+    # CHARGE_FULL[_DESIGN] is microamp-hours; either ratio is a valid health %.
+    #
+    # MEASURED on a Legion Go S, 2026-07-22 (verbatim in tests/test_box_battery.py):
+    #   ENERGY_FULL 55500000 == ENERGY_FULL_DESIGN 55500000 -> 100%, CYCLE_COUNT 53.
+    for full_k, design_k in (
+            ("POWER_SUPPLY_ENERGY_FULL", "POWER_SUPPLY_ENERGY_FULL_DESIGN"),
+            ("POWER_SUPPLY_CHARGE_FULL", "POWER_SUPPLY_CHARGE_FULL_DESIGN")):
+        try:
+            full, design = int(batt[full_k]), int(batt[design_k])
+        except (KeyError, ValueError):
+            continue
+        if design <= 0:
+            continue
+        health = round(full * 100 / design)
+        # A fresh pack routinely reports full slightly ABOVE design (>100%): that
+        # is real and reported as-is, NOT clamped -- same principle as the verbatim
+        # platform profile above. But a ratio beyond ~120% is a gauge reporting
+        # nonsense; degrade closed and omit rather than show "137% healthy".
+        if 0 < health <= 120:
+            out["health_pct"] = health
+        break
+
+    # Charge cycles. A count of 0 is a legitimately new pack, so the gate is
+    # ">= 0", not truthiness; a non-integer node is dropped rather than cleaned.
+    try:
+        cycles = int(batt["POWER_SUPPLY_CYCLE_COUNT"])
+        if cycles >= 0:
+            out["cycle_count"] = cycles
+    except (KeyError, ValueError):
+        pass
+
+    # The kernel's coarse capacity bucket (Full / Normal / Low / Critical), when
+    # the driver provides it. Reported VERBATIM (read_power_profile precedent) --
+    # a value we do not recognise is still the box's honest self-report.
+    level = batt.get("POWER_SUPPLY_CAPACITY_LEVEL")
+    if level:
+        out["capacity_level"] = level
+
     # Time to FULL while charging. Separate field, NOT folded into `minutes`:
     # that one means "runtime left on battery" to every app already shipped, and
     # reusing it here would make a 2.9.40-era app cheerfully report "42m left"
@@ -20478,7 +20616,9 @@ def mock_gaming():
                 "vram_used_mb": 3300, "vram_total_mb": 8192,
                 # Mock a DISCRETE card: gtt smaller than vram, so the app takes
                 # the non-shared branch. A handheld APU is the other shape.
-                "gtt_used_mb": 210, "gtt_total_mb": 4096, "busy_pct": 63},
+                # power_w/clock_mhz non-quiet so the GPU power/clock line renders.
+                "gtt_used_mb": 210, "gtt_total_mb": 4096, "busy_pct": 63,
+                "power_w": 42.5, "clock_mhz": 2400},
         # TWO cards, the dual-GPU laptop shape, so --mock exercises the
         # multi-GPU render path (the single-card boxes here never would).
         # `gpu` above is the discrete one, matching what the payload builder
@@ -20486,10 +20626,12 @@ def mock_gaming():
         "gpus": [
             {"name": "amdgpu", "card": "card0", "temp_c": 47.0,
              "vram_used_mb": 19, "vram_total_mb": 512,
-             "gtt_used_mb": 15, "gtt_total_mb": 19659, "busy_pct": 3},
+             "gtt_used_mb": 15, "gtt_total_mb": 19659, "busy_pct": 3,
+             "power_w": 4.5, "clock_mhz": 800},
             {"name": "amdgpu", "card": "card1", "temp_c": 61.0,
              "vram_used_mb": 3300, "vram_total_mb": 8192,
-             "gtt_used_mb": 210, "gtt_total_mb": 4096, "busy_pct": 63},
+             "gtt_used_mb": 210, "gtt_total_mb": 4096, "busy_pct": 63,
+             "power_w": 42.5, "clock_mhz": 2400},
         ],
         "game": {"appid": 1091500, "label": "Cyberpunk 2077"},
         "output": {"name": "DP-1", "internal": False},

--- a/app/app/(tabs)/actions.tsx
+++ b/app/app/(tabs)/actions.tsx
@@ -12,6 +12,7 @@ import {
 import { useFocusEffect } from 'expo-router';
 import Ionicons from '@expo/vector-icons/Ionicons';
 
+import { ArmedActionBar } from '@/components/ArmedActionBar';
 import { BootSessionCard } from '@/components/BootSessionCard';
 import { DeckyActionCard } from '@/components/DeckyActionCard';
 import { EditableSection } from '@/components/EditableSection';
@@ -20,6 +21,7 @@ import { Gated } from '@/components/Gated';
 import { TabScreen } from '@/components/TabScreen';
 import { TourAnchor } from '@/components/TourAnchor';
 import { registerScroller } from '@/hooks/useTourAnchor';
+import { useArmedAction } from '@/hooks/useArmedAction';
 import { useLockOrientation } from '@/hooks/useLockOrientation';
 import { usePoll } from '@/hooks/usePoll';
 import { ActionInfo, ActionResult, api, Danger, hostKey } from '@/lib/api';
@@ -73,14 +75,6 @@ const BADGE_TEXT: Record<Danger, string> = {
  *  absent (height ~0) so it shows no orphan reorder/hide controls. */
 const SECTION_ORDER = ['decky', 'boot', 'routine', 'medium', 'high'] as const;
 
-/** Seconds a session-ending action waits, cancellable, before it actually fires.
- *  This REPLACES the old blind second "Are you sure?" dialog: one confirm, then a
- *  visible countdown you can cancel — which also catches the fleet-era mistake the
- *  dialogs cannot, confirming with the WRONG BOX selected (the box is named in the
- *  countdown). App-side only: the request is simply not sent until the window
- *  elapses, so leaving the screen or switching boxes cancels it for free. */
-const COUNTDOWN_SECS = 5;
-
 /** Confirm helper that also works on web (Alert buttons are no-ops on web). */
 function confirm(title: string, message: string, onConfirm: () => void) {
   if (Platform.OS === 'web') {
@@ -117,10 +111,6 @@ function ActionsScreen() {
   const styles = useThemedStyles(makeStyles);
   const { settings, ready } = useSettings();
   const [run, setRun] = useState<RunRecord | null>(null);
-  // A session-ending action that has been confirmed and is counting down. Null
-  // when nothing is pending. Cleared (never fired) by Cancel, a box switch, or
-  // leaving the screen.
-  const [pending, setPending] = useState<{ action: ActionInfo; secs: number } | null>(null);
 
   const DANGER_COLOR = useMemo<Record<Danger, string>>(
     () => ({ low: t.slate, medium: t.amber, high: t.red }),
@@ -173,54 +163,31 @@ function ActionsScreen() {
     [settings],
   );
 
+  // A session-ending action is confirmed once, then ARMED: a visible countdown
+  // (ArmedActionBar) the user can Cancel or skip with "Do it now". The hook owns
+  // the timer, the box-switch abort, and the background abort; see useArmedAction.
+  const { armed, arm, cancel, fireNow } = useArmedAction(hostKey(settings));
+
   const onTap = useCallback(
     (action: ActionInfo) => {
       hapticLight();
       confirm(action.label, `${action.description}\n\nRun this action?`, () => {
         if (action.danger === 'high') {
           // One confirm, then a cancellable countdown — not a second blind dialog.
-          setPending({ action, secs: COUNTDOWN_SECS });
+          arm(action.label, () => execute(action));
         } else {
           execute(action);
         }
       });
     },
-    [execute],
+    [execute, arm],
   );
 
-  // Tick the pending countdown once a second; fire the action when it reaches
-  // zero. `execute` is read through a ref so that a `settings` change (e.g. a
-  // background caps write, which re-memoizes execute) cannot re-arm the timer
-  // mid-count — that would reset the current second and, if it churned faster
-  // than 1/s, stall the countdown so it never fires. The effect depends on
-  // `pending` alone; Cancel / box-switch / tab-blur all clear it (below).
-  const executeRef = useRef(execute);
-  executeRef.current = execute;
-  useEffect(() => {
-    if (!pending) return;
-    const id = setTimeout(() => {
-      if (pending.secs <= 1) {
-        const a = pending.action;
-        setPending(null);
-        executeRef.current(a);
-      } else {
-        setPending({ action: pending.action, secs: pending.secs - 1 });
-      }
-    }, 1000);
-    return () => clearTimeout(id);
-  }, [pending]);
-
-  // Switching boxes must abort a pending countdown — otherwise it would fire on
-  // whatever box is now selected, the exact wrong-box mistake this guards against.
-  const hk = hostKey(settings);
-  useEffect(() => { setPending(null); }, [hk]);
-
-  // Leaving the Actions tab also aborts it. Tab screens are FROZEN, not
-  // unmounted, so a plain effect's cleanup never runs on blur — the setTimeout
-  // would keep counting under react-freeze and fire on a tab the user already
-  // left, with no visible countdown to cancel. useFocusEffect's cleanup runs on
-  // blur: walk away and nothing destructive happens.
-  useFocusEffect(useCallback(() => () => setPending(null), []));
+  // Leaving the Actions tab also aborts a pending countdown. Tab screens are
+  // FROZEN, not unmounted, so a plain effect's cleanup never runs on blur — the
+  // hook's unmount/AppState guards would not catch a tab-switch. useFocusEffect's
+  // cleanup does: walk away and nothing destructive fires.
+  useFocusEffect(useCallback(() => () => cancel(), [cancel]));
 
   // "suspend" is handled by the Console tab's power control, which pairs it
   // with the Wake-on-LAN wake button and the wired-only guard, so it is left
@@ -410,27 +377,13 @@ function ActionsScreen() {
         </View>
       )}
 
-      {/* Countdown before a session-ending action fires */}
-      {pending && (
-        <View style={styles.countdownPanel}>
-          <View style={styles.countdownText}>
-            <Text style={styles.countdownTitle} numberOfLines={1}>
-              {pending.action.label} in {pending.secs}s
-            </Text>
-            <Text style={styles.countdownSub} numberOfLines={1}>
-              on {settings.host}
-            </Text>
-          </View>
-          <Pressable
-            onPress={() => { hapticLight(); setPending(null); }}
-            hitSlop={8}
-            accessibilityRole="button"
-            accessibilityLabel={`Cancel ${pending.action.label}`}
-            style={({ pressed }) => [styles.countdownCancel, pressed && styles.pressed]}>
-            <Text style={styles.countdownCancelText}>CANCEL</Text>
-          </Pressable>
-        </View>
-      )}
+      {/* Countdown before a session-ending action fires: Cancel or Do it now. */}
+      <ArmedActionBar
+        armed={armed}
+        boxName={settings.host}
+        onCancel={cancel}
+        onFireNow={fireNow}
+      />
 
       {/* Result panel */}
       {run && (
@@ -559,25 +512,4 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   resultErr: { color: t.red, fontSize: 13, fontFamily: mono },
   resultScroll: { maxHeight: 150 },
   resultOut: { color: t.textDim, fontSize: 12, fontFamily: mono, lineHeight: 17 },
-  countdownPanel: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-    backgroundColor: t.redDeep,
-    borderColor: t.red,
-    borderWidth: 1,
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 8,
-  },
-  countdownText: { flex: 1 },
-  countdownTitle: { color: t.onRedDeep, fontSize: 15, fontWeight: '800' },
-  countdownSub: { color: t.onRedDeep, opacity: 0.8, fontSize: 12, marginTop: 2, fontFamily: mono },
-  countdownCancel: {
-    backgroundColor: t.red,
-    paddingVertical: 10,
-    paddingHorizontal: 22,
-    borderRadius: 8,
-  },
-  countdownCancelText: { color: t.onRed, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
 });

--- a/app/app/(tabs)/index.tsx
+++ b/app/app/(tabs)/index.tsx
@@ -228,6 +228,17 @@ function ConsoleScreen() {
                 <Text style={styles.vlabel}>MEM</Text>
                 <Text style={[styles.vval, { color: pctColor(memPct, t) }]}>{memPct}%</Text>
               </View>
+              {/* CPU clock (agent >= 2.9.107). Key-presence gate exactly like BATT:
+                  the agent OMITS `cpu` on a box with no cpufreq, so no dash — the
+                  tile simply is not there. Peak live core clock in GHz. */}
+              {s.cpu?.cur_mhz != null && (
+                <View style={styles.vcell}>
+                  <Text style={styles.vlabel}>CLOCK</Text>
+                  <Text style={[styles.vval, { color: t.text }]}>
+                    {(s.cpu.cur_mhz / 1000).toFixed(1)}G
+                  </Text>
+                </View>
+              )}
               {s.battery && (
                 <View style={styles.vcell}>
                   <Text style={styles.vlabel}>BATT</Text>
@@ -304,7 +315,12 @@ function ConsoleScreen() {
               </Text>
             </View>
             <Bar pct={s.battery.pct} color={batteryColor(s.battery.pct, t)} />
-            {(s.battery.watts != null || s.battery.profile) && (
+            {(s.battery.watts != null ||
+              s.battery.profile ||
+              s.battery.health_pct != null ||
+              s.battery.cycle_count != null ||
+              (s.battery.capacity_level != null &&
+                s.battery.capacity_level !== 'Normal')) && (
               <Text style={styles.ipLine}>
                 {[
                   s.battery.watts != null
@@ -313,6 +329,14 @@ function ConsoleScreen() {
                       }`
                     : null,
                   s.battery.profile,
+                  // Wear indicators (agent >= 2.9.107). capacity_level is shown
+                  // only when it is NOT the healthy "Normal" \u2014 a quiet detail line
+                  // shouldn't announce the everyday case (mirrors the MEM card).
+                  s.battery.health_pct != null ? `health ${s.battery.health_pct}%` : null,
+                  s.battery.cycle_count != null ? `${s.battery.cycle_count} cycles` : null,
+                  s.battery.capacity_level != null && s.battery.capacity_level !== 'Normal'
+                    ? s.battery.capacity_level
+                    : null,
                 ]
                   .filter(Boolean)
                   .join('  \u00b7  ')}
@@ -570,10 +594,13 @@ const makeStyles = (t: Palette) => StyleSheet.create({
   foldSub: { color: t.textFaint, fontSize: 12, flex: 1 },
   // Vitals glance strip (pass #4): one row of the four scanned numbers, then a
   // quiet uptime/ip line. Detail cards (memory/disks/battery) render below.
-  vstrip: { flexDirection: 'row', gap: 14 },
+  // Five cells (TEMP/LOAD/MEM/CLOCK/BATT) share the row on a handheld; the gap
+  // and value size are tuned so a 4-char value ("0.59", "2.7G") does not wrap on
+  // a 360-375pt phone. BATT is omitted on a desktop, leaving four roomier cells.
+  vstrip: { flexDirection: 'row', gap: 10 },
   vcell: { flex: 1 },
-  vlabel: { color: t.textFaint, fontFamily: mono, fontSize: 10, letterSpacing: 1 },
-  vval: { ...numeric, fontSize: 22, fontWeight: '700', marginTop: 2 },
+  vlabel: { color: t.textFaint, fontFamily: mono, fontSize: 10, letterSpacing: 0.5 },
+  vval: { ...numeric, fontSize: 18, fontWeight: '700', marginTop: 2 },
   vsub: { color: t.textFaint, fontFamily: mono, fontSize: 11, marginTop: 8 },
   doneBtn: {
     backgroundColor: t.blue, borderRadius: 999,

--- a/app/app/decky.tsx
+++ b/app/app/decky.tsx
@@ -60,6 +60,8 @@ import {
 } from '@/lib/deckyPlugins';
 import { hapticLight, hapticSuccess, hapticWarning } from '@/lib/haptics';
 import { useSettings } from '@/lib/SettingsContext';
+import { useArmedAction } from '@/hooks/useArmedAction';
+import { ArmedActionBar } from '@/components/ArmedActionBar';
 import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
 
 type Tab = 'installed' | 'store';
@@ -359,17 +361,24 @@ export default function DeckyPage() {
     }, title);
   }, [settings, refreshLoader]);
 
+  // Reboot: confirm once, then a cancellable countdown (Cancel / Do it now) —
+  // the same window the Actions tab gives a session-ending action, instead of a
+  // one-shot Alert that reboots the instant you tap through.
+  const { armed, arm, cancel, fireNow } = useArmedAction(key);
   const [rebooting, setRebooting] = useState(false);
+  const runReboot = useCallback(() => {
+    void (async () => {
+      setRebooting(true);
+      hapticLight();
+      try { await api.runAction(settings, 'reboot'); } catch { /* connection drops on reboot — expected */ }
+      finally { setRebooting(false); }
+    })();
+  }, [settings]);
   const reboot = useCallback(() => {
     deckyConfirm('Reboot the box?', 'Steam restarts with it and the Decky menu appears. Any unsaved work is lost.', 'Reboot', () => {
-      void (async () => {
-        setRebooting(true);
-        hapticLight();
-        try { await api.runAction(settings, 'reboot'); } catch { /* connection drops on reboot — expected */ }
-        finally { setRebooting(false); }
-      })();
+      arm('Reboot the box', runReboot);
     }, true);
-  }, [settings]);
+  }, [arm, runReboot]);
 
   // ---- plugins / store / jobs (Phase B; each 404s → null on a Phase A agent) ----
   const installed = !!l?.installed;
@@ -873,6 +882,17 @@ export default function DeckyPage() {
         </Pressable>
         <Text style={styles.title}>Decky</Text>
         <View style={{ width: 26 }} />
+      </View>
+
+      {/* Pinned above the list so an armed reboot's countdown is visible no
+          matter how far the plugin list is scrolled. */}
+      <View style={{ paddingHorizontal: 14 }}>
+        <ArmedActionBar
+          armed={armed}
+          boxName={settings.host}
+          onCancel={cancel}
+          onFireNow={fireNow}
+        />
       </View>
 
       {!configured ? (

--- a/app/components/ArmedActionBar.tsx
+++ b/app/components/ArmedActionBar.tsx
@@ -1,0 +1,100 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+
+import { hapticHeavy, hapticLight } from '@/lib/haptics';
+import { mono, useTheme, useThemedStyles, type Palette } from '@/lib/theme';
+import type { Armed } from '@/hooks/useArmedAction';
+
+type Props = {
+  /** The armed action, or null when nothing is counting down. */
+  armed: Armed | null;
+  /** The box the action targets — its NAME, so the wrong-box mistake this window
+   *  exists to catch is easy to spot (a raw host:port is not). */
+  boxName: string;
+  onCancel: () => void;
+  onFireNow: () => void;
+};
+
+/**
+ * The red countdown bar for an armed destructive action: a live "in Ns", the box
+ * it targets, and two ways out — CANCEL (abort) and DO IT NOW (skip the wait and
+ * fire immediately). CANCEL is the prominent, filled control because it is the
+ * safe default; DO IT NOW is a ghost button, the deliberate escape hatch.
+ *
+ * accessibilityRole="alert" so a screen reader announces that a reboot is seconds
+ * away rather than leaving a blind user to the silent timer.
+ */
+export function ArmedActionBar({ armed, boxName, onCancel, onFireNow }: Props) {
+  const styles = useThemedStyles(makeStyles);
+  useTheme(); // re-render on theme change (styles are theme-derived)
+  if (!armed) return null;
+  return (
+    <View style={styles.panel} accessibilityRole="alert">
+      <View style={styles.text}>
+        <Text style={styles.title} numberOfLines={1}>
+          {armed.label} in {armed.secs}s
+        </Text>
+        <Text style={styles.sub} numberOfLines={1}>
+          on {boxName}
+        </Text>
+      </View>
+      <Pressable
+        onPress={() => {
+          hapticLight();
+          onCancel();
+        }}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Cancel ${armed.label}`}
+        style={({ pressed }) => [styles.cancel, pressed && styles.pressed]}>
+        <Text style={styles.cancelText}>CANCEL</Text>
+      </Pressable>
+      <Pressable
+        onPress={() => {
+          hapticHeavy();
+          onFireNow();
+        }}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Run ${armed.label} now`}
+        style={({ pressed }) => [styles.now, pressed && styles.pressed]}>
+        <Text style={styles.nowText}>DO IT NOW</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const makeStyles = (t: Palette) =>
+  StyleSheet.create({
+    panel: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 10,
+      backgroundColor: t.redDeep,
+      borderColor: t.red,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 12,
+      marginBottom: 8,
+    },
+    text: { flex: 1 },
+    title: { color: t.onRedDeep, fontSize: 15, fontWeight: '800' },
+    sub: { color: t.onRedDeep, opacity: 0.8, fontSize: 12, marginTop: 2, fontFamily: mono },
+    // Filled: the safe default gets the visual weight.
+    cancel: {
+      backgroundColor: t.red,
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      borderRadius: 8,
+    },
+    cancelText: { color: t.onRed, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+    // Ghost: the escape hatch is available but not the eye-catcher.
+    now: {
+      borderColor: t.onRedDeep,
+      borderWidth: 1,
+      paddingVertical: 10,
+      paddingHorizontal: 14,
+      borderRadius: 8,
+    },
+    nowText: { color: t.onRedDeep, fontWeight: '800', fontSize: 13, letterSpacing: 1 },
+    pressed: { opacity: 0.7 },
+  });

--- a/app/components/GamingCard.tsx
+++ b/app/components/GamingCard.tsx
@@ -192,6 +192,19 @@ function GpuBlock({
           <Bar pct={vramPct} color={pctColor(vramPct, t)} height={6} />
         </>
       )}
+      {/* Package power draw + core clock (agent >= 2.9.107). Each independently
+          optional — Intel/NVIDIA and older agents omit them, so the line simply
+          does not appear rather than showing a mislabelled zero. */}
+      {(gpu.power_w != null || gpu.clock_mhz != null) && (
+        <Text style={styles.dim}>
+          {[
+            gpu.power_w != null ? `${gpu.power_w.toFixed(1)} W` : null,
+            gpu.clock_mhz != null ? `${(gpu.clock_mhz / 1000).toFixed(2)} GHz` : null,
+          ]
+            .filter(Boolean)
+            .join('  ·  ')}
+        </Text>
+      )}
     </View>
   );
 }

--- a/app/components/SystemUpdatesCard.tsx
+++ b/app/components/SystemUpdatesCard.tsx
@@ -20,6 +20,8 @@ import { useCallback, useRef, useState } from 'react';
 import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
 
 import { usePoll } from '@/hooks/usePoll';
+import { useArmedAction } from '@/hooks/useArmedAction';
+import { ArmedActionBar } from '@/components/ArmedActionBar';
 import { api, FlatpakStatus, hostKey, OsStatus } from '@/lib/api';
 import { isFlatpakUpdateComplete } from '@/lib/flatpakUpdate';
 import { hapticLight } from '@/lib/haptics';
@@ -187,26 +189,29 @@ export function SystemUpdatesCard() {
     [fp.data?.count, hasFp, hasOs, runFlatpak, runOs],
   );
 
+  // Confirm once, then a cancellable countdown (Cancel / Do it now) before the
+  // reboot actually fires — the same window the Actions tab gives a session-
+  // ending action, instead of the one-shot Alert this used to be.
+  const { armed, arm, cancel, fireNow } = useArmedAction(hostKey(settings));
+  const runReboot = useCallback(() => {
+    void (async () => {
+      setRebooting(true);
+      hapticLight();
+      try {
+        await api.runAction(settings, 'reboot');
+      } catch {
+        // connection drops on reboot — expected
+      } finally {
+        setRebooting(false);
+      }
+    })();
+  }, [settings]);
   const reboot = useCallback(() => {
     Alert.alert('Reboot the box?', 'This applies the staged OS update. Any unsaved work will be lost.', [
       { text: 'Cancel', style: 'cancel' },
-      {
-        text: 'Reboot',
-        style: 'destructive',
-        onPress: async () => {
-          setRebooting(true);
-          hapticLight();
-          try {
-            await api.runAction(settings, 'reboot');
-          } catch {
-            // connection drops on reboot — expected
-          } finally {
-            setRebooting(false);
-          }
-        },
-      },
+      { text: 'Reboot', style: 'destructive', onPress: () => arm('Reboot the box', runReboot) },
     ]);
-  }, [settings]);
+  }, [arm, runReboot]);
 
   if (!configured || (!hasFp && !hasOs)) return null;
 
@@ -250,6 +255,13 @@ export function SystemUpdatesCard() {
       )}
 
       {msg ? <Text style={styles.msg}>{msg}</Text> : null}
+
+      <ArmedActionBar
+        armed={armed}
+        boxName={settings.host}
+        onCancel={cancel}
+        onFireNow={fireNow}
+      />
 
       {osStaged ? (
         <Pressable

--- a/app/components/WatchPanel.tsx
+++ b/app/components/WatchPanel.tsx
@@ -10,7 +10,8 @@ import {
 
 import { usePoll } from '@/hooks/usePoll';
 import { api, hostKey, PlayerOp, PlayerPlayback, PlayerState } from '@/lib/api';
-import { hapticError, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { hapticError, hapticHeavy, hapticLight, hapticSuccess } from '@/lib/haptics';
+import { MEDIA_HOLD_MS } from '@/lib/mediaSeek';
 import { useSettings } from '@/lib/SettingsContext';
 import { clearRecents, noteRecent, useWatchRecents } from '@/lib/watchRecents';
 import { useTheme, useThemedStyles, type Palette } from '@/lib/theme';
@@ -311,8 +312,16 @@ export function WatchPanel() {
   // Offsets come from the BOX (seek_secs), so the app can never offer a value
   // the box would refuse. Smallest magnitude each way is what the buttons use.
   const offsets = state?.seek_secs ?? [];
-  const back = offsets.filter((n) => n < 0).sort((a, b) => b - a)[0] ?? null;
-  const fwd = offsets.filter((n) => n > 0).sort((a, b) => a - b)[0] ?? null;
+  // Ordered by magnitude each way, e.g. [-10,-30,-90] / [10,30,90]. The button
+  // TAP uses the smallest jump; a HOLD uses the next one up (the box's own next
+  // allowlisted offset, ±30 on a typical box), so both still come only from
+  // seek_secs — the app never invents an offset the box would refuse.
+  const backSteps = offsets.filter((n) => n < 0).sort((a, b) => b - a);
+  const fwdSteps = offsets.filter((n) => n > 0).sort((a, b) => a - b);
+  const back = backSteps[0] ?? null;
+  const fwd = fwdSteps[0] ?? null;
+  const backHold = backSteps[1] ?? null;
+  const fwdHold = fwdSteps[1] ?? null;
 
   const transport = useCallback(
     async (op: PlayerOp, opts: { secs?: number; value?: string } = {}) => {
@@ -503,8 +512,22 @@ export function WatchPanel() {
                 {back != null && (
                   <Pressable
                     onPress={() => transport('seek', { secs: back })}
+                    onLongPress={
+                      backHold != null
+                        ? () => {
+                            hapticHeavy();
+                            transport('seek', { secs: backHold });
+                          }
+                        : undefined
+                    }
+                    delayLongPress={MEDIA_HOLD_MS}
                     disabled={busy !== null}
                     testID="watch-seek-back"
+                    accessibilityHint={
+                      backHold != null
+                        ? `Hold to jump back ${Math.abs(backHold)} seconds`
+                        : undefined
+                    }
                     style={({ pressed }) => [styles.tBtn, pressed && styles.pressed]}
                   >
                     <Text style={styles.tBtnText}>{back}s</Text>
@@ -527,8 +550,20 @@ export function WatchPanel() {
                 {fwd != null && (
                   <Pressable
                     onPress={() => transport('seek', { secs: fwd })}
+                    onLongPress={
+                      fwdHold != null
+                        ? () => {
+                            hapticHeavy();
+                            transport('seek', { secs: fwdHold });
+                          }
+                        : undefined
+                    }
+                    delayLongPress={MEDIA_HOLD_MS}
                     disabled={busy !== null}
                     testID="watch-seek-fwd"
+                    accessibilityHint={
+                      fwdHold != null ? `Hold to jump forward ${fwdHold} seconds` : undefined
+                    }
                     style={({ pressed }) => [styles.tBtn, pressed && styles.pressed]}
                   >
                     <Text style={styles.tBtnText}>+{fwd}s</Text>

--- a/app/hooks/useArmedAction.ts
+++ b/app/hooks/useArmedAction.ts
@@ -1,0 +1,83 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AppState } from 'react-native';
+
+/** Default window a destructive action waits, cancellable, before it fires. */
+export const ARMED_ACTION_SECS = 5;
+
+export type Armed = { label: string; secs: number };
+
+/**
+ * A cancellable countdown before a destructive action fires. Confirm once
+ * elsewhere, then `arm(label, onFire)`: a visible N-second window the caller
+ * renders (see ArmedActionBar) with two ways out — Cancel aborts, "Do it now"
+ * skips the wait. The request is not sent until the window elapses, so a box
+ * switch, the app going to the background, or this hook unmounting all abort it
+ * for free. A reboot must never fire from a phone the user put in their pocket.
+ *
+ * This began inline in app/(tabs)/actions.tsx (#429). It was lifted here so the
+ * Decky screen's reboot and the System Updates card's reboot get the SAME window
+ * instead of a one-shot Alert that fires the instant you tap through.
+ *
+ * `boxKey` is hostKey(settings): when it changes the arm is cancelled, so a
+ * countdown can never fire on a box other than the one it was armed for.
+ */
+export function useArmedAction(boxKey: string) {
+  const [armed, setArmed] = useState<Armed | null>(null);
+  // The thunk to run when the current arm fires. Held in a ref, not state, so
+  // nulling it is SYNCHRONOUS — that null is the whole double-fire guard below.
+  const fireRef = useRef<(() => void) | null>(null);
+
+  const cancel = useCallback(() => {
+    fireRef.current = null;
+    setArmed(null);
+  }, []);
+
+  const arm = useCallback(
+    (label: string, onFire: () => void, secs: number = ARMED_ACTION_SECS) => {
+      fireRef.current = onFire;
+      setArmed({ label, secs });
+    },
+    [],
+  );
+
+  // Run the armed action exactly once. Nulling fireRef synchronously is the
+  // guard: whichever of {timer expiry, "Do it now"} runs first consumes the
+  // thunk and the other finds null. A doubled reboot POST is a real hazard —
+  // api.request() never retries POSTs precisely for this reason.
+  const fireNow = useCallback(() => {
+    const run = fireRef.current;
+    fireRef.current = null;
+    setArmed(null);
+    run?.();
+  }, []);
+
+  // Tick once a second; fire at zero. Depends on `armed` alone so a parent
+  // re-render cannot re-arm mid-count (which would reset the current second).
+  useEffect(() => {
+    if (!armed) return;
+    const id = setTimeout(() => {
+      if (armed.secs <= 1) fireNow();
+      else setArmed({ label: armed.label, secs: armed.secs - 1 });
+    }, 1000);
+    return () => clearTimeout(id);
+  }, [armed, fireNow]);
+
+  // Switching boxes aborts a pending arm — otherwise it would fire on whatever
+  // box is now selected. (Also runs once on mount; nothing is armed then.)
+  useEffect(() => {
+    cancel();
+  }, [boxKey, cancel]);
+
+  // The app leaving the foreground aborts it (degrade closed). JS timers pause
+  // in the background, so a countdown would otherwise resume and fire minutes
+  // later when the user unlocks — a reboot from a pocketed phone. Cancelling is
+  // the safe reading of "I walked away".
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (s) => {
+      if (s !== 'active') cancel();
+    });
+    return () => sub.remove();
+  }, [cancel]);
+
+  return { armed, arm, cancel, fireNow };
+}

--- a/app/lib/api.ts
+++ b/app/lib/api.ts
@@ -919,6 +919,29 @@ export type Status = {
         reported "custom" because Steam's TDP control set one. Render whatever
         arrives; do not switch on a fixed set. */
     profile?: string;
+    /** Full-charge capacity as a percent of DESIGN capacity (agent >= 2.9.107).
+        A pack's wear: 100 is factory-fresh, lower is worn. Absent on older agents
+        and on gauges that do not expose design capacity — never assume 100. May
+        exceed 100 on a fresh pack (reported as-is, not clamped). */
+    health_pct?: number;
+    /** Charge cycles the pack has been through (agent >= 2.9.107). 0 is a new
+        pack, not "unknown"; absent means the gauge does not report it. */
+    cycle_count?: number;
+    /** Kernel capacity bucket — Full/Normal/Low/Critical (agent >= 2.9.107),
+        verbatim. Absent when the driver does not provide it. */
+    capacity_level?: string;
+  };
+  /** CPU frequency scaling (agent >= 2.9.107). ABSENT on a box with no cpufreq
+      (a VM) and on older agents. On amd-pstate-epp handhelds `governor` is
+      permanently "powersave" and `epp` carries the real intent, so show both.
+      Every inner field is independently optional. */
+  cpu?: {
+    governor: string;
+    /** Highest live core clock in MHz — what the busiest core is doing now. */
+    cur_mhz?: number;
+    max_mhz?: number;
+    /** energy_performance_preference, verbatim (e.g. "balance_performance"). */
+    epp?: string;
   };
 };
 
@@ -1106,6 +1129,12 @@ export type GpuInfo = {
   /** How hard the GPU is actually working, 0-100 (agent >= 2.9.43). A memory
    *  bar says what is allocated, not whether anything is happening. */
   busy_pct?: number;
+  /** Package power draw in watts (agent >= 2.9.107): power1_average, or
+   *  power1_input on newer ASICs. Absent when the gauge reports nothing. */
+  power_w?: number;
+  /** Core (sclk) clock in MHz (agent >= 2.9.107), from freq1_input. Absent when
+   *  the card does not expose it. */
+  clock_mhz?: number;
 };
 
 export type Gaming = {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1004,9 +1004,14 @@ network and is useful alone.
 - **Verify on hardware** (a real Remote Play session from the PC to the box); the harness
   can't produce a stream.
 
-> 📋 **OPEN — still not built (reconciled 2026-08-27).**
-> Not built — none of battery-health/cycle_count, CPU governor+freq, GPU power draw, GPU clock, or fan RPM are read by the agent.
->
+> ✅ **DONE — shipped in agent 2.9.107 (PR #523, 2026-09-10). Move to Completed.**
+> Built: battery `health_pct`/`cycle_count`/`capacity_level` on read_box_battery; new
+> `read_cpu_freq()` → `cpu` block (governor/cur_mhz peak-core/max_mhz/epp) on /api/status;
+> GPU `power_w`/`clock_mhz` on _gpu_sensors_all (rides /api/gaming). App: 5th VITALS CLOCK
+> tile, battery detail line "health N% · N cycles", GamingCard "W · GHz". All additive/
+> omit-when-absent, no cap. Fan RPM deliberately NOT built (no box exposes fan1_input).
+> NOT hardware-verified: cpufreq + amdgpu power/clock sysfs reads (no box on LAN at build
+> time) — test fixtures synthetic, values anchored to the Legion Go S measurement below.
 ### More Console sensors (battery health, CPU governor, GPU power)
 - **priority:** P3 · **risk:** low · **affects:** agent + app · **depends_on:** none
 - All read-only sysfs, no new capability, no client input. **PROBED on a Legion Go S,

--- a/tests/test_actions_endpoint.py
+++ b/tests/test_actions_endpoint.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the actions routes (GET/POST /api/actions/<id>) and its allowlist.
+
+Run: python3 tests/test_actions_endpoint.py
+
+Covers what CLAUDE.md §6 requires of an endpoint that takes a client id, which
+this route had NO test for until now (the injection GATES are tested in
+test_actions_inject.py, but the route dispatch itself was not):
+  * happy path — a listed id returns the ActionResult shape,
+  * auth failure — no bearer is 401 on both GET and POST,
+  * a NON-allowlisted id is refused AND nothing runs.
+
+That last one is asserted, not inferred: `mock_action` is spied, so "the request
+was 404'd" and "no action was dispatched" are two separate observations. A test
+that only checked the status code would pass against an agent that 404s the
+caller while still running the command.
+
+Driven in --mock so no real reboot/session binary is touched; the allowlist
+membership check (`action_id not in ACTIONS`) is identical in mock and real mode.
+Pure stdlib, no pytest.
+"""
+import http.client
+import importlib.util
+import json
+import os
+import sys
+import threading
+from http.server import ThreadingHTTPServer
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+AGENT = os.path.join(HERE, "..", "agent", "couchsided.py")
+spec = importlib.util.spec_from_file_location("couchsided", AGENT)
+cs = importlib.util.module_from_spec(spec)
+sys.modules["couchsided"] = cs
+spec.loader.exec_module(cs)
+
+PASS = "  \033[32mPASS\033[0m"
+FAIL = "  \033[31mFAIL\033[0m"
+_fail = []
+TOKEN = "test-secret-token"
+
+
+def check(cond, label, detail=""):
+    print((PASS if cond else FAIL) + "  " + label + ("" if cond else "  <- %s" % (detail,)))
+    if not cond:
+        _fail.append(label)
+
+
+def _server():
+    cs.Handler.token = TOKEN
+    cs.Handler.token_file = None
+    cs.Handler.mock = True
+    cs.Handler.port = 0
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), cs.Handler)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, srv.server_address[1]
+
+
+def _req(port, method, path, body=None, token=TOKEN):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=10)
+    headers = {"Authorization": "Bearer " + token} if token is not None else {}
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    conn.request(method, path, body=body, headers=headers)
+    resp = conn.getresponse()
+    data = resp.read()
+    conn.close()
+    try:
+        return resp.status, json.loads(data or b"{}")
+    except ValueError:
+        return resp.status, {}
+
+
+class SpyAction:
+    """Records every action id actually dispatched, so 'nothing ran' is an
+    observation and not an inference."""
+
+    def __init__(self):
+        self.ids = []
+        self._orig = cs.mock_action
+
+    def __enter__(self):
+        def spy(action_id):
+            self.ids.append(action_id)
+            return self._orig(action_id)
+        cs.mock_action = spy
+        return self
+
+    def __exit__(self, *exc):
+        cs.mock_action = self._orig
+
+
+def test_get_requires_bearer():
+    print("GET /api/actions requires the bearer token")
+    srv, port = _server()
+    try:
+        status, _ = _req(port, "GET", "/api/actions", token=None)
+        check(status == 401, "no token -> 401", status)
+    finally:
+        srv.shutdown()
+
+
+def test_get_lists_actions():
+    print("GET /api/actions lists the allowlisted actions")
+    srv, port = _server()
+    try:
+        status, body = _req(port, "GET", "/api/actions")
+        acts = body.get("actions")
+        check(status == 200, "authorised GET -> 200", status)
+        check(isinstance(acts, list) and len(acts) > 0, "returns a non-empty actions list")
+        first = acts[0] if acts else {}
+        check({"id", "label", "danger"} <= set(first), "each action has id/label/danger",
+              sorted(first))
+    finally:
+        srv.shutdown()
+
+
+def test_known_id_runs_and_shape():
+    print("POST a listed id runs and returns the ActionResult shape")
+    srv, port = _server()
+    try:
+        _, body = _req(port, "GET", "/api/actions")
+        aid = body["actions"][0]["id"]
+        with SpyAction() as spy:
+            status, result = _req(port, "POST", "/api/actions/" + aid, body="{}")
+        check(status == 200, "listed id -> 200", status)
+        check({"ok", "exit_code", "stdout", "stderr", "duration_ms"} <= set(result),
+              "result carries the ActionResult keys", sorted(result))
+        check(spy.ids == [aid], "the dispatched action was exactly the one requested", spy.ids)
+    finally:
+        srv.shutdown()
+
+
+def test_unknown_id_refused_and_nothing_runs():
+    print("POST a non-allowlisted id is refused AND nothing runs")
+    srv, port = _server()
+    try:
+        with SpyAction() as spy:
+            status, body = _req(port, "POST", "/api/actions/not-a-real-action", body="{}")
+        check(status == 404, "unknown id -> 404", status)
+        check(body.get("error") == "unknown action", "error names the refusal", body)
+        check(spy.ids == [], "NOTHING was dispatched for the unknown id", spy.ids)
+    finally:
+        srv.shutdown()
+
+
+def test_post_requires_bearer():
+    print("POST /api/actions/<id> requires the bearer token")
+    srv, port = _server()
+    try:
+        with SpyAction() as spy:
+            status, _ = _req(port, "POST", "/api/actions/reboot", body="{}", token=None)
+        check(status == 401, "no token -> 401", status)
+        check(spy.ids == [], "an unauthorised POST dispatched nothing", spy.ids)
+    finally:
+        srv.shutdown()
+
+
+if __name__ == "__main__":
+    for fn in (test_get_requires_bearer,
+               test_get_lists_actions,
+               test_known_id_runs_and_shape,
+               test_unknown_id_refused_and_nothing_runs,
+               test_post_requires_bearer):
+        fn()
+    if _fail:
+        print("\n%d FAILED: %s" % (len(_fail), ", ".join(_fail)))
+        sys.exit(1)
+    print("\nall good")

--- a/tests/test_box_battery.py
+++ b/tests/test_box_battery.py
@@ -395,6 +395,128 @@ def test_handheld_with_paired_controller_reads_its_own_pack():
         s.close()
 
 
+def test_health_from_energy_gauge():
+    """The VERBATIM Legion Go S pack: ENERGY_FULL == ENERGY_FULL_DESIGN
+    (55500000) -> 100% health, CYCLE_COUNT 53, CAPACITY_LEVEL Normal (emitted
+    verbatim by the agent even though the app hides the healthy 'Normal')."""
+    print("test_health_from_energy_gauge")
+    s = Supplies({"BAT0": BAT0, "ACAD": ACAD_OFFLINE})
+    try:
+        got = cs.read_box_battery()
+        check("health 100%", got.get("health_pct"), 100)
+        check("cycle count 53", got.get("cycle_count"), 53)
+        check("capacity level verbatim", got.get("capacity_level"), "Normal")
+    finally:
+        s.close()
+
+
+def test_health_degraded_pack():
+    """A worn pack: ENERGY_FULL 48285000 / DESIGN 55500000 = 87%."""
+    print("test_health_degraded_pack")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_ENERGY_FULL=55500000",
+                                       "POWER_SUPPLY_ENERGY_FULL=48285000")})
+    try:
+        check("health 87%", cs.read_box_battery().get("health_pct"), 87)
+    finally:
+        s.close()
+
+
+def test_health_from_charge_gauge():
+    """A CHARGE-based gauge (uAh) with no ENERGY_* still yields health:
+    CHARGE_FULL 5400000 / CHARGE_FULL_DESIGN 6000000 = 90%."""
+    print("test_health_from_charge_gauge")
+    s = Supplies({"BAT1": """POWER_SUPPLY_NAME=BAT1
+POWER_SUPPLY_TYPE=Battery
+POWER_SUPPLY_STATUS=Discharging
+POWER_SUPPLY_PRESENT=1
+POWER_SUPPLY_CAPACITY=50
+POWER_SUPPLY_CHARGE_FULL_DESIGN=6000000
+POWER_SUPPLY_CHARGE_FULL=5400000
+POWER_SUPPLY_CYCLE_COUNT=0
+"""})
+    try:
+        got = cs.read_box_battery()
+        check("health 90% from charge gauge", got.get("health_pct"), 90)
+        # A zero cycle count is a NEW pack, not "unknown" -- it must be kept.
+        check("cycle count 0 kept", got.get("cycle_count"), 0)
+    finally:
+        s.close()
+
+
+def test_health_omitted_without_design():
+    """No *_FULL_DESIGN -> no way to compute wear -> the key is OMITTED, never a
+    fabricated 100%."""
+    print("test_health_omitted_without_design")
+    s = Supplies({"BAT0": BAT0.replace(
+        "POWER_SUPPLY_ENERGY_FULL_DESIGN=55500000\n", "")})
+    try:
+        check("no health_pct key", "health_pct" in cs.read_box_battery(), False)
+    finally:
+        s.close()
+
+
+def test_health_fresh_pack_over_100_reported_verbatim():
+    """A fresh pack routinely reports full ABOVE design. That is real and
+    reported as-is (101%), not clamped to 100 -- same principle as the verbatim
+    platform profile."""
+    print("test_health_fresh_pack_over_100_reported_verbatim")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_ENERGY_FULL=55500000",
+                                       "POWER_SUPPLY_ENERGY_FULL=56000000")})
+    try:
+        check("101% reported, not clamped", cs.read_box_battery().get("health_pct"), 101)
+    finally:
+        s.close()
+
+
+def test_health_absurd_ratio_rejected():
+    """A ratio beyond ~120% is a gauge reporting nonsense: degrade closed and
+    OMIT rather than show '126% healthy'. full 70000000 / design 55500000."""
+    print("test_health_absurd_ratio_rejected")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_ENERGY_FULL=55500000",
+                                       "POWER_SUPPLY_ENERGY_FULL=70000000")})
+    try:
+        check("no health_pct for absurd ratio", "health_pct" in cs.read_box_battery(), False)
+    finally:
+        s.close()
+
+
+def test_cycle_count_garbage_omitted():
+    """A non-integer cycle count is dropped rather than cleaned."""
+    print("test_cycle_count_garbage_omitted")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_CYCLE_COUNT=53",
+                                       "POWER_SUPPLY_CYCLE_COUNT=abc")})
+    try:
+        check("no cycle_count key for garbage", "cycle_count" in cs.read_box_battery(), False)
+    finally:
+        s.close()
+
+
+def test_capacity_level_non_normal_verbatim():
+    """capacity_level is the box's honest self-report, emitted verbatim -- a
+    'Low' bucket is passed straight through (the app decides how to show it)."""
+    print("test_capacity_level_non_normal_verbatim")
+    s = Supplies({"BAT0": BAT0.replace("POWER_SUPPLY_CAPACITY_LEVEL=Normal",
+                                       "POWER_SUPPLY_CAPACITY_LEVEL=Low")})
+    try:
+        check("capacity level Low verbatim", cs.read_box_battery().get("capacity_level"), "Low")
+    finally:
+        s.close()
+
+
+def test_mains_desktop_carries_no_health():
+    """CONTROL: a machine with no battery returns {} -- and therefore none of the
+    new health keys leak onto a desktop."""
+    print("test_mains_desktop_carries_no_health")
+    s = Supplies({"ACAD": ACAD_ONLINE})
+    try:
+        got = cs.read_box_battery()
+        check("empty on a desktop", got, {})
+        check("no health_pct", "health_pct" in got, False)
+        check("no cycle_count", "cycle_count" in got, False)
+    finally:
+        s.close()
+
+
 if __name__ == "__main__":
     for fn in (test_real_handheld,
                test_watts_from_power_now,
@@ -413,7 +535,16 @@ if __name__ == "__main__":
                test_garbage_capacity_rejected,
                test_desktop_with_paired_controller_is_not_on_battery,
                test_device_scope_alone_degrades_closed,
-               test_handheld_with_paired_controller_reads_its_own_pack):
+               test_handheld_with_paired_controller_reads_its_own_pack,
+               test_health_from_energy_gauge,
+               test_health_degraded_pack,
+               test_health_from_charge_gauge,
+               test_health_omitted_without_design,
+               test_health_fresh_pack_over_100_reported_verbatim,
+               test_health_absurd_ratio_rejected,
+               test_cycle_count_garbage_omitted,
+               test_capacity_level_non_normal_verbatim,
+               test_mains_desktop_carries_no_health):
         fn()
     if FAILURES:
         print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))

--- a/tests/test_console_sensors.py
+++ b/tests/test_console_sensors.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Tests for the Console's CPU-frequency sensor (read_cpu_freq) and its additive
+splice into GET /api/status.
+
+Run: python3 tests/test_console_sensors.py
+
+Drives the REAL agent function against a filesystem fixture — the per-CPU sysfs
+root is a module constant (_CPUFREQ_DIR) the test repoints, so nothing is
+reimplemented.
+
+The cpufreq tree here is SYNTHETIC, not a verbatim hardware capture: the repo has
+no dumped /sys/devices/system/cpu tree, and CI has no handheld to read one from.
+The VALUES are anchored to a real Legion Go S measurement recorded in
+docs/ROADMAP.md (governor "powersave", scaling_cur_freq ~2160 MHz) — an
+amd-pstate-epp handheld reports governor "powersave" permanently while the EPP
+carries the real intent, which is exactly why read_cpu_freq surfaces both. The
+shape is faithful to that; the file paths are the documented cpufreq ABI. Read
+the values off a box before shipping any UI copy that quotes them (CLAUDE.md
+§11.1: test the thing).
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_spec = importlib.util.spec_from_file_location(
+    "couchsided", os.path.join(ROOT, "agent", "couchsided.py"))
+cs = importlib.util.module_from_spec(_spec)
+sys.modules["couchsided"] = cs
+_spec.loader.exec_module(cs)
+
+FAILURES = []
+
+
+def check(name, got, want):
+    if got == want:
+        print("  PASS  %s" % name)
+    else:
+        print("  FAIL  %s (got %r, want %r)" % (name, got, want))
+        FAILURES.append(name)
+
+
+def _write(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write(text)
+
+
+class CpuTree:
+    """A fake /sys/devices/system/cpu the REAL read_cpu_freq walks."""
+
+    def __init__(self, cpus, decoys=()):
+        # cpus: {"cpu0": {"scaling_governor": "powersave", ...}, ...}
+        self.dir = tempfile.mkdtemp(prefix="cpufreq-")
+        for name, files in cpus.items():
+            for fname, val in files.items():
+                _write(os.path.join(self.dir, name, "cpufreq", fname), val + "\n")
+        # Real sysfs also holds non-cpuN entries (cpufreq/, cpuidle/, kernel_max);
+        # re.fullmatch(cpu\d+) must skip them.
+        for name in decoys:
+            os.makedirs(os.path.join(self.dir, name), exist_ok=True)
+        self._old = cs._CPUFREQ_DIR
+        cs._CPUFREQ_DIR = self.dir
+
+    def close(self):
+        cs._CPUFREQ_DIR = self._old
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+
+def test_full_handheld_reading():
+    """governor from cpu0; cur_mhz is the PEAK across cores (cpu3 busier than
+    cpu0); max + epp when present."""
+    print("test_full_handheld_reading")
+    t = CpuTree(
+        {
+            "cpu0": {"scaling_governor": "powersave",
+                     "scaling_cur_freq": "2000000",
+                     "scaling_max_freq": "4900000",
+                     "energy_performance_preference": "balance_performance"},
+            "cpu3": {"scaling_cur_freq": "2160000"},
+        },
+        decoys=("cpufreq", "cpuidle", "kernel_max"),
+    )
+    try:
+        got = cs.read_cpu_freq()
+        check("governor", got.get("governor"), "powersave")
+        check("cur_mhz is the peak core (2160, not cpu0's 2000)", got.get("cur_mhz"), 2160)
+        check("max_mhz", got.get("max_mhz"), 4900)
+        check("epp verbatim", got.get("epp"), "balance_performance")
+    finally:
+        t.close()
+
+
+def test_no_cpufreq_degrades_to_empty():
+    """A box with no cpufreq (a VM) -> {} , never a fabricated governor."""
+    print("test_no_cpufreq_degrades_to_empty")
+    t = CpuTree({})  # cpu0/cpufreq/scaling_governor absent
+    try:
+        check("empty dict", cs.read_cpu_freq(), {})
+    finally:
+        t.close()
+
+
+def test_optional_fields_omitted():
+    """governor present but the rest missing/garbage -> only governor, and no
+    cur_mhz for a non-positive reading (rejected, not reported as 0)."""
+    print("test_optional_fields_omitted")
+    t = CpuTree({"cpu0": {"scaling_governor": "schedutil",
+                          "scaling_cur_freq": "0"}})
+    try:
+        got = cs.read_cpu_freq()
+        check("governor kept", got.get("governor"), "schedutil")
+        check("cur_mhz omitted for 0", "cur_mhz" in got, False)
+        check("max_mhz omitted when absent", "max_mhz" in got, False)
+        check("epp omitted when absent", "epp" in got, False)
+    finally:
+        t.close()
+
+
+def test_garbage_cur_freq_omitted():
+    """A non-integer scaling_cur_freq is dropped, not cleaned."""
+    print("test_garbage_cur_freq_omitted")
+    t = CpuTree({"cpu0": {"scaling_governor": "performance",
+                          "scaling_cur_freq": "notanumber"}})
+    try:
+        got = cs.read_cpu_freq()
+        check("governor still read", got.get("governor"), "performance")
+        check("cur_mhz omitted for garbage", "cur_mhz" in got, False)
+    finally:
+        t.close()
+
+
+def test_status_splices_cpu_when_present():
+    """real_status() carries the `cpu` block when the box has cpufreq..."""
+    print("test_status_splices_cpu_when_present")
+    t = CpuTree({"cpu0": {"scaling_governor": "powersave",
+                          "scaling_cur_freq": "2100000"}})
+    try:
+        st = cs.real_status()
+        check("cpu key present", "cpu" in st, True)
+        check("cpu.governor", st.get("cpu", {}).get("governor"), "powersave")
+    finally:
+        t.close()
+
+
+def test_status_omits_cpu_when_absent():
+    """...and OMITS it entirely on a box with no cpufreq (additive-and-omitted,
+    like `battery` — never a null block)."""
+    print("test_status_omits_cpu_when_absent")
+    t = CpuTree({})
+    try:
+        check("cpu key omitted", "cpu" in cs.real_status(), False)
+    finally:
+        t.close()
+
+
+if __name__ == "__main__":
+    for fn in (test_full_handheld_reading,
+               test_no_cpufreq_degrades_to_empty,
+               test_optional_fields_omitted,
+               test_garbage_cur_freq_omitted,
+               test_status_splices_cpu_when_present,
+               test_status_omits_cpu_when_absent):
+        fn()
+    if FAILURES:
+        print("\n%d FAILED: %s" % (len(FAILURES), ", ".join(FAILURES)))
+        sys.exit(1)
+    print("\nall good")

--- a/tests/test_gaming_card.py
+++ b/tests/test_gaming_card.py
@@ -73,6 +73,9 @@ def test_gpu_sensors():
         dev = os.path.join(d, "card1", "device")
         _write(os.path.join(dev, "hwmon", "hwmon5", "name"), "amdgpu\n")
         _write(os.path.join(dev, "hwmon", "hwmon5", "temp1_input"), "61000\n")
+        # Package power (microwatts) + core clock (Hz), from the same hwmon.
+        _write(os.path.join(dev, "hwmon", "hwmon5", "power1_average"), "5070000\n")
+        _write(os.path.join(dev, "hwmon", "hwmon5", "freq1_input"), "800000000\n")
         _write(os.path.join(dev, "mem_info_vram_total"), str(8 * 1024**3) + "\n")
         _write(os.path.join(dev, "mem_info_vram_used"), str(3300 * 1024**2) + "\n")
         # ...and a CONNECTOR dir that also matches a bare card* glob and also has
@@ -86,12 +89,40 @@ def test_gpu_sensors():
         check(gpu.get("temp_c") == 61.0, "temp from the matched hwmon (not hwmonN)")
         check(gpu.get("vram_total_mb") == 8192, "vram_total in MB from card1, NOT the connector")
         check(gpu.get("vram_used_mb") == 3300, "vram_used in MB")
+        check(gpu.get("power_w") == 5.1, "power_w = power1_average uW/1e6 (5.07 -> 5.1)")
+        check(gpu.get("clock_mhz") == 800, "clock_mhz = freq1_input Hz//1e6")
 
         # Intel i915: a device hwmon that is not amdgpu -> no GPU block at all.
         d2 = tempfile.mkdtemp()
         cs._DRM_DIR = d2
         _write(os.path.join(d2, "card0", "device", "hwmon", "hwmon1", "name"), "i915\n")
         check(cs._gpu_sensors() == {}, "Intel i915 -> {} (no GPU block, not CPU temp)")
+    finally:
+        cs._DRM_DIR = orig
+
+
+def test_gpu_power_clock_fallback_and_omission():
+    print("GPU power/clock: power1_input fallback + omission")
+    # A card that exposes ONLY power1_input (newer ASICs) still reports power_w.
+    d = tempfile.mkdtemp()
+    orig = cs._DRM_DIR
+    cs._DRM_DIR = d
+    try:
+        dev = os.path.join(d, "card1", "device")
+        _write(os.path.join(dev, "hwmon", "hwmon0", "name"), "amdgpu\n")
+        _write(os.path.join(dev, "hwmon", "hwmon0", "power1_input"), "12340000\n")
+        gpu = cs._gpu_sensors()
+        check(gpu.get("power_w") == 12.3, "power_w falls back to power1_input")
+        check("clock_mhz" not in gpu, "no clock_mhz when freq1_input absent")
+
+        # A card with NEITHER: no power/clock keys, never a mislabelled zero.
+        d2 = tempfile.mkdtemp()
+        cs._DRM_DIR = d2
+        _write(os.path.join(d2, "card1", "device", "hwmon", "hwmon0", "name"), "amdgpu\n")
+        _write(os.path.join(d2, "card1", "device", "hwmon", "hwmon0", "power1_average"), "0\n")
+        gpu2 = cs._gpu_sensors()
+        check("power_w" not in gpu2, "power1_average 0 -> no power_w (gauge not measuring)")
+        check("clock_mhz" not in gpu2, "no clock_mhz when the card exposes none")
     finally:
         cs._DRM_DIR = orig
 
@@ -379,6 +410,7 @@ def test_payload_omits_absent_fields():
 if __name__ == "__main__":
     test_appid_from_cmdline()
     test_gpu_sensors()
+    test_gpu_power_clock_fallback_and_omission()
     test_payload_reports_every_gpu()
     test_vram_sanity()
     test_controllers_and_battery()


### PR DESCRIPTION
Three small, additive features off the roadmap, built together.

## 1. More Console sensors (agent 2.9.107)
Additive fields on `/api/status` and `/api/gaming`, each **omitted when unavailable** (never null/0), **no new capability key**.
- **Battery health** — `health_pct` (full-charge ÷ design capacity; a fresh pack's >100% is reported verbatim, an absurd >120% ratio rejected), `cycle_count` (0 kept — a new pack, not "unknown"), `capacity_level` (verbatim bucket). Renders as a quiet BATTERY detail line: `health 94% · 112 cycles`.
- **CPU governor/clock** — new `read_cpu_freq()` → `{governor, cur_mhz (peak core), max_mhz, epp}`, spliced as an omit-when-absent `cpu` block. EPP is surfaced because amd-pstate-epp handhelds sit on `powersave` permanently. New 5th VITALS tile **CLOCK**.
- **GPU power/clock** — `power_w` (`power1_average`, else `power1_input`) + `clock_mhz` (`freq1_input`) on the GPU block the Console already draws.

## 2. Destructive-action countdown: "Do it now" + wider coverage
- The cancellable countdown (#429) gains **DO IT NOW** (fire immediately, skip the wait) beside CANCEL, extracted into a reusable `useArmedAction` hook + `ArmedActionBar`.
- **Double-fire guard**: a synchronously-nulled ref means "Do it now" and the timer expiry can never both fire (a doubled reboot POST is real — `api.request` never retries POSTs).
- **Degrades closed**: backgrounding the app (JS timers pause → would otherwise fire minutes later from a pocketed phone) now aborts the countdown, as does a box switch. Bar is `accessibilityRole="alert"`.
- The **Decky screen reboot** and **System Updates card reboot** now route through the same window instead of a one-shot Alert that rebooted the instant you tapped through.
- Closes a standing §6 gap: `test_actions_endpoint.py` proves an unknown action id is 404'd and **dispatches nothing** (spied), plus the bearer gate.

## 3. Player seek-hold
Watch panel's −10/+10 buttons: tap = smallest offset (unchanged), **hold = next offset up (±30)**. Both come only from the box's `seek_secs` — never a hardcoded value. Agent unchanged (already allowlists ±10/±30/±90).

## Verification
- **Agent**: new/changed unit tests pass (`test_box_battery`, `test_console_sensors`, `test_gaming_card`, `test_actions_endpoint`) + adjacent suites + `test_ci_wiring` + `test_protocol_parity`; `py_compile` clean.
- **App**: `tsc --noEmit` clean (the 3 `/decky` typed-route errors are pre-existing and resolve under CI's `npm ci` typegen); 491 bare-Node tests pass.
- **Web harness (mock), pressed not rendered**:
  - Countdown — counting `POST /api/actions/reboot` in the agent log: **DO IT NOW fires exactly one** reboot with **no second fire** after the timer would have elapsed; **CANCEL fires nothing**; expiry fires exactly one.
  - Sensors at 375pt — VITALS `CLOCK 2.7G` (no wrap after tuning tile size/gap), battery `7.7W draw · balanced · health 94% · 112 cycles`, GPU `4.5 W · 0.80 GHz` / `42.5 W · 2.40 GHz`, header `service v2.9.107`.
  - Seek-hold — offset derivation confirmed against live mock `/api/player` (`seek_secs [-90,-30,-10,10,30,90]` → tap ±10, hold ±30).

## NOT verified (owner device pass)
- **Hardware sysfs reads**: `read_cpu_freq` (cpufreq tree) and amdgpu `power1_average`/`freq1_input` — no box on this LAN; test fixtures are synthetic, values anchored to a real Legion Go S in `docs/ROADMAP.md`. Read on a box before quoting the numbers in copy.
- **Countdown AppState abort** on a real locked/backgrounded phone.
- **Seek-hold gesture** itself — the mock player reports `running:false`, so the transport row does not render in the harness; the seek path and allowlist are otherwise covered.

## Release impact
- Agent `VERSION` → **2.9.107** (additive status/gaming fields only; old apps unaffected — shapes never changed). Ships whenever the next agent release is cut (`release-agent.sh`), publishing onto the current app tag.
- App changes ride the next app build; every field is probe-and-appear, so a new app against an old agent simply shows fewer tiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)